### PR TITLE
Allows @API on ElementType.FIELD

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/meta/API.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/meta/API.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  *
  * @since 1.0
  */
-@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(Experimental)


### PR DESCRIPTION
While working on #144 I noticed that public-scoped fields (presumably constants) can only inherit their @API Usage from the enclosing class.  This change would, at a minimum, allows constants to be marked with Usage.Deprecated or Usage.Internal while their enclosing class remains accessible.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

