### PR TITLE
Test will now print the error to the console when they fail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,10 @@ allprojects { subproj ->
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 	}
 
+	tasks.withType(Test) { task ->
+		task.testLogging.exceptionFormat = 'full'
+	}
+
 	tasks.withType(JavaCompile) {
 		sourceCompatibility = rootProject.sourceCompatibility
 		targetCompatibility = rootProject.targetCompatibility


### PR DESCRIPTION
## Overview

This will make debugging CI build easier without having to keep track of
all the artifacts that get generated.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.