### PR TITLE
Introduce ExtensionPointConfiguration

### DIFF
--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -253,6 +253,31 @@ public final class ReflectionUtils {
 		return Arrays.stream(clazz.getDeclaredClasses()).filter(predicate).collect(toList());
 	}
 
+	//TODO: Search in hierarchy
+	public static Optional<Field> findField(Class<?> clazz, String fieldName) {
+		try {
+			return Optional.of(clazz.getDeclaredField(fieldName));
+		}
+		catch (NoSuchFieldException e) {
+			return Optional.empty();
+		}
+	}
+
+	public static Object getFieldValue(Field field, Object target) {
+		Preconditions.notNull(field, "field must not be null");
+		Preconditions.condition((target != null || isStatic(field)),
+			() -> String.format("Cannot get value from non-static field [%s] on a null target.",
+				field.toGenericString()));
+
+		try {
+			makeAccessible(field);
+			return field.get(target);
+		}
+		catch (Throwable t) {
+			throw ExceptionUtils.throwAsUncheckedException(getUnderlyingCause(t));
+		}
+	}
+
 	public static Optional<Method> findMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
 		Predicate<Method> nameAndParameterTypesMatch = (method -> method.getName().equals(methodName)
 				&& Arrays.equals(method.getParameterTypes(), parameterTypes));

--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
-
 import org.junit.gen5.commons.meta.API;
 
 /**
@@ -251,31 +250,6 @@ public final class ReflectionUtils {
 		Preconditions.notNull(predicate, "predicate must not be null");
 
 		return Arrays.stream(clazz.getDeclaredClasses()).filter(predicate).collect(toList());
-	}
-
-	//TODO: Search in hierarchy
-	public static Optional<Field> findField(Class<?> clazz, String fieldName) {
-		try {
-			return Optional.of(clazz.getDeclaredField(fieldName));
-		}
-		catch (NoSuchFieldException e) {
-			return Optional.empty();
-		}
-	}
-
-	public static Object getFieldValue(Field field, Object target) {
-		Preconditions.notNull(field, "field must not be null");
-		Preconditions.condition((target != null || isStatic(field)),
-			() -> String.format("Cannot get value from non-static field [%s] on a null target.",
-				field.toGenericString()));
-
-		try {
-			makeAccessible(field);
-			return field.get(target);
-		}
-		catch (Throwable t) {
-			throw ExceptionUtils.throwAsUncheckedException(getUnderlyingCause(t));
-		}
 	}
 
 	public static Optional<Method> findMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {

--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -10,8 +10,7 @@
 
 package org.junit.gen5.commons.util;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.*;
 import static org.junit.gen5.commons.meta.API.Usage.Internal;
 
 import java.io.File;

--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/ReflectionUtils.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+
 import org.junit.gen5.commons.meta.API;
 
 /**

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSortingTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSortingTests.java
@@ -27,8 +27,6 @@ import org.junit.gen5.api.extension.ExtensionPoint;
 import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
 import org.junit.gen5.commons.util.ReflectionUtils;
-import org.junit.gen5.engine.junit5.extension.ExtensionPointSorter;
-import org.junit.gen5.engine.junit5.extension.RegisteredExtensionPoint;
 
 /**
  * Unit tests for {@link ExtensionPointSorter}.
@@ -129,7 +127,7 @@ public class ExtensionPointSortingTests {
 		pointsToSort.add(point2);
 
 		ExtensionConfigurationException ex = expectThrows(ExtensionConfigurationException.class,
-			() -> sorter.sort(LocalExtensionPoint.class, pointsToSort));
+			() -> sorter.sort(pointsToSort, LocalExtensionPoint.ALLOWED_POSITIONS));
 
 		assertTrue(ex.getMessage().startsWith("Conflicting extensions:"));
 		assertTrue(ex.getMessage().contains(fooMethod.toString()));
@@ -144,14 +142,14 @@ public class ExtensionPointSortingTests {
 		pointsToSort.add(point2);
 
 		ExtensionConfigurationException ex = expectThrows(ExtensionConfigurationException.class,
-			() -> sorter.sort(LocalExtensionPoint.class, pointsToSort));
+			() -> sorter.sort(pointsToSort, LocalExtensionPoint.ALLOWED_POSITIONS));
 
 		assertTrue(ex.getMessage().startsWith("Conflicting extensions:"));
 		assertTrue(ex.getMessage().contains(fooMethod.toString()));
 	}
 
 	private void assertSorting(RegisteredExtensionPoint... points) {
-		sorter.sort(LocalExtensionPoint.class, pointsToSort);
+		sorter.sort(pointsToSort, LocalExtensionPoint.ALLOWED_POSITIONS);
 
 		String failureMessage = String.format("Expected %s but was %s", Arrays.asList(points), pointsToSort);
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSortingTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSortingTests.java
@@ -148,6 +148,19 @@ public class ExtensionPointSortingTests {
 		assertTrue(ex.getMessage().contains(fooMethod.toString()));
 	}
 
+	@Test
+	void extension_withNotAllowedPosition_throwException() {
+		RegisteredExtensionPoint point1 = createExtensionPoint(Position.FIRST);
+
+		pointsToSort.add(point1);
+
+		ExtensionConfigurationException ex = expectThrows(ExtensionConfigurationException.class,
+			() -> sorter.sort(pointsToSort, LocalExtensionPoint.ALLOWED_POSITIONS));
+
+		assertTrue(ex.getMessage().startsWith("'Position.FIRST' not allowed:"));
+		assertTrue(ex.getMessage().contains(fooMethod.toString()));
+	}
+
 	private void assertSorting(RegisteredExtensionPoint... points) {
 		sorter.sort(pointsToSort, LocalExtensionPoint.ALLOWED_POSITIONS);
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSortingTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSortingTests.java
@@ -148,19 +148,6 @@ public class ExtensionPointSortingTests {
 		assertTrue(ex.getMessage().contains(fooMethod.toString()));
 	}
 
-	@Test
-	void extension_withNotAllowedPosition_throwException() {
-		RegisteredExtensionPoint point1 = createExtensionPoint(Position.FIRST);
-
-		pointsToSort.add(point1);
-
-		ExtensionConfigurationException ex = expectThrows(ExtensionConfigurationException.class,
-			() -> sorter.sort(pointsToSort, LocalExtensionPoint.ALLOWED_POSITIONS));
-
-		assertTrue(ex.getMessage().startsWith("'Position.FIRST' not allowed:"));
-		assertTrue(ex.getMessage().contains(fooMethod.toString()));
-	}
-
 	private void assertSorting(RegisteredExtensionPoint... points) {
 		sorter.sort(pointsToSort, LocalExtensionPoint.ALLOWED_POSITIONS);
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSortingTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSortingTests.java
@@ -13,6 +13,7 @@ package org.junit.gen5.engine.junit5.extension;
 import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.api.Assertions.assertTrue;
 import static org.junit.gen5.api.Assertions.expectThrows;
+import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import org.junit.gen5.api.BeforeEach;
 import org.junit.gen5.api.Test;
 import org.junit.gen5.api.extension.ExtensionConfigurationException;
 import org.junit.gen5.api.extension.ExtensionPoint;
+import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
 import org.junit.gen5.commons.util.ReflectionUtils;
 import org.junit.gen5.engine.junit5.extension.ExtensionPointSorter;
@@ -127,7 +129,7 @@ public class ExtensionPointSortingTests {
 		pointsToSort.add(point2);
 
 		ExtensionConfigurationException ex = expectThrows(ExtensionConfigurationException.class,
-			() -> sorter.sort(pointsToSort));
+			() -> sorter.sort(LocalExtensionPoint.class, pointsToSort));
 
 		assertTrue(ex.getMessage().startsWith("Conflicting extensions:"));
 		assertTrue(ex.getMessage().contains(fooMethod.toString()));
@@ -142,14 +144,14 @@ public class ExtensionPointSortingTests {
 		pointsToSort.add(point2);
 
 		ExtensionConfigurationException ex = expectThrows(ExtensionConfigurationException.class,
-			() -> sorter.sort(pointsToSort));
+			() -> sorter.sort(LocalExtensionPoint.class, pointsToSort));
 
 		assertTrue(ex.getMessage().startsWith("Conflicting extensions:"));
 		assertTrue(ex.getMessage().contains(fooMethod.toString()));
 	}
 
 	private void assertSorting(RegisteredExtensionPoint... points) {
-		sorter.sort(pointsToSort);
+		sorter.sort(LocalExtensionPoint.class, pointsToSort);
 
 		String failureMessage = String.format("Expected %s but was %s", Arrays.asList(points), pointsToSort);
 
@@ -174,6 +176,9 @@ public class ExtensionPointSortingTests {
 
 	@FunctionalInterface
 	interface LocalExtensionPoint extends ExtensionPoint {
+
+		ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
+				INNERMOST };
 
 		void doSomething();
 	}

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
@@ -131,12 +131,11 @@ public class ExtensionRegistryTests {
 
 		AtomicBoolean hasRun = new AtomicBoolean(false);
 
-		registry.stream(MyExtensionPoint.class, ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(
-			registeredExtensionPoint -> {
-				assertEquals(MyExtension.class.getName(), registeredExtensionPoint.getSource().getClass().getName());
-				assertEquals(Position.DEFAULT, registeredExtensionPoint.getPosition());
-				hasRun.set(true);
-			});
+		registry.stream(MyExtensionPoint.class).forEach(registeredExtensionPoint -> {
+			assertEquals(MyExtension.class.getName(), registeredExtensionPoint.getSource().getClass().getName());
+			assertEquals(Position.DEFAULT, registeredExtensionPoint.getPosition());
+			hasRun.set(true);
+		});
 
 		assertTrue(hasRun.get());
 
@@ -166,22 +165,20 @@ public class ExtensionRegistryTests {
 	private void assertBehaviorForExtensionPointRegisteredFromLambdaExpressionOrMethodReference() throws Exception {
 		AtomicBoolean hasRun = new AtomicBoolean(false);
 
-		registry.stream(MyExtensionPoint.class, ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(
-			registeredExtensionPoint -> {
-				Class<? extends MyExtensionPoint> lambdaType = registeredExtensionPoint.getExtensionPoint().getClass();
-				assertTrue(lambdaType.getName().contains("$Lambda$"));
-				assertEquals(getClass().getName(), registeredExtensionPoint.getSource().getClass().getName());
-				assertEquals(Position.DEFAULT, registeredExtensionPoint.getPosition());
-				hasRun.set(true);
-			});
+		registry.stream(MyExtensionPoint.class).forEach(registeredExtensionPoint -> {
+			Class<? extends MyExtensionPoint> lambdaType = registeredExtensionPoint.getExtensionPoint().getClass();
+			assertTrue(lambdaType.getName().contains("$Lambda$"));
+			assertEquals(getClass().getName(), registeredExtensionPoint.getSource().getClass().getName());
+			assertEquals(Position.DEFAULT, registeredExtensionPoint.getPosition());
+			hasRun.set(true);
+		});
 
 		assertTrue(hasRun.get());
 	}
 
 	private int countExtensionPoints(Class<? extends ExtensionPoint> extensionPointType) throws Exception {
 		AtomicInteger counter = new AtomicInteger();
-		registry.stream(extensionPointType, ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(
-			registeredExtensionPoint -> counter.incrementAndGet());
+		registry.stream(extensionPointType).forEach(registeredExtensionPoint -> counter.incrementAndGet());
 		return counter.get();
 	}
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
@@ -17,12 +17,15 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.gen5.api.AfterAll;
 import org.junit.gen5.api.Assertions;
+import org.junit.gen5.api.BeforeAll;
 import org.junit.gen5.api.BeforeEach;
 import org.junit.gen5.api.Test;
 import org.junit.gen5.api.extension.ContainerExecutionCondition;
 import org.junit.gen5.api.extension.Extension;
 import org.junit.gen5.api.extension.ExtensionPoint;
+import org.junit.gen5.api.extension.ExtensionPointConfiguration;
 import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
 import org.junit.gen5.api.extension.ExtensionRegistrar;
@@ -35,6 +38,18 @@ import org.junit.gen5.api.extension.TestExecutionCondition;
 public class ExtensionRegistryTests {
 
 	private ExtensionRegistry registry;
+
+	@BeforeAll
+	static void registerExtensionPoint() {
+		ExtensionPointConfiguration.register(MyExtensionPoint.class, ExtensionPointConfiguration.DEFAULT);
+		ExtensionPointConfiguration.register(AnotherExtensionPoint.class, ExtensionPointConfiguration.DEFAULT);
+	}
+
+	@AfterAll
+	static void unregisterExtensionPoints() {
+		ExtensionPointConfiguration.unregister(MyExtensionPoint.class);
+		ExtensionPointConfiguration.unregister(AnotherExtensionPoint.class);
+	}
 
 	@BeforeEach
 	public void initRegistry() {

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
@@ -131,7 +131,7 @@ public class ExtensionRegistryTests {
 
 		AtomicBoolean hasRun = new AtomicBoolean(false);
 
-		registry.stream(MyExtensionPoint.class, ExtensionRegistry.ApplicationOrder.FORWARD).forEach(
+		registry.stream(MyExtensionPoint.class, ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(
 			registeredExtensionPoint -> {
 				assertEquals(MyExtension.class.getName(), registeredExtensionPoint.getSource().getClass().getName());
 				assertEquals(Position.DEFAULT, registeredExtensionPoint.getPosition());
@@ -166,7 +166,7 @@ public class ExtensionRegistryTests {
 	private void assertBehaviorForExtensionPointRegisteredFromLambdaExpressionOrMethodReference() throws Exception {
 		AtomicBoolean hasRun = new AtomicBoolean(false);
 
-		registry.stream(MyExtensionPoint.class, ExtensionRegistry.ApplicationOrder.FORWARD).forEach(
+		registry.stream(MyExtensionPoint.class, ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(
 			registeredExtensionPoint -> {
 				Class<? extends MyExtensionPoint> lambdaType = registeredExtensionPoint.getExtensionPoint().getClass();
 				assertTrue(lambdaType.getName().contains("$Lambda$"));
@@ -180,7 +180,7 @@ public class ExtensionRegistryTests {
 
 	private int countExtensionPoints(Class<? extends ExtensionPoint> extensionPointType) throws Exception {
 		AtomicInteger counter = new AtomicInteger();
-		registry.stream(extensionPointType, ExtensionRegistry.ApplicationOrder.FORWARD).forEach(
+		registry.stream(extensionPointType, ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(
 			registeredExtensionPoint -> counter.incrementAndGet());
 		return counter.get();
 	}

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
@@ -224,7 +224,7 @@ interface MyExtensionPoint extends ExtensionPoint {
 	 * Configuration for {@code BeforeEachExtensionPoint}
 	 */
 	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
