### PR TITLE
Use parent name in Surefire reporting if class source is missing

### DIFF
--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
@@ -95,8 +95,7 @@ final class RunListenerAdapter implements TestExecutionListener {
 		else {
 			// Test source unknown. Use display names of parent and current identifier
 			// as class and method, respectively.
-			return ignored(parentDisplayName(testIdentifier), testIdentifier.getDisplayName(),
-				throwable.map(Throwable::getMessage).orElse(null));
+			return new SimpleReportEntry(parentDisplayName(testIdentifier), testIdentifier.getDisplayName(), null);
 		}
 	}
 

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
@@ -60,7 +60,7 @@ final class RunListenerAdapter implements TestExecutionListener {
 
 	@Override
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-		String source = getClassName(testIdentifier).orElse(parentDisplayName(testIdentifier));
+		String source = getClassName(testIdentifier).orElseGet(() -> parentDisplayName(testIdentifier));
 		runListener.testSkipped(ignored(source, testIdentifier.getDisplayName(), reason));
 	}
 
@@ -113,7 +113,7 @@ final class RunListenerAdapter implements TestExecutionListener {
 		return testPlan
 			.flatMap((TestPlan p) -> p.getParent(testIdentifier))
 			.map(TestIdentifier::getDisplayName)
-			.orElse(testIdentifier.getUniqueId());
+			.orElseGet(() -> testIdentifier.getUniqueId());
 		// @formatter:on
 	}
 }


### PR DESCRIPTION
## Overview

In surefire reporting, when a test identifier has no class source attached to it, use the display name in the parent as source.

This fixes #616 (which used unique-ids of current test instead of display name of parent)

## Test cases

Contains a new test case for the sourceless case.

Furthermore, a selection of the test cases for checking that certain events fired now also check that the events come with proper class name, method name, and trace writer, if appropriate.

Some common setup code was refactored to the BeforeEach-annotated method.

## Refactorings

Extracted the (somewhat duplicated) code for retrieving a class name from a test identifier into a dedicated method.

## Additional Change

The source-less case covered in this change is now reported using a regular "SimpleReportEntry" -- it used to be reported as an "ignored" entry, which seems incorrect as it is called from the 'executionStarted' method.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
