### PR TITLE
Remove abandoned TODO about configuring Launcher.

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ExecuteTestsTask.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ExecuteTestsTask.java
@@ -54,8 +54,6 @@ public class ExecuteTestsTask implements ConsoleTask {
 
 	private int executeTests(PrintWriter out) {
 		Launcher launcher = launcherSupplier.get();
-		// TODO Configure launcher?
-
 		SummaryGeneratingListener summaryListener = registerListeners(out, launcher);
 
 		TestDiscoveryRequest discoveryRequest = new DiscoveryRequestCreator().toDiscoveryRequest(options);


### PR DESCRIPTION
## Overview

The TODO is there since the beginning. The current `Launcher` interface does no allow any configuration except of adding listeners.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

