### PR TITLE
Introduced interface Launcher and renamed old to JUnit5Launcher

### DIFF
--- a/junit-console/src/main/java/org/junit/gen5/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-console/src/main/java/org/junit/gen5/console/tasks/DiscoveryRequestCreator.java
@@ -13,7 +13,7 @@ package org.junit.gen5.console.tasks;
 import static java.util.stream.Collectors.toCollection;
 import static org.junit.gen5.engine.discovery.ClasspathSelector.forPaths;
 import static org.junit.gen5.engine.discovery.NameBasedSelector.forNames;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.io.File;
 import java.util.LinkedHashSet;

--- a/junit-console/src/main/java/org/junit/gen5/console/tasks/ExecuteTestsTask.java
+++ b/junit-console/src/main/java/org/junit/gen5/console/tasks/ExecuteTestsTask.java
@@ -22,7 +22,7 @@ import org.junit.gen5.console.options.CommandLineOptions;
 import org.junit.gen5.launcher.*;
 import org.junit.gen5.launcher.listeners.SummaryGeneratingListener;
 import org.junit.gen5.launcher.listeners.TestExecutionSummary;
-import org.junit.gen5.launcher.main.Launcher;
+import org.junit.gen5.launcher.main.JUnit5Launcher;
 
 /**
  * @since 5.0
@@ -33,7 +33,7 @@ public class ExecuteTestsTask implements ConsoleTask {
 	private final Supplier<Launcher> launcherSupplier;
 
 	public ExecuteTestsTask(CommandLineOptions options) {
-		this(options, Launcher::new);
+		this(options, JUnit5Launcher::get);
 	}
 
 	// for tests only

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/Launcher.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/Launcher.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.launcher;
+
+/**
+ * Main entry point for client code that wants to <em>discover</em>
+ * and <em>execute</em> tests using dynamically registered test engines.
+ *
+ * <p>You get hold of an instance of this interface by using
+ * <pre>
+ *     JUnit5Launcher.get()
+ * </pre>
+ *
+ * <p>Test engines are registered at runtime using the
+ * {@link java.util.ServiceLoader ServiceLoader} facility. For that purpose, a
+ * text file named {@code META-INF/services/org.junit.gen5.engine.TestEngine}
+ * has to be added to the engine's JAR file in which the fully qualified name
+ * of the implementation class of the {@link org.junit.gen5.engine.TestEngine} interface is stated.
+ *
+ * <p>Discovering or executing tests requires a {@link TestDiscoveryRequest}
+ * which is passed to all registered engines. Each engine decides which tests
+ * it can discover and later execute according to this {@link TestDiscoveryRequest}.
+ *
+ * <p>Users of this class may optionally call {@link #discover} prior to
+ * {@link #execute} in order to inspect the {@link TestPlan} before executing
+ * it.
+ *
+ * <p>Prior to executing tests, users of this class should
+ * {@linkplain #registerTestExecutionListeners register} one or more
+ * {@link TestExecutionListener} instances in order to get feedback about the
+ * progress and results of test execution. Listeners are notified of events
+ * in the order in which they were registered.
+ *
+ * @since 5.0
+ * @see TestDiscoveryRequest
+ * @see TestPlan
+ * @see TestExecutionListener
+ * @see org.junit.gen5.launcher.main.JUnit5Launcher
+ */
+public interface Launcher {
+
+	/**
+	 * Register one or more listeners for test execution.
+	 *
+	 * @param listeners the listeners to be notified of test execution events
+	 */
+	void registerTestExecutionListeners(TestExecutionListener... listeners);
+
+	/**
+	 * Discover tests and build a {@link TestPlan} according to the supplied
+	 * {@link TestDiscoveryRequest} by querying all registered engines and
+	 * collecting their results.
+	 *
+	 * @param discoveryRequest the discovery request
+	 * @return a {@code TestPlan} that contains all resolved
+	 *         {@linkplain TestIdentifier identifiers} from all registered engines
+	 */
+	TestPlan discover(TestDiscoveryRequest discoveryRequest);
+
+	/**
+	 * Execute a {@link TestPlan} which is built according to the supplied
+	 * {@link TestDiscoveryRequest} by querying all registered engines and
+	 * collecting their results, and notify {@linkplain #registerTestExecutionListeners
+	 * registered listeners} about the progress and results of the execution.
+	 *
+	 * @param discoveryRequest the discovery request to be executed
+	 */
+	void execute(TestDiscoveryRequest discoveryRequest);
+
+}

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestDiscoveryRequest.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestDiscoveryRequest.java
@@ -13,15 +13,17 @@ package org.junit.gen5.launcher;
 import java.util.*;
 
 import org.junit.gen5.engine.*;
