### PR TITLE
Add Android support to the Gradle plugin

### DIFF
--- a/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
+++ b/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'groovy'
 
+repositories {
+	jcenter()
+}
+
 dependencies {
 	compile localGroovy()
 	compile gradleApi()
@@ -7,5 +11,6 @@ dependencies {
 	testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
 		transitive = false
 	}
+	testCompile('com.android.tools.build:gradle:2.2.0-rc1')
 	testRuntime("junit:junit:${junit4Version}")
 }

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -172,73 +172,73 @@ class JUnitPlatformPluginSpec extends Specification {
 		true == true
 	}
 
-    @Requires({ System.getenv("ANDROID_HOME") })
-    def "creating junitPlatformTest tasks (android)"() {
+	@Requires({ System.getenv("ANDROID_HOME") })
+	def "creating junitPlatformTest tasks (android)"() {
 
-        Project androidProject = ProjectBuilder.builder().withParent(project).build()
-        androidProject.file(".").mkdir();
-        androidProject.apply plugin: 'com.android.application'
-        androidProject.apply plugin: 'org.junit.platform.gradle.plugin'
-        androidProject.repositories {
-            jcenter()
-        }
+		Project androidProject = ProjectBuilder.builder().withParent(project).build()
+		androidProject.file(".").mkdir();
+		androidProject.apply plugin: 'com.android.application'
+		androidProject.apply plugin: 'org.junit.platform.gradle.plugin'
+		androidProject.repositories {
+			jcenter()
+		}
 
-        when:
-        androidProject.android {
-            compileSdkVersion 24
-            buildToolsVersion "24.0.2"
+		when:
+		androidProject.android {
+			compileSdkVersion 24
+			buildToolsVersion "24.0.2"
 
-            defaultConfig {
-                applicationId "org.junit.android.sample"
-                minSdkVersion 24
-                targetSdkVersion 24
-                versionCode 1
-                versionName "1.0"
-            }
+			defaultConfig {
+				applicationId "org.junit.android.sample"
+				minSdkVersion 24
+				targetSdkVersion 24
+				versionCode 1
+				versionName "1.0"
+			}
 
-            flavorDimensions "version"
+			flavorDimensions "version"
 
-            productFlavors {
-                free {
-                    dimension "version"
-                }
-                paid {
-                    dimension "version"
-                }
-            }
-        }
-        androidProject.junitPlatform {
-            platformVersion '5.0.0-M2'
-            includeClassNamePattern '.*Tests?'
-            logManager 'org.apache.logging.log4j.jul.LogManager'
-            tags {
-                include 'fast'
-                exclude 'slow'
-            }
-            reportsDir new File("any")
-        }
-        androidProject.evaluate()
+			productFlavors {
+				free {
+					dimension "version"
+				}
+				paid {
+					dimension "version"
+				}
+			}
+		}
+		androidProject.junitPlatform {
+			platformVersion '5.0.0-M2'
+			includeClassNamePattern '.*Tests?'
+			logManager 'org.apache.logging.log4j.jul.LogManager'
+			tags {
+				include 'fast'
+				exclude 'slow'
+			}
+			reportsDir new File("any")
+		}
+		androidProject.evaluate()
 
-        then:
-        // Assert that each variant is being assigned a task:
-        // With 2 build types ("debug", "release") and 1 flavor dimension ("version"),
-        // expect 4 tasks to be created in total
-        // * junitPlatformTestFreeDebug
-        // * junitPlatformTestFreeRelease
-        // * junitPlatformTestPaidDebug
-        // * junitPlatformTestPaidRelease
-        def junitTasks = androidProject.tasks.findAll { it.name.contains("junitPlatformTest") }
-        junitTasks.size() == 4
-        junitTasks.each { task ->
-            task instanceof JavaExec
-            task.main == ConsoleLauncher.class.getName()
+		then:
+		// Assert that each variant is being assigned a task:
+		// With 2 build types ("debug", "release") and 1 flavor dimension ("version"),
+		// expect 4 tasks to be created in total
+		// * junitPlatformTestFreeDebug
+		// * junitPlatformTestFreeRelease
+		// * junitPlatformTestPaidDebug
+		// * junitPlatformTestPaidRelease
+		def junitTasks = androidProject.tasks.findAll { it.name.contains("junitPlatformTest") }
+		junitTasks.size() == 4
+		junitTasks.each { task ->
+			task instanceof JavaExec
+			task.main == ConsoleLauncher.class.getName()
 
-            task.args.contains('--hide-details')
-            task.args.contains('--scan-class-path')
-            task.args.containsAll('-n', '.*Tests?')
-            task.args.containsAll('-t', 'fast')
-            task.args.containsAll('-T', 'slow')
-            task.args.containsAll('--reports-dir', new File('any').getCanonicalFile().toString())
-        }
-    }
+			task.args.contains('--hide-details')
+			task.args.contains('--scan-class-path')
+			task.args.containsAll('-n', '.*Tests?')
+			task.args.containsAll('-t', 'fast')
+			task.args.containsAll('-T', 'slow')
+			task.args.containsAll('--reports-dir', new File('any').getCanonicalFile().toString())
+		}
+	}
 }

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -195,6 +195,17 @@ class JUnitPlatformPluginSpec extends Specification {
                 versionCode 1
                 versionName "1.0"
             }
