### PR TITLE
Add overload of 'ExtensionContext::publishReportEntry'

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.meta.API.Usage.Experimental;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -125,6 +126,17 @@ public interface ExtensionContext {
 	 * {@code null} or blank
 	 */
 	void publishReportEntry(Map<String, String> map);
+
+	/**
+	 * Publish the specified key-value pair to be consumed by an
+	 * {@code org.junit.platform.engine.EngineExecutionListener}.
+	 *
+	 * @param key the key of the published pair; never {@code null} or blank
+	 * @param value the value of the published pair; never {@code null} or blank
+	 */
+	default void publishReportEntry(String key, String value) {
+		this.publishReportEntry(Collections.singletonMap(key, value));
+	}
 
 	/**
 	 * Get the {@link Store} for the default, global {@link Namespace}.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExecutableInvoker.java
@@ -185,7 +185,7 @@ public class ExecutableInvoker {
 					.collect(toList());
 			// @formatter:on
 
-			if (matchingResolvers.size() == 0) {
+			if (matchingResolvers.isEmpty()) {
 				throw new ParameterResolutionException(
 					String.format("No ParameterResolver registered for parameter [%s] in executable [%s].",
 						parameterContext.getParameter(), executable.toGenericString()));


### PR DESCRIPTION
This overload, just like the one on `TestReporter`, makes it easier to publish a single key-value pair.

There is also a small fix of a collection emptiness check in there.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.