### PR TITLE
Issue 58: Support for DynamicTest creation on runtime

### DIFF
--- a/documentation/src/docs/asciidoc/extensions.adoc
+++ b/documentation/src/docs/asciidoc/extensions.adoc
@@ -208,7 +208,19 @@ but rethrow any other type of exception:
 include::{testDir}/example/exception/IgnoreIOExceptionExtension.java[tags=user_guide]
 ----
 
+=== Dynamic Test Creation
 
+To add dynamic tests on runtime, an `Extension` API `DynamicTestCreator` is available.
+It can be used to replace an existing `void` method annotated by `@Dynamic` by a number of
+`DynamicTest` created on runtime. This can easily be used to create parameterized tests.
+
+[source,java,indent=0]
+[subs="verbatim"]
+.An extension replacing a `void` method with a `boolean` parameter by two dynamic tests,
+one for each value.
+----
+include::{testDir}/extensions/DynamicTestExtension.java[tags=user_guide]
+----
 
 === Keeping State in Extensions
 
@@ -220,5 +232,3 @@ from one invocation of an extension point to the next? ...
 === Additional Planned Extensions
 
 Several additional extensions are planned, including but not limited to the following:
-
-* Dynamic test registration – for example, for computing parameterized tests at runtime

--- a/documentation/src/test/java/example/DynamicTestsDemo.java
+++ b/documentation/src/test/java/example/DynamicTestsDemo.java
@@ -17,15 +17,19 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import extensions.DynamicTestExtension;
+
 import org.junit.gen5.api.Assertions;
 import org.junit.gen5.api.Dynamic;
 import org.junit.gen5.api.DynamicTest;
 import org.junit.gen5.api.Tag;
+import org.junit.gen5.api.extension.ExtendWith;
 import org.junit.gen5.junit4.runner.JUnit5;
 import org.junit.runner.RunWith;
 
 @RunWith(JUnit5.class)
 @Tag("exclude")
+@ExtendWith(DynamicTestExtension.class)
 public class DynamicTestsDemo {
 
 	//	@Dynamic
@@ -102,4 +106,8 @@ public class DynamicTestsDemo {
 			index -> Assertions.assertFalse(index % AVERAGE == 0));
 	}
 
+	@Dynamic
+	void dynamicTestsFromExtension(boolean success) {
+		Assertions.assertTrue(success, "failing");
+	}
 }

--- a/documentation/src/test/java/extensions/DynamicTestExtension.java
+++ b/documentation/src/test/java/extensions/DynamicTestExtension.java
@@ -10,8 +10,6 @@
 
 package extensions;
 
-import static org.junit.gen5.commons.util.ReflectionUtils.invokeMethod;
-
 import java.util.stream.Stream;
 
 import org.junit.gen5.api.DynamicTest;
@@ -19,24 +17,27 @@ import org.junit.gen5.api.Executable;
 import org.junit.gen5.api.extension.DynamicTestCreator;
 import org.junit.gen5.api.extension.ExtensionContext;
 import org.junit.gen5.api.extension.MethodInvocationContext;
-import org.junit.gen5.commons.JUnitException;
+import org.junit.gen5.commons.util.ReflectionUtils;
 
