### PR TITLE
Gradle plugin will honor the build dir, and making extension more usable

### DIFF
--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformExtension.groovy
@@ -9,6 +9,7 @@
  */
 package org.junit.platform.gradle.plugin
 
+import org.gradle.api.Project
 import org.junit.platform.engine.discovery.ClassNameFilter
 
 /**
@@ -17,6 +18,12 @@ import org.junit.platform.engine.discovery.ClassNameFilter
  * @since 1.0
  */
 class JUnitPlatformExtension {
+
+	private Project project
+
+	JUnitPlatformExtension(Project project) {
+		this.project = project
+	}
 
 	/**
 	 * The version of the JUnit Platform to use.
@@ -37,9 +44,23 @@ class JUnitPlatformExtension {
 	/**
 	 * The directory for the test report files.
 	 *
-	 * <p>Defaults to {@code file('build/test-results/junit-platform')}.
+	 * <p>Defaults to {@code file("$buildDir/test-results/junit-platform")}.
 	 */
 	File reportsDir
+
+	/**
+	 * Accepts a path to the reportsDir. If the object is a {@link java.io.File) it
+	 * will be used as is. If the object is anything else, it will convert to File
+	 * automatically using {@link org.gradle.api.Project#file(Object)}
+	 */
+	void setReportsDir(Object reportsDir) {
+		// Work around for https://discuss.gradle.org/t/bug-in-project-file-on-windows/19917
+		if (reportsDir instanceof File) {
+			this.reportsDir = reportsDir
+		} else {
+			this.reportsDir = project.file(reportsDir)
+		}
+	}
 
 	/**
 	 * Whether or not the standard Gradle {@code test} task should be enabled.

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -25,7 +25,7 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 	private static final String TASK_NAME      = 'junitPlatformTest';
 
 	void apply(Project project) {
-		def junitExtension = project.extensions.create(EXTENSION_NAME, JUnitPlatformExtension)
+		def junitExtension = project.extensions.create(EXTENSION_NAME, JUnitPlatformExtension, project)
 		junitExtension.extensions.create('tags', TagsExtension)
 		junitExtension.extensions.create('engines', EnginesExtension)
 
@@ -49,7 +49,7 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 		}
 	}
 
-	private void configure(Project project, junitExtension) {
+	private void configure(Project project, JUnitPlatformExtension junitExtension) {
 		project.task(
 				TASK_NAME,
 				type: JavaExec,
@@ -63,7 +63,7 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 			junitTask.inputs.property('excludedTags', junitExtension.tags.exclude)
 			junitTask.inputs.property('includeClassNamePattern', junitExtension.includeClassNamePattern)
 
-			def reportsDir = junitExtension.reportsDir ?: project.file("build/test-results/junit-platform")
+			def reportsDir = junitExtension.reportsDir ?: project.file("$project.buildDir/test-results/junit-platform")
 			junitTask.outputs.dir reportsDir
 
 			if (junitExtension.logManager) {

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -145,4 +145,32 @@ class JUnitPlatformPluginSpec extends Specification {
 		testTask.enabled == true
 	}
 
+	def "when buildDir is set to non-standard location, it will be honored"() {
+		project.apply plugin: 'java'
+		project.apply plugin: 'org.junit.platform.gradle.plugin'
+
+		when:
+		project.buildDir = new File('/foo/bar/build')
+		project.evaluate()
+
+		then:
+		Task junitTask = project.tasks.findByName('junitPlatformTest')
+		junitTask.args.containsAll('--reports-dir', new File(project.buildDir, 'test-results/junit-platform').getCanonicalFile().toString())
+	}
+
+	def "users can set buildDir to be a GString, and it will be converted to file"() {
+		project.apply plugin: 'java'
+		project.apply plugin: 'org.junit.platform.gradle.plugin'
+
+		when:
+		project.junitPlatform {
+			reportsDir = "$project.buildDir/foo/bar/baz"
+		}
+		project.evaluate()
+
+		then:
+		Task junitTask = project.tasks.findByName('junitPlatformTest')
+		junitTask.args.containsAll('--reports-dir', new File(project.buildDir, 'foo/bar/baz').getCanonicalFile().toString())
+	}
+
 }


### PR DESCRIPTION
## Overview
Before this change, there was an assumption that all users use the
project directory as the buildDir. In some cases, they are re-mapped to
a single buildDir at the root of the project to make management easier.
This change uses the builDir from the project to set where the output
will be.

Also to make the plugin nicer to use, users can set the reportsDir to be
a GString (or any object really) and rely on the behavior of
Project.file(..) to resolve it to the correct path.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.