### PR TITLE
User guide fix: @InjectMock -> @Mock

### DIFF
--- a/documentation/src/docs/asciidoc/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/writing-tests.adoc
@@ -209,21 +209,22 @@ Other parameter resolvers must be explicitly enabled by registering appropriate
 [source,java,indent=0]
 [subs="verbatim"]
 ----
+import com.example.mockito.MockitoExtension;
 import org.junit.jupiter.api.*;
+import org.mockito.Mock;
 
 import static org.mockito.Mockito.when;
-import com.example.mockito.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MyMockitoTest {
 
 	@BeforeEach
-	void init(@InjectMock Person person) {
+	void init(@Mock Person person) {
 		when(person.getName()).thenReturn("Dilbert");
 	}
 
 	@Test
-	void simpleTestWithInjectedMock(@InjectMock Person person) {
+	void simpleTestWithInjectedMock(@Mock Person person) {
 		assertEquals("Dilbert", person.getName());
 	}
 


### PR DESCRIPTION
User guide fix: #376 
I have found only 2 instances of `@InjectMock`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

