### PR TITLE
Convert NoClassDefFound error to empty class optional

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -329,7 +329,7 @@ public final class ReflectionUtils {
 
 			return Optional.of(classLoader.loadClass(name));
 		}
-		catch (ClassNotFoundException ex) {
+		catch (ClassNotFoundException | NoClassDefFoundError ex) {
 			return Optional.empty();
 		}
 	}


### PR DESCRIPTION
## Overview

Fix for #565 by converting `NoClassDefFoundError` (like `ClassNotFoundException`) into an empty `Optional<Class<?>>`. This prevents warnings when trying to load `module-info` classes. The warning can be seen here: https://youtrack.jetbrains.com/issue/IDEA-163795

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

