### PR TITLE
Revise task inputs for Gradle plugin regarding incremental builds (#631)

### DIFF
--- a/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
+++ b/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
@@ -3,7 +3,7 @@ apply plugin: 'groovy'
 dependencies {
 	compile localGroovy()
 	compile gradleApi()
-	compile(project(path: ':junit-platform-console', configuration: 'shadow'))
+	compile(project(':junit-platform-console'))
 	compile(project(':junit-platform-launcher'))
 	testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
 		transitive = false


### PR DESCRIPTION
## Overview

Fixes #631 by removing `path` and `configuration` from compile-time dependency declaration.

With the change applied, Gradle can quickly pass a sequence like `gradlew clean test; gradlew test; gradlew test` from the second `test` on with:
```
[...]
:junit-platform-gradle-plugin:test UP-TO-DATE
BUILD SUCCESSFUL
Total time: 1.103 secs
11:33:56: External task execution finished 'test'.
```
---

I hereby agree to the terms of the JUnit Contributor License Agreement.
