### PR TITLE
Updated to Spotless 3.0.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 	}
 	dependencies {
-		classpath 'com.diffplug.gradle.spotless:spotless:2.4.0'
+		classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.0.0'
 		classpath 'org.ajoberstar:gradle-git:1.6.0'
 		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-SNAPSHOT'
 		classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
@@ -375,22 +375,21 @@ subprojects { subproj ->
 			licenseHeaderFile headerFile, '(package|import) '
 			importOrderFile rootProject.file('src/eclipse/junit-eclipse.importorder')
 			eclipseFormatFile rootProject.file('src/eclipse/junit-eclipse-formatter-settings.xml')
+			removeUnusedImports()
 
 			trimTrailingWhitespace()
 			endWithNewline()
-
-			custom 'Lambda fix', { it.replace('} )', '})').replace('} ,', '},') }
 		}
 
 		format 'groovy', {
-			target '**/*.groovy'
+			target 'src/**/*.groovy'
 			indentWithTabs()
 			trimTrailingWhitespace()
 			endWithNewline()
 			licenseHeaderFile headerFile, "package "
 
-			customReplaceRegex 'class-level Javadoc indentation fix', /^\*/, ' *'
-			customReplaceRegex 'nested Javadoc indentation fix', /\t\*/, '\t *'
+			replaceRegex 'class-level Javadoc indentation fix', /^\*/, ' *'
+			replaceRegex 'nested Javadoc indentation fix', /\t\*/, '\t *'
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -375,7 +375,6 @@ subprojects { subproj ->
 			licenseHeaderFile headerFile, '(package|import) '
 			importOrderFile rootProject.file('src/eclipse/junit-eclipse.importorder')
 			eclipseFormatFile rootProject.file('src/eclipse/junit-eclipse-formatter-settings.xml')
-			removeUnusedImports()
 
 			trimTrailingWhitespace()
 			endWithNewline()

--- a/documentation/src/test/java/example/JUnit4ClassDemo.java
+++ b/documentation/src/test/java/example/JUnit4ClassDemo.java
@@ -11,7 +11,6 @@
 package example;
 
 // tag::user_guide[]
-
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- added removeUnusedImports() rule
- removed lamda fix (no longer needed)
- changed groovy target to `src/**/*.groovy`,
  because it is faster to resolve than `**/*.groovy`.
- renamed `customReplaceRegex` to its new name
  `replaceRegex`.

Time for a `spotlessCheck` to execute before this commit: 8.4s config, 5s execution (total 13.4s)
Time for a `spotlessCheck` to execute after this commit: 5.5s config, 0.3s execution (total 5.8s).
So about twice as fast.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
