### PR TITLE
Introduce assertIterableEquals() methods in Assertions

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -26,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -821,6 +823,79 @@ public final class Assertions {
 		assertArrayEquals(expected, actual, new ArrayDeque<>(), messageSupplier);
 	}
 
+	// --- assertIterableEquals --------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} iterables are deeply equal.
+	 * <p>Similarly to the check for deep equality in {@link #assertArrayEquals(Object[], Object[])},
+	 * if two iterables are encountered (including {@code expected} and {@code actual}) then their
+	 * iterators must return equal elements in the same order as each other. <strong>Note:</strong>
+	 * this means that the iterables <em>do not</em> need to be of the same type. Example: <pre>{@code
+	 * import static java.util.Arrays.asList;
+	 *  . . .
+	 * Iterable<Integer> i0 = new ArrayList<>(asList(1, 2, 3));
+	 * Iterable<Integer> i1 = new LinkedList<>(asList(1, 2, 3));
+	 * assertIterableEquals(i0, i1); // Passes
+	 * }</pre>
+	 * <p>If both {@code expected} and {@code actual} are {@code null}, they are considered equal.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 * @see #assertArrayEquals(Object[], Object[])
+	 */
+	public static void assertIterableEquals(Iterable<?> expected, Iterable<?> actual) {
+		assertIterableEquals(expected, actual, () -> null);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} iterables are deeply equal.
+	 * <p>Similarly to the check for deep equality in
+	 * {@link #assertArrayEquals(Object[], Object[], String)}, if two iterables are encountered
+	 * (including {@code expected} and {@code actual}) then their iterators must return equal
+	 * elements in the same order as each other. <strong>Note:</strong> this means that the iterables
+	 * <em>do not</em> need to be of the same type. Example: <pre>{@code
+	 * import static java.util.Arrays.asList;
+	 *  . . .
+	 * Iterable<Integer> i0 = new ArrayList<>(asList(1, 2, 3));
+	 * Iterable<Integer> i1 = new LinkedList<>(asList(1, 2, 3));
+	 * assertIterableEquals(i0, i1); // Passes
+	 * }</pre>
+	 * <p>If both {@code expected} and {@code actual} are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 * @see #assertArrayEquals(Object[], Object[], String)
+	 */
+	public static void assertIterableEquals(Iterable<?> expected, Iterable<?> actual, String message) {
+		assertIterableEquals(expected, actual, () -> message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} iterables are deeply equal.
+	 * <p>Similarly to the check for deep equality in
+	 * {@link #assertArrayEquals(Object[], Object[], Supplier)}, if two iterables are encountered
+	 * (including {@code expected} and {@code actual}) then their iterators must return equal
+	 * elements in the same order as each other. <strong>Note:</strong> this means that the iterables
+	 * <em>do not</em> need to be of the same type. Example: <pre>{@code
+	 * import static java.util.Arrays.asList;
+	 *  . . .
+	 * Iterable<Integer> i0 = new ArrayList<>(asList(1, 2, 3));
+	 * Iterable<Integer> i1 = new LinkedList<>(asList(1, 2, 3));
+	 * assertIterableEquals(i0, i1); // Passes
+	 * }</pre>
+	 * <p>If both {@code expected} and {@code actual} are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 * @see #assertArrayEquals(Object[], Object[], Supplier)
+	 */
+	public static void assertIterableEquals(Iterable<?> expected, Iterable<?> actual,
+			Supplier<String> messageSupplier) {
+		assertIterableEquals(expected, actual, new ArrayDeque<>(), messageSupplier);
+	}
+
 	// --- assertNotEquals -----------------------------------------------------
 
 	/**
@@ -1479,12 +1554,90 @@ public final class Assertions {
 		return result;
 	}
 
-	private static String formatIndexes(Deque<Integer> indexes) {
-		if (indexes == null || indexes.isEmpty()) {
-			return "";
+	// --- assertIterableEquals helpers ----------------------------------
+
+	private static void assertIterableEquals(Iterable<?> expected, Iterable<?> actual, Deque<Integer> indexes,
+			Supplier<String> messageSupplier) {
+
+		if (expected == actual) {
+			return;
 		}
-		String indexesString = indexes.stream().map(Object::toString).collect(joining("][", "[", "]"));
-		return " at index " + indexesString;
+		assertIterablesNotNull(expected, actual, indexes, messageSupplier);
+
+		Iterator<?> expectedIterator = expected.iterator();
+		Iterator<?> actualIterator = actual.iterator();
+
+		int processed = 0;
+		while (expectedIterator.hasNext() && actualIterator.hasNext()) {
+			processed++;
+			Object expectedElement = expectedIterator.next();
+			Object actualElement = actualIterator.next();
+
+			if (expectedElement == actualElement) {
+				continue;
+			}
+
+			indexes.addLast(processed - 1);
+			assertIterableElementsEqual(expectedElement, actualElement, indexes, messageSupplier);
+			indexes.removeLast();
+		}
+
+		assertIteratorsAreEmpty(expectedIterator, actualIterator, processed, indexes, messageSupplier);
+	}
+
+	private static void assertIterableElementsEqual(Object expected, Object actual, Deque<Integer> indexes,
+			Supplier<String> messageSupplier) {
+		if (expected instanceof Iterable && actual instanceof Iterable) {
+			assertIterableEquals((Iterable<?>) expected, (Iterable<?>) actual, indexes, messageSupplier);
+		}
+		else if (!Objects.equals(expected, actual)) {
+			assertIterablesNotNull(expected, actual, indexes, messageSupplier);
+			failIterablesNotEqual(expected, actual, indexes, messageSupplier);
+		}
+	}
+
+	private static void assertIterablesNotNull(Object expected, Object actual, Deque<Integer> indexes,
+			Supplier<String> messageSupplier) {
+
+		if (expected == null) {
+			failExpectedIterableIsNull(indexes, messageSupplier);
+		}
+		if (actual == null) {
+			failActualIterableIsNull(indexes, messageSupplier);
+		}
+	}
+
+	private static void failExpectedIterableIsNull(Deque<Integer> indexes, Supplier<String> messageSupplier) {
+		fail(buildPrefix(nullSafeGet(messageSupplier)) + "expected iterable was <null>" + formatIndexes(indexes));
+	}
+
+	private static void failActualIterableIsNull(Deque<Integer> indexes, Supplier<String> messageSupplier) {
+		fail(buildPrefix(nullSafeGet(messageSupplier)) + "actual iterable was <null>" + formatIndexes(indexes));
+	}
+
+	private static void assertIteratorsAreEmpty(Iterator<?> expected, Iterator<?> actual, int processed,
+			Deque<Integer> indexes, Supplier<String> messageSupplier) {
+
+		if (expected.hasNext() || actual.hasNext()) {
+			AtomicInteger expectedCount = new AtomicInteger(processed);
+			expected.forEachRemaining(e -> expectedCount.incrementAndGet());
+
+			AtomicInteger actualCount = new AtomicInteger(processed);
+			actual.forEachRemaining(e -> actualCount.incrementAndGet());
+
+			String prefix = buildPrefix(nullSafeGet(messageSupplier));
+			String message = "iterable lengths differ" + formatIndexes(indexes) + ", expected: <" + expectedCount.get()
+					+ "> but was: <" + actualCount.get() + ">";
+			fail(prefix + message);
+		}
+	}
+
+	private static void failIterablesNotEqual(Object expected, Object actual, Deque<Integer> indexes,
+			Supplier<String> messageSupplier) {
+
+		String prefix = buildPrefix(nullSafeGet(messageSupplier));
+		String message = "iterable contents differ" + formatIndexes(indexes) + ", " + formatValues(expected, actual);
+		fail(prefix + message);
 	}
 
 	// -------------------------------------------------------------------------
@@ -1588,6 +1741,14 @@ public final class Assertions {
 
 	private static void failIllegalDelta(String delta) {
 		fail("positive delta expected but was: <" + delta + ">");
+	}
+
+	private static String formatIndexes(Deque<Integer> indexes) {
+		if (indexes == null || indexes.isEmpty()) {
+			return "";
+		}
+		String indexesString = indexes.stream().map(Object::toString).collect(joining("][", "[", "]"));
+		return " at index " + indexesString;
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsTests.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -26,11 +27,14 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.expectThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.IterableFactory.listOf;
+import static org.junit.jupiter.api.IterableFactory.setOf;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -2740,6 +2744,415 @@ public class AssertionsTests {
 		catch (AssertionFailedError ex) {
 			assertMessageStartsWith(ex, "message");
 			assertMessageEndsWith(ex, "array contents differ at index [4][1][0], expected: <3> but was: <5>");
+		}
+	}
+
+	// --- assertIterableEquals --------------------------------------------
+
+	@Test
+	void assertIterableEqualsEqualToSelf() {
+		List<Object> list = listOf("a", 'b', 1, 2);
+		assertIterableEquals(list, list);
+
+		Set<Object> set = setOf("a", 'b', 1, 2);
+		assertIterableEquals(set, set);
+	}
+
+	@Test
+	void assertIterableEqualsEqualObjectsOfSameType() {
+		assertIterableEquals(listOf(), listOf());
+		assertIterableEquals(listOf("abc"), listOf("abc"));
+		assertIterableEquals(listOf("abc", 1, 2L, 3D), listOf("abc", 1, 2L, 3D));
+		assertIterableEquals(setOf(), setOf());
+		assertIterableEquals(setOf("abc"), setOf("abc"));
+		assertIterableEquals(setOf("abc", 1, 2L, 3D), setOf("abc", 1, 2L, 3D));
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterables() {
+		assertIterableEquals(listOf(listOf(listOf())), listOf(listOf(listOf())));
+		assertIterableEquals(setOf(setOf(setOf())), setOf(setOf(setOf())));
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesWithNull() {
+		assertIterableEquals(listOf(null, listOf(null, listOf(null, null)), null, listOf((List<Object>) null)),
+			listOf(null, listOf(null, listOf(null, null)), null, listOf((List<Object>) null)));
+		assertIterableEquals(setOf(null, setOf(null, setOf(null, null)), null, setOf((Set<Object>) null)),
+			setOf(null, setOf(null, setOf(null, null)), null, setOf((Set<Object>) null)));
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesWithStrings() {
+		assertIterableEquals(listOf("a", listOf(listOf("b", listOf("c", "d"))), "e"),
+			listOf("a", listOf(listOf("b", listOf("c", "d"))), "e"));
+		assertIterableEquals(setOf("a", setOf(setOf("b", setOf("c", "d"))), "e"),
+			setOf("a", setOf(setOf("b", setOf("c", "d"))), "e"));
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesWithIntegers() {
+		assertIterableEquals(listOf(listOf(1), listOf(2), listOf(listOf(3, listOf(4)))),
+			listOf(listOf(1), listOf(2), listOf(listOf(3, listOf(4)))));
+		assertIterableEquals(setOf(setOf(1), setOf(2), setOf(setOf(3, setOf(4)))),
+			setOf(setOf(1), setOf(2), setOf(setOf(3, setOf(4)))));
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesWithDeeplyNestedObject() {
+		assertIterableEquals(listOf(listOf(listOf(listOf(listOf(listOf(listOf("abc"))))))),
+			listOf(listOf(listOf(listOf(listOf(listOf(listOf("abc"))))))));
+		assertIterableEquals(setOf(setOf(setOf(setOf(setOf(setOf(setOf("abc"))))))),
+			setOf(setOf(setOf(setOf(setOf(setOf(setOf("abc"))))))));
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesWithNaN() {
+		assertIterableEquals(listOf(null, listOf(null, Double.NaN, listOf(Float.NaN, null, listOf()))),
+			listOf(null, listOf(null, Double.NaN, listOf(Float.NaN, null, listOf()))));
+		assertIterableEquals(setOf(null, setOf(null, Double.NaN, setOf(Float.NaN, null, setOf()))),
+			setOf(null, setOf(null, Double.NaN, setOf(Float.NaN, null, setOf()))));
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesWithObjectsOfDifferentTypes() {
+		assertIterableEquals(listOf(new String("a"), Integer.valueOf(1), listOf(Double.parseDouble("1.1"), "b")),
+			listOf(new String("a"), Integer.valueOf(1), listOf(Double.parseDouble("1.1"), "b")));
+		assertIterableEquals(setOf(new String("a"), Integer.valueOf(1), setOf(Double.parseDouble("1.1"), "b")),
+			setOf(new String("a"), Integer.valueOf(1), setOf(Double.parseDouble("1.1"), "b")));
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesOfMixedSubtypes() {
+		assertIterableEquals(
+			listOf(1, 2, listOf(3, setOf(4, 5), setOf(6L), listOf(listOf(setOf(7)))), setOf(8), listOf(setOf(9L))),
+			listOf(1, 2, listOf(3, setOf(4, 5), setOf(6L), listOf(listOf(setOf(7)))), setOf(8), listOf(setOf(9L))));
+
+		assertIterableEquals(
+			listOf("a", setOf('b', 'c'), setOf((int) 'd'), listOf(listOf(listOf("ef"), listOf(listOf("ghi"))))),
+			setOf("a", listOf('b', 'c'), listOf((int) 'd'), setOf(setOf(setOf("ef"), setOf(setOf("ghi"))))));
+	}
+
+	@Test
+	void assertIterableEqualsIterableVsNull() {
+		try {
+			assertIterableEquals(null, listOf("a", "b", 1, listOf()));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "expected iterable was <null>");
+		}
+
+		try {
+			assertIterableEquals(listOf('a', 1, new Object(), 10L), null);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "actual iterable was <null>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterableVsNull() {
+		try {
+			assertIterableEquals(listOf(listOf(), 1, "2", setOf('3', listOf((List<Object>) null))),
+				listOf(listOf(), 1, "2", setOf('3', listOf(listOf("4")))));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "expected iterable was <null> at index [3][1][0]");
+		}
+
+		try {
+			assertIterableEquals(setOf(1, 2, listOf(3, listOf("4", setOf(5, setOf(6)))), "7"),
+				setOf(1, 2, listOf(3, listOf("4", setOf(5, null))), "7"));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "actual iterable was <null> at index [2][1][1][1]");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsIterableVsNullAndMessage() {
+		try {
+			assertIterableEquals(null, listOf('a', "b", 10, 20D), "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "expected iterable was <null>");
+		}
+
+		try {
+			assertIterableEquals(listOf("hello", 42), null, "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "actual iterable was <null>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterableVsNullAndMessage() {
+		try {
+			assertIterableEquals(listOf(1, listOf(2, 3, listOf(4, 5, listOf((List<Object>) null)))),
+				listOf(1, listOf(2, 3, listOf(4, 5, listOf(listOf(6))))), "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "expected iterable was <null> at index [1][2][2][0]");
+		}
+
+		try {
+			assertIterableEquals(listOf(1, listOf(2, listOf(3, listOf(listOf(4))))),
+				listOf(1, listOf(2, listOf(3, listOf((List<Object>) null)))), "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "actual iterable was <null> at index [1][1][1][0]");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsIterableVsNullAndMessageSupplier() {
+		try {
+			assertIterableEquals(null, setOf(42, "42", listOf(42F), 42D), () -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "expected iterable was <null>");
+		}
+
+		try {
+			assertIterableEquals(listOf(listOf("a"), listOf()), null, () -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "actual iterable was <null>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterableVsNullAndMessageSupplier() {
+		try {
+			assertIterableEquals(listOf("1", "2", "3", listOf("4", listOf((List<Object>) null))),
+				listOf("1", "2", "3", listOf("4", listOf(listOf(5)))), () -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "expected iterable was <null> at index [3][1][0]");
+		}
+
+		try {
+			assertIterableEquals(setOf(1, 2, setOf("3", setOf('4', setOf(5, 6, setOf())))),
+				setOf(1, 2, setOf("3", setOf('4', setOf(5, 6, null)))), () -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "actual iterable was <null> at index [2][1][1][2]");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsIterablesOfDifferentLength() {
+		try {
+			assertIterableEquals(listOf('a', "b", 'c'), listOf('a', "b", 'c', 1));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "iterable lengths differ, expected: <3> but was: <4>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesOfDifferentLength() {
+		try {
+			assertIterableEquals(listOf("a", setOf("b", listOf("c", "d", setOf("e", 1, 2, 3)))),
+				listOf("a", setOf("b", listOf("c", "d", setOf("e", 1, 2, 3, 4, 5)))));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "iterable lengths differ at index [1][1][2], expected: <4> but was: <6>");
+		}
+
+		try {
+			assertIterableEquals(listOf(listOf(listOf(listOf(listOf(listOf(listOf('a'))))))),
+				listOf(listOf(listOf(listOf(listOf(listOf(listOf('a', 'b'))))))));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "iterable lengths differ at index [0][0][0][0][0][0], expected: <1> but was: <2>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsIterablesOfDifferentLengthAndMessage() {
+		try {
+			assertIterableEquals(setOf('a', 1), setOf('a', 1, new Object()), "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable lengths differ, expected: <2> but was: <3>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesOfDifferentLengthAndMessage() {
+		try {
+			assertIterableEquals(listOf('a', 1, listOf(2, 3)), listOf('a', 1, listOf(2, 3, 4, 5)), "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable lengths differ at index [2], expected: <2> but was: <4>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsIterablesOfDifferentLengthAndMessageSupplier() {
+		try {
+			assertIterableEquals(setOf("a", "b", "c"), setOf("a", "b", "c", "d", "e", "f"), () -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable lengths differ, expected: <3> but was: <6>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsNestedIterablesOfDifferentLengthAndMessageSupplier() {
+		try {
+			assertIterableEquals(listOf("a", setOf(1, 2, 3, listOf(4.0, 5.1, 6.1), 7)),
+				listOf("a", setOf(1, 2, 3, listOf(4.0, 5.1, 6.1, 7.0), 8)), () -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable lengths differ at index [1][3], expected: <3> but was: <4>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsDifferentIterables() {
+		try {
+			assertIterableEquals(listOf(1L, "2", '3', 4, 5D), listOf(1L, "2", '9', 4, 5D));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "iterable contents differ at index [2], expected: <3> but was: <9>");
+		}
+
+		try {
+			assertIterableEquals(listOf("a", 10, 11, 12, Double.NaN), listOf("a", 10, 11, 12, 13.55D));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "iterable contents differ at index [4], expected: <NaN> but was: <13.55>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsDifferentNestedIterables() {
+		try {
+			assertIterableEquals(listOf(1, 2, listOf(3, listOf(4, listOf(false, true)))),
+				listOf(1, 2, listOf(3, listOf(4, listOf(true, false)))));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex,
+				"iterable contents differ at index [2][1][1][0], expected: <false> but was: <true>");
+		}
+
+		List<Object> differentElement = listOf();
+		try {
+			assertIterableEquals(listOf(1, 2, 3, listOf(listOf(4, listOf(5)))),
+				listOf(1, 2, 3, listOf(listOf(4, listOf(differentElement)))));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex,
+				"iterable contents differ at index [3][0][1][0], expected: <5> but was: <" + differentElement + ">");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsDifferentIterablesAndMessage() {
+		try {
+			assertIterableEquals(listOf(1.1D, 2L, "3"), listOf(1D, 2L, "3"), "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable contents differ at index [0], expected: <1.1> but was: <1.0>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsDifferentNestedIterablesAndMessage() {
+		try {
+			assertIterableEquals(listOf(9, 8, '6', listOf(5, 4, "3", listOf("2", '1'))),
+				listOf(9, 8, '6', listOf(5, 4, "3", listOf("99", '1'))), "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable contents differ at index [3][3][0], expected: <2> but was: <99>");
+		}
+
+		try {
+			assertIterableEquals(listOf(9, 8, '6', listOf(5, 4, "3", listOf("2", "1"))),
+				listOf(9, 8, '6', listOf(5, 4, "3", listOf("99", "1"))), "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable contents differ at index [3][3][0], expected: <2> but was: <99>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsDifferentIterablesAndMessageSupplier() {
+		try {
+			assertIterableEquals(setOf("one", 1L, Double.MIN_VALUE, "abc"), setOf("one", 1L, 42.42, "abc"),
+				() -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable contents differ at index [2], expected: <4.9E-324> but was: <42.42>");
+		}
+	}
+
+	@Test
+	void assertIterableEqualsDifferentNestedIterablesAndMessageSupplier() {
+		try {
+			assertIterableEquals(setOf("one", 1L, setOf("a", 'b', setOf(1, setOf(2, 3))), "abc"),
+				setOf("one", 1L, setOf("a", 'b', setOf(1, setOf(2, 4))), "abc"), () -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable contents differ at index [2][2][1][1], expected: <3> but was: <4>");
+		}
+
+		try {
+			assertIterableEquals(listOf("j", listOf("a"), setOf(42), "ab", setOf(1, listOf(3))),
+				listOf("j", listOf("a"), setOf(42), "ab", setOf(1, listOf(5))), () -> "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageEndsWith(ex, "iterable contents differ at index [4][1][0], expected: <3> but was: <5>");
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/IterableFactory.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/IterableFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+final class IterableFactory {
+
+	static List<Object> listOf(Object... objects) {
+		return Arrays.asList(objects);
+	}
+
+	static Set<Object> setOf(Object... objects) {
+		return new LinkedHashSet<>(listOf(objects));
+	}
+
+}


### PR DESCRIPTION
## Overview

This is a follow-on to #167 to introduce prototype `assertIterableEquals` methods to `Assertions`.

Would the JUnit team find this contribution useful? If so, is there any way it could be improved?

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

