### PR TITLE
Document Timing Extension example for test execution callbacks

### DIFF
--- a/documentation/src/docs/asciidoc/extensions.adoc
+++ b/documentation/src/docs/asciidoc/extensions.adoc
@@ -154,6 +154,33 @@ within a single extension. Consult the source code of the `{SpringExtension}` fo
 concrete example.
 
 
+==== Before and After Test Execution Callbacks
+
+The `BeforeTestExecutionCallback` and `AfterTestExecutionCallback` `Extensions` define APIs
+for adding behavior that will be executed immediately before and after a test is
+run respectively.
+
+The following example shows how to use these methods to calculate and log the
+execution time of a test method. `TimingExecution` implements both `BeforeTestExecutionCallback`
+and `AfterTestExecutionCallback` so as to time and log the test execution.
+As `TimingExtensionTests` extends with `TimingExtension`, its tests will have this behavior
+applied when they execute.
+
+[source,java,indent=0]
+[subs="verbatim"]
+.An extension that times and logs the execution of test methods
+----
+include::{testDir}/example/timing/TimingExtension.java[tags=user_guide]
+----
+
+[source,java,indent=0]
+[subs="verbatim"]
+.A test class that logs its test execution times
+----
+include::{testDir}/example/timing/TimingExtensionTests.java[tags=user_guide]
+----
+
+
 === Exception Handling
 
 `{TestExecutionExceptionHandler}` defines the API for `Extensions` that wish to handle

--- a/documentation/src/docs/asciidoc/extensions.adoc
+++ b/documentation/src/docs/asciidoc/extensions.adoc
@@ -161,7 +161,7 @@ for adding behavior that will be executed immediately before and after a test is
 run respectively.
 
 The following example shows how to use these methods to calculate and log the
-execution time of a test method. `TimingExecution` implements both `BeforeTestExecutionCallback`
+execution time of a test method. `TimingExtension` implements both `BeforeTestExecutionCallback`
 and `AfterTestExecutionCallback` so as to time and log the test execution.
 As `TimingExtensionTests` extends with `TimingExtension`, its tests will have this behavior
 applied when they execute.

--- a/documentation/src/test/java/example/timing/TimingExtension.java
+++ b/documentation/src/test/java/example/timing/TimingExtension.java
@@ -25,6 +25,8 @@ import org.junit.gen5.api.extension.TestExtensionContext;
  *
  * @since 5.0
  */
+// @formatter:off
+// tag::user_guide[]
 public class TimingExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
 	private static final Logger LOG = Logger.getLogger(TimingExtension.class.getName());
@@ -46,5 +48,6 @@ public class TimingExtension implements BeforeTestExecutionCallback, AfterTestEx
 	private Store getStore(TestExtensionContext context) {
 		return context.getStore(Namespace.of(getClass(), context));
 	}
-
 }
+// end::user_guide[]
+// @formatter:on

--- a/documentation/src/test/java/example/timing/TimingExtensionTests.java
+++ b/documentation/src/test/java/example/timing/TimingExtensionTests.java
@@ -18,6 +18,8 @@ import org.junit.gen5.api.extension.ExtendWith;
  *
  * @since 5.0
  */
+// @formatter:off
+// tag::user_guide[]
 @ExtendWith(TimingExtension.class)
 class TimingExtensionTests {
 
@@ -30,5 +32,6 @@ class TimingExtensionTests {
 	void sleep50ms() throws Exception {
 		Thread.sleep(50);
 	}
-
 }
+// end::user_guide[]
+// @formatter:on


### PR DESCRIPTION
Added a paragraph to the extensions.adoc describing how to implement before- and after-execution callbacks, using the TimingExtension and TimingExtensionTests examples.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

