### PR TITLE
Introduce deactivation mechanism for conditions

### DIFF
--- a/documentation/src/docs/asciidoc/extensions.adoc
+++ b/documentation/src/docs/asciidoc/extensions.adoc
@@ -73,6 +73,36 @@ determine if a given test method should be executed based on the supplied
 
 See the source code of `{DisabledCondition}` and `{Disabled}` for concrete examples.
 
+==== Deactivating Conditions
+
+Sometimes it can be useful to run a test suite _without_ certain conditions being active.
+For example, you may wish to run tests even if they are annotated with `@Disabled` in
+order to see if they are still _broken_. To do this, simply provide a pattern for the
+`junit.conditions.deactivate` configuration key to specify which conditions should be
+deactivated (i.e., not evaluated) for the current test run. The pattern can be supplied
+as a _configuration parameter_ in the `TestDiscoveryRequest` that is passed to the
+`Launcher`.
+
+===== Pattern Matching Syntax
+
+If the `junit.conditions.deactivate` pattern consists solely of an asterisk (`+*+`), all
+conditions will be deactivated. Otherwise, the pattern will be used to match against the
+fully qualified class name (_FQCN_) of each registered condition. Any dot (`.`) in the
+pattern will match against a dot (`.`) or a dollar sign (`$`) in the FQCN. Any asterisk
+(`+*+`) will match against one or more characters in the FQCN. All other characters in the
+pattern will be matched one-to-one against the FQCN.
+
+Examples:
+
+- `+*+`: deactivates all conditions.
+- `+org.junit.*+`: deactivates every condition under the `org.junit` base package and any
+  of its subpackages.
+- `+*.MyCondition+`: deactivates every condition whose simple class name is exactly
+  `MyCondition`.
+- `+*System*+`: deactivates every condition whose simple class name contains `System`.
+- `org.example.MyCondition`: deactivates the condition whose FQCN is exactly
+  `org.example.MyCondition`.
+
 
 === Test Instance Post-processing
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/execution/JUnit5EngineExecutionContextTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/execution/JUnit5EngineExecutionContextTests.java
@@ -11,13 +11,14 @@
 package org.junit.gen5.engine.junit5.execution;
 
 import static org.junit.gen5.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
 
 import org.junit.gen5.api.BeforeEach;
 import org.junit.gen5.api.Test;
+import org.junit.gen5.engine.ConfigurationParameters;
 import org.junit.gen5.engine.EngineExecutionListener;
 import org.junit.gen5.engine.junit5.descriptor.ClassBasedContainerExtensionContext;
 import org.junit.gen5.engine.junit5.extension.ExtensionRegistry;
