### PR TITLE
Configure additional metadata on JAR manifest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ Date buildTimeAndDate = new Date()
 ext {
 	buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
 	buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
+	builtByValue = project.hasProperty('builtBy') ? project.builtBy : project.defaultBuiltBy
 }
 
 allprojects {
@@ -230,18 +231,29 @@ subprojects {
 			}
 		}
 	}
+	
+	def normalizeVersion = { versionLiteral ->
+		try {
+			(versionLiteral =~ /(\d+)\.(\d+)\.(\d+).*/)[0][1..3].join('.')
+		} catch(x) {
+			throw new GradleException("Version '$versionLiteral' does not match version pattern, e.g. 5.0.0-QUALIFIER")
+		}
+	}
 
 	jar {
 		manifest {
 			attributes(
-				'Built-By': System.properties['user.name'],
+				'Built-By': builtByValue,
 				'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
 				'Build-Date': buildDate,
 				'Build-Time': buildTime,
 				'Build-Revision': versioning.info.commit,
 				'Specification-Title': project.name,
-				'Specification-Version': project.version,
+				'Specification-Version': normalizeVersion(project.version),
 				'Specification-Vendor': 'junit.org',
+				'Implementation-Title': project.name,
+				'Implementation-Version': project.version,
+				'Implementation-Vendor': 'junit.org'
 			)
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 buildscript {
 	repositories {
 		// mavenLocal()
@@ -9,7 +11,14 @@ buildscript {
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
 		classpath 'org.ajoberstar:gradle-git:1.3.2'
 		classpath 'org.junit:junit-gradle:5.0.0-SNAPSHOT'
+		classpath 'net.nemerosa:versioning:1.7.1'
 	}
+}
+
+Date buildTimeAndDate = new Date()
+ext {
+	buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
+	buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
 }
 
 allprojects {
@@ -19,6 +28,7 @@ allprojects {
 	apply plugin: 'idea'
 	apply plugin: 'com.diffplug.gradle.spotless'
 	apply plugin: 'checkstyle'
+	apply plugin: 'net.nemerosa.versioning'
 
 	repositories {
 		mavenCentral()
@@ -221,6 +231,20 @@ subprojects {
 		}
 	}
 
+	jar {
+		manifest {
+			attributes(
+				'Built-By': System.properties['user.name'],
+				'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+				'Build-Date': buildDate,
+				'Build-Time': buildTime,
+				'Build-Revision': versioning.info.commit,
+				'Specification-Title': project.name,
+				'Specification-Version': project.version,
+				'Specification-Vendor': 'junit.org',
+			)
+		}
+	}
 }
 
 configure(rootProject) {

--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ subprojects {
 			}
 		}
 	}
-	
+
 	def normalizeVersion = { versionLiteral ->
 		try {
 			(versionLiteral =~ /(\d+)\.(\d+)\.(\d+).*/)[0][1..3].join('.')

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,5 @@ log4JVersion   = 2.5
 mockitoVersion = 1.10.19
 ota4jVersion   = 1.0.0-SNAPSHOT
 degraphVersion = 0.1.3
+
+defaultBuiltBy = JUnit Team


### PR DESCRIPTION
Fix for #238 by adding project metadata to JAR manifest.
Relies on the `versioning` plugin to pull in the latest SCM hash.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
