### PR TITLE
Make DiscoveryRequest immutable.

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestDiscoveryRequest.java
@@ -12,106 +12,19 @@ package org.junit.platform.launcher;
 
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.platform.commons.meta.API;
-import org.junit.platform.engine.DiscoveryFilter;
-import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 
 /**
  * {@code TestDiscoveryRequest} is an extension of {@link EngineDiscoveryRequest}
  * that provides access to filters which are applied by the {@link Launcher} itself.
  *
- * <p>Moreover, the {@code add*()} methods can be used by external clients that do
- * not want to use the {@link org.junit.platform.launcher.core.TestDiscoveryRequestBuilder}.
- *
  * @since 1.0
  */
 @API(Experimental)
 public interface TestDiscoveryRequest extends EngineDiscoveryRequest {
-
-	/**
-	 * Add the supplied {@code selector} to this request.
-	 *
-	 * @param selector the {@code DiscoverySelector} to add; never {@code null}
-	 */
-	void addSelector(DiscoverySelector selector);
-
-	/**
-	 * Add all of the supplied {@code selectors} to this request.
-	 *
-	 * @param selectors the {@code DiscoverySelectors} to add; never {@code null}
-	 */
-	void addSelectors(Collection<DiscoverySelector> selectors);
-
-	/**
-	 * Add the supplied {@code engineFilter} to this request.
-	 *
-	 * <p><strong>Warning</strong>: be cautious when registering multiple competing
-	 * {@link EngineFilter#includeEngines include} {@code EngineFilters} or multiple
-	 * competing {@link EngineFilter#excludeEngines exclude} {@code EngineFilters}
-	 * for the same discovery request since doing so will likely lead to
-	 * undesirable results (i.e., zero engines being active).
-	 *
-	 * @param engineFilter the {@code EngineFilter} to add; never {@code null}
-	 */
-	void addEngineFilter(EngineFilter engineFilter);
-
-	/**
-	 * Add all of the supplied {@code engineFilters} to this request.
-	 *
-	 * <p><strong>Warning</strong>: be cautious when registering multiple competing
-	 * {@link EngineFilter#includeEngines include} {@code EngineFilters} or multiple
-	 * competing {@link EngineFilter#excludeEngines exclude} {@code EngineFilters}
-	 * for the same discovery request since doing so will likely lead to
-	 * undesirable results (i.e., zero engines being active).
-	 *
-	 * @param engineFilters the {@code EngineFilters} to add; never {@code null}
-	 */
-	void addEngineFilters(Collection<EngineFilter> engineFilters);
-
-	/**
-	 * Add the supplied {@code discoveryFilter} to this request.
-	 *
-	 * @param discoveryFilter the {@code DiscoveryFilter} to add;
-	 * never {@code null}
-	 */
-	void addFilter(DiscoveryFilter<?> discoveryFilter);
-
-	/**
-	 * Add all of the supplied {@code discoveryFilters} to this request.
-	 *
-	 * @param discoveryFilters the {@code DiscoveryFilters} to add;
-	 * never {@code null}
-	 */
-	void addFilters(Collection<DiscoveryFilter<?>> discoveryFilters);
-
-	/**
-	 * Add the supplied {@code postDiscoveryFilter} to this request.
-	 *
-	 * @param postDiscoveryFilter the {@code PostDiscoveryFilter} to add;
-	 * never {@code null}
-	 */
-	void addPostFilter(PostDiscoveryFilter postDiscoveryFilter);
-
-	/**
-	 * Add all of the supplied {@code postDiscoveryFilters} to this request.
-	 *
-	 * @param postDiscoveryFilters the {@code PostDiscoveryFilters} to add;
-	 * never {@code null}
-	 */
-	void addPostFilters(Collection<PostDiscoveryFilter> postDiscoveryFilters);
-
-	/**
-	 * Add the supplied configuration parameters to this request.
-	 *
-	 * @param configurationParameters the map of configuration parameters to add;
-	 * never {@code null}
-	 */
-	void addConfigurationParameters(Map<String, String> configurationParameters);
 
 	/**
 	 * Get the {@code EngineFilters} that have been added to this request.

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryRequest.java
@@ -13,10 +13,7 @@ package org.junit.platform.launcher.core;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
-import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.ConfigurationParameters;
@@ -54,65 +51,28 @@ import org.junit.platform.launcher.TestDiscoveryRequest;
 final class DiscoveryRequest implements TestDiscoveryRequest {
 
 	// Selectors provided to the engines to be used for discovering tests
-	private final List<DiscoverySelector> selectors = new LinkedList<>();
+	private final List<DiscoverySelector> selectors;
 
 	// Filters based on engines
-	private final List<EngineFilter> engineFilters = new LinkedList<>();
+	private final List<EngineFilter> engineFilters;
 
 	// Discovery filters are handed through to all engines to be applied during discovery.
-	private final List<DiscoveryFilter<?>> discoveryFilters = new LinkedList<>();
+	private final List<DiscoveryFilter<?>> discoveryFilters;
 
 	// Descriptor filters are applied by the launcher itself after engines have performed discovery.
-	private final List<PostDiscoveryFilter> postDiscoveryFilters = new LinkedList<>();
+	private final List<PostDiscoveryFilter> postDiscoveryFilters;
 
 	// Configuration parameters can be used to provide custom configuration to engines, e.g. for extensions
-	private final LauncherConfigurationParameters configurationParameters = new LauncherConfigurationParameters();
+	private final LauncherConfigurationParameters configurationParameters;
 
-	@Override
-	public void addSelector(DiscoverySelector selector) {
-		this.selectors.add(selector);
-	}
-
-	@Override
-	public void addSelectors(Collection<DiscoverySelector> selectors) {
-		Preconditions.notNull(selectors, "selectors must not be null");
-		selectors.forEach(this::addSelector);
-	}
-
-	@Override
-	public void addEngineFilter(EngineFilter engineFilter) {
-		Preconditions.notNull(engineFilter, "engineFilter must not be null");
-		this.engineFilters.add(engineFilter);
-	}
-
-	@Override
-	public void addEngineFilters(Collection<EngineFilter> engineFilters) {
-		Preconditions.notNull(engineFilters, "engineFilters must not be null");
-		this.engineFilters.addAll(engineFilters);
-	}
-
-	@Override
-	public void addFilter(DiscoveryFilter<?> discoveryFilter) {
-		Preconditions.notNull(discoveryFilter, "discoveryFilter must not be null");
-		this.discoveryFilters.add(discoveryFilter);
-	}
-
-	@Override
-	public void addFilters(Collection<DiscoveryFilter<?>> discoveryFilters) {
-		Preconditions.notNull(discoveryFilters, "discoveryFilters must not be null");
-		this.discoveryFilters.addAll(discoveryFilters);
-	}
-
-	@Override
-	public void addPostFilter(PostDiscoveryFilter postDiscoveryFilter) {
-		Preconditions.notNull(postDiscoveryFilter, "postDiscoveryFilter must not be null");
-		this.postDiscoveryFilters.add(postDiscoveryFilter);
-	}
-
-	@Override
-	public void addPostFilters(Collection<PostDiscoveryFilter> postDiscoveryFilters) {
-		Preconditions.notNull(postDiscoveryFilters, "postDiscoveryFilters must not be null");
-		this.postDiscoveryFilters.addAll(postDiscoveryFilters);
+	DiscoveryRequest(List<DiscoverySelector> selectors, List<EngineFilter> engineFilters,
+			List<DiscoveryFilter<?>> discoveryFilters, List<PostDiscoveryFilter> postDiscoveryFilters,
+			LauncherConfigurationParameters configurationParameters) {
+		this.selectors = selectors;
+		this.engineFilters = engineFilters;
+		this.discoveryFilters = discoveryFilters;
+		this.postDiscoveryFilters = postDiscoveryFilters;
+		this.configurationParameters = configurationParameters;
 	}
 
 	@Override
@@ -140,12 +100,6 @@ final class DiscoveryRequest implements TestDiscoveryRequest {
 	@Override
 	public List<PostDiscoveryFilter> getPostDiscoveryFilters() {
 		return unmodifiableList(this.postDiscoveryFilters);
-	}
-
-	@Override
-	public void addConfigurationParameters(Map<String, String> configurationParameters) {
-		Preconditions.notNull(configurationParameters, "configurationParameters must not be null");
-		this.configurationParameters.addAll(configurationParameters);
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.launcher.core;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -23,7 +22,12 @@ import org.junit.platform.engine.ConfigurationParameters;
  */
 class LauncherConfigurationParameters implements ConfigurationParameters {
 
-	private final Map<String, String> configurationParameters = new HashMap<>();
+	private final Map<String, String> configurationParameters;
+
+	LauncherConfigurationParameters(Map<String, String> configurationParameters) {
+		Preconditions.notNull(configurationParameters, "configuration parameters must not be null");
+		this.configurationParameters = configurationParameters;
+	}
 
 	@Override
 	public Optional<String> get(String key) {
@@ -43,10 +47,6 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 	@Override
 	public int size() {
 		return this.configurationParameters.size();
-	}
-
-	void addAll(Map<String, String> configurationParameters) {
-		this.configurationParameters.putAll(configurationParameters);
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestDiscoveryRequestBuilder.java
@@ -81,6 +81,8 @@ public final class TestDiscoveryRequestBuilder {
 
 	/**
 	 * Add all of the supplied {@code selectors} to the request.
+	 *
+	 * @param selectors the {@code DiscoverySelectors} to add
 	 */
 	public TestDiscoveryRequestBuilder selectors(DiscoverySelector... selectors) {
 		if (selectors != null) {
@@ -91,6 +93,8 @@ public final class TestDiscoveryRequestBuilder {
 
 	/**
 	 * Add all of the supplied {@code selectors} to the request.
+	 *
+	 * @param selectors the {@code DiscoverySelectors} to add
 	 */
 	public TestDiscoveryRequestBuilder selectors(List<DiscoverySelector> selectors) {
 		if (selectors != null) {
@@ -101,6 +105,14 @@ public final class TestDiscoveryRequestBuilder {
 
 	/**
 	 * Add all of the supplied {@code filters} to the request.
+	 *
+	 * <p><strong>Warning</strong>: be cautious when registering multiple competing
+	 * {@link EngineFilter#includeEngines include} {@code EngineFilters} or multiple
+	 * competing {@link EngineFilter#excludeEngines exclude} {@code EngineFilters}
+	 * for the same discovery request since doing so will likely lead to
+	 * undesirable results (i.e., zero engines being active).
+	 *
+	 * @param filters the {@code Filter}s to add
 	 */
 	public TestDiscoveryRequestBuilder filters(Filter<?>... filters) {
 		if (filters != null) {
@@ -120,6 +132,8 @@ public final class TestDiscoveryRequestBuilder {
 
 	/**
 	 * Add all of the supplied {@code configurationParameters} to the request.
+	 *
+	 * @param configurationParameters the map of configuration parameters to add
 	 */
 	public TestDiscoveryRequestBuilder configurationParameters(Map<String, String> configurationParameters) {
 		if (configurationParameters != null) {
@@ -150,13 +164,10 @@ public final class TestDiscoveryRequestBuilder {
 	 * this builder.
 	 */
 	public TestDiscoveryRequest build() {
-		DiscoveryRequest discoveryRequest = new DiscoveryRequest();
-		discoveryRequest.addSelectors(this.selectors);
-		discoveryRequest.addEngineFilters(this.engineFilters);
-		discoveryRequest.addFilters(this.discoveryFilters);
-		discoveryRequest.addPostFilters(this.postDiscoveryFilters);
-		discoveryRequest.addConfigurationParameters(this.configurationParameters);
-		return discoveryRequest;
+		LauncherConfigurationParameters launcherConfigurationParameters = new LauncherConfigurationParameters(
+			this.configurationParameters);
+		return new DiscoveryRequest(this.selectors, this.engineFilters, this.discoveryFilters,
+			this.postDiscoveryFilters, launcherConfigurationParameters);
 	}
 
 }

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
@@ -38,6 +38,7 @@ import org.junit.platform.launcher.TestDiscoveryRequest;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.core.TestDiscoveryRequestBuilder;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.manipulation.Filter;
@@ -122,19 +123,19 @@ public class JUnitPlatform extends Runner implements Filterable {
 			selectors.add(selectClass(this.testClass));
 		}
 
-		TestDiscoveryRequest request = request().selectors(selectors).build();
-		addFiltersFromAnnotations(request);
-		return request;
+		TestDiscoveryRequestBuilder requestBuilder = request().selectors(selectors);
+		addFiltersFromAnnotations(requestBuilder);
+		return requestBuilder.build();
 	}
 
-	private void addFiltersFromAnnotations(TestDiscoveryRequest request) {
-		addIncludeClassNamePatternFilter(request);
+	private void addFiltersFromAnnotations(TestDiscoveryRequestBuilder requestBuilder) {
+		addIncludeClassNamePatternFilter(requestBuilder);
 
-		addIncludedTagsFilter(request);
-		addExcludedTagsFilter(request);
+		addIncludedTagsFilter(requestBuilder);
+		addExcludedTagsFilter(requestBuilder);
 
-		addIncludedEnginesFilter(request);
-		addExcludedEnginesFilter(request);
+		addIncludedEnginesFilter(requestBuilder);
+		addExcludedEnginesFilter(requestBuilder);
 	}
 
 	private List<DiscoverySelector> getSelectorsFromAnnotations() {
@@ -150,38 +151,38 @@ public class JUnitPlatform extends Runner implements Filterable {
 		return stream(sourceElements).map(transformer).collect(toList());
 	}
 
-	private void addIncludeClassNamePatternFilter(TestDiscoveryRequest discoveryRequest) {
+	private void addIncludeClassNamePatternFilter(TestDiscoveryRequestBuilder requestBuilder) {
 		String pattern = getIncludeClassNamePattern();
 		if (!pattern.isEmpty()) {
-			discoveryRequest.addFilter(includeClassNamePattern(pattern));
+			requestBuilder.filters(includeClassNamePattern(pattern));
 		}
 	}
 
-	private void addIncludedTagsFilter(TestDiscoveryRequest discoveryRequest) {
+	private void addIncludedTagsFilter(TestDiscoveryRequestBuilder requestBuilder) {
 		String[] includedTags = getIncludedTags();
 		if (includedTags.length > 0) {
-			discoveryRequest.addPostFilter(includeTags(includedTags));
+			requestBuilder.filters(includeTags(includedTags));
 		}
 	}
 
-	private void addExcludedTagsFilter(TestDiscoveryRequest discoveryRequest) {
+	private void addExcludedTagsFilter(TestDiscoveryRequestBuilder requestBuilder) {
 		String[] excludedTags = getExcludedTags();
 		if (excludedTags.length > 0) {
-			discoveryRequest.addPostFilter(excludeTags(excludedTags));
+			requestBuilder.filters(excludeTags(excludedTags));
 		}
 	}
 
-	private void addIncludedEnginesFilter(TestDiscoveryRequest discoveryRequest) {
+	private void addIncludedEnginesFilter(TestDiscoveryRequestBuilder requestBuilder) {
 		String[] engineIds = getIncludedEngineIds();
 		if (engineIds.length > 0) {
-			discoveryRequest.addEngineFilter(includeEngines(engineIds));
+			requestBuilder.filters(includeEngines(engineIds));
 		}
 	}
 
-	private void addExcludedEnginesFilter(TestDiscoveryRequest discoveryRequest) {
+	private void addExcludedEnginesFilter(TestDiscoveryRequestBuilder requestBuilder) {
 		String[] engineIds = getExcludedEngineIds();
 		if (engineIds.length > 0) {
-			discoveryRequest.addEngineFilter(excludeEngines(engineIds));
+			requestBuilder.filters(excludeEngines(engineIds));
 		}
 	}
 


### PR DESCRIPTION
## Overview

Avoid code duplication with `TestDiscoveryRequestBuilder`. Having two objects with similar responsibility is confusing, too. For the reader it is unclear which one to use.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.