+
+            flavorDimensions "version"
+
+            productFlavors {
+                free {
+                    dimension "version"
+                }
+                paid {
+                    dimension "version"
+                }
+            }
         }
         androidProject.junitPlatform {
             platformVersion '5.0.0-M2'
@@ -209,26 +220,25 @@ class JUnitPlatformPluginSpec extends Specification {
         androidProject.evaluate()
 
         then:
-        Task junitDebugTask = androidProject.tasks.findByName('junitPlatformTestDebug')
-        junitDebugTask instanceof JavaExec
-        junitDebugTask.main == ConsoleLauncher.class.getName()
+        // Assert that each variant is being assigned a task:
+        // With 2 build types ("debug", "release") and 1 flavor dimension ("version"),
+        // expect 4 tasks to be created in total
+        // * junitPlatformTestFreeDebug
+        // * junitPlatformTestFreeRelease
+        // * junitPlatformTestPaidDebug
+        // * junitPlatformTestPaidRelease
+        def junitTasks = androidProject.tasks.findAll { it.name.contains("junitPlatformTest") }
+        junitTasks.size() == 4
+        junitTasks.each { task ->
+            task instanceof JavaExec
+            task.main == ConsoleLauncher.class.getName()
 
-        junitDebugTask.args.contains('--hide-details')
-        junitDebugTask.args.contains('--scan-class-path')
-        junitDebugTask.args.containsAll('-n', '.*Tests?')
-        junitDebugTask.args.containsAll('-t', 'fast')
-        junitDebugTask.args.containsAll('-T', 'slow')
-        junitDebugTask.args.containsAll('--reports-dir', new File('any').getCanonicalFile().toString())
-
-        Task junitReleaseTask = androidProject.tasks.findByName('junitPlatformTestRelease')
-        junitReleaseTask instanceof JavaExec
-        junitReleaseTask.main == ConsoleLauncher.class.getName()
-
-        junitReleaseTask.args.contains('--hide-details')
-        junitReleaseTask.args.contains('--scan-class-path')
-        junitReleaseTask.args.containsAll('-n', '.*Tests?')
-        junitReleaseTask.args.containsAll('-t', 'fast')
-        junitReleaseTask.args.containsAll('-T', 'slow')
-        junitReleaseTask.args.containsAll('--reports-dir', new File('any').getCanonicalFile().toString())
+            task.args.contains('--hide-details')
+            task.args.contains('--scan-class-path')
+            task.args.containsAll('-n', '.*Tests?')
+            task.args.containsAll('-t', 'fast')
+            task.args.containsAll('-T', 'slow')
+            task.args.containsAll('--reports-dir', new File('any').getCanonicalFile().toString())
+        }
     }
 }


### PR DESCRIPTION
## Overview

See #204 for a discussion on the topic.

This is the overhauled port of #213, which had become outdated in regards to the rapid development that has taken place in this project since its initial submission. The functionality remains the same: `JUnitPlatformPlugin` has been made aware of Android environments, and is now able to deal with the different variants and flavors that may be present there.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
