### PR TITLE
Remove redundant toString() calls

### DIFF
--- a/junit-console/src/main/java/org/junit/gen5/console/tasks/XmlReportWriter.java
+++ b/junit-console/src/main/java/org/junit/gen5/console/tasks/XmlReportWriter.java
@@ -73,7 +73,7 @@ class XmlReportWriter {
 
 		writer.writeStartElement("testsuite");
 		writeAttributes(testIdentifier, tests, numberFormat, writer);
-		writer.writeComment("Unique ID: " + testIdentifier.getUniqueId().toString());
+		writer.writeComment("Unique ID: " + testIdentifier.getUniqueId());
 		writeSystemProperties(writer);
 		for (TestIdentifier test : tests) {
 			writeTestcase(test, numberFormat, writer);
@@ -117,7 +117,7 @@ class XmlReportWriter {
 		Optional<TestIdentifier> parent = reportData.getTestPlan().getParent(test);
 		writer.writeAttribute("classname", parent.map(TestIdentifier::getName).orElse("<unrooted>"));
 		writer.writeAttribute("time", getTime(test, numberFormat));
-		writer.writeComment("Unique ID: " + test.getUniqueId().toString());
+		writer.writeComment("Unique ID: " + test.getUniqueId());
 
 		writeSkippedOrErrorOrFailureElement(test, writer);
 		writeReportEntriesToSystemOutElement(test, writer);

--- a/junit-console/src/main/java/org/junit/gen5/console/tasks/XmlReportsWritingListener.java
+++ b/junit-console/src/main/java/org/junit/gen5/console/tasks/XmlReportsWritingListener.java
@@ -86,7 +86,7 @@ class XmlReportsWritingListener implements TestExecutionListener {
 
 	private void writeXmlReportInCaseOfRoot(TestIdentifier testIdentifier) {
 		if (isARoot(testIdentifier)) {
-			String rootName = UniqueId.parse(testIdentifier.getUniqueId().toString()).getSegments().get(0).getValue();
+			String rootName = UniqueId.parse(testIdentifier.getUniqueId()).getSegments().get(0).getValue();
 			writeXmlReportSafely(testIdentifier, rootName);
 		}
 	}

--- a/surefire-junit5/src/main/java/org/junit/gen5/surefire/RunListenerAdapter.java
+++ b/surefire-junit5/src/main/java/org/junit/gen5/surefire/RunListenerAdapter.java
@@ -84,7 +84,7 @@ final class RunListenerAdapter implements TestExecutionListener {
 	}
 
 	private String getClassNameOrUniqueId(TestIdentifier testIdentifier) {
-		return getClassName(testIdentifier).orElse(testIdentifier.getUniqueId().toString());
+		return getClassName(testIdentifier).orElse(testIdentifier.getUniqueId());
 	}
 
 	private Optional<String> getClassName(TestIdentifier testIdentifier) {


### PR DESCRIPTION
## Overview

String.toString() just returns the string itself, so calling toString()
on a String instance is pointless.

This patch removes the occurrences of this faulty pattern from the
codebase, and replaces them with a straight-forward use of the strings
themselves.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

Signed-off-by: Allon Mureinik <mureinik@gmail.com>