### PR TITLE
Make @API public to allow Extensions and TestEngines to adopt API semantics

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/meta/API.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/meta/API.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.commons.meta;
 
-import static org.junit.platform.commons.meta.API.Usage.Internal;
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
 @Retention(RetentionPolicy.CLASS)
 @Documented
-@API(Internal)
+@API(Experimental)
 public @interface API {
 
 	Usage value();


### PR DESCRIPTION
Making @API public allows Extension and TestEngine developers to adopt JUnit 5's API "typing".  This also makes the API tools proposed in #144 more useful as they'd be applicable to the other projects.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

