### PR TITLE
HierarchicalTestEngine is no longer a generic type.

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/JupiterTestEngine.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/JupiterTestEngine.java
@@ -21,13 +21,14 @@ import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine;
 
 /**
  * @since 5.0
  */
 @API(Experimental)
-public class JupiterTestEngine extends HierarchicalTestEngine<JupiterEngineExecutionContext> {
+public class JupiterTestEngine extends HierarchicalTestEngine {
 
 	public static final String ENGINE_ID = "junit-jupiter";
 
@@ -57,7 +58,7 @@ public class JupiterTestEngine extends HierarchicalTestEngine<JupiterEngineExecu
 	}
 
 	@Override
-	protected JupiterEngineExecutionContext createExecutionContext(ExecutionRequest request) {
+	protected EngineExecutionContext createExecutionContext(ExecutionRequest request) {
 		return new JupiterEngineExecutionContext(request.getEngineExecutionListener(),
 			request.getConfigurationParameters());
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestEngine.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestEngine.java
@@ -20,12 +20,11 @@ import org.junit.platform.engine.TestEngine;
  * Abstract base class for all {@link TestEngine} implementations that wish
  * to organize test suites hierarchically based on the {@link Node} abstraction.
  *
- * @param <C> the type of {@code EngineExecutionContext} used by this engine
  * @since 1.0
  * @see Node
  */
 @API(Experimental)
-public abstract class HierarchicalTestEngine<C extends EngineExecutionContext> implements TestEngine {
+public abstract class HierarchicalTestEngine implements TestEngine {
 
 	/**
 	 * Create an initial {@linkplain #createExecutionContext execution
@@ -40,7 +39,7 @@ public abstract class HierarchicalTestEngine<C extends EngineExecutionContext> i
 	 */
 	@Override
 	public final void execute(ExecutionRequest request) {
-		new HierarchicalTestExecutor<>(request, createExecutionContext(request)).execute();
+		new HierarchicalTestExecutor(request, createExecutionContext(request)).execute();
 	}
 
 	/**
@@ -50,6 +49,6 @@ public abstract class HierarchicalTestEngine<C extends EngineExecutionContext> i
 	 * @param request the request about to be executed
 	 * @return the initial context that will be passed to nodes in the hierarchy
 	 */
-	protected abstract C createExecutionContext(ExecutionRequest request);
+	protected abstract EngineExecutionContext createExecutionContext(ExecutionRequest request);
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
@@ -29,19 +29,17 @@ import org.junit.platform.engine.support.hierarchical.Node.SkipResult;
  * executing nodes in the hierarchy in the appropriate order as well as
  * firing the necessary events in the {@link EngineExecutionListener}.
  *
- * @param <C> the type of {@code EngineExecutionContext} used by the
- * {@code HierarchicalTestEngine}
  * @since 1.0
  */
-class HierarchicalTestExecutor<C extends EngineExecutionContext> {
+class HierarchicalTestExecutor {
 
 	private static final SingleTestExecutor singleTestExecutor = new SingleTestExecutor();
 
 	private final TestDescriptor rootTestDescriptor;
 	private final EngineExecutionListener listener;
-	private final C rootContext;
+	private final EngineExecutionContext rootContext;
 
-	HierarchicalTestExecutor(ExecutionRequest request, C rootContext) {
+	HierarchicalTestExecutor(ExecutionRequest request, EngineExecutionContext rootContext) {
 		this.rootTestDescriptor = request.getRootTestDescriptor();
 		this.listener = request.getEngineExecutionListener();
 		this.rootContext = rootContext;
@@ -51,10 +49,10 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 		execute(this.rootTestDescriptor, this.rootContext);
 	}
 
-	private void execute(TestDescriptor testDescriptor, C parentContext) {
-		Node<C> node = asNode(testDescriptor);
+	private void execute(TestDescriptor testDescriptor, EngineExecutionContext parentContext) {
+		Node<EngineExecutionContext> node = asNode(testDescriptor);
 
-		C preparedContext;
+		EngineExecutionContext preparedContext;
 		try {
 			preparedContext = node.prepare(parentContext);
 			SkipResult skipResult = node.shouldBeSkipped(preparedContext);
@@ -75,7 +73,7 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 		this.listener.executionStarted(testDescriptor);
 
 		TestExecutionResult result = singleTestExecutor.executeSafely(() -> {
-			C context = preparedContext;
+			EngineExecutionContext context = preparedContext;
 			try {
 				context = node.before(context);
 				context = node.execute(context);
@@ -98,8 +96,8 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 	}
 
 	@SuppressWarnings("unchecked")
-	private Node<C> asNode(TestDescriptor testDescriptor) {
-		return (testDescriptor instanceof Node ? (Node<C>) testDescriptor : noOpNode);
+	private Node<EngineExecutionContext> asNode(TestDescriptor testDescriptor) {
+		return (testDescriptor instanceof Node ? (Node<EngineExecutionContext>) testDescriptor : noOpNode);
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DummyTestEngine.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DummyTestEngine.java
@@ -22,7 +22,7 @@ import org.junit.platform.engine.support.descriptor.JavaMethodSource;
 /**
  * @since 1.0
  */
-public final class DummyTestEngine extends HierarchicalTestEngine<DummyEngineExecutionContext> {
+public final class DummyTestEngine extends HierarchicalTestEngine {
 
 	private final String engineId;
 	private final DummyEngineDescriptor engineDescriptor;
@@ -87,7 +87,7 @@ public final class DummyTestEngine extends HierarchicalTestEngine<DummyEngineExe
 	}
 
 	@Override
-	protected DummyEngineExecutionContext createExecutionContext(ExecutionRequest request) {
+	protected EngineExecutionContext createExecutionContext(ExecutionRequest request) {
 		return new DummyEngineExecutionContext();
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -45,7 +45,7 @@ public class HierarchicalTestExecutorTests {
 	MyContainer root;
 	EngineExecutionListener listener;
 	MyEngineExecutionContext rootContext;
-	HierarchicalTestExecutor<MyEngineExecutionContext> executor;
+	HierarchicalTestExecutor executor;
 
 	@BeforeEach
 	public void init() {
@@ -53,7 +53,7 @@ public class HierarchicalTestExecutorTests {
 		listener = mock(EngineExecutionListener.class);
 		rootContext = new MyEngineExecutionContext();
 		ExecutionRequest request = new ExecutionRequest(root, listener, null);
-		executor = new MyExecutor(request, rootContext);
+		executor = new HierarchicalTestExecutor(request, rootContext);
 	}
 
 	@Test
@@ -405,13 +405,6 @@ public class HierarchicalTestExecutorTests {
 		@Override
 		public boolean isLeaf() {
 			return !isContainer();
-		}
-	}
-
-	private static class MyExecutor extends HierarchicalTestExecutor<MyEngineExecutionContext> {
-
-		MyExecutor(ExecutionRequest request, MyEngineExecutionContext rootContext) {
-			super(request, rootContext);
 		}
 	}
 


### PR DESCRIPTION
## Overview

The engine did not use the type parameter. Making HierarchicalTestEngine a simple type reduces complexity.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.