### PR TITLE
Make behavior of Precondition.notEmpty(Collection) consistent with

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/Preconditions.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/Preconditions.java
@@ -99,6 +99,7 @@ public final class Preconditions {
 	public static <T extends Collection<?>> T notEmpty(T collection, String message)
 			throws PreconditionViolationException {
 		condition(collection != null && !collection.isEmpty(), () -> message);
+		collection.forEach(object -> notNull(object, () -> message));
 		return collection;
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/PreconditionsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/PreconditionsTests.java
@@ -124,6 +124,16 @@ class PreconditionsTests {
 	}
 
 	@Test
+	void notEmptyThrowsForCollectionWithNullElements() {
+		String message = "collection contains null elements";
+
+		PreconditionViolationException exception = expectThrows(PreconditionViolationException.class,
+			() -> Preconditions.notEmpty(Collections.singletonList(null), message));
+
+		assertEquals(message, exception.getMessage());
+	}
+
+	@Test
 	void notBlankPassesForNonBlankString() {
 		String string = "abc";
 		String nonBlankString = Preconditions.notBlank(string, "");


### PR DESCRIPTION
## Overview

- As discussed in #496

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

Precondition.notNull(Object[]).

Null elements in the collection will no longer be accepted. This
is part of #496.