-import org.mockito.Mockito;
 
 /**
  * Microtests for {@link JUnit5EngineExecutionContext}
@@ -29,8 +30,9 @@ class JUnit5EngineExecutionContextTests {
 
 	@BeforeEach
 	void initOriginalContext() {
-		engineExecutionListener = Mockito.mock(EngineExecutionListener.class);
-		originalContext = new JUnit5EngineExecutionContext(engineExecutionListener);
+		engineExecutionListener = mock(EngineExecutionListener.class);
+		originalContext = new JUnit5EngineExecutionContext(engineExecutionListener,
+			mock(ConfigurationParameters.class));
 	}
 
 	@Test
@@ -45,7 +47,7 @@ class JUnit5EngineExecutionContextTests {
 		ClassBasedContainerExtensionContext extensionContext = new ClassBasedContainerExtensionContext(null, null,
 			null);
 		ExtensionRegistry extensionRegistry = ExtensionRegistry.createRegistryWithDefaultExtensions();
-		TestInstanceProvider testInstanceProvider = Mockito.mock(TestInstanceProvider.class);
+		TestInstanceProvider testInstanceProvider = mock(TestInstanceProvider.class);
 		JUnit5EngineExecutionContext newContext = originalContext.extend() //
 				.withExtensionContext(extensionContext) //
 				.withExtensionRegistry(extensionRegistry) //
@@ -62,7 +64,7 @@ class JUnit5EngineExecutionContextTests {
 		ClassBasedContainerExtensionContext extensionContext = new ClassBasedContainerExtensionContext(null, null,
 			null);
 		ExtensionRegistry extensionRegistry = ExtensionRegistry.createRegistryWithDefaultExtensions();
-		TestInstanceProvider testInstanceProvider = Mockito.mock(TestInstanceProvider.class);
+		TestInstanceProvider testInstanceProvider = mock(TestInstanceProvider.class);
 		ClassBasedContainerExtensionContext newExtensionContext = new ClassBasedContainerExtensionContext(
 			extensionContext, null, null);
 

--- a/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/sub/SystemPropertyCondition.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/junit5/extension/sub/SystemPropertyCondition.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.junit5.extension.sub;
+
+import static org.junit.gen5.commons.util.AnnotationUtils.findAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.junit.gen5.api.extension.ConditionEvaluationResult;
+import org.junit.gen5.api.extension.ContainerExecutionCondition;
+import org.junit.gen5.api.extension.ContainerExtensionContext;
+import org.junit.gen5.api.extension.ExtendWith;
+import org.junit.gen5.api.extension.ExtensionContext;
+import org.junit.gen5.api.extension.TestExecutionCondition;
+import org.junit.gen5.api.extension.TestExtensionContext;
+
+/**
+ * Intentionally in a subpackage in order to properly test deactivation
+ * of conditions based on patterns. In other words, we do not want this
+ * condition declared in the same package as the
+ * {@link org.junit.gen5.engine.junit5.extension.DisabledCondition}
+ *
+ * @since 5.0
+ */
+public class SystemPropertyCondition implements TestExecutionCondition, ContainerExecutionCondition {
+
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@ExtendWith(SystemPropertyCondition.class)
+	public @interface SystemProperty {
+
+		String key();
+
+		String value();
+	}
+
+	@Override
+	public ConditionEvaluationResult evaluate(ContainerExtensionContext context) {
+		return evaluate((ExtensionContext) context);
+	}
+
+	@Override
+	public ConditionEvaluationResult evaluate(TestExtensionContext context) {
+		return evaluate((ExtensionContext) context);
+	}
+
+	private ConditionEvaluationResult evaluate(ExtensionContext context) {
+		Optional<SystemProperty> optional = findAnnotation(context.getElement(), SystemProperty.class);
+
+		if (optional.isPresent()) {
+			SystemProperty systemProperty = optional.get();
+			String key = systemProperty.key();
+			String expected = systemProperty.value();
+			String actual = System.getProperty(key);
+
+			if (!Objects.equals(expected, actual)) {
+				return ConditionEvaluationResult.disabled(
+					String.format("System property [%s] has a value of [%s] instead of [%s]", key, actual, expected));
+			}
+		}
+
+		return ConditionEvaluationResult.enabled("@SystemProperty is not present");
+	}
+
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/Constants.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/Constants.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.junit5;
+
+/**
+ * Collection of constants related to the {@link JUnit5TestEngine}.
+ *
+ * @since 5.0
+ */
+public final class Constants {
+
+	/**
+	 * Property name used to provide a pattern for deactivating conditions.
+	 *
+	 * <h3>Pattern Matching Syntax</h3>
+	 *
+	 * <p>If the pattern consists solely of an asterisk ({@code *}), all conditions
+	 * will be deactivated. Otherwise, the pattern will be used to match against
+	 * the fully qualified class name (<em>FQCN</em>) of each registered condition.
+	 * Any dot ({@code .}) in the pattern will match against a dot ({@code .})
+	 * or a dollar sign ({@code $}) in the FQCN. Any asterisk ({@code *}) will match
+	 * against one or more characters in the FQCN. All other characters in the
+	 * pattern will be matched one-to-one against the FQCN.
+	 *
+	 * <h3>Examples</h3>
+	 *
+	 * <ul>
+	 * <li>{@code *}: deactivates all conditions.
+	 * <li>{@code org.junit.*}: deactivates every condition under the {@code org.junit}
+	 * base package and any of its subpackages.
+	 * <li>{@code *.MyCondition}: deactivates every condition whose simple class name is
+	 * exactly {@code MyCondition}.
+	 * <li>{@code *System*}: deactivates every condition whose simple class name contains
+	 * {@code System}.
+	 * <li>{@code org.example.MyCondition}: deactivates the condition whose FQCN is
+	 * exactly {@code org.example.MyCondition}.
+	 * </ul>
+	 *
+	 * @see #DEACTIVATE_ALL_CONDITIONS_PATTERN
+	 * @see org.junit.gen5.api.extension.ContainerExecutionCondition
+	 * @see org.junit.gen5.api.extension.TestExecutionCondition
+	 */
+	public static final String DEACTIVATE_CONDITIONS_PATTERN_PROPERTY_NAME = "junit.conditions.deactivate";
+
+	/**
+	 * Wildcard pattern which signals that all conditions should be deactivated.
+	 *
+	 * @see #DEACTIVATE_CONDITIONS_PATTERN_PROPERTY_NAME
+	 * @see org.junit.gen5.api.extension.ContainerExecutionCondition
+	 * @see org.junit.gen5.api.extension.TestExecutionCondition
+	 */
+	public static final String DEACTIVATE_ALL_CONDITIONS_PATTERN = "*";
+
+	private Constants() {
+		/* no-op */
+	}
+
+}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/JUnit5TestEngine.java
@@ -55,7 +55,8 @@ public class JUnit5TestEngine extends HierarchicalTestEngine<JUnit5EngineExecuti
 
 	@Override
 	protected JUnit5EngineExecutionContext createExecutionContext(ExecutionRequest request) {
-		return new JUnit5EngineExecutionContext(request.getEngineExecutionListener());
+		return new JUnit5EngineExecutionContext(request.getEngineExecutionListener(),
+			request.getConfigurationParameters());
 	}
 
 }

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/ClassTestDescriptor.java
@@ -136,7 +136,8 @@ public class ClassTestDescriptor extends JUnit5TestDescriptor implements Contain
 	@Override
 	public SkipResult shouldBeSkipped(JUnit5EngineExecutionContext context) throws Exception {
 		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForContainer(
-			context.getExtensionRegistry(), (ContainerExtensionContext) context.getExtensionContext());
+			context.getExtensionRegistry(), context.getConfigurationParameters(),
+			(ContainerExtensionContext) context.getExtensionContext());
 		if (evaluationResult.isDisabled()) {
 			return SkipResult.skip(evaluationResult.getReason().orElse("<unknown>"));
 		}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/descriptor/MethodTestDescriptor.java
