### PR TITLE
Fix indentation for failed tests in ConsoleRunner

### DIFF
--- a/junit-console/src/main/java/org/junit/gen5/console/tasks/ColoredPrintingTestListener.java
+++ b/junit-console/src/main/java/org/junit/gen5/console/tasks/ColoredPrintingTestListener.java
@@ -13,6 +13,7 @@ package org.junit.gen5.console.tasks;
 import static org.junit.gen5.console.tasks.ColoredPrintingTestListener.Color.*;
 
 import java.io.PrintWriter;
+import java.util.regex.Pattern;
 
 import org.junit.gen5.engine.TestExecutionResult;
 import org.junit.gen5.engine.TestExecutionResult.Status;
@@ -25,6 +26,10 @@ import org.junit.gen5.launcher.TestPlan;
  * @since 5.0
  */
 class ColoredPrintingTestListener implements TestExecutionListener {
+
+	private static final Pattern LINE_START_PATTERN = Pattern.compile("(?m)^");
+
+	static final String INDENTATION = "             ";
 
 	private final PrintWriter out;
 	private final boolean disableAnsiColors;
@@ -98,7 +103,7 @@ class ColoredPrintingTestListener implements TestExecutionListener {
 	}
 
 	private void printlnMessage(Color color, String message, String detail) {
-		println(color, "             => " + message + ": %s", detail);
+		println(color, INDENTATION + "=> " + message + ": %s", indented(detail));
 	}
 
 	private void println(Color color, String format, Object... args) {
@@ -113,6 +118,17 @@ class ColoredPrintingTestListener implements TestExecutionListener {
 			// Use string concatenation to avoid ANSI disruption on console
 			out.println(color + message + NONE);
 		}
+	}
+
+	/**
+	 * Indents the given message if it is a multi-line string. {@link #INDENTATION} is used to prefix the start of each
+	 * new line except the first one.
+	 *
+	 * @param message the message to indent.
+	 * @return indented message.
+	 */
+	private static String indented(String message) {
+		return LINE_START_PATTERN.matcher(message).replaceAll(INDENTATION).trim();
 	}
 
 	enum Color {

--- a/junit-tests/src/test/java/org/junit/gen5/console/tasks/ColoredPrintingTestListenerTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/console/tasks/ColoredPrintingTestListenerTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.console.tasks;
+
+import static org.junit.gen5.api.Assertions.*;
+import static org.junit.gen5.console.tasks.ColoredPrintingTestListener.INDENTATION;
+import static org.junit.gen5.engine.TestExecutionResult.Status.FAILED;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.junit.gen5.api.Test;
+import org.junit.gen5.engine.TestDescriptorStub;
+import org.junit.gen5.engine.TestExecutionResult;
+import org.junit.gen5.engine.UniqueId;
+import org.junit.gen5.engine.reporting.ReportEntry;
+import org.junit.gen5.launcher.TestIdentifier;
+
+public class ColoredPrintingTestListenerTests {
+
+	@Test
+	public void executionSkippedMessageIndented() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter out = new PrintWriter(stringWriter);
+		ColoredPrintingTestListener listener = new ColoredPrintingTestListener(out, true);
+
+		listener.executionSkipped(newTestIdentifier(), "Test\n\tdisabled");
+		String output = stringWriter.toString();
+
+		String expected = "Skipped:     failingTest [[engine:junit]]\n" + INDENTATION + "=> Reason: Test\n"
+				+ INDENTATION + "\tdisabled\n";
+
+		assertEquals(expected, output);
+	}
+
+	@Test
+	public void reportingEntryPublishedMessageIndented() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter out = new PrintWriter(stringWriter);
+		ColoredPrintingTestListener listener = new ColoredPrintingTestListener(out, true);
+
+		listener.reportingEntryPublished(newTestIdentifier(), ReportEntry.from("foo", "bar"));
+		String[] split = stringWriter.toString().split(System.lineSeparator());
+
+		assertEquals(3, split.length);
+		assertAll("lines in the message", () -> assertEquals("Reported:    failingTest [[engine:junit]]", split[0]),
+			() -> assertTrue(split[1].startsWith(INDENTATION + "=> Reported values: Report Entry")),
+			() -> assertEquals(INDENTATION + "\t- foo: bar", split[2]));
+	}
+
+	@Test
+	public void exceptionMessageIndented() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter out = new PrintWriter(stringWriter);
+		ColoredPrintingTestListener listener = new ColoredPrintingTestListener(out, true);
+
+		listener.executionFinished(newTestIdentifier(), newFailureResult("Fail\n\texpected: <foo> but was: <bar>"));
+		String output = stringWriter.toString();
+
+		String expected = "Finished:    failingTest [[engine:junit]]\n" + INDENTATION + "=> Exception: Fail\n"
+				+ INDENTATION + "\texpected: <foo> but was: <bar>\n";
+
+		assertEquals(expected, output);
+	}
+
+	private static TestIdentifier newTestIdentifier() {
+		TestDescriptorStub testDescriptor = new TestDescriptorStub(UniqueId.forEngine("junit"), "failingTest");
+		return TestIdentifier.from(testDescriptor);
+	}
+
+	private static TestExecutionResult newFailureResult(String message) {
+		Throwable throwable = new Throwable(message);
+		return new TestExecutionResult(FAILED, throwable);
+	}
+}


### PR DESCRIPTION
## Overview

Indentation for failed tests was a bit off because printed exception message could be a multi line string.

This PR fixes indentation by changing exception messages to contain same amount of spaces as the rest of the output.

Fixes #160 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.