### PR TITLE
Eliminate NPE when TestEngine's discovery() method returns null

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -106,6 +106,8 @@ class DefaultLauncher implements Launcher {
 
 			UniqueId uniqueEngineId = UniqueId.forEngine(testEngine.getId());
 			TestDescriptor engineRoot = testEngine.discover(discoveryRequest, uniqueEngineId);
+			Preconditions.notNull(engineRoot,
+				"The discover() method must return at least the engine's TestDescriptor.");
 			root.add(testEngine, engineRoot);
 		}
 		root.applyPostDiscoveryFilters(discoveryRequest);


### PR DESCRIPTION
## Overview

When creating a new TestEngine by extending HierarchicalTestEngine, there's a Precondition failure if the getId() method returns null, but an NPE is thrown if the discover() method returns null.  If the createExecutionContext() method returns null, it's up to the test engine to decide whether that's a problem.  This pull request adds a precondition (with message) after calling discover()  and before adding the engine's TestDescriptor to the root.

For reference, here's the stack trace that occurs if the discover() method returns null:

```
java.lang.NullPointerException
	at org.junit.platform.launcher.core.Root.lambda$acceptInAllTestEngines$2(Root.java:85)
	at java.util.LinkedHashMap$LinkedValues.forEach(LinkedHashMap.java:600)
	at org.junit.platform.launcher.core.Root.acceptInAllTestEngines(Root.java:85)
	at org.junit.platform.launcher.core.Root.applyPostDiscoveryFilters(Root.java:66)
	at org.junit.platform.launcher.core.DefaultLauncher.discoverRoot(DefaultLauncher.java:111)
	at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:78)
	at org.junit.platform.runner.JUnitPlatform.generateTestTree(JUnitPlatform.java:113)
	at org.junit.platform.runner.JUnitPlatform.<init>(JUnitPlatform.java:96)
	at org.junit.platform.runner.JUnitPlatform.<init>(JUnitPlatform.java:88)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.junit.internal.builders.AnnotatedBuilder.buildRunner(AnnotatedBuilder.java:104)
	at org.junit.internal.builders.AnnotatedBuilder.runnerForClass(AnnotatedBuilder.java:86)
	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
	at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:26)
	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
	at org.junit.internal.requests.ClassRequest.getRunner(ClassRequest.java:33)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.createUnfilteredTest(JUnit4TestLoader.java:84)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.createTest(JUnit4TestLoader.java:70)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.loadTests(JUnit4TestLoader.java:43)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:444)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:678)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

