### PR TITLE
Updates references to AssertionFailedError to use its FQCN.

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -45,10 +45,10 @@ import org.opentest4j.MultipleFailuresError;
  * conditions in tests.
  *
  * <p>Unless otherwise noted, a <em>failed</em> assertion will throw an
- * {@link AssertionFailedError} or a subclass thereof.
+ * {@link org.opentest4j.AssertionFailedError} or a subclass thereof.
  *
  * @since 5.0
- * @see AssertionFailedError
+ * @see org.opentest4j.AssertionFailedError
  * @see Assumptions
  */
 @API(Maintained)


### PR DESCRIPTION
Since javadocs are produced and published to Maven Central for both the JUnit 5 and OpenTest4J projects, Eclipse and other IDES don't have a problem linking imported Javadocs between the projects.  The JUnit 5 javadocs published at http://junit.org/junit5/docs/current/api/ cannot however resolve these links, so providing the FQCN provides readers with additional information to locate the related javadocs.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

Resolves #560.