### PR TITLE
Change use of "JUnit Platform launcher" to "runner"

### DIFF
--- a/documentation/src/docs/asciidoc/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/migration-from-junit4.adoc
@@ -19,7 +19,7 @@ developers have plenty of time to migrate to JUnit Jupiter on their own schedule
 === Running JUnit 4 Tests on the JUnit Platform
 
 Just make sure that the `junit-vintage-engine` artifact is in your test runtime path. In that
-case JUnit 3 and JUnit 4 tests will automatically be picked up by the JUnit Platform launcher.
+case JUnit 3 and JUnit 4 tests will automatically be picked up by the JUnit Platform runner.
 
 See the example projects in the {junit5-samples-repo}[`junit5-samples`] repository to
 find out how this is done with Gradle and Maven.


### PR DESCRIPTION
One slight error: you've mixed up junit-platform-runner and junit-platform-launcher. The former contains the JUnitPlatform class which is a JUnit 4 based `Runner`.

:stuck_out_tongue_winking_eye: 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

