### PR TITLE
Include LICENSE.md inside META-INF of all jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,13 @@ subprojects { subproj ->
 			archives javadocJar
 		}
 
+		tasks.withType(Jar) {
+			from(rootProject.projectDir) {
+				include 'LICENSE.md'
+				into 'META-INF'
+			}
+		}
+
 		def signArtifacts = !project.version.contains('SNAPSHOT')
 
 		afterEvaluate {


### PR DESCRIPTION
## Overview

- Includes the `LICENSE.md` file inside `META-INF of all `.jar` files that are built by gradle.
- Fixes #260.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.