+import org.junit.gen5.launcher.main.JUnit5Launcher;
+import org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder;
 
 /**
  * This class extends the {@link EngineDiscoveryRequest}
  * by providing access to filters which are applied by the
- * {@link org.junit.gen5.launcher.main.Launcher} itself
+ * {@link JUnit5Launcher} itself
  *
  * <p>Moreover, the add*-methods can be used by external clients
  * that do not want to use the
- * {@link org.junit.gen5.launcher.main.DiscoveryRequestBuilder}.
+ * {@link TestDiscoveryRequestBuilder}.
  *
  * @since 5.0
  */

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestDiscoveryRequest.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestDiscoveryRequest.java
@@ -13,17 +13,15 @@ package org.junit.gen5.launcher;
 import java.util.*;
 
 import org.junit.gen5.engine.*;
-import org.junit.gen5.launcher.main.JUnit5Launcher;
-import org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder;
 
 /**
  * This class extends the {@link EngineDiscoveryRequest}
  * by providing access to filters which are applied by the
- * {@link JUnit5Launcher} itself
+ * {@link Launcher} itself
  *
  * <p>Moreover, the add*-methods can be used by external clients
  * that do not want to use the
- * {@link TestDiscoveryRequestBuilder}.
+ * {@link org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder}.
  *
  * @since 5.0
  */

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestExecutionListener.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestExecutionListener.java
@@ -13,7 +13,7 @@ package org.junit.gen5.launcher;
 import org.junit.gen5.commons.reporting.ReportingEntry;
 import org.junit.gen5.engine.TestExecutionResult;
 import org.junit.gen5.engine.TestExecutionResult.Status;
-import org.junit.gen5.launcher.main.Launcher;
+import org.junit.gen5.launcher.Launcher;
 
 /**
  * Register an instance of this class with a {@link Launcher} to be notified of

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
@@ -24,7 +24,7 @@ import java.util.function.Predicate;
 import org.junit.gen5.commons.util.PreconditionViolationException;
 import org.junit.gen5.commons.util.Preconditions;
 import org.junit.gen5.engine.TestDescriptor;
-import org.junit.gen5.launcher.main.Launcher;
+import org.junit.gen5.launcher.Launcher;
 
 /**
  * {@code TestPlan} describes the tree of tests and containers as discovered

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/listeners/package-info.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/listeners/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Common {@link org.junit.gen5.launcher.TestExecutionListener
  * TestExecutionListener} implementations and related support classes for
- * the JUnit {@link org.junit.gen5.launcher.main.JUnit5Launcher Launcher}.
+ * the JUnit {@link org.junit.gen5.launcher.Launcher Launcher}.
  */
 
 package org.junit.gen5.launcher.listeners;

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/listeners/package-info.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/listeners/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Common {@link org.junit.gen5.launcher.TestExecutionListener
  * TestExecutionListener} implementations and related support classes for
