### PR TITLE
Add new TestDescriptors to existing parents

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/JavaElementsResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/JavaElementsResolver.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -162,16 +163,21 @@ class JavaElementsResolver {
 			ElementResolver resolver) {
 
 		Set<TestDescriptor> resolvedDescriptors = resolver.resolveElement(element, parent);
+		Set<TestDescriptor> result = new LinkedHashSet<>();
 
 		resolvedDescriptors.forEach(testDescriptor -> {
 			Optional<TestDescriptor> existingTestDescriptor = findTestDescriptorByUniqueId(
 				testDescriptor.getUniqueId());
-			if (!existingTestDescriptor.isPresent()) {
+			if (existingTestDescriptor.isPresent()) {
+				result.add(existingTestDescriptor.get());
+			}
+			else {
 				parent.addChild(testDescriptor);
+				result.add(testDescriptor);
 			}
 		});
 
-		return resolvedDescriptors;
+		return result;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
@@ -10,7 +10,9 @@
 
 package org.junit.jupiter.engine.discovery;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
@@ -79,6 +81,18 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(LocalTestCase.class, testMethod)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
+	}
+
+	@Test
+	public void discoverMultipleMethodsOfSameClass() throws NoSuchMethodException {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(LocalTestCase.class, "test1"),
+			selectMethod(LocalTestCase.class, "test2")).build();
+
+		TestDescriptor engineDescriptor = discoverTests(request);
+
+		assertThat(engineDescriptor.getChildren()).hasSize(1);
+		TestDescriptor classDescriptor = getOnlyElement(engineDescriptor.getChildren());
+		assertThat(classDescriptor.getChildren()).hasSize(2);
 	}
 
 	@Test


### PR DESCRIPTION
This fixes #589.

@junit-team/junit-lambda Please take a look! I'm still astonished that we didn't discover (no pun intended) this bug until now.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.