### PR TITLE
fix documentation for test inner class

### DIFF
--- a/documentation/src/docs/asciidoc/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/writing-tests.adoc
@@ -262,7 +262,7 @@ class MyObjectTest {
 	void testEmptyObject() {}
 
 	@Nested
-	class WithChildren() {
+	class WithChildren {
 
 		@BeforeEach
 		void initWithChildren() {


### PR DESCRIPTION
This small patch fixes the documentation for inner class sample.
---
I hereby agree to the terms of the JUnit Contributor License Agreement.