### PR TITLE
Remove test literal from method names.

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestReporterParameterResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestReporterParameterResolverTests.java
@@ -33,7 +33,7 @@ class TestReporterParameterResolverTests {
 	TestReporterParameterResolver resolver = new TestReporterParameterResolver();
 
 	@Test
-	void testSupports() {
+	void supports() {
 		Parameter parameter1 = findParameterOfMethod("methodWithTestReporterParameter", TestReporter.class);
 		assertTrue(this.resolver.supports(parameterContext(parameter1), null));
 
@@ -42,7 +42,7 @@ class TestReporterParameterResolverTests {
 	}
 
 	@Test
-	void testResolve() {
+	void resolve() {
 		Parameter parameter = findParameterOfMethod("methodWithTestReporterParameter", TestReporter.class);
 
 		TestReporter testReporter = this.resolver.resolve(parameterContext(parameter),

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
@@ -43,7 +43,7 @@ class LauncherFactoryTests {
 	}
 
 	@Test
-	void testCreate() {
+	void create() {
 		Launcher launcher = LauncherFactory.create();
 		LauncherDiscoveryRequest discoveryRequest = this.createLauncherDiscoveryRequestForBothStandardEngineExampleClasses();
 


### PR DESCRIPTION
## Overview

Solves #587 by renaming the 3 test methods.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
