### PR TITLE
Improve assertEquals for floats and doubles

### DIFF
--- a/junit-tests/src/test/java/org/junit/gen5/api/AssertionsTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/api/AssertionsTests.java
@@ -545,6 +545,18 @@ public class AssertionsTests {
 	}
 
 	@Test
+	void assertEqualsFloatWithIllegalDelta() {
+		AssertionFailedError e1 = expectThrows(AssertionFailedError.class, () -> assertEquals(0.1f, 0.2f, -0.9f));
+		assertMessageEndsWith(e1, "positive delta expected but was: <-0.9>");
+
+		AssertionFailedError e2 = expectThrows(AssertionFailedError.class, () -> assertEquals(.0f, .0f, -10.5f));
+		assertMessageEndsWith(e2, "positive delta expected but was: <-10.5>");
+
+		AssertionFailedError e3 = expectThrows(AssertionFailedError.class, () -> assertEquals(4.5f, 4.6f, Float.NaN));
+		assertMessageEndsWith(e3, "positive delta expected but was: <NaN>");
+	}
+
+	@Test
 	void assertEqualsFloatWithDeltaWithUnequalValues() {
 		AssertionFailedError e1 = expectThrows(AssertionFailedError.class, () -> assertEquals(0.5f, 0.2f, 0.2f));
 		assertMessageEndsWith(e1, "expected: <0.5> but was: <0.2>");
@@ -555,11 +567,11 @@ public class AssertionsTests {
 		AssertionFailedError e3 = expectThrows(AssertionFailedError.class, () -> assertEquals(100.0f, 50.0f, 10.0f));
 		assertMessageEndsWith(e3, "expected: <100.0> but was: <50.0>");
 
-		AssertionFailedError e4 = expectThrows(AssertionFailedError.class, () -> assertEquals(-3.5f, -3.3f, -42.0f));
+		AssertionFailedError e4 = expectThrows(AssertionFailedError.class, () -> assertEquals(-3.5f, -3.3f, 0.01f));
 		assertMessageEndsWith(e4, "expected: <-3.5> but was: <-3.3>");
 
-		AssertionFailedError e5 = expectThrows(AssertionFailedError.class, () -> assertEquals(+0.0f, -0.0f, -1.0f));
-		assertMessageEndsWith(e5, "expected: <0.0> but was: <-0.0>");
+		AssertionFailedError e5 = expectThrows(AssertionFailedError.class, () -> assertEquals(+0.0f, -0.001f, .00001f));
+		assertMessageEndsWith(e5, "expected: <0.0> but was: <-0.001>");
 	}
 
 	@Test
@@ -636,6 +648,18 @@ public class AssertionsTests {
 	}
 
 	@Test
+	void assertEqualsDoubleWithIllegalDelta() {
+		AssertionFailedError e1 = expectThrows(AssertionFailedError.class, () -> assertEquals(1.1d, 1.11d, -0.5d));
+		assertMessageEndsWith(e1, "positive delta expected but was: <-0.5>");
+
+		AssertionFailedError e2 = expectThrows(AssertionFailedError.class, () -> assertEquals(.55d, .56d, -10.5d));
+		assertMessageEndsWith(e2, "positive delta expected but was: <-10.5>");
+
+		AssertionFailedError e3 = expectThrows(AssertionFailedError.class, () -> assertEquals(1.1d, 1.1d, Double.NaN));
+		assertMessageEndsWith(e3, "positive delta expected but was: <NaN>");
+	}
+
+	@Test
 	void assertEqualsDoubleWithDeltaWithUnequalValues() {
 		AssertionFailedError e1 = expectThrows(AssertionFailedError.class, () -> assertEquals(9.9d, 9.7d, 0.1d));
 		assertMessageEndsWith(e1, "expected: <9.9> but was: <9.7>");
@@ -646,11 +670,11 @@ public class AssertionsTests {
 		AssertionFailedError e3 = expectThrows(AssertionFailedError.class, () -> assertEquals(17.11d, 15.11d, 1.1d));
 		assertMessageEndsWith(e3, "expected: <17.11> but was: <15.11>");
 
-		AssertionFailedError e4 = expectThrows(AssertionFailedError.class, () -> assertEquals(-7.2d, -5.9d, -42.0d));
+		AssertionFailedError e4 = expectThrows(AssertionFailedError.class, () -> assertEquals(-7.2d, -5.9d, 1.1d));
 		assertMessageEndsWith(e4, "expected: <-7.2> but was: <-5.9>");
 
-		AssertionFailedError e5 = expectThrows(AssertionFailedError.class, () -> assertEquals(+0.0d, -0.0d, -1.0d));
-		assertMessageEndsWith(e5, "expected: <0.0> but was: <-0.0>");
+		AssertionFailedError e5 = expectThrows(AssertionFailedError.class, () -> assertEquals(+0.0d, -0.001d, .00001d));
+		assertMessageEndsWith(e5, "expected: <0.0> but was: <-0.001>");
 	}
 
 	@Test

--- a/junit-tests/src/test/java/org/junit/gen5/api/AssertionsTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/api/AssertionsTests.java
@@ -538,6 +538,51 @@ public class AssertionsTests {
 	}
 
 	@Test
+	void assertEqualsFloatWithDelta() {
+		assertEquals(0.56f, 0.6f, 0.05f);
+		assertEquals(0.01f, 0.011f, 0.002f);
+		assertEquals(Float.NaN, Float.NaN, 0.5f);
+	}
+
+	@Test
+	void assertEqualsFloatWithDeltaWithUnequalValues() {
+		AssertionFailedError e1 = expectThrows(AssertionFailedError.class, () -> assertEquals(0.5f, 0.2f, 0.2f));
+		assertMessageEndsWith(e1, "expected: <0.5> but was: <0.2>");
+
+		AssertionFailedError e2 = expectThrows(AssertionFailedError.class, () -> assertEquals(0.1f, 0.2f, 0.000001f));
+		assertMessageEndsWith(e2, "expected: <0.1> but was: <0.2>");
+
+		AssertionFailedError e3 = expectThrows(AssertionFailedError.class, () -> assertEquals(100.0f, 50.0f, 10.0f));
+		assertMessageEndsWith(e3, "expected: <100.0> but was: <50.0>");
+
+		AssertionFailedError e4 = expectThrows(AssertionFailedError.class, () -> assertEquals(-3.5f, -3.3f, -42.0f));
+		assertMessageEndsWith(e4, "expected: <-3.5> but was: <-3.3>");
+
+		AssertionFailedError e5 = expectThrows(AssertionFailedError.class, () -> assertEquals(+0.0f, -0.0f, -1.0f));
+		assertMessageEndsWith(e5, "expected: <0.0> but was: <-0.0>");
+	}
+
+	@Test
+	void assertEqualsFloatWithDeltaWithUnequalValuesAndMessage() {
+		Executable assertion = () -> assertEquals(0.5f, 0.45f, 0.03f, "message");
+
+		AssertionFailedError e = expectThrows(AssertionFailedError.class, assertion);
+
+		assertMessageStartsWith(e, "message");
+		assertMessageEndsWith(e, "expected: <0.5> but was: <0.45>");
+	}
+
+	@Test
+	void assertEqualsFloatWithDeltaWithUnequalValuesAndMessageSupplier() {
+		Executable assertion = () -> assertEquals(0.5f, 0.45f, 0.03f, () -> "message");
+
+		AssertionFailedError e = expectThrows(AssertionFailedError.class, assertion);
+
+		assertMessageStartsWith(e, "message");
+		assertMessageEndsWith(e, "expected: <0.5> but was: <0.45>");
+	}
+
+	@Test
 	void assertEqualsDouble() {
 		assertEquals(1.0d, 1.0d);
 		assertEquals(Double.NaN, Double.NaN);
@@ -581,6 +626,51 @@ public class AssertionsTests {
 			assertMessageStartsWith(ex, "message");
 			assertMessageEndsWith(ex, "expected: <1.0> but was: <1.1>");
 		}
+	}
+
+	@Test
+	void assertEqualsDoubleWithDelta() {
+		assertEquals(0.42d, 0.24d, 0.19d);
+		assertEquals(0.02d, 0.011d, 0.01d);
+		assertEquals(Double.NaN, Double.NaN, 0.2d);
+	}
+
+	@Test
+	void assertEqualsDoubleWithDeltaWithUnequalValues() {
+		AssertionFailedError e1 = expectThrows(AssertionFailedError.class, () -> assertEquals(9.9d, 9.7d, 0.1d));
+		assertMessageEndsWith(e1, "expected: <9.9> but was: <9.7>");
+
+		AssertionFailedError e2 = expectThrows(AssertionFailedError.class, () -> assertEquals(0.1d, 0.05d, 0.001d));
+		assertMessageEndsWith(e2, "expected: <0.1> but was: <0.05>");
+
+		AssertionFailedError e3 = expectThrows(AssertionFailedError.class, () -> assertEquals(17.11d, 15.11d, 1.1d));
+		assertMessageEndsWith(e3, "expected: <17.11> but was: <15.11>");
+
+		AssertionFailedError e4 = expectThrows(AssertionFailedError.class, () -> assertEquals(-7.2d, -5.9d, -42.0d));
+		assertMessageEndsWith(e4, "expected: <-7.2> but was: <-5.9>");
+
+		AssertionFailedError e5 = expectThrows(AssertionFailedError.class, () -> assertEquals(+0.0d, -0.0d, -1.0d));
+		assertMessageEndsWith(e5, "expected: <0.0> but was: <-0.0>");
+	}
+
+	@Test
+	void assertEqualsDoubleWithDeltaWithUnequalValuesAndMessage() {
+		Executable assertion = () -> assertEquals(42.42d, 42.4d, 0.001d, "message");
+
+		AssertionFailedError e = expectThrows(AssertionFailedError.class, assertion);
+
+		assertMessageStartsWith(e, "message");
+		assertMessageEndsWith(e, "expected: <42.42> but was: <42.4>");
+	}
+
+	@Test
+	void assertEqualsDoubleWithDeltaWithUnequalValuesAndMessageSupplier() {
+		Executable assertion = () -> assertEquals(0.9d, 10.12d, 5.001d, () -> "message");
+
+		AssertionFailedError e = expectThrows(AssertionFailedError.class, assertion);
+
+		assertMessageStartsWith(e, "message");
+		assertMessageEndsWith(e, "expected: <0.9> but was: <10.12>");
 	}
 
 	@Test

--- a/junit-tests/src/test/java/org/junit/gen5/api/AssertionsTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/api/AssertionsTests.java
@@ -493,6 +493,13 @@ public class AssertionsTests {
 	@Test
 	void assertEqualsFloat() {
 		assertEquals(1.0f, 1.0f);
+		assertEquals(Float.NaN, Float.NaN);
+		assertEquals(Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
+		assertEquals(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
+		assertEquals(Float.MIN_VALUE, Float.MIN_VALUE);
+		assertEquals(Float.MAX_VALUE, Float.MAX_VALUE);
+		assertEquals(Float.MIN_NORMAL, Float.MIN_NORMAL);
+		assertEquals(Double.NaN, Float.NaN);
 	}
 
 	@Test
@@ -533,6 +540,12 @@ public class AssertionsTests {
 	@Test
 	void assertEqualsDouble() {
 		assertEquals(1.0d, 1.0d);
+		assertEquals(Double.NaN, Double.NaN);
+		assertEquals(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
+		assertEquals(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+		assertEquals(Double.MIN_VALUE, Double.MIN_VALUE);
+		assertEquals(Double.MAX_VALUE, Double.MAX_VALUE);
+		assertEquals(Double.MIN_NORMAL, Double.MIN_NORMAL);
 	}
 
 	@Test

--- a/junit5-api/src/main/java/org/junit/gen5/api/Assertions.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/Assertions.java
@@ -363,6 +363,36 @@ public final class Assertions {
 	}
 
 	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 */
+	public static void assertEquals(float expected, float actual, float delta) {
+		assertEquals(expected, actual, delta, () -> null);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 */
+	public static void assertEquals(float expected, float actual, float delta, String message) {
+		assertEquals(expected, actual, delta, () -> message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(float expected, float actual, float delta, Supplier<String> messageSupplier) {
+		if (floatsDifferent(expected, actual, delta)) {
+			failNotEqual(expected, actual, nullSafeGet(messageSupplier));
+		}
+	}
+
+	/**
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
@@ -388,6 +418,36 @@ public final class Assertions {
 	 */
 	public static void assertEquals(double expected, double actual, Supplier<String> messageSupplier) {
 		if (!doublesEqual(expected, actual)) {
+			failNotEqual(expected, actual, nullSafeGet(messageSupplier));
+		}
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 */
+	public static void assertEquals(double expected, double actual, double delta) {
+		assertEquals(expected, actual, delta, () -> null);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 */
+	public static void assertEquals(double expected, double actual, double delta, String message) {
+		assertEquals(expected, actual, delta, () -> message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(double expected, double actual, double delta, Supplier<String> messageSupplier) {
+		if (doublesDifferent(expected, actual, delta)) {
 			failNotEqual(expected, actual, nullSafeGet(messageSupplier));
 		}
 	}
@@ -665,6 +725,26 @@ public final class Assertions {
 
 	private static String nullSafeGet(Supplier<String> messageSupplier) {
 		return (messageSupplier != null ? messageSupplier.get() : null);
+	}
+
+	private static boolean floatsDifferent(float value1, float value2, float delta) {
+		if (floatsEqual(value1, value2)) {
+			return false;
+		}
+		if (Math.abs(value1 - value2) <= delta) {
+			return false;
+		}
+		return true;
+	}
+
+	private static boolean doublesDifferent(double value1, double value2, double delta) {
+		if (doublesEqual(value1, value2)) {
+			return false;
+		}
+		if (Math.abs(value1 - value2) <= delta) {
+			return false;
+		}
+		return true;
 	}
 
 	private static boolean floatsEqual(float value1, float value2) {

--- a/junit5-api/src/main/java/org/junit/gen5/api/Assertions.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/Assertions.java
@@ -334,6 +334,8 @@ public final class Assertions {
 
 	/**
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
 	 */
 	public static void assertEquals(float expected, float actual) {
 		assertEquals(expected, actual, () -> null);
@@ -341,6 +343,8 @@ public final class Assertions {
 
 	/**
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
 	 */
 	public static void assertEquals(float expected, float actual, String message) {
 		assertEquals(expected, actual, () -> message);
@@ -348,16 +352,20 @@ public final class Assertions {
 
 	/**
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertEquals(float expected, float actual, Supplier<String> messageSupplier) {
-		if (expected != actual) {
+		if (!floatsEqual(expected, actual)) {
 			failNotEqual(expected, actual, nullSafeGet(messageSupplier));
 		}
 	}
 
 	/**
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
 	 */
 	public static void assertEquals(double expected, double actual) {
 		assertEquals(expected, actual, () -> null);
@@ -365,6 +373,8 @@ public final class Assertions {
 
 	/**
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
 	 */
 	public static void assertEquals(double expected, double actual, String message) {
 		assertEquals(expected, actual, () -> message);
@@ -372,10 +382,12 @@ public final class Assertions {
 
 	/**
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertEquals(double expected, double actual, Supplier<String> messageSupplier) {
-		if (expected != actual) {
+		if (!doublesEqual(expected, actual)) {
 			failNotEqual(expected, actual, nullSafeGet(messageSupplier));
 		}
 	}
@@ -653,6 +665,14 @@ public final class Assertions {
 
 	private static String nullSafeGet(Supplier<String> messageSupplier) {
 		return (messageSupplier != null ? messageSupplier.get() : null);
+	}
+
+	private static boolean floatsEqual(float value1, float value2) {
+		return Float.floatToIntBits(value1) == Float.floatToIntBits(value2);
+	}
+
+	private static boolean doublesEqual(double value1, double value2) {
+		return Double.doubleToLongBits(value1) == Double.doubleToLongBits(value2);
 	}
 
 }

--- a/junit5-api/src/main/java/org/junit/gen5/api/Assertions.java
+++ b/junit5-api/src/main/java/org/junit/gen5/api/Assertions.java
@@ -728,6 +728,9 @@ public final class Assertions {
 	}
 
 	private static boolean floatsDifferent(float value1, float value2, float delta) {
+		if (Float.isNaN(delta) || delta <= 0.0) {
+			failIllegalDelta(String.valueOf(delta));
+		}
 		if (floatsEqual(value1, value2)) {
 			return false;
 		}
@@ -738,6 +741,9 @@ public final class Assertions {
 	}
 
 	private static boolean doublesDifferent(double value1, double value2, double delta) {
+		if (Double.isNaN(delta) || delta <= 0.0) {
+			failIllegalDelta(String.valueOf(delta));
+		}
 		if (doublesEqual(value1, value2)) {
 			return false;
 		}
@@ -745,6 +751,10 @@ public final class Assertions {
 			return false;
 		}
 		return true;
+	}
+
+	private static void failIllegalDelta(String delta) {
+		fail("positive delta expected but was: <" + delta + ">");
 	}
 
 	private static boolean floatsEqual(float value1, float value2) {


### PR DESCRIPTION
## Overview

This PR includes two commits:

 - Handle NaNs when comparing doubles and floats

 This commit makes methods `assertEquals(double, double)` and
`assertEquals(float, float)` treat NaNs as equal. Same applies to variations
of those methods that accept a message or a message supplier.

 Such behaviour is consistent with `Double#compare(double, double)` and
`Float#compare(float, float)` but not consistent with `==` and `!=`. It will
cause less confusion for users that execute code like
`assertEquals(Double.NaN, Double.NaN)`.

 - Added assertEquals for doubles & floats with delta

 This commit introduces `assertEquals(double, double, double)` and
`assertEquals(float, float, float)` where the third parameter is delta. First
two parameters are compared within this given delta. Also added methods with
delta parameter that accept a message and a message supplier.

 Such methods are needed because exact comparison of floating point numbers
does not always make sense.

Fixes #269 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.