@@ -132,7 +132,7 @@ public class MethodTestDescriptor extends JUnit5TestDescriptor implements Leaf<J
 	@Override
 	public SkipResult shouldBeSkipped(JUnit5EngineExecutionContext context) throws Exception {
 		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForTest(context.getExtensionRegistry(),
-			(TestExtensionContext) context.getExtensionContext());
+			context.getConfigurationParameters(), (TestExtensionContext) context.getExtensionContext());
 		if (evaluationResult.isDisabled()) {
 			return SkipResult.skip(evaluationResult.getReason().orElse("<unknown>"));
 		}

--- a/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/JUnit5EngineExecutionContext.java
+++ b/junit5-engine/src/main/java/org/junit/gen5/engine/junit5/execution/JUnit5EngineExecutionContext.java
@@ -15,6 +15,7 @@ import static org.junit.gen5.commons.meta.API.Usage.Internal;
 import org.junit.gen5.api.extension.ExtensionContext;
 import org.junit.gen5.commons.JUnitException;
 import org.junit.gen5.commons.meta.API;
+import org.junit.gen5.engine.ConfigurationParameters;
 import org.junit.gen5.engine.EngineExecutionListener;
 import org.junit.gen5.engine.junit5.extension.ExtensionRegistry;
 import org.junit.gen5.engine.support.hierarchical.EngineExecutionContext;
@@ -27,8 +28,9 @@ public class JUnit5EngineExecutionContext implements EngineExecutionContext {
 
 	private final State state;
 
-	public JUnit5EngineExecutionContext(EngineExecutionListener executionListener) {
-		this(new State(executionListener));
+	public JUnit5EngineExecutionContext(EngineExecutionListener executionListener,
+			ConfigurationParameters configurationParameters) {
+		this(new State(executionListener, configurationParameters));
 	}
 
 	private JUnit5EngineExecutionContext(State state) {
@@ -37,6 +39,10 @@ public class JUnit5EngineExecutionContext implements EngineExecutionContext {
 
 	public EngineExecutionListener getExecutionListener() {
 		return this.state.executionListener;
+	}
+
+	public ConfigurationParameters getConfigurationParameters() {
+		return this.state.configurationParameters;
 	}
 
 	public TestInstanceProvider getTestInstanceProvider() {
@@ -62,12 +68,14 @@ public class JUnit5EngineExecutionContext implements EngineExecutionContext {
 	private static final class State implements Cloneable {
 
 		final EngineExecutionListener executionListener;
+		final ConfigurationParameters configurationParameters;
 		TestInstanceProvider testInstanceProvider;
 		ExtensionRegistry extensionRegistry;
 		ExtensionContext extensionContext;
 
-		public State(EngineExecutionListener executionListener) {
+		public State(EngineExecutionListener executionListener, ConfigurationParameters configurationParameters) {
 			this.executionListener = executionListener;
+			this.configurationParameters = configurationParameters;
 		}
 
 		@Override


### PR DESCRIPTION
Prior to this commit, there was no way to deactivate or turn off
support for conditional test execution. In other words, there was no
way to execute a `@Disabled` test and no way to deactivate custom
implementations of `ContainerExecutionCondition` or
`TestExecutionCondition`.

This commit addresses this issue by introducing support for supplying a
`junit.conditions.deactivate` pattern to the `Launcher` via a
configuration parameter in the `TestDiscoveryRequest`.

If the `junit.conditions.deactivate` pattern consists solely of an
asterisk (`*`), all conditions will be deactivated. Otherwise, the
pattern will be used to match against the fully qualified class name
(FQCN) of each registered condition. Any dot (`.`) in the pattern will
match against a dot (`.`) or a dollar sign (`$`) in the FQCN. Any asterisk
(`*`) will match against one or more characters in the FQCN. All other
characters in the pattern will be matched one-to-one against the FQCN.

Examples:

- `*`: deactivates all conditions.
- `org.junit.*`: deactivates every condition under the `org.junit` base
   package and any of its subpackages..
- `*.MyCondition`: deactivates every condition whose simple class
   name is exactly `MyCondition`.
- `*System*`: deactivates every condition whose simple class name
   contains `System`.
- `org.example.MyCondition`: deactivates the condition whose FQCN is
  exactly `org.example.MyCondition`.

Issue: #78

---

I hereby agree to the terms of the JUnit Contributor License Agreement.