### PR TITLE
Change Preconditions.notNull() to throw NullPointerException

### DIFF
--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/CollectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/CollectionUtils.java
@@ -28,8 +28,9 @@ public final class CollectionUtils {
 	 *
 	 * @param collection the collection to get the element from
 	 * @return the only element of the collection
-	 * @throws IllegalArgumentException if the collection is {@code null}
-	 * or does not contain exactly one element
+	 * @throws NullPointerException if the collection is {@code null}
+	 * @throws IllegalArgumentException if the collection does not contain
+	 * exactly one element
 	 */
 	public static <T> T getOnlyElement(Collection<T> collection) {
 		Preconditions.notNull(collection, "collection must not be null");

--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/Preconditions.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/Preconditions.java
@@ -17,9 +17,6 @@ import java.util.function.Supplier;
  * Collection of utilities for asserting preconditions for method and
  * constructor arguments.
  *
- * <p>Each method in this class throws an {@link IllegalArgumentException}
- * if the precondition fails.
- *
  * @since 5.0
  */
 public final class Preconditions {
@@ -33,10 +30,12 @@ public final class Preconditions {
 	 *
 	 * @param object the object to check
 	 * @param message precondition failure message
+	 * @return the passed in object
+	 * @throws NullPointerException if the object is {@code null}
 	 * @see #notNull(Object, Supplier)
 	 */
-	public static void notNull(Object object, String message) throws IllegalArgumentException {
-		notNull(object, () -> message);
+	public static <T> T notNull(T object, String message) throws NullPointerException {
+		return notNull(object, () -> message);
 	}
 
 	/**
@@ -44,10 +43,15 @@ public final class Preconditions {
 	 *
 	 * @param object the object to check
 	 * @param messageSupplier precondition failure message supplier
+	 * @return the passed in object
+	 * @throws NullPointerException if the object is {@code null}
 	 * @see #condition(boolean, Supplier)
 	 */
-	public static void notNull(Object object, Supplier<String> messageSupplier) throws IllegalArgumentException {
-		condition(object != null, messageSupplier);
+	public static <T> T notNull(T object, Supplier<String> messageSupplier) throws NullPointerException {
+		if (object == null) {
+			throw new NullPointerException(messageSupplier.get());
+		}
+		return object;
 	}
 
 	/**
@@ -55,6 +59,7 @@ public final class Preconditions {
 	 *
 	 * @param str the string to check
 	 * @param message precondition failure message
+	 * @throws IllegalArgumentException if the string is {@code null} or empty
 	 * @see #notEmpty(String, Supplier)
 	 */
 	public static void notEmpty(String str, String message) throws IllegalArgumentException {
@@ -67,6 +72,7 @@ public final class Preconditions {
 	 * @param str the string to check
 	 * @param messageSupplier precondition failure message supplier
 	 * @see StringUtils#isNotEmpty(CharSequence)
+	 * @throws IllegalArgumentException if the string is {@code null} or empty
 	 * @see #condition(boolean, Supplier)
 	 */
 	public static void notEmpty(String str, Supplier<String> messageSupplier) throws IllegalArgumentException {
@@ -78,6 +84,7 @@ public final class Preconditions {
 	 *
 	 * @param collection the collection to check
 	 * @param message precondition failure message
+	 * @throws IllegalArgumentException if the collection is {@code null} or empty
 	 * @see #condition(boolean, Supplier)
 	 */
 	public static void notEmpty(Collection<?> collection, String message) throws IllegalArgumentException {
@@ -89,6 +96,7 @@ public final class Preconditions {
 	 *
 	 * @param str the string to check
 	 * @param message precondition failure message
+	 * @throws IllegalArgumentException if the string is {@code null} or blank
 	 * @see #notBlank(String, Supplier)
 	 */
 	public static void notBlank(String str, String message) throws IllegalArgumentException {
@@ -100,6 +108,7 @@ public final class Preconditions {
 	 *
 	 * @param str the string to check
 	 * @param messageSupplier precondition failure message supplier
+	 * @throws IllegalArgumentException if the string is {@code null} or blank
 	 * @see StringUtils#isNotBlank(String)
 	 * @see #condition(boolean, Supplier)
 	 */
@@ -112,6 +121,7 @@ public final class Preconditions {
 	 *
 	 * @param predicate the predicate to check
 	 * @param message precondition failure message
+	 * @throws IllegalArgumentException if the predicate is {@code false}
 	 * @see #condition(boolean, Supplier)
 	 */
 	public static void condition(boolean predicate, String message) throws IllegalArgumentException {

--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ToStringBuilder.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ToStringBuilder.java
@@ -35,8 +35,7 @@ public class ToStringBuilder {
 	}
 
 	public ToStringBuilder(Class<?> type) {
-		Preconditions.notNull(type, "Class must not be null");
-		this.type = type;
+		this.type = Preconditions.notNull(type, "Class must not be null");
 	}
 
 	public ToStringBuilder append(String name, Object value) {

--- a/junit-tests/src/test/java/org/junit/gen5/commons/util/CollectionUtilsTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/commons/util/CollectionUtilsTests.java
@@ -23,7 +23,7 @@ class CollectionUtilsTests {
 
 	@Test
 	void getOnlyElementWithNullCollection() {
-		IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+		NullPointerException exception = expectThrows(NullPointerException.class, () -> {
 			CollectionUtils.getOnlyElement(null);
 		});
 		assertEquals("collection must not be null", exception.getMessage());

--- a/junit-tests/src/test/java/org/junit/gen5/commons/util/FunctionUtilsTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/commons/util/FunctionUtilsTests.java
@@ -21,7 +21,7 @@ class FunctionUtilsTests {
 
 	@Test
 	void whereWithNullFunction() {
-		IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+		NullPointerException exception = expectThrows(NullPointerException.class, () -> {
 			FunctionUtils.where(null, o -> true);
 		});
 		assertEquals("function must not be null", exception.getMessage());
@@ -29,7 +29,7 @@ class FunctionUtilsTests {
 
 	@Test
 	void whereWithNullPredicate() {
-		IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> {
+		NullPointerException exception = expectThrows(NullPointerException.class, () -> {
 			FunctionUtils.where(o -> o, null);
 		});
 		assertEquals("predicate must not be null", exception.getMessage());

--- a/junit-tests/src/test/java/org/junit/gen5/commons/util/ToStringBuilderTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/commons/util/ToStringBuilderTests.java
@@ -26,14 +26,14 @@ public class ToStringBuilderTests {
 
 	@Test
 	public void withNullObject() {
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(NullPointerException.class, () -> {
 			new ToStringBuilder((Object) null);
 		});
 	}
 
 	@Test
 	public void withNullClass() {
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(NullPointerException.class, () -> {
 			new ToStringBuilder((Class<?>) null);
 		});
 	}

--- a/junit-tests/src/test/java/org/junit/gen5/engine/FileSystemSourceTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/FileSystemSourceTests.java
@@ -23,7 +23,7 @@ class FileSystemSourceTests {
 
 	@Test
 	void nullSourceFileOrDirectoryYieldsException() {
-		assertThrows(IllegalArgumentException.class, () -> {
+		assertThrows(NullPointerException.class, () -> {
 			new FileSystemSource(null);
 		});
 	}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
@@ -64,9 +64,7 @@ public class ClassTestDescriptor extends JUnit5TestDescriptor implements Contain
 	ClassTestDescriptor(String uniqueId, Class<?> testClass) {
 		super(uniqueId);
 
-		Preconditions.notNull(testClass, "Class must not be null");
-
-		this.testClass = testClass;
+		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
 		this.displayName = determineDisplayName(testClass, testClass.getName());
 
 		setSource(new JavaSource(testClass));

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/JUnit5TestableFactory.java
@@ -155,7 +155,11 @@ class JUnit5TestableFactory {
 	}
 
 	private Class<?> loadClassByName(String className) {
-		return ReflectionUtils.loadClass(className).orElse(null);
+		return ReflectionUtils.loadClass(className).orElseThrow(() -> createCannotLoadClassException(className));
+	}
+
+	private RuntimeException createCannotLoadClassException(String className) {
+		return new IllegalArgumentException(String.format("Cannot load class '%s'", className));
 	}
 
 	private Class<?> loadRequiredClass(String className, String fullUniqueId, String uniqueIdPart) {


### PR DESCRIPTION
Change Preconditions.notNull() to throw NullPointerException
instead of IllegalArgumentException. Also updated it to return
the passed-in value.

I thought this might be controversial, so here's my thoughts:

According to Joshua Bloch in Effective Java, 2nd Edition, Item 60,
"If a caller passes null in some parameter for which null values
are prohibited, convention dictates that NullPointerException be thrown
rather than IllegalArgumentException."

Throwing NPE in these cases is also quite common in the JDK.
(see java.util.Collections for many examples).

The Guava Preconditions.checkNotNull() methods also throws a NPE.

Finally, if somehere someone deferences a null variable without
checking it, a NPE would naturally be thrown. If we later add an
explicit check, we wouldn't want the code to start throwing an
IllegalArgumentException.
