### PR TITLE
Make Gradle incremental build work

### DIFF
--- a/junit-platform-console/junit-platform-console.gradle
+++ b/junit-platform-console/junit-platform-console.gradle
@@ -42,6 +42,11 @@ javadoc {
 jar.enabled = false
 
 shadowJar {
+	// Generate shadow jar only if the underlying manifest was regenerated.
+	// See https://github.com/junit-team/junit5/issues/631
+	onlyIf {
+		project.generateManifest
+	}
 	classifier = null
 	configurations = [project.configurations.shadowed]
 	exclude 'META-INF/**'


### PR DESCRIPTION
## Overview

Executing `gradlew clean test; gradlew test; gradlew test` resulted in
all tests being executed thrice instead of just once. By generating the
shadowed `junit-platform-console-x.y.z.jar` only if code changes are
made, Gradles' UP-TO-DATE checks succeed again.

Copied from `build.gradle` file:
```
 // Generate JAR manifest only if code was compiled or recompiled;
 // otherwise the junitPlatformTest task will always be executed even if
 // no code changes were made. The reason is that the generation of
 // the buildDate and buildTime causes JAR manifests to be modified
 // which triggers unnecessary rebuilding of the dependent JARs.
```

Fixes #631

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