-		new ExtensionPointRegistry.Position[] { FIRST, DEFAULT, LAST },
+		new ExtensionPointRegistry.Position[] { FIRST, DEFAULT, LAST }, Position.DEFAULT,
 		ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	void doNothing(String test);

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
@@ -143,9 +143,9 @@ public class ExtensionRegistryTests {
 	@Test
 	void registerExtensionPointWithNotAllowedPositionFails() {
 		ExtensionConfigurationException ex = expectThrows(ExtensionConfigurationException.class,
-			() -> registry.registerExtension(FaultyExtensionRegistrar.class));
+			() -> registry.registerExtension(RegistrarUsingNotAllowedPosition.class));
 		assertTrue(ex.getMessage().startsWith("'Position.OUTERMOST' not allowed:"));
-		assertTrue(ex.getMessage().contains(FaultyExtensionRegistrar.class.getName()));
+		assertTrue(ex.getMessage().contains(RegistrarUsingNotAllowedPosition.class.getName()));
 	}
 
 	@Test
@@ -279,7 +279,7 @@ class MyExtensionRegistrar implements ExtensionRegistrar {
 	}
 }
 
-class FaultyExtensionRegistrar implements ExtensionRegistrar {
+class RegistrarUsingNotAllowedPosition implements ExtensionRegistrar {
 
 	@Override
 	public void registerExtensions(ExtensionPointRegistry registry) {

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
@@ -11,7 +11,6 @@
 package org.junit.gen5.api.extension;
 
 import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
-
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
@@ -10,6 +10,8 @@
 
 package org.junit.gen5.api.extension;
 
+import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
+
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;
@@ -32,6 +34,9 @@ import org.junit.gen5.commons.meta.API;
 @FunctionalInterface
 @API(Experimental)
 public interface AfterAllExtensionPoint extends ExtensionPoint {
+
+	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
+			INNERMOST };
 
 	/**
 	 * Callback that is invoked <em>after</em> all test methods have been invoked.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
@@ -39,7 +39,7 @@ public interface AfterAllExtensionPoint extends ExtensionPoint {
 	 */
 	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
 		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
-		ExtensionPointRegistry.ApplicationOrder.BACKWARD);
+		ExtensionPointRegistry.Position.DEFAULT, ExtensionPointRegistry.ApplicationOrder.BACKWARD);
 
 	/**
 	 * Callback that is invoked <em>after</em> all test methods have been invoked.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterAllExtensionPoint.java
@@ -35,8 +35,12 @@ import org.junit.gen5.commons.meta.API;
 @API(Experimental)
 public interface AfterAllExtensionPoint extends ExtensionPoint {
 
-	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
-			INNERMOST };
+	/**
+	 * Configuration for {@code AfterAllExtensionPoint}
+	 */
+	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
+		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
+		ExtensionPointRegistry.ApplicationOrder.BACKWARD);
 
 	/**
 	 * Callback that is invoked <em>after</em> all test methods have been invoked.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterEachExtensionPoint.java
@@ -40,7 +40,7 @@ public interface AfterEachExtensionPoint extends ExtensionPoint {
 	 */
 	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
 		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
-		ExtensionPointRegistry.ApplicationOrder.BACKWARD);
+		ExtensionPointRegistry.Position.DEFAULT, ExtensionPointRegistry.ApplicationOrder.BACKWARD);
 
 	/**
 	 * Callback that is invoked after each test

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterEachExtensionPoint.java
@@ -11,7 +11,6 @@
 package org.junit.gen5.api.extension;
 
 import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
-
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterEachExtensionPoint.java
@@ -36,8 +36,12 @@ import org.junit.gen5.commons.meta.API;
 @API(Experimental)
 public interface AfterEachExtensionPoint extends ExtensionPoint {
 
-	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
-			INNERMOST };
+	/**
+	 * Configuration for {@code AfterEachExtensionPoint}
+	 */
+	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
+		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
+		ExtensionPointRegistry.ApplicationOrder.BACKWARD);
 
 	/**
 	 * Callback that is invoked after each test

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/AfterEachExtensionPoint.java
@@ -10,6 +10,8 @@
 
 package org.junit.gen5.api.extension;
 
+import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
+
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;
@@ -33,6 +35,9 @@ import org.junit.gen5.commons.meta.API;
 @FunctionalInterface
 @API(Experimental)
 public interface AfterEachExtensionPoint extends ExtensionPoint {
+
+	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
+			INNERMOST };
 
 	/**
 	 * Callback that is invoked after each test

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
@@ -11,7 +11,6 @@
 package org.junit.gen5.api.extension;
 
 import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
-
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
@@ -10,6 +10,8 @@
 
 package org.junit.gen5.api.extension;
 
+import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
+
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;
@@ -32,6 +34,9 @@ import org.junit.gen5.commons.meta.API;
 @FunctionalInterface
 @API(Experimental)
 public interface BeforeAllExtensionPoint extends ExtensionPoint {
+
+	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
+			INNERMOST };
 
 	/**
 	 * Callback that is invoked <em>before</em> all {@code @BeforeAll}

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
@@ -35,8 +35,12 @@ import org.junit.gen5.commons.meta.API;
 @API(Experimental)
 public interface BeforeAllExtensionPoint extends ExtensionPoint {
 
-	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
-			INNERMOST };
+	/**
+	 * Configuration for {@code BeforeAllExtensionPoint}
+	 */
+	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
+		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
+		ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	/**
 	 * Callback that is invoked <em>before</em> all {@code @BeforeAll}

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeAllExtensionPoint.java
@@ -39,7 +39,7 @@ public interface BeforeAllExtensionPoint extends ExtensionPoint {
 	 */
 	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
 		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
