### PR TITLE
Generate and upload User Guide to new directory structure

### DIFF
--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	testRuntime("org.apache.logging.log4j:log4j-jul:${log4JVersion}")
 }
 
+def asciidoctorOutputDir = "$buildDir/asciidoc"
+
 githubPages {
 	repoUri = 'https://github.com/junit-team/junit5.git'
 
@@ -37,14 +39,18 @@ githubPages {
 	}
 
 	pages {
-		from file(asciidoctor.outputDir.path + '/html5')
-		from file('src/docs/static')
+		from file(asciidoctorOutputDir)
 	}
+
+	deleteExistingFiles = false
 }
 
 publishGhPages.dependsOn asciidoctor
 
 asciidoctor {
+	outputDir = file(asciidoctorOutputDir + '/docs/current/user-guide')
+	separateOutputDirs = false
+	sources { include 'index.adoc' }
 	attributes	'junit-version': project.version,
 				'revnumber' : project.version,
 				'mainDir': project.sourceSets.main.java.srcDirs[0],

--- a/documentation/src/docs/static/README.md
+++ b/documentation/src/docs/static/README.md
@@ -1,4 +1,0 @@
-# JUnit 5 User Guide
-
-This branch contains the website sources available at:
-http://junit-team.github.io/junit5/


### PR DESCRIPTION
## Overview

- Generate only index.html for User Guide
- Remove static files kept in master that were added every time to
  gh-pages branch (now kept there)
- Use new directory structure for user guide (docs/current/user-guide)

Related issue: #205.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

- Generate only index.html for User Guide
- Keep existing files in gh-pages branch
- Remove static files kept in master that were added every time to
  gh-pages branch
- Use new directory structure (docs/current/user-guide)