### PR TITLE
Apply InstancePostProcessor extensions for every test instance

### DIFF
--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/InstancePostProcessorTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/InstancePostProcessorTests.java
@@ -22,8 +22,8 @@ import org.junit.gen5.api.BeforeEach;
 import org.junit.gen5.api.Nested;
 import org.junit.gen5.api.Test;
 import org.junit.gen5.api.extension.ExtendWith;
+import org.junit.gen5.api.extension.ExtensionContext;
 import org.junit.gen5.api.extension.InstancePostProcessor;
-import org.junit.gen5.api.extension.TestExtensionContext;
 import org.junit.gen5.engine.ExecutionEventRecorder;
 import org.junit.gen5.engine.junit5.AbstractJUnit5TestEngineTests;
 import org.junit.gen5.launcher.TestDiscoveryRequest;
@@ -48,13 +48,18 @@ public class InstancePostProcessorTests extends AbstractJUnit5TestEngineTests {
 		assertEquals(asList(
 
 			// OuterTestCase
-			"fooPostProcessTestInstance:OuterTestCase", "beforeOuterMethod", "testOuter",
+			"fooPostProcessTestInstance:OuterTestCase",
+				"beforeOuterMethod",
+					"testOuter",
 
 			// InnerTestCase
 
-			// TODO Uncomment once issue #252 is fixed.
-			// "fooPostProcessTestInstance:OuterTestCase",
-			"fooPostProcessTestInstance:InnerTestCase", "barPostProcessTestInstance:InnerTestCase", "beforeOuterMethod", "beforeInnerMethod", "testInner"
+			"fooPostProcessTestInstance:OuterTestCase",
+			"fooPostProcessTestInstance:InnerTestCase",
+				"barPostProcessTestInstance:InnerTestCase",
+					"beforeOuterMethod",
+						"beforeInnerMethod",
+							"testInner"
 
 		), callSequence, "wrong call sequence");
 		// @formatter:on
@@ -101,8 +106,7 @@ public class InstancePostProcessorTests extends AbstractJUnit5TestEngineTests {
 
 			@Test
 			void testInner() {
-				// TODO Uncomment once issue #252 is fixed.
-				// assertEquals("foo", outerName);
+				assertEquals("foo", outerName);
 				assertEquals("bar", innerName);
 				callSequence.add("testInner");
 			}
@@ -113,8 +117,7 @@ public class InstancePostProcessorTests extends AbstractJUnit5TestEngineTests {
 	private static class FooInstancePostProcessor implements InstancePostProcessor {
 
 		@Override
-		public void postProcessTestInstance(TestExtensionContext context) throws Exception {
-			Object testInstance = context.getTestInstance();
+		public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
 			if (testInstance instanceof Named) {
 				((Named) testInstance).setName("foo");
 			}
@@ -125,12 +128,11 @@ public class InstancePostProcessorTests extends AbstractJUnit5TestEngineTests {
 	private static class BarInstancePostProcessor implements InstancePostProcessor {
 
 		@Override
-		public void postProcessTestInstance(TestExtensionContext context) throws Exception {
-			Object testInstance = context.getTestInstance();
+		public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
 			if (testInstance instanceof Named) {
 				((Named) testInstance).setName("bar");
 			}
-			callSequence.add("barPostProcessTestInstance:" + context.getTestInstance().getClass().getSimpleName());
+			callSequence.add("barPostProcessTestInstance:" + testInstance.getClass().getSimpleName());
 		}
 	}
 

--- a/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/extension/InstancePostProcessor.java
@@ -30,11 +30,11 @@ import org.junit.gen5.commons.meta.API;
 public interface InstancePostProcessor extends Extension {
 
 	/**
-	 * Callback for post-processing the test instance in the supplied
-	 * {@link TestExtensionContext}.
+	 * Callback for post-processing the supplied test instance.
 	 *
-	 * @param context the current test extension context
+	 * @param testInstance the instance to post-process
+	 * @param context the current extension context
 	 */
-	void postProcessTestInstance(TestExtensionContext context) throws Exception;
+	void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception;
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
@@ -24,7 +24,6 @@ import org.junit.gen5.api.extension.BeforeEachCallback;
 import org.junit.gen5.api.extension.BeforeTestMethodCallback;
 import org.junit.gen5.api.extension.ConditionEvaluationResult;
 import org.junit.gen5.api.extension.ExceptionHandler;
-import org.junit.gen5.api.extension.InstancePostProcessor;
 import org.junit.gen5.api.extension.MethodInvocationContext;
 import org.junit.gen5.api.extension.TestExtensionContext;
 import org.junit.gen5.commons.meta.API;
@@ -146,8 +145,6 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 		TestExtensionContext testExtensionContext = (TestExtensionContext) context.getExtensionContext();
 		ThrowableCollector throwableCollector = new ThrowableCollector();
 
-		invokeInstancePostProcessors(registry, testExtensionContext);
-
 		// @formatter:off
 		invokeBeforeEachCallbacks(registry, testExtensionContext);
 			invokeBeforeEachMethods(registry, testExtensionContext);
@@ -161,11 +158,6 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 		throwableCollector.assertEmpty();
 
 		return context;
-	}
-
-	private void invokeInstancePostProcessors(ExtensionRegistry registry, TestExtensionContext context) {
-		registry.stream(InstancePostProcessor.class)//
-				.forEach(extension -> executeAndMaskThrowable(() -> extension.postProcessTestInstance(context)));
 	}
 
 	private void invokeBeforeEachCallbacks(ExtensionRegistry registry, TestExtensionContext context) {

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/NestedClassTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/NestedClassTestDescriptor.java
@@ -14,6 +14,7 @@ import static org.junit.gen5.commons.meta.API.Usage.Internal;
 
 import java.util.Set;
 
+import org.junit.gen5.api.extension.ExtensionContext;
 import org.junit.gen5.commons.meta.API;
 import org.junit.gen5.commons.util.ReflectionUtils;
 import org.junit.gen5.engine.TestDescriptor;
@@ -21,6 +22,7 @@ import org.junit.gen5.engine.TestTag;
 import org.junit.gen5.engine.UniqueId;
 import org.junit.gen5.engine.junit5.execution.JUnit5EngineExecutionContext;
 import org.junit.gen5.engine.junit5.execution.TestInstanceProvider;
+import org.junit.gen5.engine.junit5.extension.ExtensionRegistry;
 
 /**
  * {@link TestDescriptor} for tests based on nested (but not static) Java classes.
@@ -35,10 +37,14 @@ public class NestedClassTestDescriptor extends ClassTestDescriptor {
 	}
 
 	@Override
-	protected TestInstanceProvider testInstanceProvider(JUnit5EngineExecutionContext context) {
+	protected TestInstanceProvider testInstanceProvider(JUnit5EngineExecutionContext parentExecutionContext,
+			ExtensionRegistry registry, ExtensionContext extensionContext) {
+
 		return () -> {
-			Object outerInstance = context.getTestInstanceProvider().getTestInstance();
-			return ReflectionUtils.newInstance(getTestClass(), outerInstance);
+			Object outerInstance = parentExecutionContext.getTestInstanceProvider().getTestInstance();
+			Object instance = ReflectionUtils.newInstance(getTestClass(), outerInstance);
+			invokeInstancePostProcessors(instance, registry, extensionContext);
+			return instance;
 		};
 	}
 

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestInstanceProvider.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/TestInstanceProvider.java
@@ -14,6 +14,9 @@ import static org.junit.gen5.commons.meta.API.Usage.Internal;
 
 import org.junit.gen5.commons.meta.API;
 
+/**
+ * @since 5.0
+ */
 @FunctionalInterface
 @API(Internal)
 public interface TestInstanceProvider {


### PR DESCRIPTION
Prior to this commit, InstancePostProcessor extensions were only applied
during the execution of a MethodTestDescriptor instead of at the point
when such an instance was physically instantiated. Consequently,
InstancePostProcessor extensions were never applied to instances of
outer classes when test methods in a nested class were executed, which
lead to improperly initialized outer instances (e.g,
NullPointerExceptions, etc.).

This commit fixes this bug by relocating the invocation of
InstancePostProcessor extensions to places in the framework where test
instances are physically instantiated (i.e., in ClassTestDescriptor and
NestedClassTestDescriptor).

Furthermore, the argument list for the postProcessTestInstance() method
in the InstancePostProcessor API has been modified to accept the test
instance and a generic ExtensionContext.

Issue: #252

---

I hereby agree to the terms of the JUnit Contributor License Agreement.