### PR TITLE
Introduce support for before/after callbacks once per entire test run

### DIFF
--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/GlobalExtensionPoint.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/GlobalExtensionPoint.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine;
+
+import java.util.Map;
+
+/**
+ * @author Tadaya Tsuyukubo
+ */
+public interface GlobalExtensionPoint {
+
+	default void beforeExecute(Map<String, Object> requestAttributes) {
+		// no-op
+	}
+
+	default void afterExecute(Map<String, Object> requestAttributes) {
+		// no-op
+	}
+
+}

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/EngineExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/EngineExtensionPoint.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.api.extension;
+
+/**
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public interface EngineExtensionPoint extends ExtensionPoint {
+
+	default void beforeEngine(ExtensionContext extensionContext) {
+		// no-op
+	}
+
+	default void afterEngine(ExtensionContext extensionContext) {
+		// no-op
+	}
+
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -12,11 +12,13 @@ package org.junit.gen5.engine.junit5;
 
 import static org.junit.gen5.commons.meta.API.Usage.Experimental;
 
+import org.junit.gen5.api.extension.ExtensionContext;
 import org.junit.gen5.commons.meta.API;
 import org.junit.gen5.commons.util.Preconditions;
 import org.junit.gen5.engine.EngineDiscoveryRequest;
 import org.junit.gen5.engine.ExecutionRequest;
 import org.junit.gen5.engine.TestDescriptor;
+import org.junit.gen5.engine.junit5.descriptor.GlobalExtensionContext;
 import org.junit.gen5.engine.junit5.discovery.DiscoverySelectorResolver;
 import org.junit.gen5.engine.junit5.discovery.JUnit5EngineDescriptor;
 import org.junit.gen5.engine.junit5.execution.JUnit5EngineExecutionContext;
@@ -55,6 +57,20 @@ public class JUnit5TestEngine extends HierarchicalTestEngine<JUnit5EngineExecuti
 
 	@Override
 	protected JUnit5EngineExecutionContext createExecutionContext(ExecutionRequest request) {
-		return new JUnit5EngineExecutionContext(request.getEngineExecutionListener());
+
+		ExtensionContext rootExtensionContext = new GlobalExtensionContext(request.getEngineExecutionListener(),
+			request.getRootTestDescriptor());
+
+		// populate extension-context-store from request attributes
+		request.getAttributes().entrySet().forEach(
+			entry -> rootExtensionContext.getStore().put(entry.getKey(), entry.getValue()));
+
+		// @formatter:off
+		return new JUnit5EngineExecutionContext(request.getEngineExecutionListener())
+				.extend()
+				.withExtensionContext(rootExtensionContext)
+				.build();
+		// @formatter:on
+
 	}
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/EngineBasedExtensionContext.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/EngineBasedExtensionContext.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.junit5.descriptor;
+
+import java.lang.reflect.AnnotatedElement;
+
+import org.junit.gen5.api.extension.ExtensionContext;
+import org.junit.gen5.engine.EngineExecutionListener;
+import org.junit.gen5.engine.TestDescriptor;
+
+/**
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class EngineBasedExtensionContext extends AbstractExtensionContext {
+
+	public EngineBasedExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
+			TestDescriptor testDescriptor) {
+		super(parent, engineExecutionListener, testDescriptor);
+	}
+
+	@Override
+	public String getUniqueId() {
+		return getTestDescriptor().getUniqueId();
+	}
+
+	@Override
+	public String getName() {
+		return getTestDescriptor().getName();
+	}
+
+	@Override
+	public String getDisplayName() {
+		return getTestDescriptor().getDisplayName();
+	}
+
+	@Override
+	public Class<?> getTestClass() {
+		return null;
+	}
+
+	@Override
+	public AnnotatedElement getElement() {
+		return null;
+	}
+
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/GlobalExtensionContext.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/GlobalExtensionContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.junit5.descriptor;
+
+import java.lang.reflect.AnnotatedElement;
+
+import org.junit.gen5.engine.EngineExecutionListener;
+import org.junit.gen5.engine.TestDescriptor;
+
+/**
+ * @author Tadaya Tsuyukubo
+ */
+public class GlobalExtensionContext extends AbstractExtensionContext {
+
+	public GlobalExtensionContext(EngineExecutionListener engineExecutionListener, TestDescriptor testDescriptor) {
+		super(null, engineExecutionListener, testDescriptor);
+	}
+
+	@Override
+	public String getUniqueId() {
+		return "global";
+	}
+
+	@Override
+	public String getName() {
+		return "global";
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "Global Context";
+	}
+
+	@Override
+	public Class<?> getTestClass() {
+		return null;
+	}
+
+	@Override
+	public AnnotatedElement getElement() {
+		return null;
+	}
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/discovery/JUnit5EngineDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/discovery/JUnit5EngineDescriptor.java
@@ -12,7 +12,14 @@ package org.junit.gen5.engine.junit5.discovery;
 
 import static org.junit.gen5.commons.meta.API.Usage.Internal;
 
+import java.util.ServiceLoader;
+import java.util.function.Consumer;
+
+import org.junit.gen5.api.extension.EngineExtensionPoint;
+import org.junit.gen5.api.extension.ExtensionContext;
 import org.junit.gen5.commons.meta.API;
+import org.junit.gen5.commons.util.ReflectionUtils;
+import org.junit.gen5.engine.junit5.descriptor.EngineBasedExtensionContext;
 import org.junit.gen5.engine.junit5.execution.JUnit5EngineExecutionContext;
 import org.junit.gen5.engine.junit5.extension.ExtensionRegistry;
 import org.junit.gen5.engine.support.descriptor.EngineDescriptor;
@@ -30,7 +37,53 @@ public class JUnit5EngineDescriptor extends EngineDescriptor implements Containe
 
 	@Override
 	public JUnit5EngineExecutionContext beforeAll(JUnit5EngineExecutionContext context) {
-		return context.extend().withExtensionRegistry(new ExtensionRegistry()).build();
+
+		ExtensionContext extensionContext = context.getExtensionContext();
+		callEngineExtensionPoint(extensionPoint -> extensionPoint.beforeEngine(extensionContext));
+
+		// @formatter:off
+		return context.extend()
+				.withExtensionRegistry(new ExtensionRegistry())
+				.withExtensionContext(extensionContext)
+				.build();
+		// @formatter:on
 	}
 
+	@Override
+	public JUnit5EngineExecutionContext afterAll(JUnit5EngineExecutionContext context) throws Exception {
+		// TODO: make here work with ThrowableCollector  ref: ClassTestDescriptor#afterAll()
+
+		ExtensionContext extensionContext = context.getExtensionContext();
+		callEngineExtensionPoint(extensionPoint -> extensionPoint.afterEngine(extensionContext));
+
+		// @formatter:off
+		return context.extend()   // TODO: not really need to extend it
+				.withExtensionContext(extensionContext)
+				.build();
+		// @formatter:on
+	}
+
+	private void callEngineExtensionPoint(Consumer<EngineExtensionPoint> consumer) {
+		Iterable<EngineExtensionPoint> extensionPoints = ServiceLoader.load(EngineExtensionPoint.class,
+			ReflectionUtils.getDefaultClassLoader());
+
+		// TODO: log which classes have discovered
+
+		for (EngineExtensionPoint extensionPoint : extensionPoints) {
+			consumer.accept(extensionPoint);
+		}
+	}
+
+	@Override
+	public JUnit5EngineExecutionContext prepare(JUnit5EngineExecutionContext context) throws Exception {
+
+		ExtensionContext extensionContext = new EngineBasedExtensionContext(context.getExtensionContext(),
+			context.getExecutionListener(), this);
+
+		// @formatter:off
+		return context.extend()
+				.withExtensionContext(extensionContext)
+				.build();
+		// @formatter:on
+	}
 }


### PR DESCRIPTION
Initially wrote it [here](https://github.com/junit-team/junit-lambda/wiki/OLD-Prototype-Feedback#lack-of-beforealltests-afteralltests-or-suitetags-level-annotations).

Nice to have callback interfaces once per entire test run or engine/tag/etc. (e.g.: _@BeforeAllTests/@AfterAllTests_)
Would be nice that they receive `TestExecutionContext` in argument, so that implementations can populate beans which could be resolved/used/injected across all tests.
