### PR TITLE
Regression: assertThrows should not use wildcard for expected exception type

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
@@ -24,7 +24,7 @@ import org.opentest4j.AssertionFailedError;
 class AssertThrows {
 
 	@SuppressWarnings("unchecked")
-	static <T extends Throwable> T assertThrows(Class<? extends Throwable> expectedType, Executable executable) {
+	static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
 		try {
 			executable.execute();
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -1023,7 +1023,7 @@ public final class Assertions {
 	 * <p>If you do not want to perform additional checks on the exception instance,
 	 * simply ignore the return value.
 	 */
-	public static <T extends Throwable> T assertThrows(Class<? extends Throwable> expectedType, Executable executable) {
+	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
 		return AssertThrows.assertThrows(expectedType, executable);
 	}
 


### PR DESCRIPTION
For this case, instead of using a wildcard declared as `? extends Throwable`, we use a type T as the type argument of a given generic type.
It will help compiler to infer correct concrete return type for method instead of returning `Throwable` every time.

For example, in IDEA, press *Cmd+Option+V*
Before:
```java
Throwable t = assertThrows(AwesomeException.class, () -> { /* smth */ });
```

After:
```java
AwesomeException e = assertThrows(AwesomeException.class, () -> { /* smth */ });
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.