### PR TITLE
replace constructor with intention revealing factory method

### DIFF
--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/execution/JUnit5EngineExecutionContextTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/execution/JUnit5EngineExecutionContextTests.java
@@ -44,7 +44,7 @@ class JUnit5EngineExecutionContextTests {
 	void extendWithAllAttributes() {
 		ClassBasedContainerExtensionContext extensionContext = new ClassBasedContainerExtensionContext(null, null,
 			null);
-		ExtensionRegistry extensionRegistry = new ExtensionRegistry();
+		ExtensionRegistry extensionRegistry = ExtensionRegistry.newRootRegistryWithDefaultExtensions();
 		TestInstanceProvider testInstanceProvider = Mockito.mock(TestInstanceProvider.class);
 		JUnit5EngineExecutionContext newContext = originalContext.extend() //
 				.withExtensionContext(extensionContext) //
@@ -61,7 +61,7 @@ class JUnit5EngineExecutionContextTests {
 	void canOverrideAttributeWhenContextIsExtended() {
 		ClassBasedContainerExtensionContext extensionContext = new ClassBasedContainerExtensionContext(null, null,
 			null);
-		ExtensionRegistry extensionRegistry = new ExtensionRegistry();
+		ExtensionRegistry extensionRegistry = ExtensionRegistry.newRootRegistryWithDefaultExtensions();
 		TestInstanceProvider testInstanceProvider = Mockito.mock(TestInstanceProvider.class);
 		ClassBasedContainerExtensionContext newExtensionContext = new ClassBasedContainerExtensionContext(
 			extensionContext, null, null);

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistryTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.gen5.engine.junit5.extension;
 
+import static java.util.Collections.emptyList;
 import static org.junit.gen5.api.Assertions.assertEquals;
 import static org.junit.gen5.api.Assertions.assertTrue;
 
@@ -38,7 +39,7 @@ public class ExtensionRegistryTests {
 
 	@BeforeEach
 	public void initRegistry() {
-		registry = new ExtensionRegistry();
+		registry = ExtensionRegistry.newRootRegistryWithDefaultExtensions();
 	}
 
 	@Test
@@ -98,17 +99,17 @@ public class ExtensionRegistryTests {
 	@Test
 	public void extensionsAreInheritedFromParent() throws Exception {
 
-		ExtensionRegistry parent = new ExtensionRegistry();
+		ExtensionRegistry parent = ExtensionRegistry.newRootRegistryWithDefaultExtensions();
 		parent.registerExtension(MyExtension.class);
 
-		registry = new ExtensionRegistry(parent);
+		registry = ExtensionRegistry.newRegistryFrom(parent, emptyList());
 		registry.registerExtension(YourExtension.class);
 
 		assertExtensionRegistered(registry, MyExtension.class);
 		assertExtensionRegistered(registry, YourExtension.class);
 		assertEquals(2, countExtensionPoints(MyExtensionPoint.class));
 
-		ExtensionRegistry grandChild = new ExtensionRegistry(registry);
+		ExtensionRegistry grandChild = ExtensionRegistry.newRegistryFrom(registry, emptyList());
 		assertExtensionRegistered(grandChild, MyExtension.class);
 		assertExtensionRegistered(registry, YourExtension.class);
 		assertEquals(2, countExtensionPoints(MyExtensionPoint.class));

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/discovery/JUnit5EngineDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/discovery/JUnit5EngineDescriptor.java
@@ -31,7 +31,7 @@ public class JUnit5EngineDescriptor extends EngineDescriptor implements Containe
 
 	@Override
 	public JUnit5EngineExecutionContext beforeAll(JUnit5EngineExecutionContext context) {
-		return context.extend().withExtensionRegistry(new ExtensionRegistry()).build();
+		return context.extend().withExtensionRegistry(ExtensionRegistry.newRootRegistryWithDefaultExtensions()).build();
 	}
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/extension/ExtensionRegistry.java
@@ -62,10 +62,24 @@ public class ExtensionRegistry {
 	 */
 	public static ExtensionRegistry newRegistryFrom(ExtensionRegistry parentRegistry,
 			List<Class<? extends Extension>> extensionTypes) {
-
-		ExtensionRegistry newExtensionRegistry = new ExtensionRegistry(parentRegistry);
+		// @formatter:off
+		ExtensionRegistry newExtensionRegistry = Optional.ofNullable(parentRegistry)
+				.map(parent -> new ExtensionRegistry(Optional.of(parent)))
+				.orElseGet(ExtensionRegistry::newRootRegistryWithDefaultExtensions);
+		// @formatter:on
 		extensionTypes.forEach(newExtensionRegistry::registerExtension);
 		return newExtensionRegistry;
+	}
+
+	/**
+	 * Factory for creating and populating a new root registry with the default extension types.
+	 *
+	 * @return a new {@code ExtensionRegistry}
+	 */
+	public static ExtensionRegistry newRootRegistryWithDefaultExtensions() {
+		ExtensionRegistry extensionRegistry = new ExtensionRegistry(Optional.empty());
+		getDefaultExtensionTypes().stream().forEach(extensionRegistry::registerExtension);
+		return extensionRegistry;
 	}
 
 	private static final Logger LOG = Logger.getLogger(ExtensionRegistry.class.getName());
@@ -86,19 +100,8 @@ public class ExtensionRegistry {
 
 	private final Optional<ExtensionRegistry> parent;
 
-	public ExtensionRegistry() {
-		this(null);
-	}
-
-	ExtensionRegistry(ExtensionRegistry parent) {
-		this.parent = Optional.ofNullable(parent);
-		if (!this.parent.isPresent()) {
-			addDefaultExtensions();
-		}
-	}
-
-	private void addDefaultExtensions() {
-		getDefaultExtensionTypes().stream().forEach(this::registerExtension);
+	public ExtensionRegistry(Optional<ExtensionRegistry> parent) {
+		this.parent = parent;
 	}
 
 	/**


### PR DESCRIPTION
While working on #142 I was surprised by the fact that a `new ExtensionRegistry()` already contains `MethodParameterResolver`s. I was expecting an empty `ExtensionRegistry`.

I replaced the default constructor with the factory method `ExtensionRegistry.newRootRegistryWithDefaultExtensions()` to better inform about the default extensions being added. With the single constructor remaining it is now possible to create an empty `ExtensionRegistry` what makes the tests in #142 easier to write.

## Overview
* replaced default constructor of `ExtensionRegistry` with factory method `newRootRegistryWithDefaultExtensions()`
* enable instantiation of empty `ExtensionRegistry`

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

