### PR TITLE
Fix nullSafeToString NullException

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
@@ -93,7 +93,7 @@ public final class StringUtils {
 		if (classes == null || classes.length == 0) {
 			return "";
 		}
-		return stream(classes).map(mapper).collect(joining(", "));
+		return stream(classes).map(v -> v == null ? "" : mapper.apply(v)).collect(joining(", "));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/StringUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/StringUtilsTests.java
@@ -36,6 +36,8 @@ class StringUtilsTests {
 		assertEquals("", StringUtils.nullSafeToString());
 		assertEquals("java.lang.String", StringUtils.nullSafeToString(String.class));
 		assertEquals("java.lang.String, java.lang.Integer", StringUtils.nullSafeToString(String.class, Integer.class));
+		assertEquals("java.lang.String, , java.lang.Integer",
+			StringUtils.nullSafeToString(String.class, null, Integer.class));
 	}
 
 }


### PR DESCRIPTION
## Overview

-

Fix that when call like StringUtils.nullSafeToString(String.class, null, Integer.class) there throws a NullException.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

