### PR TITLE
Issue314 exclude classname patterns

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -53,6 +53,7 @@ class AvailableOptions {
 
 	// Filters
 	private final OptionSpec<String> includeClassNamePattern;
+	private final OptionSpec<String> excludeClassNamePattern;
 	private final OptionSpec<String> includePackage;
 	private final OptionSpec<String> excludePackage;
 	private final OptionSpec<String> includeTag;
@@ -149,6 +150,10 @@ class AvailableOptions {
 					+ "When this option is repeated, all patterns will be combined using OR semantics.") //
 				.withRequiredArg() //
 				.defaultsTo(ClassNameFilter.STANDARD_INCLUDE_PATTERN);
+		excludeClassNamePattern = parser.acceptsAll(asList("N", "exclude-classname"),
+			"Provide a regular expression to exclude those classes whose fully qualified names match. " //
+					+ "When this option is repeated, all patterns will be combined using OR semantics.") //
+				.withRequiredArg();
 
 		includePackage = parser.accepts("include-package",
 			"Provide a package to be included in the test run. This option can be repeated.") //
@@ -202,6 +207,7 @@ class AvailableOptions {
 
 		// Filters
 		result.setIncludedClassNamePatterns(detectedOptions.valuesOf(this.includeClassNamePattern));
+		result.setExcludedClassNamePatterns(detectedOptions.valuesOf(this.excludeClassNamePattern));
 		result.setIncludedPackages(detectedOptions.valuesOf(this.includePackage));
 		result.setExcludedPackages(detectedOptions.valuesOf(this.excludePackage));
 		result.setIncludedTags(detectedOptions.valuesOf(this.includeTag));

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
@@ -49,6 +49,7 @@ public class CommandLineOptions {
 	private List<String> selectedClasspathResources = emptyList();
 
 	private List<String> includedClassNamePatterns = singletonList(STANDARD_INCLUDE_PATTERN);
+	private List<String> excludedClassNamePatterns = emptyList();
 	private List<String> includedPackages = emptyList();
 	private List<String> excludedPackages = emptyList();
 	private List<String> includedEngines = emptyList();
@@ -159,6 +160,14 @@ public class CommandLineOptions {
 
 	public void setIncludedClassNamePatterns(List<String> includedClassNamePatterns) {
 		this.includedClassNamePatterns = includedClassNamePatterns;
+	}
+
+	public List<String> getExcludedClassNamePatterns() {
+		return excludedClassNamePatterns;
+	}
+
+	public void setExcludedClassNamePatterns(List<String> excludedClassNamePatterns) {
+		this.excludedClassNamePatterns = excludedClassNamePatterns;
 	}
 
 	public List<String> getIncludedPackages() {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.console.tasks;
 
+import static org.junit.platform.engine.discovery.ClassNameFilter.excludeClassNamePatterns;
 import static org.junit.platform.engine.discovery.ClassNameFilter.includeClassNamePatterns;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClasspathRoots;
 import static org.junit.platform.engine.discovery.PackageNameFilter.excludePackageNames;
@@ -86,6 +87,11 @@ class DiscoveryRequestCreator {
 
 	private void addFilters(LauncherDiscoveryRequestBuilder requestBuilder, CommandLineOptions options) {
 		requestBuilder.filters(includeClassNamePatterns(options.getIncludedClassNamePatterns().toArray(new String[0])));
+
+		if (!options.getExcludedClassNamePatterns().isEmpty()) {
+			requestBuilder.filters(
+				excludeClassNamePatterns(options.getExcludedClassNamePatterns().toArray(new String[0])));
+		}
 
 		if (!options.getIncludedPackages().isEmpty()) {
 			requestBuilder.filters(includePackageNames(options.getIncludedPackages()));

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/AbstractClassNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/AbstractClassNameFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.discovery;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * Abstract {@link ClassNameFilter} that servers as a superclass
+ * for filters including or excluding fully qualified class names
+ * based on pattern-matching.
+ *
+ * @since 1.0
+ */
+abstract class AbstractClassNameFilter implements ClassNameFilter {
+
+	protected final List<Pattern> patterns;
+	protected final String patternDescription;
+
+	AbstractClassNameFilter(String... patterns) {
+		Preconditions.notEmpty(patterns, "patterns must not be null or empty");
+		Preconditions.containsNoNullElements(patterns, "patterns must not contain null elements");
+		this.patterns = Arrays.stream(patterns).map(Pattern::compile).collect(toList());
+		this.patternDescription = Arrays.stream(patterns).collect(joining("' OR '", "'", "'"));
+	}
+
+	@Override
+	public abstract Predicate<String> toPredicate();
+
+	protected Optional<Pattern> findMatchingPattern(String className) {
+		return this.patterns.stream().filter(pattern -> pattern.matcher(className).matches()).findAny();
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassNameFilter.java
@@ -48,4 +48,20 @@ public interface ClassNameFilter extends DiscoveryFilter<String> {
 		return new IncludeClassNameFilter(patterns);
 	}
 
+	/**
+	 * Create a new <em>exclude</em> {@link ClassNameFilter} based on the
+	 * supplied patterns.
+	 *
+	 * <p>The patterns are combined using OR semantics, i.e. if the fully
+	 * qualified name of a class matches against at least one of the patterns,
+	 * the class will be excluded from the result set.
+	 *
+	 * @param patterns regular expressions to match against fully qualified
+	 * class names; never {@code null}, empty, or containing {@code null}
+	 * @see Class#getName()
+	 */
+	static ClassNameFilter excludeClassNamePatterns(String... patterns) {
+		return new ExcludeClassNameFilter(patterns);
+	}
+
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludeClassNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludeClassNameFilter.java
@@ -23,39 +23,39 @@ import org.junit.platform.engine.FilterResult;
  * patterns in the form of regular expressions.
  *
  * <p>If the fully qualified name of a class matches against at least one
- * pattern, the class will be included.
+ * pattern, the class will be excluded.
  *
  * @since 1.0
  */
-class IncludeClassNameFilter extends AbstractClassNameFilter {
+class ExcludeClassNameFilter extends AbstractClassNameFilter {
 
-	IncludeClassNameFilter(String... patterns) {
+	ExcludeClassNameFilter(String... patterns) {
 		super(patterns);
 	}
 
 	@Override
 	public FilterResult apply(String className) {
 		return findMatchingPattern(className) //
-				.map(pattern -> included(formatInclusionReason(className, pattern))) //
-				.orElseGet(() -> excluded(formatExclusionReason(className)));
+				.map(pattern -> excluded(formatExclusionReason(className, pattern))) //
+				.orElseGet(() -> included(formatInclusionReason(className)));
 	}
 
-	private String formatExclusionReason(String className) {
-		return String.format("Class name [%s] does not match any included pattern: %s", className, patternDescription);
+	private String formatExclusionReason(String className, Pattern pattern) {
+		return String.format("Class name [%s] matches excluded pattern: '%s'", className, pattern);
 	}
 
-	private String formatInclusionReason(String className, Pattern pattern) {
-		return String.format("Class name [%s] matches included pattern: '%s'", className, pattern);
+	private String formatInclusionReason(String className) {
+		return String.format("Class name [%s] does not match any excluded pattern: %s", className, patternDescription);
 	}
 
 	@Override
 	public Predicate<String> toPredicate() {
-		return className -> findMatchingPattern(className).isPresent();
+		return className -> !findMatchingPattern(className).isPresent();
 	}
 
 	@Override
 	public String toString() {
-		return "Includes class names that match regular expression " + patternDescription;
+		return "Excludes class names that match regular expression " + patternDescription;
 	}
 
 }

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/FiltersExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/FiltersExtension.groovy
@@ -30,8 +30,22 @@ class FiltersExtension {
 	 */
 	List<String> includeClassNamePatterns
 
+	/**
+	 * List of class name patterns in the form of regular expressions for
+	 * classes that should be <em>excluded</em> from the test plan.
+	 *
+	 * <p>The patterns are combined using OR semantics, i.e. if the fully
+	 * qualified name of a class matches against at least one of the patterns,
+	 * the class will be excluded from the test plan.
+	 */
+	List<String> excludeClassNamePatterns
+
 	protected List<String> getIncludeClassNamePatterns() {
 		return includeClassNamePatterns ?: [ ClassNameFilter.STANDARD_INCLUDE_PATTERN ];
+	}
+
+	protected List<String> getExcludeClassNamePatterns() {
+		return excludeClassNamePatterns
 	}
 
 	/**
@@ -49,6 +63,23 @@ class FiltersExtension {
 			includeClassNamePatterns = []
 		}
 		includeClassNamePatterns.addAll(patterns)
+	}
+
+	/**
+	 * Add a pattern to the list of <em>excluded</em> patterns.
+	 */
+	void excludeClassNamePattern(String pattern) {
+		excludeClassNamePatterns(pattern)
+	}
+
+	/**
+	 * Add patterns to the list of <em>included</em> patterns.
+	 */
+	void excludeClassNamePatterns(String... patterns) {
+		if (excludeClassNamePatterns == null) {
+			excludeClassNamePatterns = []
+		}
+		excludeClassNamePatterns.addAll(patterns)
 	}
 
 }

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/FiltersExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/FiltersExtension.groovy
@@ -73,7 +73,7 @@ class FiltersExtension {
 	}
 
 	/**
-	 * Add patterns to the list of <em>included</em> patterns.
+	 * Add patterns to the list of <em>excluded</em> patterns.
 	 */
 	void excludeClassNamePatterns(String... patterns) {
 		if (excludeClassNamePatterns == null) {

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -129,6 +129,9 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 		filters.includeClassNamePatterns.each { pattern ->
 			args.addAll(['-n', pattern])
 		}
+		filters.excludeClassNamePatterns.each { pattern ->
+			args.addAll(['-N', pattern])
+		}
 		filters.packages.include.each { includedPackage ->
 			args.addAll(['--include-package',includedPackage])
 		}

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -52,6 +52,7 @@ class JUnitPlatformPluginSpec extends Specification {
 
 			filters {
 				includeClassNamePattern '.*Tests?'
+				excludeClassNamePattern '.*TestCase'
 				engines {
 					include 'foo'
 					exclude 'bar'
@@ -83,6 +84,8 @@ class JUnitPlatformPluginSpec extends Specification {
 			filters {
 				includeClassNamePattern '.*Tests?'
 				includeClassNamePatterns 'Foo', 'Bar'
+				excludeClassNamePattern '.*TestCase'
+				excludeClassNamePatterns 'One', 'Two'
 				packages {
 					include 'testpackage.included.p1', 'testpackage.included.p2'
 					exclude 'testpackage.excluded.p1', 'testpackage.excluded.p2'
@@ -110,6 +113,7 @@ class JUnitPlatformPluginSpec extends Specification {
 
 		junitTask.args.containsAll('--details', 'FLAT')
 		junitTask.args.containsAll('-n', '.*Tests?', '-n', 'Foo', '-n', 'Bar')
+		junitTask.args.containsAll('-N', '.*TestCase', '-N', 'One', '-N', 'Two')
 		junitTask.args.containsAll('--include-package', 'testpackage.included.p1', '--include-package', 'testpackage.included.p2')
 		junitTask.args.containsAll('--exclude-package', 'testpackage.excluded.p1', '--exclude-package', 'testpackage.excluded.p2')
 		junitTask.args.containsAll('-t', 'fast')

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/ExcludeClassNamePatterns.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/ExcludeClassNamePatterns.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.runner;
+
+import static org.junit.platform.commons.meta.API.Usage.Maintained;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.engine.discovery.ClassNameFilter;
+
+/**
+ * {@code @ExcludeClassNamePatterns} specifies regular expressions that are used
+ * to match against fully qualified class names when running a test suite via
+ * {@code @RunWith(JUnitPlatform.class)}.
+ *
+ * <p>The patterns are combined using OR semantics, i.e. if the fully
+ * qualified name of a class matches against at least one of the patterns,
+ * the class will be excluded from the test plan.
+ *
+ * @since 1.0
+ * @see JUnitPlatform
+ * @see ClassNameFilter#excludeClassNamePatterns
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@Documented
+@API(Maintained)
+public @interface ExcludeClassNamePatterns {
+
+	/**
+	 * Regular expressions used to match against fully qualified class names.
+	 */
+	String[] value();
+
+}

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
@@ -14,6 +14,7 @@ import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.meta.API.Usage.Maintained;
 import static org.junit.platform.engine.discovery.ClassNameFilter.STANDARD_INCLUDE_PATTERN;
+import static org.junit.platform.engine.discovery.ClassNameFilter.excludeClassNamePatterns;
 import static org.junit.platform.engine.discovery.ClassNameFilter.includeClassNamePatterns;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.PackageNameFilter.excludePackageNames;
@@ -76,6 +77,7 @@ import org.junit.runners.model.InitializationError;
  * @see SelectPackages
  * @see SelectClasses
  * @see IncludeClassNamePatterns
+ * @see ExcludeClassNamePatterns
  * @see IncludeTags
  * @see ExcludeTags
  * @see IncludeEngines
@@ -140,6 +142,8 @@ public class JUnitPlatform extends Runner implements Filterable {
 
 	private void addFiltersFromAnnotations(LauncherDiscoveryRequestBuilder requestBuilder, boolean isSuite) {
 		addIncludeClassNamePatternFilter(requestBuilder, isSuite);
+		addExcludeClassNamePatternFilter(requestBuilder);
+
 		addIncludePackagesFilter(requestBuilder);
 		addExcludePackagesFilter(requestBuilder);
 
@@ -167,6 +171,13 @@ public class JUnitPlatform extends Runner implements Filterable {
 		String[] patterns = getIncludeClassNamePatterns(isSuite);
 		if (patterns.length > 0) {
 			requestBuilder.filters(includeClassNamePatterns(patterns));
+		}
+	}
+
+	private void addExcludeClassNamePatternFilter(LauncherDiscoveryRequestBuilder requestBuilder) {
+		String[] patterns = getExcludeClassNamePatterns();
+		if (patterns.length > 0) {
+			requestBuilder.filters(excludeClassNamePatterns(patterns));
 		}
 	}
 
@@ -251,6 +262,19 @@ public class JUnitPlatform extends Runner implements Filterable {
 			return new String[] { STANDARD_INCLUDE_PATTERN };
 		}
 		Preconditions.containsNoNullElements(patterns, "IncludeClassNamePatterns must not contain null elements");
+		trim(patterns);
+		return patterns;
+	}
+
+	private String[] getExcludeClassNamePatterns() {
+		String[] patterns = getValueFromAnnotation(ExcludeClassNamePatterns.class, ExcludeClassNamePatterns::value,
+			new String[0]);
+
+		if (patterns.length == 0) {
+			return new String[] {};
+		}
+
+		Preconditions.containsNoNullElements(patterns, "ExcludeClassNamePatterns must not contain null elements");
 		trim(patterns);
 		return patterns;
 	}

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
@@ -270,10 +270,6 @@ public class JUnitPlatform extends Runner implements Filterable {
 		String[] patterns = getValueFromAnnotation(ExcludeClassNamePatterns.class, ExcludeClassNamePatterns::value,
 			new String[0]);
 
-		if (patterns.length == 0) {
-			return new String[] {};
-		}
-
 		Preconditions.containsNoNullElements(patterns, "ExcludeClassNamePatterns must not contain null elements");
 		trim(patterns);
 		return patterns;

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.console;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.console.options.JOptSimpleCommandLineOptionsParser;
+import org.junit.platform.console.tasks.ConsoleTaskExecutor;
+
+/**
+ * @since 1.0
+ */
+public class ConsoleLauncherIntegrationTests {
+
+	private ByteArrayOutputStream out = new ByteArrayOutputStream();
+	private ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+	private ConsoleLauncher consoleLauncher = new ConsoleLauncher(new JOptSimpleCommandLineOptionsParser(),
+		new ConsoleTaskExecutor(new PrintStream(out), new PrintStream(err)));
+
+	@Test
+	public void runningConsoleLauncherWithoutExcludeClassnameOptionDoesNotExcludeClasses() {
+		String[] args = { "-e", "junit-jupiter", "-p", "org.junit.platform.console.subpackage" };
+		String standardOutText = this.executeLauncherAndFetchStandardOut(args);
+		assertThat(standardOutText).contains("2 tests found ");
+	}
+
+	@Test
+	public void runningConsoleLauncherWithExcludeClassnameOptionExcludesClasses() {
+		String[] args = { "-e", "junit-jupiter", "-p", "org.junit.platform.console.subpackage", "--exclude-classname",
+				"^org\\.junit\\.platform\\.console\\.subpackage\\..*" };
+		String standardOutText = this.executeLauncherAndFetchStandardOut(args);
+		assertThat(standardOutText).contains("0 tests found ");
+	}
+
+	private String executeLauncherAndFetchStandardOut(String[] args) {
+		int exitCode = this.consoleLauncher.execute(args);
+		assertEquals(0, exitCode);
+
+		String standardErr = new String(this.err.toByteArray());
+		assertTrue(standardErr.isEmpty());
+
+		String standardOutText = new String(this.out.toByteArray());
+		System.out.println(standardOutText);
+		return standardOutText;
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
@@ -52,6 +52,7 @@ class JOptSimpleCommandLineOptionsParserTests {
 			() -> assertEquals(CommandLineOptions.DEFAULT_DETAILS, options.getDetails()),
 			() -> assertFalse(options.isScanClasspath()),
 			() -> assertEquals(singletonList(STANDARD_INCLUDE_PATTERN), options.getIncludedClassNamePatterns()),
+			() -> assertEquals(emptyList(), options.getExcludedClassNamePatterns()),
 			() -> assertEquals(emptyList(), options.getIncludedPackages()),
 			() -> assertEquals(emptyList(), options.getExcludedPackages()),
 			() -> assertEquals(emptyList(), options.getIncludedTags()),
@@ -108,6 +109,17 @@ class JOptSimpleCommandLineOptionsParserTests {
 	}
 
 	@Test
+	public void parseValidExcludeClassNamePatterns() {
+		// @formatter:off
+		assertAll(
+			() -> assertEquals(singletonList(".*Test"), parseArgLine("-N .*Test").getExcludedClassNamePatterns()),
+			() -> assertEquals(asList(".*Test", ".*Tests"), parseArgLine("--exclude-classname .*Test --exclude-classname .*Tests").getExcludedClassNamePatterns()),
+			() -> assertEquals(singletonList(".*Test"), parseArgLine("--exclude-classname=.*Test").getExcludedClassNamePatterns())
+		);
+		// @formatter:on
+	}
+
+	@Test
 	public void usesDefaultClassNamePatternWithoutExplicitArgument() {
 		assertEquals(singletonList(STANDARD_INCLUDE_PATTERN), parseArgLine("").getIncludedClassNamePatterns());
 	}
@@ -115,6 +127,11 @@ class JOptSimpleCommandLineOptionsParserTests {
 	@Test
 	public void parseInvalidIncludeClassNamePatterns() throws Exception {
 		assertOptionWithMissingRequiredArgumentThrowsException("-n", "--include-classname");
+	}
+
+	@Test
+	public void parseInvalidExcludeClassNamePatterns() throws Exception {
+		assertOptionWithMissingRequiredArgumentThrowsException("-N", "--exclude-classname");
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/console/subpackage/OneTest.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/subpackage/OneTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.console.subpackage;
+
+import org.junit.jupiter.api.Test;
+
+public class OneTest {
+
+	@Test
+	public void m1() {
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/console/subpackage/TwoTest.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/subpackage/TwoTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.console.subpackage;
+
+import org.junit.jupiter.api.Test;
+
+public class TwoTest {
+
+	@Test
+	public void m2() {
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
@@ -122,6 +122,19 @@ public class DiscoveryRequestCreatorTests {
 	}
 
 	@Test
+	public void convertsExcludeClassNamePatternOption() {
+		options.setScanClasspath(true);
+		options.setExcludedClassNamePatterns(asList("Foo.*Bar", "Bar.*Foo"));
+
+		LauncherDiscoveryRequest request = convert();
+
+		List<ClassNameFilter> filter = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+		assertThat(filter).hasSize(2);
+		assertThat(filter.get(1).toString()).contains("Foo.*Bar");
+		assertThat(filter.get(1).toString()).contains("Bar.*Foo");
+	}
+
+	@Test
 	public void convertsPackageOptions() {
 		options.setScanClasspath(true);
 		options.setIncludedPackages(asList("org.junit.included1", "org.junit.included2", "org.junit.included3"));

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/ClassNameFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/ClassNameFilterTests.java
@@ -82,4 +82,64 @@ class ClassNameFilterTests {
 					+ secondRegex + "'");
 	}
 
+	@Test
+	void excludeClassNamePatternsChecksPreconditions() {
+		assertThatThrownBy(() -> ClassNameFilter.excludeClassNamePatterns((String[]) null)) //
+				.isInstanceOf(PreconditionViolationException.class) //
+				.hasMessage("patterns must not be null or empty");
+		assertThatThrownBy(() -> ClassNameFilter.excludeClassNamePatterns(new String[0])) //
+				.isInstanceOf(PreconditionViolationException.class) //
+				.hasMessage("patterns must not be null or empty");
+		assertThatThrownBy(() -> ClassNameFilter.excludeClassNamePatterns(new String[] { null })) //
+				.isInstanceOf(PreconditionViolationException.class) //
+				.hasMessage("patterns must not contain null elements");
+	}
+
+	@Test
+	void excludeClassNamePatternsWithSinglePattern() {
+		String regex = "^java\\.lang\\..*";
+
+		ClassNameFilter filter = ClassNameFilter.excludeClassNamePatterns(regex);
+
+		assertThat(filter).hasToString("Excludes class names that match regular expression '" + regex + "'");
+
+		assertTrue(filter.apply("java.lang.String").excluded());
+		assertFalse(filter.toPredicate().test("java.lang.String"));
+
+		assertThat(filter.apply("java.lang.String").getReason()).contains(
+			"Class name [java.lang.String] matches excluded pattern: '" + regex + "'");
+
+		assertTrue(filter.apply("java.time.Instant").included());
+		assertTrue(filter.toPredicate().test("java.time.Instant"));
+		assertThat(filter.apply("java.time.Instant").getReason()).contains(
+			"Class name [java.time.Instant] does not match any excluded pattern: '" + regex + "'");
+	}
+
+	@Test
+	void excludeClassNamePatternsWithMultiplePatterns() {
+		String firstRegex = "^java\\.lang\\..*";
+		String secondRegex = "^java\\.util\\..*";
+
+		ClassNameFilter filter = ClassNameFilter.excludeClassNamePatterns(firstRegex, secondRegex);
+
+		assertThat(filter).hasToString(
+			"Excludes class names that match regular expression '" + firstRegex + "' OR '" + secondRegex + "'");
+
+		assertTrue(filter.apply("java.lang.String").excluded());
+		assertFalse(filter.toPredicate().test("java.lang.String"));
+		assertThat(filter.apply("java.lang.String").getReason()).contains(
+			"Class name [java.lang.String] matches excluded pattern: '" + firstRegex + "'");
+
+		assertTrue(filter.apply("java.util.Collection").excluded());
+		assertFalse(filter.toPredicate().test("java.util.Collection"));
+		assertThat(filter.apply("java.util.Collection").getReason()).contains(
+			"Class name [java.util.Collection] matches excluded pattern: '" + secondRegex + "'");
+
+		assertFalse(filter.apply("java.time.Instant").excluded());
+		assertTrue(filter.toPredicate().test("java.time.Instant"));
+		assertThat(filter.apply("java.time.Instant").getReason()).contains(
+			"Class name [java.time.Instant] does not match any excluded pattern: '" + firstRegex + "' OR '"
+					+ secondRegex + "'");
+	}
+
 }

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -276,10 +276,36 @@ class JUnitPlatformRunnerTests {
 		}
 
 		@Test
+		void addsSingleClassNameFilterToRequestWhenExcludeClassNamePatternsAnnotationIsPresent() throws Exception {
+
+			@ExcludeClassNamePatterns(".*Foo")
+			class TestCase {
+			}
+
+			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
+
+			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			assertThat(getOnlyElement(filters).toString()).contains(".*Foo");
+		}
+
+		@Test
 		void addsMultipleExplicitClassNameFilterToRequestWhenIncludeClassNamePatternsAnnotationIsPresent()
 				throws Exception {
 
 			@IncludeClassNamePatterns({ ".*Foo", "Bar.*" })
+			class TestCase {
+			}
+
+			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
+
+			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			assertThat(getOnlyElement(filters).toString()).contains(".*Foo", "Bar.*");
+		}
+
+		@Test
+		void addsMultipleClassNameFilterToRequestWhenExcludeClassNamePatternsAnnotationIsPresent() throws Exception {
+
+			@ExcludeClassNamePatterns({ ".*Foo", "Bar.*" })
 			class TestCase {
 			}
 
@@ -304,7 +330,7 @@ class JUnitPlatformRunnerTests {
 		}
 
 		@Test
-		void addsExplicitClassNameFilterWhenIncludeClassNamePatternsAnnotationIsPresentWithEmptyArguments()
+		void doesNotAddClassNameFilterWhenIncludeClassNamePatternsAnnotationIsPresentWithEmptyArguments()
 				throws Exception {
 
 			@IncludeClassNamePatterns({})
@@ -318,9 +344,36 @@ class JUnitPlatformRunnerTests {
 		}
 
 		@Test
+		void doesNotAddClassNameFilterWhenExcludeClassNamePatternsAnnotationIsPresentWithEmptyArguments()
+				throws Exception {
+
+			@ExcludeClassNamePatterns({})
+			class TestCase {
+			}
+
+			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
+
+			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			assertThat(filters).isEmpty();
+		}
+
+		@Test
 		void trimsArgumentsOfIncludeClassNamePatternsAnnotation() throws Exception {
 
 			@IncludeClassNamePatterns({ " foo", "bar " })
+			class TestCase {
+			}
+
+			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
+
+			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			assertThat(getOnlyElement(filters).toString()).contains("'foo'", "'bar'");
+		}
+
+		@Test
+		void trimsArgumentsOfExcludeClassNamePatternsAnnotation() throws Exception {
+
+			@ExcludeClassNamePatterns({ " foo", "bar " })
 			class TestCase {
 			}
 


### PR DESCRIPTION
## Overview

This PR addresses issue #314.  
It adds support for filtering classes for exclusion in the ConsoleLauncher, the Gradle JUnit 5 plugin, and the JUnitPlatform runner.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
