### PR TITLE
Introduce composite TestSource

### DIFF
--- a/junit-engine-api/src/main/java/org/junit/gen5/engine/support/descriptor/CompositeTestSource.java
+++ b/junit-engine-api/src/main/java/org/junit/gen5/engine/support/descriptor/CompositeTestSource.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.support.descriptor;
+
+import static org.junit.gen5.commons.meta.API.Usage.Experimental;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.gen5.commons.meta.API;
+import org.junit.gen5.commons.util.Preconditions;
+import org.junit.gen5.commons.util.ToStringBuilder;
+import org.junit.gen5.engine.TestSource;
+
+/**
+ * A {@code CompositeTestSource} contains one or more {@link TestSource TestSources}.
+ *
+ * <p>{@code CompositeTestSource} and its {@link #getSources sources} are immutable.
+ *
+ * @since 5.0
+ */
+@API(Experimental)
+public class CompositeTestSource implements TestSource {
+
+	private static final long serialVersionUID = 1L;
+
+	private final List<TestSource> sources;
+
+	/**
+	 * Create a new {@code CompositeTestSource} based on the supplied
+	 * collection of {@link TestSource sources}.
+	 *
+	 * <p>This constructor makes a defensive copy of the supplied collection
+	 * and stores the sources as a list in the order in which they are
+	 * returned by the collection's iterator.
+	 *
+	 * @param sources the collection of sources to store in this
+	 * {@code CompositeTestSource}; never {@code null} or empty
+	 */
+	public CompositeTestSource(Collection<? extends TestSource> sources) {
+		Preconditions.notEmpty(sources, "TestSource collection must not be null or empty");
+		this.sources = Collections.unmodifiableList(new ArrayList<>(sources));
+	}
+
+	/**
+	 * Get an immutable list of the {@linkplain TestSource sources} stored in this
+	 * {@code CompositeTestSource}.
+	 *
+	 * @return the sources stored in this {@code CompositeTestSource}; never {@code null}
+	 */
+	public final List<TestSource> getSources() {
+		return this.sources;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		CompositeTestSource that = (CompositeTestSource) obj;
+		return this.sources.equals(that.sources);
+	}
+
+	@Override
+	public int hashCode() {
+		return this.sources.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).append("sources", this.sources).toString();
+	}
+
+}

--- a/junit-tests/src/test/java/org/junit/gen5/engine/support/descriptor/CompositeTestSourceTests.java
+++ b/junit-tests/src/test/java/org/junit/gen5/engine/support/descriptor/CompositeTestSourceTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.gen5.engine.support.descriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.gen5.api.Assertions.assertEquals;
+import static org.junit.gen5.api.Assertions.assertFalse;
+import static org.junit.gen5.api.Assertions.assertNotSame;
+import static org.junit.gen5.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.gen5.api.Test;
+import org.junit.gen5.commons.util.PreconditionViolationException;
+import org.junit.gen5.engine.TestSource;
+
+/**
+ * Unit tests for {@link CompositeTestSource}.
+ *
+ * @since 5.0
+ */
+class CompositeTestSourceTests {
+
+	@Test
+	void createCompositeTestSourceFromNullList() {
+		assertThrows(PreconditionViolationException.class, () -> new CompositeTestSource(null));
+	}
+
+	@Test
+	void createCompositeTestSourceFromEmptyList() {
+		assertThrows(PreconditionViolationException.class, () -> new CompositeTestSource(Collections.emptyList()));
+	}
+
+	@Test
+	void createCompositeTestSourceFromClassAndFileSources() {
+		FileSource fileSource = new FileSource(new File("example.test"));
+		JavaClassSource classSource = new JavaClassSource(getClass());
+		List<TestSource> sources = new ArrayList<>(Arrays.asList(fileSource, classSource));
+		CompositeTestSource compositeTestSource = new CompositeTestSource(sources);
+
+		assertThat(compositeTestSource.getSources().size()).isEqualTo(2);
+		assertThat(compositeTestSource.getSources()).contains(fileSource, classSource);
+
+		// Ensure the supplied sources list was defensively copied.
+		sources.remove(1);
+		assertThat(compositeTestSource.getSources().size()).isEqualTo(2);
+
+		// Ensure the returned sources list is immutable.
+		assertThrows(UnsupportedOperationException.class, () -> compositeTestSource.getSources().add(fileSource));
+	}
+
+	@Test
+	void equalsAndHashCode() {
+		List<TestSource> sources = Arrays.asList(new JavaClassSource(getClass()));
+		CompositeTestSource composite1 = new CompositeTestSource(sources);
+		CompositeTestSource composite2 = new CompositeTestSource(sources);
+
+		assertNotSame(composite1, composite2);
+		assertNotSame(composite1.getSources(), composite2.getSources());
+		assertFalse(composite1.equals(null));
+
+		assertEquals(composite1, composite1);
+		assertEquals(composite1, composite2);
+		assertEquals(composite2, composite1);
+		assertEquals(composite1.hashCode(), composite2.hashCode());
+	}
+
+}


### PR DESCRIPTION
This commit introduces a `CompositeTestSource` that can be used to hold one or more `TestSources`. This can be useful, for example, if the programming model for a particular testing framework relies on Java classes and associated scripts in the file system.

Issue: #271

---

I hereby agree to the terms of the JUnit Contributor License Agreement.