### PR TITLE
Rename registerListener to registerListeners.

### DIFF
--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/main/DefaultLauncher.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/main/DefaultLauncher.java
@@ -46,7 +46,7 @@ class DefaultLauncher implements Launcher {
 
 	@Override
 	public void registerTestExecutionListeners(TestExecutionListener... listeners) {
-		listenerRegistry.registerListener(listeners);
+		listenerRegistry.registerListeners(listeners);
 	}
 
 	@Override

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/main/TestExecutionListenerRegistry.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/main/TestExecutionListenerRegistry.java
@@ -27,7 +27,7 @@ class TestExecutionListenerRegistry {
 
 	private final List<TestExecutionListener> testExecutionListeners = new LinkedList<>();
 
-	void registerListener(TestExecutionListener... listeners) {
+	void registerListeners(TestExecutionListener... listeners) {
 		for (TestExecutionListener listener : listeners) {
 			this.testExecutionListeners.add(listener);
 		}


### PR DESCRIPTION
## Overview

Rename `registerListener` to `registerListeners`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.