### PR TITLE
StringUtils: clean up nullSafeToString

### DIFF
--- a/junit-commons/src/main/java/org/junit/gen5/commons/util/StringUtils.java
+++ b/junit-commons/src/main/java/org/junit/gen5/commons/util/StringUtils.java
@@ -71,7 +71,7 @@ public final class StringUtils {
 	 * the supplied class array is {@code null} or empty
 	 */
 	public static String nullSafeToString(Class<?>... classes) {
-		if (classes == null || classes.length == 0) {
+		if (classes == null) {
 			return "";
 		}
 		return join(stream(classes).map(Class::getName), ", ");


### PR DESCRIPTION
## Overview

A minor cleanup in `StringUtils#nullSafeToString`: Streaming and joining an empty class list will return an empty string (`""`), so explicitly checking for it redundant.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.