### PR TITLE
Make @API annotation available via Java reflection

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/meta/API.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/meta/API.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * @since 1.0
  */
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(Internal)
 public @interface API {


### PR DESCRIPTION
`API` annotation could be retrieved from byte code (e.g. by using `org.reflections`), however it would be much more convenient (for #144) to retrieve annotations via _Java Reflection_.

---
I hereby agree to the terms of the JUnit Contributor License Agreement.

