### PR TITLE
Add details parsing fix and tests.

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -80,6 +80,7 @@ class AvailableOptions {
 					+ ". If '" + Details.NONE + "' is selected, then only the summary and test failures are shown.") //
 				.withRequiredArg() //
 				.ofType(Details.class) //
+				.withValuesConvertedBy(new DetailsConverter()) //
 				.defaultsTo(CommandLineOptions.DEFAULT_DETAILS);
 
 		additionalClasspathEntries = parser.acceptsAll(asList(CP_OPTION, "classpath", "class-path"), //

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/DetailsConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/DetailsConverter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.console.options;
+
+import static org.junit.platform.commons.meta.API.Usage.Internal;
+
+import joptsimple.util.EnumConverter;
+
+import org.junit.platform.commons.meta.API;
+
+/**
+ * @since 1.0
+ */
+@API(Internal)
+class DetailsConverter extends EnumConverter<Details> {
+
+	DetailsConverter() {
+		super(Details.class);
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
@@ -70,11 +70,30 @@ class JOptSimpleCommandLineOptionsParserTests {
 	public void parseSwitches() {
 		// @formatter:off
 		assertAll(
-				() -> assertParses("disable ansi", CommandLineOptions::isAnsiColorOutputDisabled, "--disable-ansi-colors"),
-				() -> assertParses("help", CommandLineOptions::isDisplayHelp, "-h", "--help"),
+			() -> assertParses("disable ansi", CommandLineOptions::isAnsiColorOutputDisabled, "--disable-ansi-colors"),
+			() -> assertParses("help", CommandLineOptions::isDisplayHelp, "-h", "--help"),
 			() -> assertParses("scan class path", CommandLineOptions::isScanClasspath, "--scan-class-path")
 		);
 		// @formatter:on
+	}
+
+	@Test
+	public void parseValidDetails() {
+		// @formatter:off
+		assertAll(
+			() -> assertEquals(Details.VERBOSE, parseArgLine("--details verbose").getDetails()),
+			() -> assertEquals(Details.TREE, parseArgLine("--details tree").getDetails()),
+			() -> assertEquals(Details.FLAT, parseArgLine("--details flat").getDetails()),
+			() -> assertEquals(Details.NONE, parseArgLine("--details NONE").getDetails()),
+			() -> assertEquals(Details.NONE, parseArgLine("--details none").getDetails()),
+			() -> assertEquals(Details.NONE, parseArgLine("--details None").getDetails())
+		);
+		// @formatter:on
+	}
+
+	@Test
+	public void parseInvalidDetails() throws Exception {
+		assertOptionWithMissingRequiredArgumentThrowsException("--details");
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

PR #524 pretended to parse option details case insensitive -- but it did not. This PR fixes that issue and provides tests ensuring all of case-wise permutations from `NONE` to `none` are allowed and valid for `--details`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
