### PR TITLE
Delete EngineDiscoveryRequest.getSelectors().

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
@@ -37,11 +37,6 @@ import org.junit.platform.commons.meta.API;
 public interface EngineDiscoveryRequest {
 
 	/**
-	 * Get the {@link DiscoverySelector DiscoverySelectors} of this request.
-	 */
-	List<DiscoverySelector> getSelectors();
-
-	/**
 	 * Get the {@link DiscoverySelector DiscoverySelectors} of this request,
 	 * filtered by a particular type.
 	 *

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryRequest.java
@@ -116,11 +116,6 @@ final class DiscoveryRequest implements TestDiscoveryRequest {
 	}
 
 	@Override
-	public List<DiscoverySelector> getSelectors() {
-		return unmodifiableList(this.selectors);
-	}
-
-	@Override
 	public <T extends DiscoverySelector> List<T> getSelectorsByType(Class<T> selectorType) {
 		Preconditions.notNull(selectorType, "selectorType must not be null");
 		return this.selectors.stream().filter(selectorType::isInstance).map(selectorType::cast).collect(toList());

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DiscoveryRequestTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DiscoveryRequestTests.java
@@ -10,15 +10,11 @@
 
 package org.junit.platform.launcher.core;
 
-import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.platform.engine.discovery.NameBasedSelectors.selectName;
 import static org.junit.platform.engine.discovery.UniqueIdSelector.selectUniqueId;
 import static org.junit.platform.launcher.core.TestDiscoveryRequestBuilder.request;
-
-import java.util.Arrays;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.DiscoverySelector;
@@ -65,10 +61,10 @@ public class DiscoveryRequestTests {
 		).build();
 		// @formatter:on
 
-		assertNotNull(spec);
-		List<Class<? extends DiscoverySelector>> expected = Arrays.asList(UniqueIdSelector.class, ClassSelector.class,
-			PackageSelector.class, MethodSelector.class);
-		assertEquals(expected, spec.getSelectors().stream().map(Object::getClass).collect(toList()));
+		assertAll(() -> assertEquals(1, spec.getSelectorsByType(ClassSelector.class).size()),
+			() -> assertEquals(1, spec.getSelectorsByType(MethodSelector.class).size()),
+			() -> assertEquals(1, spec.getSelectorsByType(PackageSelector.class).size()),
+			() -> assertEquals(1, spec.getSelectorsByType(UniqueIdSelector.class).size()));
 	}
 
 	private String fullyQualifiedMethodName() throws Exception {

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -83,8 +83,9 @@ class JUnitPlatformRunnerTests {
 
 			TestDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			assertThat(request.getSelectors()).hasSize(1);
-			ClassSelector classSelector = getOnlyElement(request.getSelectorsByType(ClassSelector.class));
+			List<ClassSelector> selectors = request.getSelectorsByType(ClassSelector.class);
+			assertThat(selectors).hasSize(1);
+			ClassSelector classSelector = getOnlyElement(selectors);
 			assertEquals(TestCase.class, classSelector.getJavaClass());
 		}
 
@@ -97,8 +98,8 @@ class JUnitPlatformRunnerTests {
 
 			TestDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			assertThat(request.getSelectors()).hasSize(2);
 			List<ClassSelector> selectors = request.getSelectorsByType(ClassSelector.class);
+			assertThat(selectors).hasSize(2);
 			assertEquals(Short.class, selectors.get(0).getJavaClass());
 			assertEquals(Byte.class, selectors.get(1).getJavaClass());
 		}
@@ -112,8 +113,8 @@ class JUnitPlatformRunnerTests {
 
 			TestDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			assertThat(request.getSelectors()).hasSize(2);
 			List<PackageSelector> selectors = request.getSelectorsByType(PackageSelector.class);
+			assertThat(selectors).hasSize(2);
 			assertEquals("foo", selectors.get(0).getPackageName());
 			assertEquals("bar", selectors.get(1).getPackageName());
 		}


### PR DESCRIPTION
## Overview

This method is only used by tests. Production code always uses the method `getSelectorsByType`. By removing the method `getSelectors()` we have one method less that has to be supported and may constrain future decisions.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.