### PR TITLE
Simplify interface of the TestDescriptor.Visitor.

### DIFF
--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/TestDescriptor.java
@@ -55,6 +55,8 @@ public interface TestDescriptor {
 
 	void removeChild(TestDescriptor descriptor);
 
+	void removeFromHierarchy();
+
 	default Set<? extends TestDescriptor> allDescendants() {
 		Set<TestDescriptor> all = new LinkedHashSet<>();
 		all.addAll(getChildren());
@@ -72,7 +74,7 @@ public interface TestDescriptor {
 
 	interface Visitor {
 
-		void visit(TestDescriptor descriptor, Runnable remove);
+		void visit(TestDescriptor descriptor);
 	}
 
 	void accept(Visitor visitor);

--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/support/descriptor/AbstractTestDescriptor.java
@@ -68,7 +68,8 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 		child.setParent(null);
 	}
 
-	protected void removeFromHierarchy() {
+	@Override
+	public void removeFromHierarchy() {
 		if (isRoot()) {
 			throw new JUnitException("You cannot remove the root of a hierarchy.");
 		}
@@ -108,8 +109,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	@Override
 	public void accept(Visitor visitor) {
-		Runnable remove = this::removeFromHierarchy;
-		visitor.visit(this, remove);
+		visitor.visit(this);
 		new LinkedHashSet<>(getChildren()).forEach(child -> child.accept(visitor));
 	}
 

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/TestPlan.java
@@ -58,7 +58,7 @@ public final class TestPlan {
 
 	public static TestPlan from(Collection<TestDescriptor> engineDescriptors) {
 		TestPlan testPlan = new TestPlan();
-		Visitor visitor = (descriptor, remove) -> testPlan.add(TestIdentifier.from(descriptor));
+		Visitor visitor = descriptor -> testPlan.add(TestIdentifier.from(descriptor));
 		engineDescriptors.stream().forEach(engineDescriptor -> engineDescriptor.accept(visitor));
 		return testPlan;
 	}

--- a/junit-launcher/src/main/java/org/junit/gen5/launcher/main/Root.java
+++ b/junit-launcher/src/main/java/org/junit/gen5/launcher/main/Root.java
@@ -24,9 +24,9 @@ import org.junit.gen5.launcher.*;
  */
 class Root {
 
-	private static final TestDescriptor.Visitor REMOVE_DESCRIPTORS_WITHOUT_TESTS = (descriptor, remove) -> {
+	private static final TestDescriptor.Visitor REMOVE_DESCRIPTORS_WITHOUT_TESTS = descriptor -> {
 		if (!descriptor.isRoot() && !descriptor.hasTests())
-			remove.run();
+			descriptor.removeFromHierarchy();
 	};
 
 	private final Map<TestEngine, TestDescriptor> testEngineDescriptors = new LinkedHashMap<>();
@@ -52,9 +52,9 @@ class Root {
 
 	void applyPostDiscoveryFilters(TestDiscoveryRequest discoveryRequest) {
 		Filter<TestDescriptor> postDiscoveryFilter = composeFilters(discoveryRequest.getPostDiscoveryFilters());
-		TestDescriptor.Visitor removeExcludedTests = (descriptor, remove) -> {
+		TestDescriptor.Visitor removeExcludedTests = descriptor -> {
 			if (isExcludedTest(descriptor, postDiscoveryFilter)) {
-				remove.run();
+				descriptor.removeFromHierarchy();
 			}
 		};
 		acceptInAllTestEngines(removeExcludedTests);

--- a/junit-tests/src/test/java/org/junit/gen5/engine/support/discovery/AbstractTestDescriptorTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/support/discovery/AbstractTestDescriptorTests.java
@@ -48,21 +48,21 @@ public class AbstractTestDescriptorTests {
 	@Test
 	public void visitAllNodes() {
 		List<TestDescriptor> visited = new ArrayList<>();
-		engineDescriptor.accept((descriptor, delete) -> visited.add(descriptor));
+		engineDescriptor.accept(visited::add);
 
 		assertEquals(8, visited.size());
 	}
 
 	@Test
 	public void pruneLeaf() {
-		TestDescriptor.Visitor visitor = (TestDescriptor descriptor, Runnable delete) -> {
+		TestDescriptor.Visitor visitor = descriptor -> {
 			if (descriptor.getUniqueId().equals(UniqueId.root("leaf", "leaf1-1")))
-				delete.run();
+				descriptor.removeFromHierarchy();
 		};
 		engineDescriptor.accept(visitor);
 
 		List<UniqueId> visited = new ArrayList<>();
-		engineDescriptor.accept((descriptor, delete) -> visited.add(descriptor.getUniqueId()));
+		engineDescriptor.accept(descriptor -> visited.add(descriptor.getUniqueId()));
 
 		assertEquals(7, visited.size());
 		assertTrue(visited.contains(UniqueId.root("group", "group1")));
@@ -72,9 +72,9 @@ public class AbstractTestDescriptorTests {
 	@Test
 	public void pruneGroup() {
 		final AtomicInteger countVisited = new AtomicInteger();
-		TestDescriptor.Visitor visitor = (descriptor, delete) -> {
+		TestDescriptor.Visitor visitor = descriptor -> {
 			if (descriptor.getUniqueId().equals(UniqueId.root("group", "group1")))
-				delete.run();
+				descriptor.removeFromHierarchy();
 			countVisited.incrementAndGet();
 		};
 		engineDescriptor.accept(visitor);
@@ -82,7 +82,7 @@ public class AbstractTestDescriptorTests {
 		assertEquals(4, countVisited.get(), "Children of pruned element are not visited");
 
 		List<UniqueId> visited = new ArrayList<>();
-		engineDescriptor.accept((descriptor, delete) -> visited.add(descriptor.getUniqueId()));
+		engineDescriptor.accept(descriptor -> visited.add(descriptor.getUniqueId()));
 
 		assertEquals(3, visited.size());
 		assertFalse(visited.contains(UniqueId.root("group", "group1")));

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/DiscoveryFilterApplier.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/DiscoveryFilterApplier.java
@@ -35,10 +35,10 @@ class DiscoveryFilterApplier {
 		if (classFilters.isEmpty()) {
 			return;
 		}
-		TestDescriptor.Visitor filteringVisitor = (descriptor, remove) -> {
+		TestDescriptor.Visitor filteringVisitor = descriptor -> {
 			if (descriptor instanceof ClassTestDescriptor) {
 				if (!includeClass((ClassTestDescriptor) descriptor, classFilters))
-					remove.run();
+					descriptor.removeFromHierarchy();
 			}
 		};
 		engineDescriptor.accept(filteringVisitor);


### PR DESCRIPTION
## Overview

Every visitor gets the instance of the TestDescriptor and a Runnable for deleting it from the hierarchy. Everybody who has access to a TestDescriptor can therefore delete it, but with an approach that is not obvious. That's why I added the delete method to the TestDescriptor interface because I think that it is easier to understand compared to the Runnable.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.