-		ExtensionPointRegistry.ApplicationOrder.FORWARD);
+		ExtensionPointRegistry.Position.DEFAULT, ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	/**
 	 * Callback that is invoked <em>before</em> all {@code @BeforeAll}

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
@@ -11,7 +11,6 @@
 package org.junit.gen5.api.extension;
 
 import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
-
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
@@ -10,6 +10,8 @@
 
 package org.junit.gen5.api.extension;
 
+import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
+
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;
@@ -32,6 +34,9 @@ import org.junit.gen5.commons.meta.API;
 @FunctionalInterface
 @API(Experimental)
 public interface BeforeEachExtensionPoint extends ExtensionPoint {
+
+	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
+			INNERMOST };
 
 	/**
 	 * Callback that is invoked <em>before</em> each test method has been invoked.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
@@ -35,8 +35,12 @@ import org.junit.gen5.commons.meta.API;
 @API(Experimental)
 public interface BeforeEachExtensionPoint extends ExtensionPoint {
 
-	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT,
-			INNERMOST };
+	/**
+	 * Configuration for {@code BeforeEachExtensionPoint}
+	 */
+	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
+		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
+		ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	/**
 	 * Callback that is invoked <em>before</em> each test method has been invoked.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/BeforeEachExtensionPoint.java
@@ -39,7 +39,7 @@ public interface BeforeEachExtensionPoint extends ExtensionPoint {
 	 */
 	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
 		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
-		ExtensionPointRegistry.ApplicationOrder.FORWARD);
+		ExtensionPointRegistry.Position.DEFAULT, ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	/**
 	 * Callback that is invoked <em>before</em> each test method has been invoked.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExceptionHandlerExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExceptionHandlerExtensionPoint.java
@@ -11,7 +11,6 @@
 package org.junit.gen5.api.extension;
 
 import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
-
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExceptionHandlerExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExceptionHandlerExtensionPoint.java
@@ -31,7 +31,12 @@ import org.junit.gen5.commons.meta.API;
 @API(Experimental)
 public interface ExceptionHandlerExtensionPoint extends ExtensionPoint {
 
-	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { FIRST, DEFAULT, LAST };
+	/**
+	 * Configuration for {@code ExceptionHandlerExtensionPoint}
+	 */
+	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
+		new ExtensionPointRegistry.Position[] { FIRST, DEFAULT, LAST },
+		ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	/**
 	 * React to a {@link Throwable throwable} which has been thrown by a test method.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExceptionHandlerExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExceptionHandlerExtensionPoint.java
@@ -34,7 +34,7 @@ public interface ExceptionHandlerExtensionPoint extends ExtensionPoint {
 	 * Configuration for {@code ExceptionHandlerExtensionPoint}
 	 */
 	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
-		new ExtensionPointRegistry.Position[] { FIRST, DEFAULT, LAST },
+		new ExtensionPointRegistry.Position[] { FIRST, DEFAULT, LAST }, ExtensionPointRegistry.Position.DEFAULT,
 		ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	/**

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExceptionHandlerExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExceptionHandlerExtensionPoint.java
@@ -10,6 +10,8 @@
 
 package org.junit.gen5.api.extension;
 
+import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
+
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;
@@ -28,6 +30,8 @@ import org.junit.gen5.commons.meta.API;
 @FunctionalInterface
 @API(Experimental)
 public interface ExceptionHandlerExtensionPoint extends ExtensionPoint {
+
+	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { FIRST, DEFAULT, LAST };
 
 	/**
 	 * React to a {@link Throwable throwable} which has been thrown by a test method.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
@@ -40,12 +40,4 @@ import org.junit.gen5.commons.meta.API;
 @API(Experimental)
 public interface ExtensionPoint extends Extension {
 
-	/**
-	 * The set of allowed values for the {@link Position} when registering an {@code ExtensionPoint}
-	 * using {@link ExtensionPointRegistry#register(ExtensionPoint, Position)}.
-	 *
-	 * <p>Field is used through reflection!</p>
-	 */
-	Position[] ALLOWED_POSITIONS = { DEFAULT };
-
 }

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
@@ -10,6 +10,10 @@
 
 package org.junit.gen5.api.extension;
 
+import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.DEFAULT;
+
+import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
+
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;
@@ -35,4 +39,12 @@ import org.junit.gen5.commons.meta.API;
  */
 @API(Experimental)
 public interface ExtensionPoint extends Extension {
+
+	/**
+	 * The set of allowed values for the {@link Position} when registering an {@code ExtensionPoint}
+	 * using {@link ExtensionPointRegistry#register(ExtensionPoint, Position)}.
+	 *
+	 * <p>Field is used through reflection!</p>
+	 */
+	Position[] ALLOWED_POSITIONS = { DEFAULT };
 }

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
@@ -47,4 +47,5 @@ public interface ExtensionPoint extends Extension {
 	 * <p>Field is used through reflection!</p>
 	 */
 	Position[] ALLOWED_POSITIONS = { DEFAULT };
+
 }

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
@@ -11,11 +11,9 @@
 package org.junit.gen5.api.extension;
 
 import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.DEFAULT;
-
-import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
-
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
+import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
 import org.junit.gen5.commons.meta.API;
 
 /**

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointConfiguration.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointConfiguration.java
@@ -12,6 +12,7 @@ package org.junit.gen5.api.extension;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
 
@@ -24,22 +25,25 @@ public class ExtensionPointConfiguration {
 
 	private static Map<Class<? extends ExtensionPoint>, ExtensionPointConfiguration> type2config = new HashMap<>();
 
-	public static void register(Class<? extends ExtensionPoint> extensionPointType,
+	public static void registerType(Class<? extends ExtensionPoint> extensionPointType,
 			ExtensionPointConfiguration configuration) {
 		type2config.put(extensionPointType, configuration);
 	}
 
 	/**
 	 * Currently only used for testing purposes to unregister extension point types that are only used in a test.
-	 *
-	 * @param extensionPointType
 	 */
