### PR TITLE
Engines for DefaultLauncher must have different ids.

### DIFF
--- a/junit-tests/src/test/java/org/junit/gen5/launcher/main/DefaultLauncherTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/launcher/main/DefaultLauncherTests.java
@@ -46,10 +46,8 @@ class DefaultLauncherTests {
 
 	@Test
 	void constructLauncherWithMultipleTestEnginesWithDuplicateIds() {
-		DefaultLauncher launcher = createLauncher(new DummyTestEngine(), new DummyTestEngine());
-
 		JUnitException exception = expectThrows(JUnitException.class,
-			() -> launcher.discover(request().select(forUniqueId("foo")).build()));
+			() -> createLauncher(new DummyTestEngine("dummy id"), new DummyTestEngine("dummy id")));
 
 		assertThat(exception).hasMessageContaining("multiple engines with the same ID");
 	}


### PR DESCRIPTION
## Overview

A `DefaultLauncher` with `TestEngine`s that have equal ids is unusable. It fails to discover or execute tests. Hence it should not be possible to create such a launcher.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.