### PR TITLE
Always use status code on exit.

### DIFF
--- a/documentation/src/docs/asciidoc/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/running-tests.adoc
@@ -232,6 +232,9 @@ Test run finished after 29 ms
 [         0 tests failed    ]
 ----
 
+The `{ConsoleRunner}` exits with status code 0 if no test failed. In case of at
+least one failing test the status code is 1.
+
 ==== Options
 
 _Caution:_ These options are very likely to change as we continue to work towards the
@@ -264,8 +267,6 @@ Option                       Description
 -r, --xml-reports-dir        Enable XML report output into a specified local
                                directory (will be created if it does not
                                exist).
--x, --enable-exit-code       Exit process with number of failing tests as
-                               exit code.
 -C, --disable-ansi-colors    Disable colored output (not supported by all
                                terminals).
 -D, --hide-details           Hide details while tests are being executed.

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -24,7 +24,6 @@ class AvailableOptions {
 	private final OptionParser parser = new OptionParser();
 
 	private final OptionSpec<Void> help;
-	private final OptionSpec<Void> enableExitCode;
 	private final OptionSpec<Void> disableAnsiColors;
 	private final OptionSpec<Void> runAllTests;
 	private final OptionSpec<Void> hideDetails;
@@ -69,7 +68,7 @@ class AvailableOptions {
 			"Enable XML report output into a specified local directory (will be created if it does not exist).") //
 				.withRequiredArg();
 
-		enableExitCode = parser.acceptsAll(asList("x", "enable-exit-code"), //
+		parser.acceptsAll(asList("x", "enable-exit-code"), //
 			"Exit process with number of failing tests as exit code.");
 		disableAnsiColors = parser.acceptsAll(asList("C", "disable-ansi-colors"),
 			"Disable colored output (not supported by all terminals).");
@@ -91,7 +90,6 @@ class AvailableOptions {
 		CommandLineOptions result = new CommandLineOptions();
 
 		result.setDisplayHelp(detectedOptions.has(this.help));
-		result.setExitCodeEnabled(detectedOptions.has(this.enableExitCode));
 		result.setAnsiColorOutputDisabled(detectedOptions.has(this.disableAnsiColors));
 		result.setRunAllTests(detectedOptions.has(this.runAllTests));
 		result.setHideDetails(detectedOptions.has(this.hideDetails));

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
@@ -25,7 +25,6 @@ import org.junit.platform.commons.meta.API;
 public class CommandLineOptions {
 
 	private boolean displayHelp;
-	private boolean exitCodeEnabled;
 	private boolean ansiColorOutputDisabled;
 	private boolean runAllTests;
 	private boolean hideDetails;
@@ -50,14 +49,6 @@ public class CommandLineOptions {
 
 	public void setDisplayHelp(boolean displayHelp) {
 		this.displayHelp = displayHelp;
-	}
-
-	public boolean isExitCodeEnabled() {
-		return this.exitCodeEnabled;
-	}
-
-	public void setExitCodeEnabled(boolean exitCodeEnabled) {
-		this.exitCodeEnabled = exitCodeEnabled;
 	}
 
 	public boolean isAnsiColorOutputDisabled() {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTask.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTask.java
@@ -30,6 +30,11 @@ public interface ConsoleTask {
 	int SUCCESS = 0;
 
 	/**
+	 * Exit code indicating test failure(s)
+	 */
+	int TESTS_FAILED = 1;
+
+	/**
 	 * Execute this task and return an exit code.
 	 *
 	 * @param out writer for console output

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ExecuteTestsTask.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ExecuteTestsTask.java
@@ -98,10 +98,9 @@ public class ExecuteTestsTask implements ConsoleTask {
 	}
 
 	private int computeExitCode(TestExecutionSummary summary) {
-		if (options.isExitCodeEnabled()) {
-			long failedTests = summary.getTestsFailedCount();
-			return (int) Math.min(Integer.MAX_VALUE, failedTests);
+		if (summary.getTestsFailedCount() == 0) {
+			return SUCCESS;
 		}
-		return SUCCESS;
+		return TESTS_FAILED;
 	}
 }

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -90,7 +90,7 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 
 	private ArrayList<String> buildArgs(project, junitExtension, reportsDir) {
 
-		def args = ['--enable-exit-code', '--hide-details', '--all']
+		def args = ['--hide-details', '--all']
 
 		if (junitExtension.includeClassNamePattern) {
 			args.add('-n')

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/gen5/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/gen5/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -98,7 +98,6 @@ class JUnitPlatformPluginSpec extends Specification {
 			junitTask instanceof JavaExec
 			junitTask.main == ConsoleRunner.class.getName()
 
-			junitTask.args.contains('--enable-exit-code')
 			junitTask.args.contains('--hide-details')
 			junitTask.args.contains('--all')
 			junitTask.args.containsAll('-n', '.*Tests?')

--- a/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
@@ -46,7 +46,6 @@ class JOptSimpleCommandLineOptionsParserTests {
 		assertAll(
 			() -> assertFalse(options.isAnsiColorOutputDisabled()),
 			() -> assertFalse(options.isDisplayHelp()),
-			() -> assertFalse(options.isExitCodeEnabled()),
 			() -> assertFalse(options.isHideDetails()),
 			() -> assertFalse(options.isRunAllTests()),
 			() -> assertEquals(Optional.empty(), options.getIncludeClassNamePattern()),
@@ -64,7 +63,6 @@ class JOptSimpleCommandLineOptionsParserTests {
 		assertAll(
 			() -> assertParses("disable ansi", CommandLineOptions::isAnsiColorOutputDisabled, "-C", "--disable-ansi-colors"),
 			() -> assertParses("help", CommandLineOptions::isDisplayHelp, "-h", "--help"),
-			() -> assertParses("exit code", CommandLineOptions::isExitCodeEnabled, "-x", "--enable-exit-code"),
 			() -> assertParses("hide details", CommandLineOptions::isHideDetails, "-D", "--hide-details"),
 			() -> assertParses("run all tests", CommandLineOptions::isRunAllTests, "-a", "--all")
 		);

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/ExecuteTestsTaskTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/ExecuteTestsTaskTests.java
@@ -104,25 +104,9 @@ public class ExecuteTestsTaskTests {
 	}
 
 	@Test
-	public void hasStatusCode0EvenForFailingTestIfExitCodeIsNotEnabled() throws Exception {
+	public void hasStatusCode0ForSucceedingTest() throws Exception {
 		CommandLineOptions options = new CommandLineOptions();
 		options.setRunAllTests(true);
-		options.setExitCodeEnabled(false);
-
-		DummyTestEngine dummyTestEngine = new DummyTestEngine();
-		dummyTestEngine.addTest("failingTest", FAILING_TEST);
-
-		ExecuteTestsTask task = new ExecuteTestsTask(options, () -> createLauncher(dummyTestEngine));
-		int exitCode = task.execute(dummyWriter());
-
-		assertThat(exitCode).isEqualTo(0);
-	}
-
-	@Test
-	public void hasStatusCode0ForSucceedingTestIfExitCodeIsEnabled() throws Exception {
-		CommandLineOptions options = new CommandLineOptions();
-		options.setRunAllTests(true);
-		options.setExitCodeEnabled(true);
 
 		DummyTestEngine dummyTestEngine = new DummyTestEngine();
 		dummyTestEngine.addTest("succeedingTest", SUCCEEDING_TEST);
@@ -134,19 +118,17 @@ public class ExecuteTestsTaskTests {
 	}
 
 	@Test
-	public void hasStatusCodeEqualToNumberOfFailingTestsIfExitCodeIsEnabled() throws Exception {
+	public void hasStatusCode1ForFailingTests() throws Exception {
 		CommandLineOptions options = new CommandLineOptions();
 		options.setRunAllTests(true);
-		options.setExitCodeEnabled(true);
 
 		DummyTestEngine dummyTestEngine = new DummyTestEngine();
-		dummyTestEngine.addTest("firstFailingTest", FAILING_TEST);
-		dummyTestEngine.addTest("secondFailingTest", FAILING_TEST);
+		dummyTestEngine.addTest("failingTest", FAILING_TEST);
 
 		ExecuteTestsTask task = new ExecuteTestsTask(options, () -> createLauncher(dummyTestEngine));
 		int exitCode = task.execute(dummyWriter());
 
-		assertThat(exitCode).isEqualTo(2);
+		assertThat(exitCode).isEqualTo(1);
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

In general I consider it helpful to always return a status code that is not 0 in case of a failure. This makes it easy for scripts to decide whether all tests succeeded. In addition I cannot imagine any use case that relies on returning 0 in case of a failure.

The old implementation returned the number of failing tests as status code if the flag `enable-exit-code` has been set. But this is only possible for a small number (< 256) of failing tests. The problem was that n*256 failing tests have been reported as 0 failing tests and therefore could not be distinguished from a successful run via status code.

The parser in `AvailableOptions` still accepts the `enable-exit-code` flag because the project is build with an older version of the Gradle plugin from https://oss.sonatype.org/content/repositories/snapshots The parser does not to have accept the flag anymore once a new version of the Gradle plugin is pushed to the snapshot repository.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.