### PR TITLE
first draft for custom element resolver (#518)

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -78,7 +78,7 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 		return !isContainer();
 	}
 
-	protected ExtensionRegistry populateNewExtensionRegistryFromExtendWith(AnnotatedElement annotatedElement,
+	protected static ExtensionRegistry populateNewExtensionRegistryFromExtendWith(AnnotatedElement annotatedElement,
 			ExtensionRegistry existingExtensionRegistry) {
 		// @formatter:off
 		List<Class<? extends Extension>> extensionTypes = findRepeatableAnnotations(annotatedElement, ExtendWith.class).stream()

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -41,8 +41,8 @@ public class NestedClassTestDescriptor extends ClassTestDescriptor {
 
 	private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
 
-	public NestedClassTestDescriptor(UniqueId uniqueId, Class<?> testClass) {
-		super(uniqueId, Class::getSimpleName, testClass);
+	public NestedClassTestDescriptor(UniqueId uniqueId, ClassTestDescriptor parent, Class<?> testClass) {
+		super(uniqueId, Class::getSimpleName, testClass, parent.getExtensionRegistry());
 	}
 
 	// --- TestDescriptor ------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -47,8 +47,8 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 	private static final SingleTestExecutor singleTestExecutor = new SingleTestExecutor();
 	private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
 
-	public TestFactoryTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod) {
-		super(uniqueId, testClass, testMethod);
+	public TestFactoryTestDescriptor(UniqueId uniqueId, ClassTestDescriptor parentClassDescriptor, Method testMethod) {
+		super(uniqueId, parentClassDescriptor, testMethod);
 	}
 
 	// --- TestDescriptor ------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ElementResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ElementResolver.java
@@ -16,6 +16,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.jupiter.api.extension.Extension;
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
@@ -24,7 +25,7 @@ import org.junit.platform.engine.UniqueId;
  * @since 5.0
  */
 @API(Experimental)
-interface ElementResolver {
+public interface ElementResolver extends Extension {
 
 	/**
 	 * Return a set of {@link TestDescriptor TestDescriptors} that can be

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/NestedTestsResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/NestedTestsResolver.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.engine.discovery;
 
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
+import java.util.Optional;
+
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsNestedTestClass;
@@ -55,8 +57,11 @@ class NestedTestsResolver extends TestContainerResolver {
 	}
 
 	@Override
-	protected TestDescriptor resolveClass(Class<?> testClass, UniqueId uniqueId) {
-		return new NestedClassTestDescriptor(uniqueId, testClass);
+	protected Optional<TestDescriptor> resolveClass(TestDescriptor parent, Class<?> testClass, UniqueId uniqueId) {
+		if (parent instanceof ClassTestDescriptor) {
+			return Optional.of(new NestedClassTestDescriptor(uniqueId, (ClassTestDescriptor) parent, testClass));
+		}
+		return Optional.empty();
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestContainerResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestContainerResolver.java
@@ -44,7 +44,7 @@ class TestContainerResolver implements ElementResolver {
 			return Collections.emptySet();
 
 		UniqueId uniqueId = createUniqueId(clazz, parent);
-		return Collections.singleton(resolveClass(clazz, uniqueId));
+		return resolveClass(parent, clazz, uniqueId).map(Collections::singleton).orElse(Collections.emptySet());
 	}
 
 	@Override
@@ -67,7 +67,7 @@ class TestContainerResolver implements ElementResolver {
 			return Optional.empty();
 
 		UniqueId uniqueId = createUniqueId(containerClass, parent);
-		return Optional.of(resolveClass(containerClass, uniqueId));
+		return resolveClass(parent, containerClass, uniqueId);
 	}
 
 	protected Class<? extends TestDescriptor> requiredParentType() {
@@ -94,8 +94,8 @@ class TestContainerResolver implements ElementResolver {
 		return parent.getUniqueId().append(getSegmentType(), getSegmentValue(testClass));
 	}
 
-	protected TestDescriptor resolveClass(Class<?> testClass, UniqueId uniqueId) {
-		return new ClassTestDescriptor(uniqueId, testClass);
+	protected Optional<TestDescriptor> resolveClass(TestDescriptor parent, Class<?> testClass, UniqueId uniqueId) {
+		return Optional.of(new ClassTestDescriptor(uniqueId, testClass));
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestFactoryMethodResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestFactoryMethodResolver.java
@@ -53,7 +53,7 @@ class TestFactoryMethodResolver extends TestMethodResolver {
 	@Override
 	protected TestDescriptor resolveMethod(Method testMethod, ClassTestDescriptor parentClassDescriptor,
 			UniqueId uniqueId) {
-		return new TestFactoryTestDescriptor(uniqueId, parentClassDescriptor.getTestClass(), testMethod);
+		return new TestFactoryTestDescriptor(uniqueId, parentClassDescriptor, testMethod);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestMethodResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestMethodResolver.java
@@ -99,7 +99,7 @@ class TestMethodResolver implements ElementResolver {
 
 	protected TestDescriptor resolveMethod(Method testMethod, ClassTestDescriptor parentClassDescriptor,
 			UniqueId uniqueId) {
-		return new MethodTestDescriptor(uniqueId, parentClassDescriptor.getTestClass(), testMethod);
+		return new MethodTestDescriptor(uniqueId, parentClassDescriptor, testMethod);
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
@@ -67,7 +67,7 @@ class DiscoveryFilterApplierTests {
 		TestDescriptor engineDescriptor = engineDescriptor()
 			.with(
 				classTestDescriptor("matching", MatchingClass.class)
-					.with(nestedClassTestDescriptor("nested", MatchingClass.NestedClass.class))
+					.with(nestedClassTestDescriptor("nested", null, MatchingClass.NestedClass.class))
 			)
 			.build();
 		// @formatter:on

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
@@ -39,24 +39,26 @@ import org.junit.platform.engine.UniqueId;
  */
 public class JupiterTestDescriptorTests {
 
-	private static final UniqueId uniqueId = UniqueId.root("enigma", "foo");
+	private static final UniqueId classUniqueId = UniqueId.root("enigma", "foo");
+	private static final UniqueId methodUniqueId = classUniqueId.append("machine", "bar");
 
 	@Test
 	public void constructFromMethod() throws Exception {
 		Class<?> testClass = ASampleTestCase.class;
+		ClassTestDescriptor classDescriptor = new ClassTestDescriptor(classUniqueId, testClass);
 		Method testMethod = testClass.getDeclaredMethod("test");
-		MethodTestDescriptor descriptor = new MethodTestDescriptor(uniqueId, testClass, testMethod);
+		MethodTestDescriptor descriptor = new MethodTestDescriptor(methodUniqueId, classDescriptor, testMethod);
 
-		assertEquals(uniqueId, descriptor.getUniqueId());
+		assertEquals(methodUniqueId, descriptor.getUniqueId());
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("test()", descriptor.getDisplayName(), "display name:");
 	}
 
 	@Test
 	public void constructFromMethodWithAnnotations() throws Exception {
-		JupiterTestDescriptor classDescriptor = new ClassTestDescriptor(uniqueId, ASampleTestCase.class);
+		ClassTestDescriptor classDescriptor = new ClassTestDescriptor(classUniqueId, ASampleTestCase.class);
 		Method testMethod = ASampleTestCase.class.getDeclaredMethod("foo");
-		MethodTestDescriptor methodDescriptor = new MethodTestDescriptor(uniqueId, ASampleTestCase.class, testMethod);
+		MethodTestDescriptor methodDescriptor = new MethodTestDescriptor(methodUniqueId, classDescriptor, testMethod);
 		classDescriptor.addChild(methodDescriptor);
 
 		assertEquals(testMethod, methodDescriptor.getTestMethod());
@@ -74,7 +76,7 @@ public class JupiterTestDescriptorTests {
 
 	@Test
 	public void constructClassDescriptorWithAnnotations() throws Exception {
-		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, ASampleTestCase.class);
+		ClassTestDescriptor descriptor = new ClassTestDescriptor(classUniqueId, ASampleTestCase.class);
 
 		assertEquals(ASampleTestCase.class, descriptor.getTestClass());
 		assertThat(descriptor.getTags()).containsExactly(TestTag.create("classTag1"), TestTag.create("classTag2"));
@@ -82,8 +84,9 @@ public class JupiterTestDescriptorTests {
 
 	@Test
 	public void constructFromMethodWithCustomTestAnnotation() throws Exception {
+		ClassTestDescriptor classDescriptor = new ClassTestDescriptor(classUniqueId, ASampleTestCase.class);
 		Method testMethod = ASampleTestCase.class.getDeclaredMethod("customTestAnnotation");
-		MethodTestDescriptor descriptor = new MethodTestDescriptor(uniqueId, ASampleTestCase.class, testMethod);
+		MethodTestDescriptor descriptor = new MethodTestDescriptor(methodUniqueId, classDescriptor, testMethod);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("custom name", descriptor.getDisplayName(), "display name:");
@@ -92,8 +95,9 @@ public class JupiterTestDescriptorTests {
 
 	@Test
 	public void constructFromMethodWithParameters() throws Exception {
+		ClassTestDescriptor classDescriptor = new ClassTestDescriptor(classUniqueId, ASampleTestCase.class);
 		Method testMethod = ASampleTestCase.class.getDeclaredMethod("test", String.class, BigDecimal.class);
-		MethodTestDescriptor descriptor = new MethodTestDescriptor(uniqueId, ASampleTestCase.class, testMethod);
+		MethodTestDescriptor descriptor = new MethodTestDescriptor(methodUniqueId, classDescriptor, testMethod);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("test(String, BigDecimal)", descriptor.getDisplayName(), "display name:");
@@ -101,17 +105,17 @@ public class JupiterTestDescriptorTests {
 
 	@Test
 	void defaultDisplayNamesForTestClasses() {
-		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, getClass());
+		ClassTestDescriptor descriptor = new ClassTestDescriptor(classUniqueId, getClass());
 		assertEquals(getClass().getSimpleName(), descriptor.getDisplayName());
 
-		descriptor = new NestedClassTestDescriptor(uniqueId, NestedTestCase.class);
+		descriptor = new NestedClassTestDescriptor(classUniqueId, descriptor, NestedTestCase.class);
 		assertEquals(NestedTestCase.class.getSimpleName(), descriptor.getDisplayName());
 
-		descriptor = new ClassTestDescriptor(uniqueId, StaticTestCase.class);
+		descriptor = new ClassTestDescriptor(classUniqueId, StaticTestCase.class);
 		String staticDisplayName = getClass().getSimpleName() + "$" + StaticTestCase.class.getSimpleName();
 		assertEquals(staticDisplayName, descriptor.getDisplayName());
 
-		descriptor = new ClassTestDescriptor(uniqueId, StaticTestCaseLevel2.class);
+		descriptor = new ClassTestDescriptor(classUniqueId, StaticTestCaseLevel2.class);
 		staticDisplayName += "$" + StaticTestCaseLevel2.class.getSimpleName();
 		assertEquals(staticDisplayName, descriptor.getDisplayName());
 	}

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
@@ -159,7 +159,8 @@ class RunListenerAdapterTests {
 	}
 
 	private static TestIdentifier newMethodIdentifier() throws Exception {
-		TestDescriptor testDescriptor = new MethodTestDescriptor(newId(), TestClass.class,
+		ClassTestDescriptor classDescriptor = new ClassTestDescriptor(newId(), TestClass.class);
+		TestDescriptor testDescriptor = new MethodTestDescriptor(newId(), classDescriptor,
 			TestClass.class.getDeclaredMethod("test1"));
 		return TestIdentifier.from(testDescriptor);
 	}


### PR DESCRIPTION
## Overview

To be able to provide a custom `ElementResolver` (#518), I tried some things and like this one quite well at the moment.

## Details

It fits quite nice (IMHO) into the existing code / API by resolving the `ExtensionRegistry` earlier within the affected test descriptions (problem of mutability should be solved, though). This could also be more generalized by moving the new property up to `JupiterTestDescription` and add the current default element resolvers from `DiscoverySelectorResolver` to default extensions. 

## Disclaimer

The junit-dataprovider tests would already run using some quick and dirty implementation, see https://github.com/TNG/junit-dataprovider/compare/issue75-custom-junit5-element-resolver?expand=1
Also the test fixes are a bit hacky at the moment

## Your opinion?
 
Does that go into the right direction? Or do you have something different in mind? What and why do you like / not like it (such that I can think of another solution)?

P.S.: This is just a first PoC / draft to discuss it more concrete ;-)

----

I hereby agree to the terms of the JUnit Contributor License Agreement.