### PR TITLE
Don't accept flag enable-exit-code.

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -68,8 +68,6 @@ class AvailableOptions {
 			"Enable XML report output into a specified local directory (will be created if it does not exist).") //
 				.withRequiredArg();
 
-		parser.acceptsAll(asList("x", "enable-exit-code"), //
-			"Exit process with number of failing tests as exit code.");
 		disableAnsiColors = parser.acceptsAll(asList("C", "disable-ansi-colors"),
 			"Disable colored output (not supported by all terminals).");
 		hideDetails = parser.acceptsAll(asList("D", "hide-details"),


### PR DESCRIPTION
## Overview

This is a follow-up to e568a3563c417829a20eec988daa98797c8391b3. That commit removed support for the flag `enable-exit-code`. It is already deployed to the snapshot repository. Therefore we can now remove support for this flag from `AvailableOptions`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.