### PR TITLE
Rename getAllDescendants() to getDescendants().

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
@@ -52,7 +52,7 @@ class DiscoveryFilterApplierTests {
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getAllDescendants().stream().map(
+		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
 			TestDescriptor::getUniqueId).collect(Collectors.toList());
 		Assertions.assertEquals(1, includedDescriptors.size());
 		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
@@ -74,7 +74,7 @@ class DiscoveryFilterApplierTests {
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getAllDescendants().stream().map(
+		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
 			TestDescriptor::getUniqueId).collect(Collectors.toList());
 		Assertions.assertEquals(2, includedDescriptors.size());
 		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DynamicTestGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DynamicTestGenerationTests.java
@@ -53,7 +53,7 @@ class DynamicTestGenerationTests extends AbstractJupiterTestEngineTests {
 	void testFactoryMethodsAreCorrectlyDiscoveredForClassSelector() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(MyDynamicTestCase.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(5, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(5, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
@@ -61,7 +61,7 @@ class DynamicTestGenerationTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest request = request().selectors(
 			DiscoverySelectors.selectMethod(MyDynamicTestCase.class, "dynamicStream")).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(2, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -36,7 +36,7 @@ public class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 	public void nestedTestsAreCorrectlyDiscovered() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(TestCaseWithNesting.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(5, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(5, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 	public void doublyNestedTestsAreCorrectlyDiscovered() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(TestCaseWithDoubleNesting.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(8, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(8, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/StandardTestClassTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/StandardTestClassTests.java
@@ -42,14 +42,14 @@ public class StandardTestClassTests extends AbstractJupiterTestEngineTests {
 	public void standardTestClassIsCorrectlyDiscovered() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(MyStandardTestCase.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(5, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(5, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
 	public void moreThanOneTestClassIsCorrectlyDiscovered() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(SecondOfTwoTestCases.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(2 + 2, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(2 + 2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -70,7 +70,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(4, engineDescriptor.getAllDescendants().size());
+		assertEquals(4, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
@@ -85,7 +85,7 @@ public class DiscoverySelectorResolverTests {
 			selectClass(MyTestClass.class) //
 		).build(), engineDescriptor);
 
-		assertEquals(4, engineDescriptor.getAllDescendants().size());
+		assertEquals(4, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
@@ -100,7 +100,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector1, selector2).build(), engineDescriptor);
 
-		assertEquals(7, engineDescriptor.getAllDescendants().size());
+		assertEquals(7, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
@@ -117,7 +117,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(3, engineDescriptor.getAllDescendants().size());
+		assertEquals(3, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()")));
@@ -131,7 +131,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(2, engineDescriptor.getAllDescendants().size());
+		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
@@ -143,7 +143,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(2, engineDescriptor.getAllDescendants().size());
+		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(HerTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(HerTestClass.class, "test1()")));
@@ -155,7 +155,7 @@ public class DiscoverySelectorResolverTests {
 		MethodSelector selector = selectMethod(notATest.getDeclaringClass(), notATest);
 		EngineDiscoveryRequest request = request().selectors(selector).build();
 		resolver.resolveSelectors(request, engineDescriptor);
-		assertTrue(engineDescriptor.getAllDescendants().isEmpty());
+		assertTrue(engineDescriptor.getDescendants().isEmpty());
 	}
 
 	@Test
@@ -164,7 +164,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(4, engineDescriptor.getAllDescendants().size());
+		assertEquals(4, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
@@ -178,7 +178,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(3, engineDescriptor.getAllDescendants().size());
+		assertEquals(3, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()")));
@@ -192,7 +192,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(2, engineDescriptor.getAllDescendants().size());
+		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()")));
@@ -204,7 +204,7 @@ public class DiscoverySelectorResolverTests {
 		EngineDiscoveryRequest request = request().selectors(selector).build();
 
 		resolver.resolveSelectors(request, engineDescriptor);
-		assertTrue(engineDescriptor.getAllDescendants().isEmpty());
+		assertTrue(engineDescriptor.getDescendants().isEmpty());
 	}
 
 	@Test
@@ -213,7 +213,7 @@ public class DiscoverySelectorResolverTests {
 		EngineDiscoveryRequest request = request().selectors(selector).build();
 
 		resolver.resolveSelectors(request, engineDescriptor);
-		assertTrue(engineDescriptor.getAllDescendants().isEmpty());
+		assertTrue(engineDescriptor.getDescendants().isEmpty());
 	}
 
 	@Test
@@ -251,7 +251,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(2, engineDescriptor.getAllDescendants().size());
+		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
@@ -263,7 +263,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(2, engineDescriptor.getAllDescendants().size());
+		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 
 		assertTrue(uniqueIds.contains(uniqueIdForClass(HerTestClass.class)));
@@ -277,7 +277,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(2, engineDescriptor.getAllDescendants().size());
+		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(HerTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(HerTestClass.class, "test7(java.lang.String)")));
@@ -290,7 +290,7 @@ public class DiscoverySelectorResolverTests {
 		EngineDiscoveryRequest request = request().selectors(selector).build();
 
 		resolver.resolveSelectors(request, engineDescriptor);
-		assertTrue(engineDescriptor.getAllDescendants().isEmpty());
+		assertTrue(engineDescriptor.getDescendants().isEmpty());
 	}
 
 	@Test
@@ -301,7 +301,7 @@ public class DiscoverySelectorResolverTests {
 		// adding same selector twice should have no effect
 		resolver.resolveSelectors(request().selectors(selector1, selector2, selector2).build(), engineDescriptor);
 
-		assertEquals(3, engineDescriptor.getAllDescendants().size());
+		assertEquals(3, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
@@ -324,7 +324,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertThat(engineDescriptor.getAllDescendants()).hasSize(2);
+		assertThat(engineDescriptor.getDescendants()).hasSize(2);
 
 		assertThat(uniqueIds()).containsSequence(uniqueIdForClass(MyTestClass.class),
 			uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()"));
@@ -336,7 +336,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertThat(engineDescriptor.getAllDescendants()).hasSize(2);
+		assertThat(engineDescriptor.getDescendants()).hasSize(2);
 
 		assertThat(uniqueIds()).containsSequence(uniqueIdForClass(MyTestClass.class),
 			uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()"));
@@ -348,7 +348,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(6, engineDescriptor.getAllDescendants().size());
+		assertEquals(6, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(Class1WithTestCases.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()")));
@@ -363,7 +363,7 @@ public class DiscoverySelectorResolverTests {
 		resolver.resolveSelectors(request().selectors(selectPackage("")).build(), engineDescriptor);
 
 		// 150 is completely arbitrary. The actual number is likely much higher.
-		assertThat(engineDescriptor.getAllDescendants().size()).isGreaterThan(150).as(
+		assertThat(engineDescriptor.getDescendants().size()).isGreaterThan(150).as(
 			"Too few test descriptors in classpath");
 
 		List<UniqueId> uniqueIds = uniqueIds();
@@ -385,7 +385,7 @@ public class DiscoverySelectorResolverTests {
 		resolver.resolveSelectors(request().selectors(selectors).build(), engineDescriptor);
 
 		// 150 is completely arbitrary. The actual number is likely much higher.
-		assertThat(engineDescriptor.getAllDescendants().size()).isGreaterThan(150).as(
+		assertThat(engineDescriptor.getDescendants().size()).isGreaterThan(150).as(
 			"Too few test descriptors in classpath");
 
 		List<UniqueId> uniqueIds = uniqueIds();
@@ -474,7 +474,7 @@ public class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 
-		assertEquals(4, engineDescriptor.getAllDescendants().size());
+		assertEquals(4, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.class)));
 		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class)));
@@ -498,13 +498,12 @@ public class DiscoverySelectorResolverTests {
 	}
 
 	private TestDescriptor descriptorByUniqueId(UniqueId uniqueId) {
-		return engineDescriptor.getAllDescendants().stream().filter(
+		return engineDescriptor.getDescendants().stream().filter(
 			d -> d.getUniqueId().equals(uniqueId)).findFirst().get();
 	}
 
 	private List<UniqueId> uniqueIds() {
-		return engineDescriptor.getAllDescendants().stream().map(TestDescriptor::getUniqueId).collect(
-			Collectors.toList());
+		return engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId).collect(Collectors.toList());
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
@@ -38,14 +38,14 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	public void discoverTestClass() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(LocalTestCase.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(7, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(7, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
 	public void doNotDiscoverAbstractTestClass() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(AbstractTestCase.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(0, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(0, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
@@ -53,7 +53,7 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest request = request().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test1()"))).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(2, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
@@ -61,7 +61,7 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest request = request().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test4()"))).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(2, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
@@ -69,7 +69,7 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest request = request().selectors(selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(
 			LocalTestCase.class, "test4(" + TestInfo.class.getName() + ")"))).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(2, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
@@ -78,7 +78,7 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(LocalTestCase.class, testMethod)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertEquals(2, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
@@ -88,7 +88,7 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 			selectClass(LocalTestCase.class)).build();
 
 		TestDescriptor engineDescriptor = discoverTests(spec);
-		assertEquals(7, engineDescriptor.getAllDescendants().size(), "# resolved test descriptors");
+		assertEquals(7, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	// -------------------------------------------------------------------

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -87,7 +87,7 @@ public interface TestDescriptor {
 	 *
 	 * @return the set of children of this descriptor; never {@code null}
 	 * but potentially empty
-	 * @see #getAllDescendants()
+	 * @see #getDescendants()
 	 */
 	Set<? extends TestDescriptor> getChildren();
 
@@ -99,13 +99,13 @@ public interface TestDescriptor {
 	 *
 	 * @see #getChildren()
 	 */
-	default Set<? extends TestDescriptor> getAllDescendants() {
-		Set<TestDescriptor> all = new LinkedHashSet<>();
-		all.addAll(getChildren());
+	default Set<? extends TestDescriptor> getDescendants() {
+		Set<TestDescriptor> descendants = new LinkedHashSet<>();
+		descendants.addAll(getChildren());
 		for (TestDescriptor child : getChildren()) {
-			all.addAll(child.getAllDescendants());
+			descendants.addAll(child.getDescendants());
 		}
-		return all;
+		return descendants;
 	}
 
 	/**

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdFilter.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdFilter.java
@@ -60,7 +60,7 @@ class UniqueIdFilter extends RunnerTestDescriptorAwareFilter {
 		if (identifiedTestDescriptor.isPresent()) {
 			// @formatter:off
 			return identifiedTestDescriptor.get()
-					.getAllDescendants()
+					.getDescendants()
 					.stream()
 					.map(VintageTestDescriptor.class::cast)
 					.map(VintageTestDescriptor::getDescription)

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -48,7 +48,7 @@ class TestRun {
 	TestRun(RunnerTestDescriptor runnerTestDescriptor, Logger logger) {
 		this.runnerTestDescriptor = runnerTestDescriptor;
 		this.logger = logger;
-		runnerDescendants = runnerTestDescriptor.getAllDescendants();
+		runnerDescendants = runnerTestDescriptor.getDescendants();
 		// @formatter:off
 		descriptionToDescriptors = concat(Stream.of(runnerTestDescriptor), runnerDescendants.stream())
 			.map(VintageTestDescriptor.class::cast)


### PR DESCRIPTION
## Overview

Rename `getAllDescendants()` to `getDescendants()`. The word all is redundant. I always expect to get all `X` when I call a method `getX()`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.