### PR TITLE
Remove includeClassNamePattern(String) with all dependencies

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -23,6 +23,9 @@ on GitHub.
 * Removed deprecated `selectNames()` name-based discovery selector from
   `DiscoverySelectors` in favor of the dedicated `selectPackage(String)`,
   `selectClass(String)`, and `selectMethod(String)` methods.
+* `ClassNameFilter.includeClassNamePattern` was removed, please use
+  `ClassNameFilter.includeClassNamePatterns` instead.
+* `@IncludeClassNamePattern` was removed, please use `@IncludeClassNamePatterns` instead.
 
 ===== New Features
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassNameFilter.java
@@ -33,24 +33,6 @@ public interface ClassNameFilter extends DiscoveryFilter<String> {
 	String STANDARD_INCLUDE_PATTERN = "^.*Tests?$";
 
 	/**
-	 * Create a new <em>include</em> {@link ClassNameFilter} based on the supplied
-	 * pattern.
-	 *
-	 * <p>If the fully qualified name of a class matches against the pattern,
-	 * the class will be included in the result set.
-	 *
-	 * @param pattern a regular expression to match against fully qualified
-	 * class names; never {@code null} or blank
-	 * @see Class#getName()
-	 * @deprecated This method will be removed in 5.0 M4; use
-	 * {@link #includeClassNamePatterns} instead.
-	 */
-	@Deprecated
-	static ClassNameFilter includeClassNamePattern(String pattern) {
-		return new IncludeClassNameFilter(pattern);
-	}
-
-	/**
 	 * Create a new <em>include</em> {@link ClassNameFilter} based on the
 	 * supplied patterns.
 	 *

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
@@ -246,7 +246,8 @@ public class JUnitPlatform extends Runner implements Filterable {
 	}
 
 	private String[] getIncludeClassNamePatterns(boolean isSuite) {
-		String[] patterns = getIncludeClassNamePatterns();
+		String[] patterns = getValueFromAnnotation(IncludeClassNamePatterns.class, IncludeClassNamePatterns::value,
+			new String[0]);
 		if (patterns.length == 0 && isSuite) {
 			return new String[] { STANDARD_INCLUDE_PATTERN };
 		}
@@ -259,20 +260,6 @@ public class JUnitPlatform extends Runner implements Filterable {
 		for (int i = 0; i < patterns.length; i++) {
 			patterns[i] = patterns[i].trim();
 		}
-	}
-
-	@SuppressWarnings("deprecation")
-	private String[] getIncludeClassNamePatterns() {
-		String[] patterns = getValueFromAnnotation(IncludeClassNamePatterns.class, IncludeClassNamePatterns::value,
-			new String[0]);
-		String patternFromDeprecatedAnnotation = getValueFromAnnotation(IncludeClassNamePattern.class,
-			IncludeClassNamePattern::value, EMPTY_STRING);
-		Preconditions.condition(patterns.length == 0 || patternFromDeprecatedAnnotation.isEmpty(),
-			"You must not specify both @IncludeClassNamePattern and @IncludeClassNamePatterns");
-		if (patterns.length == 0 && !patternFromDeprecatedAnnotation.isEmpty()) {
-			patterns = new String[] { patternFromDeprecatedAnnotation };
-		}
-		return patterns;
 	}
 
 	private <A extends Annotation, V> V getValueFromAnnotation(Class<A> annotationClass, Function<A, V> extractor,

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -263,11 +263,10 @@ class JUnitPlatformRunnerTests {
 		}
 
 		@Test
-		void addsExplicitClassNameFilterToRequestWhenDeprecatedIncludeClassNamePatternAnnotationIsPresent()
+		void addsSingleExplicitClassNameFilterToRequestWhenIncludeClassNamePatternsAnnotationIsPresent()
 				throws Exception {
 
-			@SuppressWarnings("deprecation")
-			@IncludeClassNamePattern(".*Foo")
+			@IncludeClassNamePatterns(".*Foo")
 			class TestCase {
 			}
 
@@ -278,7 +277,8 @@ class JUnitPlatformRunnerTests {
 		}
 
 		@Test
-		void addsExplicitClassNameFilterToRequestWhenIncludeClassNamePatternsAnnotationIsPresent() throws Exception {
+		void addsMultipleExplicitClassNameFilterToRequestWhenIncludeClassNamePatternsAnnotationIsPresent()
+				throws Exception {
 
 			@IncludeClassNamePatterns({ ".*Foo", "Bar.*" })
 			class TestCase {
@@ -316,22 +316,6 @@ class JUnitPlatformRunnerTests {
 
 			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
 			assertThat(filters).isEmpty();
-		}
-
-		@Test
-		void throwsExceptionWhenBothIncludeClassNamePatternsAnnotationsArePresent() throws Exception {
-
-			@SuppressWarnings("deprecation")
-			@IncludeClassNamePattern("foo")
-			@IncludeClassNamePatterns("foo")
-			class TestCase {
-			}
-
-			PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
-				() -> instantiateRunnerAndCaptureGeneratedRequest(TestCase.class));
-
-			assertThat(exception).hasMessage(
-				"You must not specify both @IncludeClassNamePattern and @IncludeClassNamePatterns");
 		}
 
 		@Test


### PR DESCRIPTION
## Overview

- Remove deprecated ```includeClassNamePattern(String)``` and ```@IncludeClassNamePattern```as described in #547.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
