### PR TITLE
Fixed typo in TestingAStackDemo

### DIFF
--- a/documentation/src/test/java/example/TestingAStackDemo.java
+++ b/documentation/src/test/java/example/TestingAStackDemo.java
@@ -75,7 +75,7 @@ class TestingAStackDemo {
 
 			@Test
 			@DisplayName("it is no longer empty")
-			void isEmpty() {
+			void isNotEmpty() {
 				assertFalse(stack.isEmpty());
 			}
 


### PR DESCRIPTION
## Overview

- AfterPushing context contained a typo, `isEmpty()` is changed to `isNotEmpty()`. After pushing an element in a stack it is no longer empty. The display name is correct but method name was not reflecting the intention. 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

There was a typo in `AfterPushing` context, `isEmpty` is changed to `isNotEmpty`