- * the JUnit {@link org.junit.gen5.launcher.main.Launcher Launcher}.
+ * the JUnit {@link org.junit.gen5.launcher.main.JUnit5Launcher Launcher}.
  */
 
 package org.junit.gen5.launcher.listeners;

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/main/JUnit5Launcher.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/main/JUnit5Launcher.java
@@ -19,52 +19,38 @@ import org.junit.gen5.engine.TestEngine;
 import org.junit.gen5.launcher.*;
 
 /**
- * Facade for <em>discovering</em> and <em>executing</em> tests using
- * dynamically registered test engines.
+ * The currently only implementation of {@link Launcher}.
  *
- * <p>Test engines are registered at runtime using the
- * {@link java.util.ServiceLoader ServiceLoader} facility. For that purpose, a
- * text file named {@code META-INF/services/org.junit.gen5.engine.TestEngine}
- * has to be added to the engine's JAR file in which the fully qualified name
- * of the implementation class of the {@link TestEngine} interface is stated.
- *
- * <p>Discovering or executing tests requires a {@link DiscoveryRequest}
- * which is passed to all registered engines. Each engine decides which tests
- * it can discover and later execute according to this {@link DiscoveryRequest}.
- *
- * <p>Users of this class may optionally call {@link #discover} prior to
- * {@link #execute} in order to inspect the {@link TestPlan} before executing
- * it.
- *
- * <p>Prior to executing tests, users of this class should
- * {@linkplain #registerTestExecutionListeners register} one or more
- * {@link TestExecutionListener} instances in order to get feedback about the
- * progress and results of test execution. Listeners are notified of events
- * in the order in which they were registered.
+ * <p>External clients get hold of an instance by calling {@link #get}</p>
  *
  * @since 5.0
+ * @see Launcher
  * @see DiscoveryRequest
  * @see TestPlan
  * @see TestExecutionListener
  */
