### PR TITLE
Add engines to console distribution runtime dependencies

### DIFF
--- a/junit-platform-console/junit-platform-console.gradle
+++ b/junit-platform-console/junit-platform-console.gradle
@@ -1,12 +1,15 @@
 apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'com.github.jlouns.cpe'
 
 buildscript {
 	repositories {
 		jcenter()
+		maven { url "https://plugins.gradle.org/m2/" }
 	}
 	dependencies {
 		classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+		classpath 'gradle.plugin.com.github.jlouns:gradle-cross-platform-exec-plugin:0.4.1'
 	}
 }
 
@@ -16,6 +19,8 @@ configurations {
 
 dependencies {
 	compile(project(':junit-platform-launcher'))
+	runtime(project(':junit-jupiter-engine'))
+	runtime(project(':junit-vintage-engine'))
 	shadowed('net.sf.jopt-simple:jopt-simple:5.0.3')
 }
 
@@ -64,3 +69,22 @@ artifacts {
 distZip.dependsOn(shadowJar)
 distTar.dependsOn(shadowJar)
 installDist.dependsOn(shadowJar)
+
+task runDist(type: CrossPlatformExec) {
+	workingDir "$buildDir/install/$project.name/bin"
+	commandLine "$project.name", '--scan-classpath', '--hide-details'
+	standardOutput = new ByteArrayOutputStream()
+	errorOutput = new ByteArrayOutputStream()
+}
+
+task checkDist {
+	doLast {
+		String text = runDist.errorOutput.toString() + runDist.standardOutput.toString()
+		assert text.contains("junit-jupiter (group ID: org.junit.jupiter, artifact ID: junit-jupiter-engine, version: $rootProject.version)")
+		assert text.contains("junit-vintage (group ID: org.junit.vintage, artifact ID: junit-vintage-engine, version: $vintageVersion)")
+	}
+}
+
+runDist.dependsOn(installDist)
+checkDist.dependsOn(runDist)
+check.dependsOn(checkDist)


### PR DESCRIPTION
## Overview

This PR adds `junit-jupiter-engine`  and `junit-vintage-engine` to the runtime dependency of `junit-platform-console` application -- resulting in the following exploded `lib` folder:
```
junit-platform-console/build/install/junit-platform-console/lib/hamcrest-core-1.3.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-4.12.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-jupiter-api-5.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-jupiter-engine-5.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-platform-commons-1.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-platform-console-1.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-platform-engine-1.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-platform-launcher-1.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-vintage-engine-4.12.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/opentest4j-1.0.0-M1.jar
```
The current zip does not contain a single engine, it only contains the platform jars:
```
junit-platform-console/build/install/junit-platform-console/lib/junit-platform-commons-1.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-platform-console-1.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-platform-engine-1.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/junit-platform-launcher-1.0.0-SNAPSHOT.jar
junit-platform-console/build/install/junit-platform-console/lib/opentest4j-1.0.0-M1.jar
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