+// @formatter:off
+// tag::user_guide[]
 public class DynamicTestExtension implements DynamicTestCreator {
 	@Override
-	public boolean supports(MethodInvocationContext methodInvocationContext, ExtensionContext extensionContext)
-			throws JUnitException {
-		Class<?>[] parameterTypes = methodInvocationContext.getMethod().getParameterTypes();
+	public boolean supports(MethodInvocationContext context, ExtensionContext extension) {
+		Class<?>[] parameterTypes = context.getMethod().getParameterTypes();
 		return parameterTypes.length == 1 && parameterTypes[0] == Boolean.TYPE;
 	}
 
 	@Override
-	public Stream<DynamicTest> replace(MethodInvocationContext methodInvocationContext,
-			ExtensionContext extensionContext) throws JUnitException {
-		return Stream.of(new DynamicTest("extensionTest", testExecutable(methodInvocationContext, true)),
-			new DynamicTest("extensionTest", testExecutable(methodInvocationContext, false)));
+	public Stream<DynamicTest> replace(MethodInvocationContext context, ExtensionContext extension) {
+		return Stream.of(
+				new DynamicTest("extensionTest", testExecutable(context, true)),
+				new DynamicTest("extensionTest", testExecutable(context, false)));
 	}
 
 	private Executable testExecutable(MethodInvocationContext context, boolean parameter) {
-		return () -> invokeMethod(context.getMethod(), context.getInstance(), parameter);
+		return () -> ReflectionUtils.invokeMethod(context.getMethod(), context.getInstance(), parameter);
 	}
 }
+// end::user_guide[]
+// @formatter:on

--- a/documentation/src/test/java/extensions/DynamicTestExtension.java
+++ b/documentation/src/test/java/extensions/DynamicTestExtension.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package extensions;
+
+import static org.junit.gen5.commons.util.ReflectionUtils.invokeMethod;
+
+import java.util.stream.Stream;
+
+import org.junit.gen5.api.DynamicTest;
+import org.junit.gen5.api.Executable;
+import org.junit.gen5.api.extension.DynamicTestCreator;
+import org.junit.gen5.api.extension.ExtensionContext;
+import org.junit.gen5.api.extension.MethodInvocationContext;
+import org.junit.gen5.commons.JUnitException;
+
+public class DynamicTestExtension implements DynamicTestCreator {
+	@Override
+	public boolean supports(MethodInvocationContext methodInvocationContext, ExtensionContext extensionContext)
+			throws JUnitException {
+		Class<?>[] parameterTypes = methodInvocationContext.getMethod().getParameterTypes();
+		return parameterTypes.length == 1 && parameterTypes[0] == Boolean.TYPE;
+	}
+
+	@Override
+	public Stream<DynamicTest> replace(MethodInvocationContext methodInvocationContext,
+			ExtensionContext extensionContext) throws JUnitException {
+		return Stream.of(new DynamicTest("extensionTest", testExecutable(methodInvocationContext, true)),
+			new DynamicTest("extensionTest", testExecutable(methodInvocationContext, false)));
+	}
+
+	private Executable testExecutable(MethodInvocationContext context, boolean parameter) {
+		return () -> invokeMethod(context.getMethod(), context.getInstance(), parameter);
+	}
+}

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/DynamicTestCreator.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/DynamicTestCreator.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package org.junit.gen5.api.extension;
 
 import org.junit.gen5.commons.JUnitException;
@@ -15,29 +25,29 @@ import org.junit.gen5.commons.JUnitException;
  */
 public interface DynamicTestCreator extends ExtensionPoint {
 
-    /**
-     * Determine if this creator supports replacement of the supplied
-     * {@link MethodInvocationContext} and {@link ExtensionContext}.
-     *
-     * @param methodInvocationContext method invocation context for the creation
-     * @param extensionContext extension context of the method about to be replaced
-     * @return {@code true} if this creator can replace the method
-     * @see #replace(MethodInvocationContext, ExtensionContext)
-     */
-    boolean supports(MethodInvocationContext methodInvocationContext,
-                     ExtensionContext extensionContext) throws JUnitException;
+	/**
+	 * Determine if this creator supports replacement of the supplied
+	 * {@link MethodInvocationContext} and {@link ExtensionContext}.
+	 *
+	 * @param methodInvocationContext method invocation context for the creation
+	 * @param extensionContext extension context of the method about to be replaced
+	 * @return {@code true} if this creator can replace the method
+	 * @see #replace(MethodInvocationContext, ExtensionContext)
+	 */
+	boolean supports(MethodInvocationContext methodInvocationContext, ExtensionContext extensionContext)
+			throws JUnitException;
 
-    /**
-     * Replace the method for the supplied {@link MethodInvocationContext} and
-     * {@link ExtensionContext} by the returned {@link java.util.stream.Stream},
-     * {@link java.util.Collection} or {@link Iterable} of
-     * {@link org.junit.gen5.api.DynamicTest DynamicTests}.
-     *
-     * @param methodInvocationContext method invocation context for the creation
-     * @param extensionContext extension context of the method about to be replaced
-     * @return the dynamic tests
-     * @see #supports(MethodInvocationContext, ExtensionContext)
-     */
-    Object replace(MethodInvocationContext methodInvocationContext,
-                   ExtensionContext extensionContext) throws JUnitException;
+	/**
+	 * Replace the method for the supplied {@link MethodInvocationContext} and
+	 * {@link ExtensionContext} by the returned {@link java.util.stream.Stream},
+	 * {@link java.util.Collection} or {@link Iterable} of
+	 * {@link org.junit.gen5.api.DynamicTest DynamicTests}.
+	 *
+	 * @param methodInvocationContext method invocation context for the creation
+	 * @param extensionContext extension context of the method about to be replaced
+	 * @return the dynamic tests
+	 * @see #supports(MethodInvocationContext, ExtensionContext)
+	 */
+	Object replace(MethodInvocationContext methodInvocationContext, ExtensionContext extensionContext)
+			throws JUnitException;
 }

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/DynamicTestCreator.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/DynamicTestCreator.java
@@ -1,0 +1,43 @@
+package org.junit.gen5.api.extension;
+
+import org.junit.gen5.commons.JUnitException;
+
+/**
+ * {@code DynamicTestCreator} defines the API for {@link Extension
+ * Extensions} that wish to add dynamic tests at runtime.
+ *
+ * <p>A {@link org.junit.gen5.api.Dynamic @Dynamic} method of return type {@code void}
+ * can be replaced by {@link org.junit.gen5.api.DynamicTest DynamicTests}.
+ *
+ * <p>Implementations must provide a no-args constructor.
+ *
+ * @since 5.0
+ */
+public interface DynamicTestCreator extends ExtensionPoint {
+
+    /**
+     * Determine if this creator supports replacement of the supplied
+     * {@link MethodInvocationContext} and {@link ExtensionContext}.
+     *
+     * @param methodInvocationContext method invocation context for the creation
+     * @param extensionContext extension context of the method about to be replaced
+     * @return {@code true} if this creator can replace the method
+     * @see #replace(MethodInvocationContext, ExtensionContext)
+     */
+    boolean supports(MethodInvocationContext methodInvocationContext,
+                     ExtensionContext extensionContext) throws JUnitException;
+
+    /**
+     * Replace the method for the supplied {@link MethodInvocationContext} and
+     * {@link ExtensionContext} by the returned {@link java.util.stream.Stream},
+     * {@link java.util.Collection} or {@link Iterable} of
+     * {@link org.junit.gen5.api.DynamicTest DynamicTests}.
+     *
+     * @param methodInvocationContext method invocation context for the creation
+     * @param extensionContext extension context of the method about to be replaced
+     * @return the dynamic tests
+     * @see #supports(MethodInvocationContext, ExtensionContext)
+     */
+    Object replace(MethodInvocationContext methodInvocationContext,
+                   ExtensionContext extensionContext) throws JUnitException;
+}

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/ExtensionPoint.java
@@ -32,6 +32,7 @@ import org.junit.gen5.commons.meta.API;
  * @see BeforeAllExtensionPoint
  * @see AfterAllExtensionPoint
  * @see ExtensionRegistrar
+ * @see DynamicTestCreator
  */
 @API(Experimental)
 public interface ExtensionPoint extends Extension {


### PR DESCRIPTION
## Overview

Support for DynamicTest creation on runtime.

* Created a new extension point `DynamicTestCreator`.
* Used the new extension point for `void` methods annotated by `@Dynamic` in `DynamicMethodTestDescriptor`.
* Added a test to `DynamicTestGenerationTests`
* Extended documentation including example.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.