### PR TITLE
Use assertThrows instead of expectThrows.

### DIFF
--- a/documentation/src/test/java/example/TestingAStackDemo.java
+++ b/documentation/src/test/java/example/TestingAStackDemo.java
@@ -50,13 +50,13 @@ class TestingAStackDemo {
 		@Test
 		@DisplayName("throws EmptyStackException when popped")
 		void throwsExceptionWhenPopped() {
-			Assertions.expectThrows(EmptyStackException.class, () -> stack.pop());
+			Assertions.assertThrows(EmptyStackException.class, () -> stack.pop());
 		}
 
 		@Test
 		@DisplayName("throws EmptyStackException when peeked")
 		void throwsExceptionWhenPeeked() {
-			Assertions.expectThrows(EmptyStackException.class, () -> stack.peek());
+			Assertions.assertThrows(EmptyStackException.class, () -> stack.peek());
 		}
 
 		@Nested


### PR DESCRIPTION
According to our own documentation `assertThrows` should be used if the test does not deal with the return value of `expectThrows`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
