### PR TITLE
Replace displayHelp call with method reference.

### DIFF
--- a/junit-console/src/main/java/org/junit/gen5/console/ConsoleRunner.java
+++ b/junit-console/src/main/java/org/junit/gen5/console/ConsoleRunner.java
@@ -48,7 +48,7 @@ public class ConsoleRunner {
 	int execute(String... args) {
 		CommandLineOptions options = commandLineOptionsParser.parse(args);
 		ConsoleTask task = determineTask(options);
-		return consoleTaskExecutor.executeTask(task, out -> displayHelp(out));
+		return consoleTaskExecutor.executeTask(task, this::displayHelp);
 	}
 
 	private ConsoleTask determineTask(CommandLineOptions options) {


### PR DESCRIPTION
## Overview

- Replace displayHelp call with method reference.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

