### PR TITLE
the spec failed because the path in args is OS dependent

### DIFF
--- a/junit-gradle/src/test/groovy/org/junit/gen5/gradle/JUnit5PluginSpec.groovy
+++ b/junit-gradle/src/test/groovy/org/junit/gen5/gradle/JUnit5PluginSpec.groovy
@@ -80,6 +80,6 @@ class JUnit5PluginSpec extends Specification {
 			junit5TestTask.args.containsAll('-n', '.*Tests?')
 			junit5TestTask.args.containsAll('-t', 'fast')
 			junit5TestTask.args.containsAll('-T', 'slow')
-			junit5TestTask.args.containsAll('-r', '/any')
+			junit5TestTask.args.containsAll('-r', new File('/any').getCanonicalFile().toString())
 	}
 }


### PR DESCRIPTION
On my system it was actually D:\any instead of /any

Fixed by creating the canonical path for the assertion

---

I hereby agree to the terms of the JUnit Contributor License Agreement.