### PR TITLE
Add reference to docker extension

### DIFF
--- a/documentation/src/docs/asciidoc/extensions.adoc
+++ b/documentation/src/docs/asciidoc/extensions.adoc
@@ -140,8 +140,8 @@ process_ test instances.
 Common use cases include injecting dependencies into the test instance, invoking custom
 initialization methods on the test instance, etc.
 
-For concrete examples, consult the source code for the `{MockitoExtension}` and the
-`{SpringExtension}`.
+For concrete examples, consult the source code for the `{MockitoExtension}`, `{SpringExtension}` and the
+`{DockerExtension}`.
 
 [[extensions-parameter-resolution]]
 === Parameter Resolution

--- a/documentation/src/docs/asciidoc/index.adoc
+++ b/documentation/src/docs/asciidoc/index.adoc
@@ -64,6 +64,8 @@ Stefan Bechtold; Sam Brannen; Johannes Link; Matthias Merdes; Marc Philipp
 :SpringExtension:                   https://github.com/spring-projects/spring-framework/tree/master/spring-test/src/main/java/org/springframework/test/context/junit/jupiter/SpringExtension.java[SpringExtension]
 :Truth:                             http://google.github.io/truth/[Truth]
 
+:DockerExtension:                   https://github.com/FaustXVI/junit5-docker/blob/master/src/main/java/com/github/junit5docker/DockerExtension.java[DockerExtension]
+
 
 include::overview.adoc[]
 


### PR DESCRIPTION
## Overview

Add a link to an extension that allow the user to start docker containers from their tests.

JUnit5-Docker has just been pushed to maven contral as a release candidate for version 1.0.0.
It only implements one feature : start one container from your test. The idea is to have something that works early. More features to come.

I think it will be a very useful extension and adding the reference to the documentation would show that an extension can do something else than integrate with another framework.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

