### PR TITLE
Replace reference to `ConsoleRunner` with `ConsoleLauncher`

### DIFF
--- a/junit-platform-console/junit-platform-console.gradle
+++ b/junit-platform-console/junit-platform-console.gradle
@@ -5,4 +5,4 @@ dependencies {
 	compile('net.sf.jopt-simple:jopt-simple:5.0.2')
 }
 
-mainClassName = "org.junit.platform.console.ConsoleRunner"
+mainClassName = "org.junit.platform.console.ConsoleLauncher"


### PR DESCRIPTION
The script in the [M1 ConsoleLauncher-ZIP](https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console/1.0.0-M1/junit-platform-console-1.0.0-M1.zip) ends with

    exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.junit.platform.console.ConsoleRunner "$@"

But the class is now called `ConsoleLauncher`.

The proposed change seems to fix the only reference to `ConsoleRunner`, so I assume the script is generated from this information?

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