-	public static void unregister(Class<? extends ExtensionPoint> extensionPointType) {
+	public static void unregisterType(Class<? extends ExtensionPoint> extensionPointType) {
 		type2config.remove(extensionPointType);
 	}
 
-	public static ExtensionPointConfiguration getFor(Class<? extends ExtensionPoint> extensionPointType) {
+	public static ExtensionPointConfiguration getConfigurationForType(
+			Class<? extends ExtensionPoint> extensionPointType) {
 		return type2config.get(extensionPointType);
+	}
+
+	public static Set<Class<? extends ExtensionPoint>> getAllExtensionPointTypes() {
+		return type2config.keySet();
 	}
 
 	/**

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointConfiguration.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointConfiguration.java
@@ -29,11 +29,24 @@ public class ExtensionPointConfiguration {
 		type2config.put(extensionPointType, configuration);
 	}
 
-	public static ExtensionPointConfiguration getFor(Class<? extends ExtensionPoint> extensionPointType) {
-		return type2config.getOrDefault(extensionPointType, DEFAULT);
+	/**
+	 * Currently only used for testing purposes to unregister extension point types that are only used in a test.
+	 *
+	 * @param extensionPointType
+	 */
+	public static void unregister(Class<? extends ExtensionPoint> extensionPointType) {
+		type2config.remove(extensionPointType);
 	}
 
-	private static ExtensionPointConfiguration DEFAULT = new ExtensionPointConfiguration(
+	public static ExtensionPointConfiguration getFor(Class<? extends ExtensionPoint> extensionPointType) {
+		return type2config.get(extensionPointType);
+	}
+
+	/**
+	 * Default configuration which only allows {@link Position#DEFAULT} and applies the extension point
+	 * in {@link ExtensionPointRegistry.ApplicationOrder#FORWARD FORWARD} order.
+	 */
+	public static ExtensionPointConfiguration DEFAULT = new ExtensionPointConfiguration(
 		new Position[] { Position.DEFAULT }, ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	public Position[] getAllowedPositions() {

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointConfiguration.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.api.extension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
+
+/**
+ * Configuration for a concrete subtype of {@link ExtensionPoint}
+ *
+ * @since 5.0
+ */
+public class ExtensionPointConfiguration {
+
+	private static Map<Class<? extends ExtensionPoint>, ExtensionPointConfiguration> type2config = new HashMap<>();
+
+	public static void register(Class<? extends ExtensionPoint> extensionPointType,
+			ExtensionPointConfiguration configuration) {
+		type2config.put(extensionPointType, configuration);
+	}
+
+	public static ExtensionPointConfiguration getFor(Class<? extends ExtensionPoint> extensionPointType) {
+		return type2config.getOrDefault(extensionPointType, DEFAULT);
+	}
+
+	private static ExtensionPointConfiguration DEFAULT = new ExtensionPointConfiguration(
+		new Position[] { Position.DEFAULT }, ExtensionPointRegistry.ApplicationOrder.FORWARD);
+
+	public Position[] getAllowedPositions() {
+		return allowedPositions;
+	}
+
+	public ExtensionPointRegistry.ApplicationOrder getApplicationOrder() {
+		return applicationOrder;
+	}
+
+	private final Position[] allowedPositions;
+	private final ExtensionPointRegistry.ApplicationOrder applicationOrder;
+
+	public ExtensionPointConfiguration(Position[] allowedPositions,
+			ExtensionPointRegistry.ApplicationOrder applicationOrder) {
+		this.allowedPositions = allowedPositions;
+		this.applicationOrder = applicationOrder;
+	}
+}

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointConfiguration.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointConfiguration.java
@@ -51,7 +51,7 @@ public class ExtensionPointConfiguration {
 	 * in {@link ExtensionPointRegistry.ApplicationOrder#FORWARD FORWARD} order.
 	 */
 	public static ExtensionPointConfiguration DEFAULT = new ExtensionPointConfiguration(
-		new Position[] { Position.DEFAULT }, ExtensionPointRegistry.ApplicationOrder.FORWARD);
+		new Position[] { Position.DEFAULT }, Position.DEFAULT, ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	public Position[] getAllowedPositions() {
 		return allowedPositions;
@@ -62,11 +62,24 @@ public class ExtensionPointConfiguration {
 	}
 
 	private final Position[] allowedPositions;
+
+	/**
+	 * The defaultPosition for a given extension point type. Currently all have Position.DEFAULT,
+	 * but others are probable, eg. Position.UNIQUE for extension points that can only be registered once.
+	 */
+	//TODO: Is not used yet, but should be used during extension point registration.
+	// That will require to register all extension points individually though.
+	public Position getDefaultPosition() {
+		return defaultPosition;
+	}
+
+	private final Position defaultPosition;
 	private final ExtensionPointRegistry.ApplicationOrder applicationOrder;
 
-	public ExtensionPointConfiguration(Position[] allowedPositions,
+	public ExtensionPointConfiguration(Position[] allowedPositions, Position defaultPosition,
 			ExtensionPointRegistry.ApplicationOrder applicationOrder) {
 		this.allowedPositions = allowedPositions;
+		this.defaultPosition = defaultPosition;
 		this.applicationOrder = applicationOrder;
 	}
 }

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
@@ -10,6 +10,11 @@
 
 package org.junit.gen5.api.extension;
 
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import org.junit.gen5.commons.util.ReflectionUtils;
+
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;
@@ -108,6 +113,17 @@ public interface ExtensionPointRegistry {
 	 */
 	static class Position {
 
+		public static <T extends ExtensionPoint> Position[] getAllowedPositionsFor(Class<T> extensionPointType) {
+			Optional<Field> allowedPositionsField = ReflectionUtils.findField(extensionPointType, "ALLOWED_POSITIONS");
+
+			Position[] positions = new Position[] { Position.DEFAULT };
+			if (allowedPositionsField.isPresent()) {
+				//TODO: Check for correct type of field etc.
+				positions = (Position[]) ReflectionUtils.getFieldValue(allowedPositionsField.get(), null);
+			}
+			return positions;
+		}
+
 		/**
 		 * Apply first.
 		 *
@@ -117,7 +133,7 @@ public interface ExtensionPointRegistry {
 		 */
 		public static Position OUTERMOST = new Position(1, true);
 
-		public static Position FIRST = OUTERMOST;
+		public static Position FIRST = new Position(1, true);
 
 		/**
 		 * Apply after {@link #OUTERMOST} but before {@link #DEFAULT},
@@ -141,7 +157,7 @@ public interface ExtensionPointRegistry {
 		// TODO Document INNERMOST position.
 		public static Position INNERMOST = new Position(5, true);
 
-		public static Position LAST = INNERMOST;
+		public static Position LAST = new Position(5, true);
 
 		private final int ordinalValue;
 

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
@@ -10,14 +10,13 @@
 
 package org.junit.gen5.api.extension;
 
+import static org.junit.gen5.commons.meta.API.Usage.Experimental;
+
 import java.lang.reflect.Field;
 import java.util.Optional;
 
-import org.junit.gen5.commons.util.ReflectionUtils;
-
-import static org.junit.gen5.commons.meta.API.Usage.Experimental;
-
 import org.junit.gen5.commons.meta.API;
+import org.junit.gen5.commons.util.ReflectionUtils;
 
 /**
  * A registry for {@link ExtensionPoint} implementations which can be

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
@@ -82,6 +82,19 @@ import org.junit.gen5.commons.meta.API;
 public interface ExtensionPointRegistry {
 
 	/**
+	 * The order in which a specific {@link ExtensionPoint} is applied.
+	 *
+	 * <p>{@code FORWARD} means that registered extension points are applied
+	 * from lower to higher {@link Position#ordinal()}. {@code BACKWARD} is the other way round.</p>
+	 *
+	 * <p>{@code FORWARD} is typical for extension points before the actual test execution.
+	 *  {@code BACKWARD} for those after the test execution. There can be exceptions, though.</p>
+	 */
+	enum ApplicationOrder {
+		FORWARD, BACKWARD
+	}
+
+	/**
 	 * {@code Position} specifies the position in which a registered
 	 * {@link ExtensionPoint} is applied with regard to all other registered
 	 * extension points of the same type.
@@ -93,7 +106,7 @@ public interface ExtensionPointRegistry {
 	 * {@link #DEFAULT DEFAULT}, {@link #INSIDE_DEFAULT INSIDE_DEFAULT}, and
 	 * {@link #INNERMOST INNERMOST}.
 	 */
-	enum Position {
+	static class Position {
 
 		/**
 		 * Apply first.
@@ -102,7 +115,9 @@ public interface ExtensionPointRegistry {
 		 * otherwise, an {@link ExtensionConfigurationException} will be
 		 * thrown.
 		 */
-		OUTERMOST,
+		public static Position OUTERMOST = new Position(1);
+
+		public static Position FIRST = OUTERMOST;
 
 		/**
 		 * Apply after {@link #OUTERMOST} but before {@link #DEFAULT},
@@ -111,17 +126,32 @@ public interface ExtensionPointRegistry {
 		 * <p>Multiple extensions can be assigned this position; however,
 		 * the ordering among such extensions is undefined.
 		 */
-		OUTSIDE_DEFAULT,
+		public static Position OUTSIDE_DEFAULT = new Position(2);
 
-		// TODO Document DEFAULT position.
-		DEFAULT,
+		/**
+		 * Use the position derived from the order of registration using {@link ExtendWith}
+		 * in the source code. That means than an {@link ExtensionPoint} registered above or in
+		 * a superclass comes before one that is registered below.
+		 */
+		public static Position DEFAULT = new Position(3);
 
 		// TODO Document INSIDE_DEFAULT position.
-		INSIDE_DEFAULT,
+		public static Position INSIDE_DEFAULT = new Position(4);
 
 		// TODO Document INNERMOST position.
-		INNERMOST;
+		public static Position INNERMOST = new Position(5);
 
+		public static Position LAST = INNERMOST;
+
+		private final int ordinalValue;
+
+		Position(int ordinalValue) {
+			this.ordinalValue = ordinalValue;
+		}
+
+		public int ordinal() {
+			return ordinalValue;
+		}
 	}
 
 	/**

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
@@ -115,7 +115,7 @@ public interface ExtensionPointRegistry {
 		 * otherwise, an {@link ExtensionConfigurationException} will be
 		 * thrown.
 		 */
-		public static Position OUTERMOST = new Position(1);
+		public static Position OUTERMOST = new Position(1, true);
 
 		public static Position FIRST = OUTERMOST;
 
@@ -139,18 +139,29 @@ public interface ExtensionPointRegistry {
 		public static Position INSIDE_DEFAULT = new Position(4);
 
 		// TODO Document INNERMOST position.
-		public static Position INNERMOST = new Position(5);
+		public static Position INNERMOST = new Position(5, true);
 
 		public static Position LAST = INNERMOST;
 
 		private final int ordinalValue;
 
+		private final boolean unique;
+
 		Position(int ordinalValue) {
+			this(ordinalValue, false);
+		}
+
+		Position(int ordinalValue, boolean unique) {
 			this.ordinalValue = ordinalValue;
+			this.unique = unique;
 		}
 
 		public int ordinal() {
 			return ordinalValue;
+		}
+
+		public boolean shouldBeUnique() {
+			return unique;
 		}
 	}
 

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
@@ -131,9 +131,9 @@ public interface ExtensionPointRegistry {
 		 * otherwise, an {@link ExtensionConfigurationException} will be
 		 * thrown.
 		 */
-		public static Position OUTERMOST = new Position(1, true);
+		public static Position OUTERMOST = new Position("OUTERMOST", 1, true);
 
-		public static Position FIRST = new Position(1, true);
+		public static Position FIRST = new Position("FIRST", 1, true);
 
 		/**
 		 * Apply after {@link #OUTERMOST} but before {@link #DEFAULT},
@@ -142,32 +142,33 @@ public interface ExtensionPointRegistry {
 		 * <p>Multiple extensions can be assigned this position; however,
 		 * the ordering among such extensions is undefined.
 		 */
-		public static Position OUTSIDE_DEFAULT = new Position(2);
+		public static Position OUTSIDE_DEFAULT = new Position("OUTSIDE_DEFAULT", 2);
 
 		/**
 		 * Use the position derived from the order of registration using {@link ExtendWith}
 		 * in the source code. That means than an {@link ExtensionPoint} registered above or in
 		 * a superclass comes before one that is registered below.
 		 */
-		public static Position DEFAULT = new Position(3);
+		public static Position DEFAULT = new Position("DEFAULT", 3);
 
 		// TODO Document INSIDE_DEFAULT position.
-		public static Position INSIDE_DEFAULT = new Position(4);
+		public static Position INSIDE_DEFAULT = new Position("INSIDE_DEFAULT", 4);
 
 		// TODO Document INNERMOST position.
-		public static Position INNERMOST = new Position(5, true);
+		public static Position INNERMOST = new Position("INNERMOST", 5, true);
 
-		public static Position LAST = new Position(5, true);
+		public static Position LAST = new Position("LAST", 5, true);
 
+		private final String displayName;
 		private final int ordinalValue;
-
 		private final boolean unique;
 
-		Position(int ordinalValue) {
-			this(ordinalValue, false);
+		Position(String displayName, int ordinalValue) {
+			this(displayName, ordinalValue, false);
 		}
 
-		Position(int ordinalValue, boolean unique) {
+		Position(String displayName, int ordinalValue, boolean unique) {
+			this.displayName = displayName;
 			this.ordinalValue = ordinalValue;
 			this.unique = unique;
 		}
@@ -178,6 +179,11 @@ public interface ExtensionPointRegistry {
 
 		public boolean shouldBeUnique() {
 			return unique;
+		}
+
+		@Override
+		public String toString() {
+			return "Position." + displayName;
 		}
 	}
 

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPointRegistry.java
@@ -111,18 +111,7 @@ public interface ExtensionPointRegistry {
 	 * {@link #DEFAULT DEFAULT}, {@link #INSIDE_DEFAULT INSIDE_DEFAULT}, and
 	 * {@link #INNERMOST INNERMOST}.
 	 */
-	static class Position {
-
-		public static <T extends ExtensionPoint> Position[] getAllowedPositionsFor(Class<T> extensionPointType) {
-			Optional<Field> allowedPositionsField = ReflectionUtils.findField(extensionPointType, "ALLOWED_POSITIONS");
-
-			Position[] positions = new Position[] { Position.DEFAULT };
-			if (allowedPositionsField.isPresent()) {
-				//TODO: Check for correct type of field etc.
-				positions = (Position[]) ReflectionUtils.getFieldValue(allowedPositionsField.get(), null);
-			}
-			return positions;
-		}
+	class Position {
 
 		/**
 		 * Apply first.

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
@@ -31,7 +31,12 @@ import org.junit.gen5.commons.meta.API;
 @API(Experimental)
 public interface InstancePostProcessor extends ExtensionPoint {
 
-	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { FIRST, DEFAULT, LAST };
+	/**
+	 * Configuration for {@code ExceptionHandlerExtensionPoint}
+	 */
+	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
+		new ExtensionPointRegistry.Position[] { FIRST, DEFAULT, LAST },
+		ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	/**
 	 * Callback for post-processing the test instance in the supplied

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
@@ -11,7 +11,6 @@
 package org.junit.gen5.api.extension;
 
 import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
-
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
@@ -34,7 +34,7 @@ public interface InstancePostProcessor extends ExtensionPoint {
 	 * Configuration for {@code ExceptionHandlerExtensionPoint}
 	 */
 	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
-		new ExtensionPointRegistry.Position[] { FIRST, DEFAULT, LAST },
+		new ExtensionPointRegistry.Position[] { FIRST, DEFAULT, LAST }, ExtensionPointRegistry.Position.DEFAULT,
 		ExtensionPointRegistry.ApplicationOrder.FORWARD);
 
 	/**

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
@@ -10,6 +10,8 @@
 
 package org.junit.gen5.api.extension;
 
+import static org.junit.gen5.api.extension.ExtensionPointRegistry.Position.*;
+
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
 import org.junit.gen5.commons.meta.API;
@@ -28,6 +30,8 @@ import org.junit.gen5.commons.meta.API;
  */
 @API(Experimental)
 public interface InstancePostProcessor extends ExtensionPoint {
+
+	ExtensionPointRegistry.Position[] ALLOWED_POSITIONS = { FIRST, DEFAULT, LAST };
 
 	/**
 	 * Callback for post-processing the test instance in the supplied

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
@@ -33,7 +33,6 @@ import org.junit.gen5.api.extension.ConditionEvaluationResult;
 import org.junit.gen5.api.extension.ContainerExtensionContext;
 import org.junit.gen5.api.extension.ExtensionConfigurationException;
 import org.junit.gen5.api.extension.ExtensionPoint;
-import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.TestExtensionContext;
 import org.junit.gen5.commons.meta.API;
 import org.junit.gen5.commons.util.Preconditions;
@@ -171,8 +170,7 @@ public class ClassTestDescriptor extends JUnit5TestDescriptor implements Contain
 				() -> registeredExtensionPoint.getExtensionPoint().beforeAll(containerExtensionContext));
 		};
 
-		newExtensionRegistry.stream(BeforeAllExtensionPoint.class,
-			ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(applyBeforeEach);
+		newExtensionRegistry.stream(BeforeAllExtensionPoint.class).forEach(applyBeforeEach);
 	}
 
 	private void invokeAfterAllExtensionPoints(ExtensionRegistry newExtensionRegistry,
@@ -184,8 +182,7 @@ public class ClassTestDescriptor extends JUnit5TestDescriptor implements Contain
 				() -> registeredExtensionPoint.getExtensionPoint().afterAll(containerExtensionContext));
 		};
 
-		newExtensionRegistry.stream(AfterAllExtensionPoint.class,
-			ExtensionPointRegistry.ApplicationOrder.BACKWARD).forEach(applyAfterAll);
+		newExtensionRegistry.stream(AfterAllExtensionPoint.class).forEach(applyAfterAll);
 	}
 
 	private void registerBeforeAllMethods(ExtensionRegistry extensionRegistry) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
@@ -33,6 +33,7 @@ import org.junit.gen5.api.extension.ConditionEvaluationResult;
 import org.junit.gen5.api.extension.ContainerExtensionContext;
 import org.junit.gen5.api.extension.ExtensionConfigurationException;
 import org.junit.gen5.api.extension.ExtensionPoint;
+import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.TestExtensionContext;
 import org.junit.gen5.commons.meta.API;
 import org.junit.gen5.commons.util.Preconditions;
@@ -170,8 +171,8 @@ public class ClassTestDescriptor extends JUnit5TestDescriptor implements Contain
 				() -> registeredExtensionPoint.getExtensionPoint().beforeAll(containerExtensionContext));
 		};
 
-		newExtensionRegistry.stream(BeforeAllExtensionPoint.class, ExtensionRegistry.ApplicationOrder.FORWARD).forEach(
-			applyBeforeEach);
+		newExtensionRegistry.stream(BeforeAllExtensionPoint.class,
+			ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(applyBeforeEach);
 	}
 
 	private void invokeAfterAllExtensionPoints(ExtensionRegistry newExtensionRegistry,
@@ -183,8 +184,8 @@ public class ClassTestDescriptor extends JUnit5TestDescriptor implements Contain
 				() -> registeredExtensionPoint.getExtensionPoint().afterAll(containerExtensionContext));
 		};
 
-		newExtensionRegistry.stream(AfterAllExtensionPoint.class, ExtensionRegistry.ApplicationOrder.BACKWARD).forEach(
-			applyAfterAll);
+		newExtensionRegistry.stream(AfterAllExtensionPoint.class,
+			ExtensionPointRegistry.ApplicationOrder.BACKWARD).forEach(applyAfterAll);
 	}
 
 	private void registerBeforeAllMethods(ExtensionRegistry extensionRegistry) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
@@ -23,6 +23,7 @@ import org.junit.gen5.api.extension.AfterEachExtensionPoint;
 import org.junit.gen5.api.extension.BeforeEachExtensionPoint;
 import org.junit.gen5.api.extension.ConditionEvaluationResult;
 import org.junit.gen5.api.extension.ExceptionHandlerExtensionPoint;
+import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.InstancePostProcessor;
 import org.junit.gen5.api.extension.MethodInvocationContext;
 import org.junit.gen5.api.extension.TestExtensionContext;
@@ -37,7 +38,6 @@ import org.junit.gen5.engine.junit5.execution.JUnit5EngineExecutionContext;
 import org.junit.gen5.engine.junit5.execution.MethodInvoker;
 import org.junit.gen5.engine.junit5.execution.ThrowableCollector;
 import org.junit.gen5.engine.junit5.extension.ExtensionRegistry;
-import org.junit.gen5.engine.junit5.extension.ExtensionRegistry.ApplicationOrder;
 import org.junit.gen5.engine.junit5.extension.RegisteredExtensionPoint;
 import org.junit.gen5.engine.support.descriptor.JavaSource;
 import org.junit.gen5.engine.support.hierarchical.Leaf;
@@ -159,7 +159,7 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 				() -> registeredExtensionPoint.getExtensionPoint().postProcessTestInstance(testExtensionContext));
 		};
 
-		extensionRegistry.stream(InstancePostProcessor.class, ApplicationOrder.FORWARD).forEach(
+		extensionRegistry.stream(InstancePostProcessor.class, ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(
 			applyInstancePostProcessor);
 	}
 
@@ -171,7 +171,8 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 				() -> registeredExtensionPoint.getExtensionPoint().beforeEach(testExtensionContext));
 		};
 
-		extensionRegistry.stream(BeforeEachExtensionPoint.class, ApplicationOrder.FORWARD).forEach(applyBeforeEach);
+		extensionRegistry.stream(BeforeEachExtensionPoint.class,
+			ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(applyBeforeEach);
 	}
 
 	private void invokeTestMethod(ExtensionRegistry ExtensionRegistry, TestExtensionContext testExtensionContext,
@@ -227,15 +228,16 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 
 	private List<ExceptionHandlerExtensionPoint> collectExceptionHandlerExtensionPoints(
 			ExtensionRegistry extensionRegistry) {
-		return extensionRegistry.stream(ExceptionHandlerExtensionPoint.class, ApplicationOrder.FORWARD).map(
-			RegisteredExtensionPoint::getExtensionPoint).collect(Collectors.toList());
+		return extensionRegistry.stream(ExceptionHandlerExtensionPoint.class,
+			ExtensionPointRegistry.ApplicationOrder.FORWARD).map(RegisteredExtensionPoint::getExtensionPoint).collect(
+				Collectors.toList());
 	}
 
 	private void invokeAfterEachExtensionPoints(ExtensionRegistry extensionRegistry,
 			TestExtensionContext testExtensionContext, ThrowableCollector throwableCollector) throws Exception {
 
-		extensionRegistry.stream(AfterEachExtensionPoint.class, ApplicationOrder.BACKWARD).forEach(
-			registeredExtensionPoint -> {
+		extensionRegistry.stream(AfterEachExtensionPoint.class,
+			ExtensionPointRegistry.ApplicationOrder.BACKWARD).forEach(registeredExtensionPoint -> {
 				throwableCollector.execute(
 					() -> registeredExtensionPoint.getExtensionPoint().afterEach(testExtensionContext));
 			});

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
@@ -23,7 +23,6 @@ import org.junit.gen5.api.extension.AfterEachExtensionPoint;
 import org.junit.gen5.api.extension.BeforeEachExtensionPoint;
 import org.junit.gen5.api.extension.ConditionEvaluationResult;
 import org.junit.gen5.api.extension.ExceptionHandlerExtensionPoint;
-import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.InstancePostProcessor;
 import org.junit.gen5.api.extension.MethodInvocationContext;
 import org.junit.gen5.api.extension.TestExtensionContext;
@@ -159,8 +158,7 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 				() -> registeredExtensionPoint.getExtensionPoint().postProcessTestInstance(testExtensionContext));
 		};
 
-		extensionRegistry.stream(InstancePostProcessor.class, ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(
-			applyInstancePostProcessor);
+		extensionRegistry.stream(InstancePostProcessor.class).forEach(applyInstancePostProcessor);
 	}
 
 	private void invokeBeforeEachExtensionPoints(ExtensionRegistry extensionRegistry,
@@ -171,8 +169,7 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 				() -> registeredExtensionPoint.getExtensionPoint().beforeEach(testExtensionContext));
 		};
 
-		extensionRegistry.stream(BeforeEachExtensionPoint.class,
-			ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(applyBeforeEach);
+		extensionRegistry.stream(BeforeEachExtensionPoint.class).forEach(applyBeforeEach);
 	}
 
 	private void invokeTestMethod(ExtensionRegistry ExtensionRegistry, TestExtensionContext testExtensionContext,
@@ -228,19 +225,17 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 
 	private List<ExceptionHandlerExtensionPoint> collectExceptionHandlerExtensionPoints(
 			ExtensionRegistry extensionRegistry) {
-		return extensionRegistry.stream(ExceptionHandlerExtensionPoint.class,
-			ExtensionPointRegistry.ApplicationOrder.FORWARD).map(RegisteredExtensionPoint::getExtensionPoint).collect(
-				Collectors.toList());
+		return extensionRegistry.stream(ExceptionHandlerExtensionPoint.class).map(
+			RegisteredExtensionPoint::getExtensionPoint).collect(Collectors.toList());
 	}
 
 	private void invokeAfterEachExtensionPoints(ExtensionRegistry extensionRegistry,
 			TestExtensionContext testExtensionContext, ThrowableCollector throwableCollector) throws Exception {
 
-		extensionRegistry.stream(AfterEachExtensionPoint.class,
-			ExtensionPointRegistry.ApplicationOrder.BACKWARD).forEach(registeredExtensionPoint -> {
-				throwableCollector.execute(
-					() -> registeredExtensionPoint.getExtensionPoint().afterEach(testExtensionContext));
-			});
+		extensionRegistry.stream(AfterEachExtensionPoint.class).forEach(registeredExtensionPoint -> {
+			throwableCollector.execute(
+				() -> registeredExtensionPoint.getExtensionPoint().afterEach(testExtensionContext));
+		});
 	}
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/ConditionEvaluator.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/ConditionEvaluator.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 import org.junit.gen5.api.extension.ConditionEvaluationResult;
 import org.junit.gen5.api.extension.ContainerExecutionCondition;
 import org.junit.gen5.api.extension.ContainerExtensionContext;
+import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.TestExecutionCondition;
 import org.junit.gen5.api.extension.TestExtensionContext;
 import org.junit.gen5.commons.meta.API;
@@ -50,7 +51,7 @@ public class ConditionEvaluator {
 	public ConditionEvaluationResult evaluateForContainer(ExtensionRegistry extensionRegistry,
 			ContainerExtensionContext context) {
 		// @formatter:off
-		return extensionRegistry.stream(ContainerExecutionCondition.class, ExtensionRegistry.ApplicationOrder.FORWARD)
+		return extensionRegistry.stream(ContainerExecutionCondition.class, ExtensionPointRegistry.ApplicationOrder.FORWARD)
 				.map(extensionPoint -> extensionPoint.getExtensionPoint())
 				.map(condition -> evaluate(condition, context))
 				.filter(ConditionEvaluationResult::isDisabled)
@@ -71,7 +72,7 @@ public class ConditionEvaluator {
 	public ConditionEvaluationResult evaluateForTest(ExtensionRegistry extensionRegistry,
 			TestExtensionContext context) {
 		// @formatter:off
-		return extensionRegistry.stream(TestExecutionCondition.class, ExtensionRegistry.ApplicationOrder.FORWARD)
+		return extensionRegistry.stream(TestExecutionCondition.class, ExtensionPointRegistry.ApplicationOrder.FORWARD)
 				.map(extensionPoint -> extensionPoint.getExtensionPoint())
 				.map(condition -> evaluate(condition, context))
 				.filter(ConditionEvaluationResult::isDisabled)

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/ConditionEvaluator.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/ConditionEvaluator.java
@@ -17,7 +17,6 @@ import java.util.logging.Logger;
 import org.junit.gen5.api.extension.ConditionEvaluationResult;
 import org.junit.gen5.api.extension.ContainerExecutionCondition;
 import org.junit.gen5.api.extension.ContainerExtensionContext;
-import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.TestExecutionCondition;
 import org.junit.gen5.api.extension.TestExtensionContext;
 import org.junit.gen5.commons.meta.API;
@@ -51,7 +50,7 @@ public class ConditionEvaluator {
 	public ConditionEvaluationResult evaluateForContainer(ExtensionRegistry extensionRegistry,
 			ContainerExtensionContext context) {
 		// @formatter:off
-		return extensionRegistry.stream(ContainerExecutionCondition.class, ExtensionPointRegistry.ApplicationOrder.FORWARD)
+		return extensionRegistry.stream(ContainerExecutionCondition.class)
 				.map(extensionPoint -> extensionPoint.getExtensionPoint())
 				.map(condition -> evaluate(condition, context))
 				.filter(ConditionEvaluationResult::isDisabled)
@@ -72,7 +71,7 @@ public class ConditionEvaluator {
 	public ConditionEvaluationResult evaluateForTest(ExtensionRegistry extensionRegistry,
 			TestExtensionContext context) {
 		// @formatter:off
-		return extensionRegistry.stream(TestExecutionCondition.class, ExtensionPointRegistry.ApplicationOrder.FORWARD)
+		return extensionRegistry.stream(TestExecutionCondition.class)
 				.map(extensionPoint -> extensionPoint.getExtensionPoint())
 				.map(condition -> evaluate(condition, context))
 				.filter(ConditionEvaluationResult::isDisabled)

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/MethodInvoker.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/MethodInvoker.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.gen5.api.extension.ExtensionContext;
-import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.MethodInvocationContext;
 import org.junit.gen5.api.extension.MethodParameterResolver;
 import org.junit.gen5.api.extension.ParameterResolutionException;
@@ -71,12 +70,11 @@ public class MethodInvoker {
 
 		try {
 			final List<MethodParameterResolver> matchingResolvers = new ArrayList<>();
-			extensionRegistry.stream(MethodParameterResolver.class,
-				ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(registeredExtensionPoint -> {
-					if (registeredExtensionPoint.getExtensionPoint().supports(parameter, methodInvocationContext,
-						extensionContext))
-						matchingResolvers.add(registeredExtensionPoint.getExtensionPoint());
-				});
+			extensionRegistry.stream(MethodParameterResolver.class).forEach(registeredExtensionPoint -> {
+				if (registeredExtensionPoint.getExtensionPoint().supports(parameter, methodInvocationContext,
+					extensionContext))
+					matchingResolvers.add(registeredExtensionPoint.getExtensionPoint());
+			});
 
 			if (matchingResolvers.size() == 0) {
 				throw new ParameterResolutionException(

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/MethodInvoker.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/MethodInvoker.java
@@ -19,13 +19,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.gen5.api.extension.ExtensionContext;
+import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.MethodInvocationContext;
 import org.junit.gen5.api.extension.MethodParameterResolver;
 import org.junit.gen5.api.extension.ParameterResolutionException;
 import org.junit.gen5.commons.meta.API;
 import org.junit.gen5.commons.util.ReflectionUtils;
 import org.junit.gen5.engine.junit5.extension.ExtensionRegistry;
-import org.junit.gen5.engine.junit5.extension.ExtensionRegistry.ApplicationOrder;
 
 /**
  * {@code MethodInvoker} encapsulates the invocation of a method, including
@@ -71,8 +71,8 @@ public class MethodInvoker {
 
 		try {
 			final List<MethodParameterResolver> matchingResolvers = new ArrayList<>();
-			extensionRegistry.stream(MethodParameterResolver.class, ApplicationOrder.FORWARD).forEach(
-				registeredExtensionPoint -> {
+			extensionRegistry.stream(MethodParameterResolver.class,
+				ExtensionPointRegistry.ApplicationOrder.FORWARD).forEach(registeredExtensionPoint -> {
 					if (registeredExtensionPoint.getExtensionPoint().supports(parameter, methodInvocationContext,
 						extensionContext))
 						matchingResolvers.add(registeredExtensionPoint.getExtensionPoint());

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSorter.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSorter.java
@@ -10,17 +10,14 @@
 
 package org.junit.gen5.engine.junit5.extension;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.gen5.api.extension.ExtensionConfigurationException;
 import org.junit.gen5.api.extension.ExtensionPoint;
 import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
-import org.junit.gen5.commons.util.ReflectionUtils;
 
 /**
  * Utility for sorting {@linkplain RegisteredExtensionPoint extension points}
@@ -52,15 +49,9 @@ class ExtensionPointSorter {
 	}
 
 	private <T extends ExtensionPoint> List<Position> getUniquePositions(Class<T> extensionPointType) {
-		Optional<Field> allowedPositionsField = ReflectionUtils.findField(extensionPointType, "ALLOWED_POSITIONS");
+		Position[] positions = Position.getAllowedPositionsFor(extensionPointType);
 
-		if (allowedPositionsField.isPresent()) {
-			//TODO: Check for correct type of field etc.
-			Position[] positions = (Position[]) ReflectionUtils.getFieldValue(allowedPositionsField.get(), null);
-			return Arrays.stream(positions).filter(position -> position.shouldBeUnique()).collect(Collectors.toList());
-		}
-
-		return Arrays.asList();
+		return Arrays.stream(positions).filter(Position::shouldBeUnique).collect(Collectors.toList());
 	}
 
 	private <T extends ExtensionPoint> void checkPositionUnique(

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSorter.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSorter.java
@@ -37,21 +37,19 @@ class ExtensionPointSorter {
 	 *
 	 * <p>Note: the supplied list instance will be resorted.
 	 *
-	 * @param extensionPointType type of extension point to sort
-	 * @param registeredExtensionPoints list of extension points in order of registration
 	 * @param <T> concrete subtype of {@link ExtensionPoint}
+	 * @param registeredExtensionPoints list of extension points in order of registration
+	 * @param allowedPositions set of all {@link Position positions} that are allowed for the {@code registeredExtensionPoints}
 	 */
-	public <T extends ExtensionPoint> void sort(Class<T> extensionPointType,
-			List<RegisteredExtensionPoint<T>> registeredExtensionPoints) {
-		List<Position> uniquePositions = getUniquePositions(extensionPointType);
+	public <T extends ExtensionPoint> void sort(List<RegisteredExtensionPoint<T>> registeredExtensionPoints,
+			Position[] allowedPositions) {
+		List<Position> uniquePositions = getUniquePositions(allowedPositions);
 		uniquePositions.stream().forEach(position -> checkPositionUnique(registeredExtensionPoints, position));
 		registeredExtensionPoints.sort(new DefaultComparator());
 	}
 
-	private <T extends ExtensionPoint> List<Position> getUniquePositions(Class<T> extensionPointType) {
-		Position[] positions = Position.getAllowedPositionsFor(extensionPointType);
-
-		return Arrays.stream(positions).filter(Position::shouldBeUnique).collect(Collectors.toList());
+	private <T extends ExtensionPoint> List<Position> getUniquePositions(Position[] allowedPositions) {
+		return Arrays.stream(allowedPositions).filter(Position::shouldBeUnique).collect(Collectors.toList());
 	}
 
 	private <T extends ExtensionPoint> void checkPositionUnique(

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSorter.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSorter.java
@@ -43,28 +43,8 @@ class ExtensionPointSorter {
 	 */
 	public <T extends ExtensionPoint> void sort(List<RegisteredExtensionPoint<T>> registeredExtensionPoints,
 			Position[] allowedPositions) {
-		checkOnlyAllowedPositions(registeredExtensionPoints, allowedPositions);
 		checkNoUniquePositionConflict(registeredExtensionPoints, allowedPositions);
 		registeredExtensionPoints.sort(new DefaultComparator());
-	}
-
-	private <T extends ExtensionPoint> void checkOnlyAllowedPositions(
-			List<RegisteredExtensionPoint<T>> registeredExtensionPoints, Position[] allowedPositions) {
-
-		// @formatter:off
-        registeredExtensionPoints
-                .stream()
-                .filter(rep -> notIn(rep.getPosition(), allowedPositions))
-                .forEach(r -> {
-                    String exceptionMessage = String.format("'%s' not allowed: %s", r.getPosition(), r.getSource());
-                    throw new ExtensionConfigurationException(exceptionMessage);
-                });
-        // @formatter:on
-
-	}
-
-	private boolean notIn(Position position, Position[] allowedPositions) {
-		return !Arrays.asList(allowedPositions).contains(position);
 	}
 
 	private <T extends ExtensionPoint> void checkNoUniquePositionConflict(

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSorter.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionPointSorter.java
@@ -43,6 +43,7 @@ class ExtensionPointSorter {
 	 */
 	public <T extends ExtensionPoint> void sort(List<RegisteredExtensionPoint<T>> registeredExtensionPoints,
 			Position[] allowedPositions) {
+		//Todo: This checking should take place during registration in ExtensionRegistry.
 		checkNoUniquePositionConflict(registeredExtensionPoints, allowedPositions);
 		registeredExtensionPoints.sort(new DefaultComparator());
 	}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -26,6 +26,7 @@ import org.junit.gen5.api.extension.AfterAllExtensionPoint;
 import org.junit.gen5.api.extension.AfterEachExtensionPoint;
 import org.junit.gen5.api.extension.BeforeAllExtensionPoint;
 import org.junit.gen5.api.extension.BeforeEachExtensionPoint;
+import org.junit.gen5.api.extension.ContainerExecutionCondition;
 import org.junit.gen5.api.extension.ExceptionHandlerExtensionPoint;
 import org.junit.gen5.api.extension.Extension;
 import org.junit.gen5.api.extension.ExtensionPoint;
@@ -35,6 +36,8 @@ import org.junit.gen5.api.extension.ExtensionPointRegistry.ApplicationOrder;
 import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
 import org.junit.gen5.api.extension.ExtensionRegistrar;
 import org.junit.gen5.api.extension.InstancePostProcessor;
+import org.junit.gen5.api.extension.MethodParameterResolver;
+import org.junit.gen5.api.extension.TestExecutionCondition;
 import org.junit.gen5.commons.meta.API;
 import org.junit.gen5.commons.util.ReflectionUtils;
 
@@ -66,8 +69,10 @@ public class ExtensionRegistry {
 		ExtensionPointConfiguration.register(AfterEachExtensionPoint.class, AfterEachExtensionPoint.CONFIG);
 		ExtensionPointConfiguration.register(AfterAllExtensionPoint.class, AfterAllExtensionPoint.CONFIG);
 		ExtensionPointConfiguration.register(InstancePostProcessor.class, InstancePostProcessor.CONFIG);
-		ExtensionPointConfiguration.register(ExceptionHandlerExtensionPoint.class,
-			ExceptionHandlerExtensionPoint.CONFIG);
+		ExtensionPointConfiguration.register(ExceptionHandlerExtensionPoint.class, ExceptionHandlerExtensionPoint.CONFIG);
+		ExtensionPointConfiguration.register(ContainerExecutionCondition.class, ExtensionPointConfiguration.DEFAULT);
+		ExtensionPointConfiguration.register(TestExecutionCondition.class, ExtensionPointConfiguration.DEFAULT);
+		ExtensionPointConfiguration.register(MethodParameterResolver.class, ExtensionPointConfiguration.DEFAULT);
 	}
 
 	/**

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -47,10 +47,6 @@ import org.junit.gen5.commons.util.ReflectionUtils;
 @API(Internal)
 public class ExtensionRegistry {
 
-	public enum ApplicationOrder {
-		FORWARD, BACKWARD
-	}
-
 	/**
 	 * Factory for creating and populating a new registry from a list of
 	 * extension types and a parent registry.
@@ -137,11 +133,11 @@ public class ExtensionRegistry {
 	 * @param order the order in which to apply the extension points after sorting
 	 */
 	public <E extends ExtensionPoint> Stream<RegisteredExtensionPoint<E>> stream(Class<E> extensionPointType,
-			ApplicationOrder order) {
+			ExtensionPointRegistry.ApplicationOrder order) {
 
 		List<RegisteredExtensionPoint<E>> registeredExtensionPoints = getRegisteredExtensionPoints(extensionPointType);
 		new ExtensionPointSorter().sort(registeredExtensionPoints);
-		if (order == ApplicationOrder.BACKWARD) {
+		if (order == ExtensionPointRegistry.ApplicationOrder.BACKWARD) {
 			Collections.reverse(registeredExtensionPoints);
 		}
 		return registeredExtensionPoints.stream();

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -136,7 +136,11 @@ public class ExtensionRegistry {
 			ExtensionPointRegistry.ApplicationOrder order) {
 
 		List<RegisteredExtensionPoint<E>> registeredExtensionPoints = getRegisteredExtensionPoints(extensionPointType);
-		new ExtensionPointSorter().sort(extensionPointType, registeredExtensionPoints);
+
+		//TODO: ExtensionPoint subtype should register their allowed positions somewhere
+		Position[] allowedPositions = Position.getAllowedPositionsFor(extensionPointType);
+
+		new ExtensionPointSorter().sort(registeredExtensionPoints, allowedPositions);
 		if (order == ExtensionPointRegistry.ApplicationOrder.BACKWARD) {
 			Collections.reverse(registeredExtensionPoints);
 		}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -136,7 +136,7 @@ public class ExtensionRegistry {
 			ExtensionPointRegistry.ApplicationOrder order) {
 
 		List<RegisteredExtensionPoint<E>> registeredExtensionPoints = getRegisteredExtensionPoints(extensionPointType);
-		new ExtensionPointSorter().sort(registeredExtensionPoints);
+		new ExtensionPointSorter().sort(extensionPointType, registeredExtensionPoints);
 		if (order == ExtensionPointRegistry.ApplicationOrder.BACKWARD) {
 			Collections.reverse(registeredExtensionPoints);
 		}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -215,6 +215,8 @@ public class ExtensionRegistry {
 	}
 
 	public void registerExtensionPoint(ExtensionPoint extension, Object source) {
+		//TODO: Use an extension type's config.getDefaultPosition() instead of Position.DEFAULT.
+		// That requires the individual registration per extension point type.
 		registerExtensionPoint(extension, source, Position.DEFAULT);
 	}
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -31,6 +31,7 @@ import org.junit.gen5.api.extension.Extension;
 import org.junit.gen5.api.extension.ExtensionPoint;
 import org.junit.gen5.api.extension.ExtensionPointConfiguration;
 import org.junit.gen5.api.extension.ExtensionPointRegistry;
+import org.junit.gen5.api.extension.ExtensionPointRegistry.ApplicationOrder;
 import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
 import org.junit.gen5.api.extension.ExtensionRegistrar;
 import org.junit.gen5.api.extension.InstancePostProcessor;
@@ -59,6 +60,7 @@ public class ExtensionRegistry {
 	 * than {@link ExtensionPointConfiguration#DEFAULT}
 	 */
 	static {
+        //TODO: Replace static block by something equivalent to registration of default extensions
 		ExtensionPointConfiguration.register(BeforeEachExtensionPoint.class, BeforeEachExtensionPoint.CONFIG);
 		ExtensionPointConfiguration.register(BeforeAllExtensionPoint.class, BeforeAllExtensionPoint.CONFIG);
 		ExtensionPointConfiguration.register(AfterEachExtensionPoint.class, AfterEachExtensionPoint.CONFIG);
@@ -151,17 +153,16 @@ public class ExtensionRegistry {
 	 * of the specified type.
 	 *
 	 * @param extensionPointType the type of {@link ExtensionPoint} to stream
-	 * @param order the order in which to apply the extension points after sorting
 	 */
-	public <E extends ExtensionPoint> Stream<RegisteredExtensionPoint<E>> stream(Class<E> extensionPointType,
-			ExtensionPointRegistry.ApplicationOrder order) {
+	public <E extends ExtensionPoint> Stream<RegisteredExtensionPoint<E>> stream(Class<E> extensionPointType) {
 
 		List<RegisteredExtensionPoint<E>> registeredExtensionPoints = getRegisteredExtensionPoints(extensionPointType);
 
 		Position[] allowedPositions = ExtensionPointConfiguration.getFor(extensionPointType).getAllowedPositions();
+		ApplicationOrder order = ExtensionPointConfiguration.getFor(extensionPointType).getApplicationOrder();
 
 		new ExtensionPointSorter().sort(registeredExtensionPoints, allowedPositions);
-		if (order == ExtensionPointRegistry.ApplicationOrder.BACKWARD) {
+		if (order == ApplicationOrder.BACKWARD) {
 			Collections.reverse(registeredExtensionPoints);
 		}
 		return registeredExtensionPoints.stream();

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -22,11 +22,18 @@ import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
+import org.junit.gen5.api.extension.AfterAllExtensionPoint;
+import org.junit.gen5.api.extension.AfterEachExtensionPoint;
+import org.junit.gen5.api.extension.BeforeAllExtensionPoint;
+import org.junit.gen5.api.extension.BeforeEachExtensionPoint;
+import org.junit.gen5.api.extension.ExceptionHandlerExtensionPoint;
 import org.junit.gen5.api.extension.Extension;
 import org.junit.gen5.api.extension.ExtensionPoint;
+import org.junit.gen5.api.extension.ExtensionPointConfiguration;
 import org.junit.gen5.api.extension.ExtensionPointRegistry;
 import org.junit.gen5.api.extension.ExtensionPointRegistry.Position;
 import org.junit.gen5.api.extension.ExtensionRegistrar;
+import org.junit.gen5.api.extension.InstancePostProcessor;
 import org.junit.gen5.commons.meta.API;
 import org.junit.gen5.commons.util.ReflectionUtils;
 
@@ -46,6 +53,20 @@ import org.junit.gen5.commons.util.ReflectionUtils;
  */
 @API(Internal)
 public class ExtensionRegistry {
+
+	/**
+	 * Register all subtypes of {@link ExtensionPoint} that have a different configuration
+	 * than {@link ExtensionPointConfiguration#DEFAULT}
+	 */
+	static {
+		ExtensionPointConfiguration.register(BeforeEachExtensionPoint.class, BeforeEachExtensionPoint.CONFIG);
+		ExtensionPointConfiguration.register(BeforeAllExtensionPoint.class, BeforeAllExtensionPoint.CONFIG);
+		ExtensionPointConfiguration.register(AfterEachExtensionPoint.class, AfterEachExtensionPoint.CONFIG);
+		ExtensionPointConfiguration.register(AfterAllExtensionPoint.class, AfterAllExtensionPoint.CONFIG);
+		ExtensionPointConfiguration.register(InstancePostProcessor.class, InstancePostProcessor.CONFIG);
+		ExtensionPointConfiguration.register(ExceptionHandlerExtensionPoint.class,
+			ExceptionHandlerExtensionPoint.CONFIG);
+	}
 
 	/**
 	 * Factory for creating and populating a new registry from a list of
@@ -137,8 +158,7 @@ public class ExtensionRegistry {
 
 		List<RegisteredExtensionPoint<E>> registeredExtensionPoints = getRegisteredExtensionPoints(extensionPointType);
 
-		//TODO: ExtensionPoint subtype should register their allowed positions somewhere
-		Position[] allowedPositions = Position.getAllowedPositionsFor(extensionPointType);
+		Position[] allowedPositions = ExtensionPointConfiguration.getFor(extensionPointType).getAllowedPositions();
 
 		new ExtensionPointSorter().sort(registeredExtensionPoints, allowedPositions);
 		if (order == ExtensionPointRegistry.ApplicationOrder.BACKWARD) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -184,6 +184,9 @@ public class ExtensionRegistry {
 	private void registerExtensionPoint(ExtensionPoint extension, Object source, Position position) {
 		LOG.finer(() -> String.format("Registering extension point [%s] from source [%s] with position [%s].",
 			extension, source, position));
+
+		//TODO: Check if position is allowed for the current ExtensionPoint
+
 		this.registeredExtensionPoints.add(new RegisteredExtensionPoint<>(extension, source, position));
 	}
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -60,7 +60,7 @@ public class ExtensionRegistry {
 	 * than {@link ExtensionPointConfiguration#DEFAULT}
 	 */
 	static {
-        //TODO: Replace static block by something equivalent to registration of default extensions
+		//TODO: Replace static block by something equivalent to registration of default extensions
 		ExtensionPointConfiguration.register(BeforeEachExtensionPoint.class, BeforeEachExtensionPoint.CONFIG);
 		ExtensionPointConfiguration.register(BeforeAllExtensionPoint.class, BeforeAllExtensionPoint.CONFIG);
 		ExtensionPointConfiguration.register(AfterEachExtensionPoint.class, AfterEachExtensionPoint.CONFIG);


### PR DESCRIPTION
This is an attempt to tackle some of the points discussed in #112 .

Every concrete subtype of `ExtensionPoint` can now register a configuration of type `ExtensionPointConfiguration`. For example:

```java
public interface BeforeEachExtensionPoint extends ExtensionPoint...
	/**
	 * Configuration for {@code BeforeEachExtensionPoint}
	 */
	ExtensionPointConfiguration CONFIG = new ExtensionPointConfiguration(
		new ExtensionPointRegistry.Position[] { OUTERMOST, OUTSIDE_DEFAULT, DEFAULT, INSIDE_DEFAULT, INNERMOST },
		ExtensionPointRegistry.ApplicationOrder.FORWARD);
```
This configuration is used in `ExtensionRegistry` two things:
- Determine the application order of an extension point. Formerly that was done by the applier of an extension point who had to know.
- Allow only certain values for `Position` when registering an extension. All other values will lead to an `ExtensionConfigurationException`.

The concept has been introduced, because not all values make sense for all types of extension points. For example, `ExceptionHandlerExtensionPoint` allows `FIRST`, `DEFAULT` and `LAST`.

Extension point types that do not come with their own configuration only allow `DEFAULT` as position and are thus ordered by their position in the source only.