-public class Launcher {
+public class JUnit5Launcher implements Launcher {
 
-	private static final Logger LOG = Logger.getLogger(Launcher.class.getName());
+	public static Launcher get() {
+		return new JUnit5Launcher();
+	}
+
+	private static final Logger LOG = Logger.getLogger(JUnit5Launcher.class.getName());
 
 	private final TestEngineRegistry testEngineRegistry;
 	private final TestExecutionListenerRegistry testExecutionListenerRegistry;
 
-	public Launcher() {
+	JUnit5Launcher() {
 		this(new ServiceLoaderTestEngineRegistry(), new TestExecutionListenerRegistry());
 	}
 
 	// For tests only
-	Launcher(TestEngineRegistry testEngineRegistry) {
+	JUnit5Launcher(TestEngineRegistry testEngineRegistry) {
 		this(testEngineRegistry, new TestExecutionListenerRegistry());
 	}
 
 	// For tests only
-	Launcher(TestEngineRegistry testEngineRegistry, TestExecutionListenerRegistry testExecutionListenerRegistry) {
+	JUnit5Launcher(TestEngineRegistry testEngineRegistry, TestExecutionListenerRegistry testExecutionListenerRegistry) {
 		this.testEngineRegistry = testEngineRegistry;
 		this.testExecutionListenerRegistry = testExecutionListenerRegistry;
 	}

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/main/TestDiscoveryRequestBuilder.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/main/TestDiscoveryRequestBuilder.java
@@ -48,32 +48,32 @@ import org.junit.gen5.launcher.*;
  *   ).build();
  * </pre>
  */
-public final class DiscoveryRequestBuilder {
+public final class TestDiscoveryRequestBuilder {
 
 	private List<DiscoverySelector> selectors = new LinkedList<>();
 	private List<EngineIdFilter> engineIdFilters = new LinkedList<>();
 	private List<DiscoveryFilter<?>> discoveryFilters = new LinkedList<>();
 	private List<PostDiscoveryFilter> postDiscoveryFilters = new LinkedList<>();
 
-	public static DiscoveryRequestBuilder request() {
-		return new DiscoveryRequestBuilder();
+	public static TestDiscoveryRequestBuilder request() {
+		return new TestDiscoveryRequestBuilder();
 	}
 
-	public DiscoveryRequestBuilder select(DiscoverySelector... elements) {
+	public TestDiscoveryRequestBuilder select(DiscoverySelector... elements) {
 		if (elements != null) {
 			select(Arrays.asList(elements));
 		}
 		return this;
 	}
 
-	public DiscoveryRequestBuilder select(List<DiscoverySelector> elements) {
+	public TestDiscoveryRequestBuilder select(List<DiscoverySelector> elements) {
 		if (elements != null) {
 			this.selectors.addAll(elements);
 		}
 		return this;
 	}
 
-	public DiscoveryRequestBuilder filter(GenericFilter<?>... filters) {
+	public TestDiscoveryRequestBuilder filter(GenericFilter<?>... filters) {
 		if (filters != null) {
 			Arrays.stream(filters).forEach(this::storeFilter);
 		}

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/main/package-info.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/main/package-info.java
@@ -1,8 +1,8 @@
 /**
- * The {@link org.junit.gen5.launcher.main.Launcher Launcher} class is the
+ * The {@link org.junit.gen5.launcher.main.JUnit5Launcher Launcher} class is the
  * main starting point for running all JUnit tests.
  *
- * <p>The {@link org.junit.gen5.launcher.main.DiscoveryRequestBuilder
+ * <p>The {@link org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder
  * DiscoveryRequestBuilder} serves as a small DSL for creating
  * {@link org.junit.gen5.launcher.TestDiscoveryRequest TestDiscoveryRequests}.
  */

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/main/package-info.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/main/package-info.java
@@ -1,9 +1,9 @@
 /**
- * The {@link org.junit.gen5.launcher.main.JUnit5Launcher Launcher} class is the
+ * The {@link org.junit.gen5.launcher.main.JUnit5Launcher JUnit5Launcher} class is the
  * main starting point for running all JUnit tests.
  *
  * <p>The {@link org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder
- * DiscoveryRequestBuilder} serves as a small DSL for creating
+ * TestDiscoveryRequestBuilder} serves as a small DSL for creating
  * {@link org.junit.gen5.launcher.TestDiscoveryRequest TestDiscoveryRequests}.
  */
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit4/JUnit4TestEngineDiscoveryTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit4/JUnit4TestEngineDiscoveryTests.java
@@ -23,7 +23,7 @@ import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
 import static org.junit.gen5.engine.discovery.ClasspathSelector.forPaths;
 import static org.junit.gen5.engine.discovery.PackageSelector.forPackageName;
 import static org.junit.gen5.engine.discovery.UniqueIdSelector.forUniqueId;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.io.File;
 import java.lang.reflect.Method;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit4/JUnit4TestEngineExecutionTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit4/JUnit4TestEngineExecutionTests.java
@@ -15,7 +15,7 @@ import static org.junit.gen5.engine.ExecutionEventConditions.*;
 import static org.junit.gen5.engine.TestExecutionResultConditions.isA;
 import static org.junit.gen5.engine.TestExecutionResultConditions.message;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.util.List;
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/AbstractJUnit5TestEngineTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/AbstractJUnit5TestEngineTests.java
@@ -11,7 +11,7 @@
 package org.junit.gen5.engine.junit5;
 
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import org.junit.gen5.api.BeforeEach;
 import org.junit.gen5.engine.ExecutionEventRecorder;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/ClassLevelCallbackTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/ClassLevelCallbackTests.java
@@ -13,7 +13,7 @@ package org.junit.gen5.engine.junit5;
 import static java.util.Arrays.asList;
 import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/DisabledTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/DisabledTests.java
@@ -14,7 +14,7 @@ import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.api.Assertions.fail;
 import static org.junit.gen5.commons.util.AnnotationUtils.findAnnotation;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/DiscoveryFilterApplierTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/DiscoveryFilterApplierTests.java
@@ -11,7 +11,7 @@
 package org.junit.gen5.engine.junit5;
 
 import static org.junit.gen5.engine.junit5.descriptor.TestDescriptorBuilder.*;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/DiscoveryTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/DiscoveryTests.java
@@ -13,7 +13,7 @@ package org.junit.gen5.engine.junit5;
 import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
 import static org.junit.gen5.engine.discovery.UniqueIdSelector.forUniqueId;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/ExceptionHandlingTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/ExceptionHandlingTests.java
@@ -23,7 +23,7 @@ import static org.junit.gen5.engine.ExecutionEventConditions.test;
 import static org.junit.gen5.engine.TestExecutionResultConditions.isA;
 import static org.junit.gen5.engine.TestExecutionResultConditions.message;
 import static org.junit.gen5.engine.TestExecutionResultConditions.suppressed;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.io.IOException;
 import java.lang.reflect.Method;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/InstancePostProcessorTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/InstancePostProcessorTests.java
@@ -13,7 +13,7 @@ package org.junit.gen5.engine.junit5;
 import static java.util.Arrays.asList;
 import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/MethodLevelCallbackTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/MethodLevelCallbackTests.java
@@ -13,7 +13,7 @@ package org.junit.gen5.engine.junit5;
 import static java.util.Arrays.asList;
 import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/NestedTestClassesTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/NestedTestClassesTests.java
@@ -13,7 +13,7 @@ package org.junit.gen5.engine.junit5;
 import static org.junit.gen5.api.Assertions.assertAll;
 import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import org.junit.gen5.api.AfterEach;
 import org.junit.gen5.api.Assertions;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/ReportingTest.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/ReportingTest.java
@@ -12,7 +12,7 @@ package org.junit.gen5.engine.junit5;
 
 import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.util.HashMap;
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/StandardTestClassTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/StandardTestClassTests.java
@@ -14,7 +14,7 @@ import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.api.Assertions.assertTrue;
 import static org.junit.gen5.api.Assertions.fail;
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import org.junit.gen5.api.AfterEach;
 import org.junit.gen5.api.BeforeEach;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/TestCaseWithInheritanceTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/TestCaseWithInheritanceTests.java
@@ -14,7 +14,7 @@ import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.api.Assertions.fail;
 import static org.junit.gen5.api.Assumptions.assumeTrue;
 import static org.junit.gen5.engine.discovery.UniqueIdSelector.forUniqueId;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import org.junit.gen5.api.AfterEach;
 import org.junit.gen5.api.BeforeEach;

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/DiscoverySelectorTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/descriptor/DiscoverySelectorTests.java
@@ -14,7 +14,7 @@ import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.api.Assertions.assertSame;
 import static org.junit.gen5.api.Assertions.assertThrows;
 import static org.junit.gen5.api.Assertions.assertTrue;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/junit-tests/src/test/java/org/junit/gen5/launcher/main/DiscoveryRequestBuilderTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/launcher/main/DiscoveryRequestBuilderTests.java
@@ -17,7 +17,7 @@ import static org.junit.gen5.engine.discovery.ClassSelector.forClassName;
 import static org.junit.gen5.engine.discovery.MethodSelector.forMethod;
 import static org.junit.gen5.engine.discovery.PackageSelector.forPackageName;
 import static org.junit.gen5.engine.discovery.UniqueIdSelector.forUniqueId;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.io.File;
 import java.lang.reflect.Method;

--- a/junit-tests/src/test/java/org/junit/gen5/launcher/main/DiscoveryRequestTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/launcher/main/DiscoveryRequestTests.java
@@ -15,7 +15,7 @@ import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.api.Assertions.assertNotNull;
 import static org.junit.gen5.engine.discovery.NameBasedSelector.forName;
 import static org.junit.gen5.engine.discovery.UniqueIdSelector.forUniqueId;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.util.Arrays;
 import java.util.List;

--- a/junit-tests/src/test/java/org/junit/gen5/launcher/main/JUnit5LauncherTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/launcher/main/JUnit5LauncherTests.java
@@ -12,8 +12,8 @@ package org.junit.gen5.launcher.main;
 
 import static org.junit.gen5.engine.discovery.UniqueIdSelector.forUniqueId;
 import static org.junit.gen5.launcher.EngineIdFilter.byEngineId;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
 import static org.junit.gen5.launcher.main.LauncherFactory.createLauncher;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import org.assertj.core.api.Assertions;
 import org.junit.gen5.api.Test;
@@ -23,11 +23,11 @@ import org.junit.gen5.launcher.TestId;
 import org.junit.gen5.launcher.TestIdentifier;
 import org.junit.gen5.launcher.TestPlan;
 
-public class LauncherTests {
+public class JUnit5LauncherTests {
 
 	@Test
 	public void discoverEmptyTestPlanWithoutAnyEngines() {
-		Launcher launcher = createLauncher();
+		JUnit5Launcher launcher = createLauncher();
 
 		TestPlan testPlan = launcher.discover(request().select(forUniqueId("foo")).build());
 
@@ -36,7 +36,7 @@ public class LauncherTests {
 
 	@Test
 	public void discoverEmptyTestPlanWithEngineWithoutAnyTests() {
-		Launcher launcher = createLauncher(new DummyTestEngine());
+		JUnit5Launcher launcher = createLauncher(new DummyTestEngine());
 
 		TestPlan testPlan = launcher.discover(request().select(forUniqueId("foo")).build());
 
@@ -48,7 +48,7 @@ public class LauncherTests {
 		DummyTestEngine engine = new DummyTestEngine("myEngine");
 		TestDescriptor testDescriptor = engine.addTest("test", noOp());
 
-		Launcher launcher = createLauncher(engine);
+		JUnit5Launcher launcher = createLauncher(engine);
 
 		TestPlan testPlan = launcher.discover(request().select(forUniqueId(testDescriptor.getUniqueId())).build());
 
@@ -65,7 +65,7 @@ public class LauncherTests {
 		DummyTestEngine secondEngine = new DummyTestEngine("engine2");
 		TestDescriptor test2 = secondEngine.addTest("test2", noOp());
 
-		Launcher launcher = createLauncher(firstEngine, secondEngine);
+		JUnit5Launcher launcher = createLauncher(firstEngine, secondEngine);
 
 		TestPlan testPlan = launcher.discover(
 			request().select(forUniqueId(test1.getUniqueId()), forUniqueId(test2.getUniqueId())).build());
@@ -82,7 +82,7 @@ public class LauncherTests {
 		DummyTestEngine secondEngine = new DummyTestEngine("second");
 		TestDescriptor test2 = secondEngine.addTest("test2", noOp());
 
-		Launcher launcher = createLauncher(firstEngine, secondEngine);
+		JUnit5Launcher launcher = createLauncher(firstEngine, secondEngine);
 
 		TestPlan testPlan = launcher.discover(
 			request().select(forUniqueId(test1.getUniqueId()), forUniqueId(test2.getUniqueId())).filter(

--- a/junit-tests/src/test/java/org/junit/gen5/launcher/main/LauncherFactory.java
+++ b/junit-tests/src/test/java/org/junit/gen5/launcher/main/LauncherFactory.java
@@ -13,14 +13,13 @@ package org.junit.gen5.launcher.main;
 import static java.util.Arrays.asList;
 
 import org.junit.gen5.engine.TestEngine;
-import org.junit.gen5.launcher.main.Launcher;
 
 public class LauncherFactory {
-	public static Launcher createLauncher(TestEngine... engines) {
+	public static JUnit5Launcher createLauncher(TestEngine... engines) {
 		return createLauncher(asList(engines));
 	}
 
-	public static Launcher createLauncher(Iterable<TestEngine> engines) {
-		return new Launcher(() -> engines);
+	public static JUnit5Launcher createLauncher(Iterable<TestEngine> engines) {
+		return new JUnit5Launcher(() -> engines);
 	}
 }

--- a/junit4-runner/src/main/java/org/junit/gen5/junit4/runner/JUnit5.java
+++ b/junit4-runner/src/main/java/org/junit/gen5/junit4/runner/JUnit5.java
@@ -12,7 +12,7 @@ package org.junit.gen5.junit4.runner;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.junit.gen5.engine.discovery.ClassSelector;
 import org.junit.gen5.engine.discovery.PackageSelector;
 import org.junit.gen5.engine.discovery.UniqueIdSelector;
 import org.junit.gen5.launcher.*;
-import org.junit.gen5.launcher.main.Launcher;
+import org.junit.gen5.launcher.main.JUnit5Launcher;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.manipulation.Filter;
@@ -63,7 +63,7 @@ public class JUnit5 extends Runner implements Filterable {
 	private static final String[] EMPTY_STRING_ARRAY = new String[0];
 	private static final String EMPTY_STRING = "";
 
-	private final Launcher launcher = new Launcher();
+	private final Launcher launcher = JUnit5Launcher.get();
 	private final Class<?> testClass;
 	private TestDiscoveryRequest discoveryRequest;
 	private JUnit5TestTree testTree;

--- a/surefire-junit5/src/main/java/org/junit/gen5/surefire/JUnitGen5Provider.java
+++ b/surefire-junit5/src/main/java/org/junit/gen5/surefire/JUnitGen5Provider.java
@@ -11,7 +11,7 @@
 package org.junit.gen5.surefire;
 
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.logging.Level;
@@ -27,7 +27,7 @@ import org.apache.maven.surefire.suite.RunResult;
 import org.apache.maven.surefire.testset.TestSetFailedException;
 import org.apache.maven.surefire.util.TestsToRun;
 import org.junit.gen5.launcher.*;
-import org.junit.gen5.launcher.main.Launcher;
+import org.junit.gen5.launcher.main.JUnit5Launcher;
 
 public class JUnitGen5Provider extends AbstractProvider {
 
@@ -52,7 +52,7 @@ public class JUnitGen5Provider extends AbstractProvider {
 			throw new UnsupportedOperationException("Forking is not yet supported.");
 		}
 
-		Launcher launcher = new Launcher();
+		Launcher launcher = JUnit5Launcher.get();
 		TestsToRun testsToRun = scanClasspath(launcher);
 		return invokeAllTests(testsToRun, launcher);
 	}

--- a/surefire-junit5/src/main/java/org/junit/gen5/surefire/TestPlanScannerFilter.java
+++ b/surefire-junit5/src/main/java/org/junit/gen5/surefire/TestPlanScannerFilter.java
@@ -11,11 +11,13 @@
 package org.junit.gen5.surefire;
 
 import static org.junit.gen5.engine.discovery.ClassSelector.forClass;
-import static org.junit.gen5.launcher.main.DiscoveryRequestBuilder.request;
+import static org.junit.gen5.launcher.main.TestDiscoveryRequestBuilder.request;
 
 import org.apache.maven.surefire.util.ScannerFilter;
-import org.junit.gen5.launcher.*;
-import org.junit.gen5.launcher.main.Launcher;
+import org.junit.gen5.launcher.Launcher;
+import org.junit.gen5.launcher.TestDiscoveryRequest;
+import org.junit.gen5.launcher.TestIdentifier;
+import org.junit.gen5.launcher.TestPlan;
 
 final class TestPlanScannerFilter implements ScannerFilter {
 


### PR DESCRIPTION
This was done to address yesterday's discussion that `Launcher` should be a top-level abstraction in module `launcher-api`.

Moreover, it further decouples clients from implementation.