### PR TITLE
Introduce @TestTemplate and accompanying extension point

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestTemplate.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestTemplate.java
@@ -33,6 +33,10 @@ import org.junit.platform.commons.meta.API;
  * org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider
  * providers}.
  *
+ * <p>Each invocation of a test template method, behaves like the execution of
+ * a regular {@link Test @Test} method, i.e. it supports the same lifecycle
+ * callbacks and extensions.
+ *
  * <p>{@code @TestTemplate} methods must not be {@code private} or {@code static}
  * and must return {@code void}.
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestTemplate.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestTemplate.java
@@ -31,7 +31,8 @@ import org.junit.platform.commons.meta.API;
  * org.junit.jupiter.api.extension.TestTemplateInvocationContext invocation
  * contexts} returned by the registered {@linkplain
  * org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider
- * providers}.
+ * providers}. Must be used together with at least one provider. Otherwise,
+ * execution will fail.
  *
  * <p>Each invocation of a test template method, behaves like the execution of
  * a regular {@link Test @Test} method, i.e. it supports the same lifecycle

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestTemplate.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestTemplate.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.platform.commons.annotation.Testable;
+import org.junit.platform.commons.meta.API;
+
+/**
+ * {@code @TestTemplate} is used to signal that the annotated method is a
+ * <em>test template</em> method.
+ *
+ * <p>In contrast to {@link Test @Test} methods, a test template is not itself
+ * a test case but rather a template for test cases.
+ *
+ * <p>{@code @TestTemplate} methods must not be {@code private} or {@code static}
+ * and must return {@code void}.
+ *
+ * <p>{@code @TestTemplate} methods may optionally declare parameters to be
+ * resolved by {@link org.junit.jupiter.api.extension.ParameterResolver
+ * ParameterResolvers}.
+ *
+ * @since 5.0
+ * @see Test
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(Experimental)
+@Testable
+public @interface TestTemplate {
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestTemplate.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestTemplate.java
@@ -26,7 +26,12 @@ import org.junit.platform.commons.meta.API;
  * <em>test template</em> method.
  *
  * <p>In contrast to {@link Test @Test} methods, a test template is not itself
- * a test case but rather a template for test cases.
+ * a test case but rather a template for test cases. As such, it is designed to
+ * be invoked multiple times depending on the number of {@linkplain
+ * org.junit.jupiter.api.extension.TestTemplateInvocationContext invocation
+ * contexts} returned by the registered {@linkplain
+ * org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider
+ * providers}.
  *
  * <p>{@code @TestTemplate} methods must not be {@code private} or {@code static}
  * and must return {@code void}.
@@ -37,6 +42,8 @@ import org.junit.platform.commons.meta.API;
  *
  * @since 5.0
  * @see Test
+ * @see org.junit.jupiter.api.extension.TestTemplateInvocationContext
+ * @see org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
@@ -10,7 +10,10 @@
 
 package org.junit.jupiter.api.extension;
 
+import static java.util.Collections.emptyList;
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import java.util.List;
 
 import org.junit.platform.commons.meta.API;
 
@@ -19,6 +22,10 @@ public interface TestTemplateInvocationContext {
 
 	default String getDisplayName(int invocationIndex) {
 		return "[" + invocationIndex + "]";
+	}
+
+	default List<Extension> getAdditionalExtensions() {
+		return emptyList();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import org.junit.platform.commons.meta.API;
+
+@API(Experimental)
+public interface TestTemplateInvocationContext {
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
@@ -17,13 +17,47 @@ import java.util.List;
 
 import org.junit.platform.commons.meta.API;
 
+/**
+ * {@code TestTemplateInvocationContext} represents the <em>context</em> of a
+ * single invocation of a {@linkplain org.junit.jupiter.api.TestTemplate test
+ * template}.
+ *
+ * <p>Each context is provided by a
+ * {@link TestTemplateInvocationContextProvider}.
+ *
+ * @since 5.0
+ * @see org.junit.jupiter.api.TestTemplate
+ * @see TestTemplateInvocationContextProvider
+ */
 @API(Experimental)
 public interface TestTemplateInvocationContext {
 
+	/**
+	 * Get the display name for this invocation.
+	 *
+	 * <p>The supplied {@code invocationIndex} is incremented by the framework
+	 * with each test invocation. Thus, in the case of multiple active
+	 * {@linkplain TestTemplateInvocationContextProvider providers}, only the
+	 * first active provider receives indices starting with {@code 1}.
+	 *
+	 * @param invocationIndex the index of this invocation (1-based).
+	 * @return the display name for this invocation; never {@code null} or blank
+	 */
 	default String getDisplayName(int invocationIndex) {
 		return "[" + invocationIndex + "]";
 	}
 
+	/**
+	 * Get the additional {@linkplain Extension extensions} for this invocation.
+	 *
+	 * <p>The extensions provided by this method will only be used for this
+	 * invocation of the test template. Thus, it does not make sense to return
+	 * an extension that acts solely on the container level (e.g.
+	 * {@link BeforeAllCallback}).
+	 *
+	 * @return the additional extensions for this invocation; never {@code null}
+	 * but potentially empty
+	 */
 	default List<Extension> getAdditionalExtensions() {
 		return emptyList();
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
@@ -16,4 +16,9 @@ import org.junit.platform.commons.meta.API;
 
 @API(Experimental)
 public interface TestTemplateInvocationContext {
+
+	default String getDisplayName(int invocationIndex) {
+		return "[" + invocationIndex + "]";
+	}
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -16,11 +16,66 @@ import java.util.Iterator;
 
 import org.junit.platform.commons.meta.API;
 
+/**
+ * {@code TestTemplateInvocationContextProvider} defines the API for
+ * {@link Extension Extensions} that wish to provide one or multiple contexts
+ * for the invocation of a
+ * {@link org.junit.jupiter.api.TestTemplate @TestTemplate} method.
+ *
+ * <p>This extension point makes it possible to execute a test template in
+ * different contexts, e.g. with different parameters, by preparing the test
+ * class instance differently, or multiple times without modifying the context.
+ *
+ * <p>This interface defines two methods: {@link #supports} and
+ * {@link #provide}. The former is called by the framework to determine whether
+ * this extension wants to act on a test template that is about to be executed.
+ * If so, the latter is called and must return an {@link Iterator} of
+ * {@link TestTemplateInvocationContext} instances. Otherwise, this provider is
+ * ignored for the execution of the current test template.
+ *
+ * <p>A provider that has returned {@code true} from its {@link #supports}
+ * method is called <em>active</em>. When multiple providers are active for a
+ * test template method, the {@code Iterators} returned by their
+ * {@link #provide} methods will be chained, i.e. the test template method will
+ * be invoked using the contexts of all active providers.
+ *
+ * <p>Implementations must provide a no-args constructor.
+ *
+ * @see org.junit.jupiter.api.TestTemplate
+ * @see TestTemplateInvocationContext
+ * @since 5.0
+ */
 @API(Experimental)
 public interface TestTemplateInvocationContextProvider extends Extension {
 
+	/**
+	 * Determine if this provider supports providing invocation contexts for the
+	 * test template method represented by the supplied {@code context}.
+	 *
+	 * @param context the container extension context for the test template
+	 * method about to be invoked; never {@code null}
+	 * @return {@code true} if this provider can provide invocation contexts
+	 * @see #provide
+	 * @see ContainerExtensionContext
+	 */
 	boolean supports(ContainerExtensionContext context);
 
+	/**
+	 * Provide {@linkplain TestTemplateInvocationContext invocation contexts}
+	 * for the test template method represented by the supplied {@code context}.
+	 *
+	 * <p>This method is only called by the framework if {@link #supports} has
+	 * previously returned {@code true} for the same
+	 * {@link ContainerExtensionContext}. Thus, it must not return an empty
+	 * {@code Iterator}.
+	 *
+	 * @param context the container extension context for the test template
+	 * method about to be invoked; never {@code null}
+	 * @return an Iterator of TestTemplateInvocationContext instances for the
+	 * invocation of the test template method; never {@code null} or empty
+	 * @see #supports
+	 * @see ContainerExtensionContext
+	 */
 	Iterator<TestTemplateInvocationContext> provide(ContainerExtensionContext context);
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import java.util.Iterator;
+
+import org.junit.platform.commons.meta.API;
+
+@API(Experimental)
+public interface TestTemplateInvocationContextProvider extends Extension {
+
+	Iterator<TestTemplateInvocationContext> provide(ContainerExtensionContext context);
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -19,6 +19,8 @@ import org.junit.platform.commons.meta.API;
 @API(Experimental)
 public interface TestTemplateInvocationContextProvider extends Extension {
 
+	boolean supports(ContainerExtensionContext context);
+
 	Iterator<TestTemplateInvocationContext> provide(ContainerExtensionContext context);
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -53,6 +53,16 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 	}
 
 	@Override
+	public String getUniqueId() {
+		return getTestDescriptor().getUniqueId().toString();
+	}
+
+	@Override
+	public String getDisplayName() {
+		return getTestDescriptor().getDisplayName();
+	}
+
+	@Override
 	public void publishReportEntry(Map<String, String> values) {
 		engineExecutionListener.reportingEntryPublished(this.testDescriptor, ReportEntry.from(values));
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -26,7 +26,6 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ContainerExtensionContext;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.extension.TestExtensionContext;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.jupiter.engine.execution.AfterEachMethodAdapter;
 import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
-import org.junit.jupiter.engine.execution.ConditionEvaluator;
 import org.junit.jupiter.engine.execution.ExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.execution.TestInstanceProvider;
@@ -63,7 +61,6 @@ import org.junit.platform.engine.support.descriptor.ClassSource;
 @API(Internal)
 public class ClassTestDescriptor extends JupiterTestDescriptor {
 
-	private static final ConditionEvaluator conditionEvaluator = new ConditionEvaluator();
 	private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
 
 	private final Class<?> testClass;
@@ -145,13 +142,7 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public SkipResult shouldBeSkipped(JupiterEngineExecutionContext context) throws Exception {
-		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForContainer(
-			context.getExtensionRegistry(), context.getConfigurationParameters(),
-			(ContainerExtensionContext) context.getExtensionContext());
-		if (evaluationResult.isDisabled()) {
-			return SkipResult.skip(evaluationResult.getReason().orElse("<unknown>"));
-		}
-		return SkipResult.doNotSkip();
+		return shouldContainerBeSkipped(context);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
@@ -10,21 +10,26 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import java.util.function.Consumer;
+
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 
 /**
  * {@link TestDescriptor} for a {@link DynamicTest}.
  *
  * @since 5.0
  */
-class DynamicTestTestDescriptor extends AbstractTestDescriptor {
+class DynamicTestTestDescriptor extends JupiterTestDescriptor {
+
+	private final DynamicTest dynamicTest;
 
 	public DynamicTestTestDescriptor(UniqueId uniqueId, DynamicTest dynamicTest, TestSource source) {
 		super(uniqueId, dynamicTest.getDisplayName());
+		this.dynamicTest = dynamicTest;
 		setSource(source);
 	}
 
@@ -38,4 +43,10 @@ class DynamicTestTestDescriptor extends AbstractTestDescriptor {
 		return false;
 	}
 
+	@Override
+	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
+			Consumer<TestDescriptor> dynamicTestExecutor) throws Exception {
+		executeAndMaskThrowable(dynamicTest.getExecutable());
+		return context;
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
@@ -10,8 +10,6 @@
 
 package org.junit.jupiter.engine.descriptor;
 
-import java.util.function.Consumer;
-
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.platform.engine.TestDescriptor;
@@ -45,7 +43,7 @@ class DynamicTestTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
-			Consumer<TestDescriptor> dynamicTestExecutor) throws Exception {
+			DynamicTestExecutor dynamicTestExecutor) throws Exception {
 		executeAndMaskThrowable(dynamicTest.getExecutable());
 		return context;
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -25,9 +25,13 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ContainerExtensionContext;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.TestExtensionContext;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.engine.execution.ConditionEvaluator;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.meta.API;
@@ -44,6 +48,8 @@ import org.junit.platform.engine.support.hierarchical.Node;
 @API(Internal)
 public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 		implements Node<JupiterEngineExecutionContext> {
+
+	private static final ConditionEvaluator conditionEvaluator = new ConditionEvaluator();
 
 	JupiterTestDescriptor(UniqueId uniqueId, String displayName) {
 		super(uniqueId, displayName);
@@ -76,6 +82,26 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 	@Override
 	public boolean isLeaf() {
 		return !isContainer();
+	}
+
+	protected SkipResult shouldContainerBeSkipped(JupiterEngineExecutionContext context) {
+		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForContainer(
+			context.getExtensionRegistry(), context.getConfigurationParameters(),
+			(ContainerExtensionContext) context.getExtensionContext());
+		return toSkipResult(evaluationResult);
+	}
+
+	protected SkipResult shouldTestBeSkipped(JupiterEngineExecutionContext context) {
+		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForTest(context.getExtensionRegistry(),
+			context.getConfigurationParameters(), (TestExtensionContext) context.getExtensionContext());
+		return toSkipResult(evaluationResult);
+	}
+
+	private SkipResult toSkipResult(ConditionEvaluationResult evaluationResult) {
+		if (evaluationResult.isDisabled()) {
+			return SkipResult.skip(evaluationResult.getReason().orElse("<unknown>"));
+		}
+		return SkipResult.doNotSkip();
 	}
 
 	protected ExtensionRegistry populateNewExtensionRegistryFromExtendWith(AnnotatedElement annotatedElement,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+
+/**
+ * Base class for {@link TestDescriptor TestDescriptors} based on Java methods.
+ */
+abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
+
+	private final Class<?> testClass;
+	private final Method testMethod;
+
+	MethodBasedTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod) {
+		this(uniqueId, determineDisplayName(Preconditions.notNull(testMethod, "Method must not be null"),
+			MethodBasedTestDescriptor::generateDefaultDisplayName), testClass, testMethod);
+	}
+
+	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod) {
+		super(uniqueId, displayName);
+
+		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
+		this.testMethod = Preconditions.notNull(testMethod, "Method must not be null");
+
+		setSource(new MethodSource(testMethod));
+	}
+
+	@Override
+	public final Set<TestTag> getTags() {
+		Set<TestTag> methodTags = getTags(getTestMethod());
+		getParent().ifPresent(parentDescriptor -> methodTags.addAll(parentDescriptor.getTags()));
+		return methodTags;
+	}
+
+	public final Class<?> getTestClass() {
+		return this.testClass;
+	}
+
+	public final Method getTestMethod() {
+		return this.testMethod;
+	}
+
+	private static String generateDefaultDisplayName(Method testMethod) {
+		return String.format("%s(%s)", testMethod.getName(),
+			StringUtils.nullSafeToString(Class::getSimpleName, testMethod.getParameterTypes()));
+	}
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestExtensionContext.java
@@ -41,16 +41,6 @@ public final class MethodBasedTestExtensionContext extends AbstractExtensionCont
 	}
 
 	@Override
-	public String getUniqueId() {
-		return getTestDescriptor().getUniqueId().toString();
-	}
-
-	@Override
-	public String getDisplayName() {
-		return getTestDescriptor().getDisplayName();
-	}
-
-	@Override
 	public Optional<AnnotatedElement> getElement() {
 		return Optional.of(getTestDescriptor().getTestMethod());
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -23,14 +23,12 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestExtensionContext;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.engine.execution.AfterEachMethodAdapter;
 import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
-import org.junit.jupiter.engine.execution.ConditionEvaluator;
 import org.junit.jupiter.engine.execution.ExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.execution.ThrowableCollector;
@@ -65,7 +63,6 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
 @API(Internal)
 public class MethodTestDescriptor extends JupiterTestDescriptor {
 
-	private static final ConditionEvaluator conditionEvaluator = new ConditionEvaluator();
 	private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
 
 	private final Class<?> testClass;
@@ -135,12 +132,7 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public SkipResult shouldBeSkipped(JupiterEngineExecutionContext context) throws Exception {
-		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForTest(context.getExtensionRegistry(),
-			context.getConfigurationParameters(), (TestExtensionContext) context.getExtensionContext());
-		if (evaluationResult.isDisabled()) {
-			return SkipResult.skip(evaluationResult.getReason().orElse("<unknown>"));
-		}
-		return SkipResult.doNotSkip();
+		return shouldTestBeSkipped(context);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
 
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -144,7 +143,7 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
-			Consumer<TestDescriptor> dynamicTestExecutor) throws Exception {
+			DynamicTestExecutor dynamicTestExecutor) throws Exception {
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 
 		// @formatter:off
@@ -203,8 +202,7 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 		}
 	}
 
-	protected void invokeTestMethod(JupiterEngineExecutionContext context,
-			Consumer<TestDescriptor> dynamicTestExecutor) {
+	protected void invokeTestMethod(JupiterEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) {
 		TestExtensionContext testExtensionContext = (TestExtensionContext) context.getExtensionContext();
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -118,8 +118,7 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) throws Exception {
-		ExtensionRegistry registry = populateNewExtensionRegistryFromExtendWith(this.testMethod,
-			context.getExtensionRegistry());
+		ExtensionRegistry registry = populateNewExtensionRegistry(context);
 		Object testInstance = context.getTestInstanceProvider().getTestInstance(Optional.of(registry));
 		ThrowableCollector throwableCollector = new ThrowableCollector();
 		TestExtensionContext testExtensionContext = new MethodBasedTestExtensionContext(context.getExtensionContext(),
@@ -132,6 +131,10 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 				.withThrowableCollector(throwableCollector)
 				.build();
 		// @formatter:on
+	}
+
+	protected ExtensionRegistry populateNewExtensionRegistry(JupiterEngineExecutionContext context) {
+		return populateNewExtensionRegistryFromExtendWith(this.testMethod, context.getExtensionRegistry());
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -15,7 +15,6 @@ import static org.junit.platform.commons.meta.API.Usage.Internal;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -34,12 +33,8 @@ import org.junit.jupiter.engine.execution.ThrowableCollector;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.commons.util.ExceptionUtils;
-import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.descriptor.MethodSource;
 
 /**
  * {@link TestDescriptor} for tests based on Java methods.
@@ -60,42 +55,16 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
  * @since 5.0
  */
 @API(Internal)
-public class MethodTestDescriptor extends JupiterTestDescriptor {
+public class MethodTestDescriptor extends MethodBasedTestDescriptor {
 
 	private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
 
-	private final Class<?> testClass;
-	private final Method testMethod;
-
 	public MethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod) {
-		this(uniqueId, determineDisplayName(Preconditions.notNull(testMethod, "Method must not be null"),
-			MethodTestDescriptor::generateDefaultDisplayName), testClass, testMethod);
+		super(uniqueId, testClass, testMethod);
 	}
 
-	public MethodTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod) {
-		super(uniqueId, displayName);
-
-		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
-		this.testMethod = testMethod;
-
-		setSource(new MethodSource(testMethod));
-	}
-
-	// --- TestDescriptor ------------------------------------------------------
-
-	@Override
-	public final Set<TestTag> getTags() {
-		Set<TestTag> methodTags = getTags(getTestMethod());
-		getParent().ifPresent(parentDescriptor -> methodTags.addAll(parentDescriptor.getTags()));
-		return methodTags;
-	}
-
-	public final Class<?> getTestClass() {
-		return this.testClass;
-	}
-
-	public final Method getTestMethod() {
-		return this.testMethod;
+	MethodTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod) {
+		super(uniqueId, displayName, testClass, testMethod);
 	}
 
 	@Override
@@ -106,11 +75,6 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 	@Override
 	public boolean isContainer() {
 		return false;
-	}
-
-	protected static String generateDefaultDisplayName(Method testMethod) {
-		return String.format("%s(%s)", testMethod.getName(),
-			StringUtils.nullSafeToString(Class::getSimpleName, testMethod.getParameterTypes()));
 	}
 
 	// --- Node ----------------------------------------------------------------
@@ -133,7 +97,7 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	protected ExtensionRegistry populateNewExtensionRegistry(JupiterEngineExecutionContext context) {
-		return populateNewExtensionRegistryFromExtendWith(this.testMethod, context.getExtensionRegistry());
+		return populateNewExtensionRegistryFromExtendWith(this.getTestMethod(), context.getExtensionRegistry());
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -143,7 +144,8 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	@Override
-	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context) throws Exception {
+	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
+			Consumer<TestDescriptor> dynamicTestExecutor) throws Exception {
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 
 		// @formatter:off
@@ -153,7 +155,7 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 				if (throwableCollector.isEmpty()) {
 					invokeBeforeTestExecutionCallbacks(context);
 					if (throwableCollector.isEmpty()) {
-						invokeTestMethod(context);
+						invokeTestMethod(context, dynamicTestExecutor);
 					}
 					invokeAfterTestExecutionCallbacks(context);
 				}
@@ -202,7 +204,8 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 		}
 	}
 
-	protected void invokeTestMethod(JupiterEngineExecutionContext context) {
+	protected void invokeTestMethod(JupiterEngineExecutionContext context,
+			Consumer<TestDescriptor> dynamicTestExecutor) {
 		TestExtensionContext testExtensionContext = (TestExtensionContext) context.getExtensionContext();
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -69,8 +69,12 @@ public class MethodTestDescriptor extends JupiterTestDescriptor {
 	private final Method testMethod;
 
 	public MethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod) {
-		super(uniqueId, determineDisplayName(Preconditions.notNull(testMethod, "Method must not be null"),
-			MethodTestDescriptor::generateDefaultDisplayName));
+		this(uniqueId, determineDisplayName(Preconditions.notNull(testMethod, "Method must not be null"),
+			MethodTestDescriptor::generateDefaultDisplayName), testClass, testMethod);
+	}
+
+	public MethodTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod) {
+		super(uniqueId, displayName);
 
 		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
 		this.testMethod = testMethod;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -19,7 +19,6 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DynamicTest;
@@ -73,8 +72,7 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 	}
 
 	@Override
-	protected void invokeTestMethod(JupiterEngineExecutionContext context,
-			Consumer<TestDescriptor> dynamicTestExecutor) {
+	protected void invokeTestMethod(JupiterEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) {
 		TestExtensionContext testExtensionContext = (TestExtensionContext) context.getExtensionContext();
 
 		context.getThrowableCollector().execute(() -> {
@@ -118,11 +116,11 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 		throw invalidReturnTypeException(testExtensionContext);
 	}
 
-	private void registerAndExecute(DynamicTest dynamicTest, int index, Consumer<TestDescriptor> dynamicTestExecutor) {
+	private void registerAndExecute(DynamicTest dynamicTest, int index, DynamicTestExecutor dynamicTestExecutor) {
 		UniqueId uniqueId = getUniqueId().append(DYNAMIC_TEST_SEGMENT_TYPE, "#" + index);
 		TestDescriptor descriptor = new DynamicTestTestDescriptor(uniqueId, dynamicTest, getSource().get());
 		addChild(descriptor);
-		dynamicTestExecutor.accept(descriptor);
+		dynamicTestExecutor.execute(descriptor);
 	}
 
 	private JUnitException invalidReturnTypeException(TestExtensionContext testExtensionContext) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateContainerExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateContainerExtensionContext.java
@@ -25,17 +25,17 @@ import org.junit.platform.engine.EngineExecutionListener;
  * @since 5.0
  */
 @API(Internal)
-public final class ClassBasedContainerExtensionContext extends AbstractExtensionContext<ClassTestDescriptor>
+public final class TestTemplateContainerExtensionContext extends AbstractExtensionContext<TestTemplateTestDescriptor>
 		implements ContainerExtensionContext {
 
-	public ClassBasedContainerExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
-			ClassTestDescriptor testDescriptor) {
+	public TestTemplateContainerExtensionContext(ExtensionContext parent,
+			EngineExecutionListener engineExecutionListener, TestTemplateTestDescriptor testDescriptor) {
 		super(parent, engineExecutionListener, testDescriptor);
 	}
 
 	@Override
 	public Optional<AnnotatedElement> getElement() {
-		return Optional.of(getTestDescriptor().getTestClass());
+		return Optional.of(getTestDescriptor().getTemplateMethod());
 	}
 
 	@Override
@@ -45,7 +45,7 @@ public final class ClassBasedContainerExtensionContext extends AbstractExtension
 
 	@Override
 	public Optional<Method> getTestMethod() {
-		return Optional.empty();
+		return Optional.of(getTestDescriptor().getTemplateMethod());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateContainerExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateContainerExtensionContext.java
@@ -25,11 +25,11 @@ import org.junit.platform.engine.EngineExecutionListener;
  * @since 5.0
  */
 @API(Internal)
-public final class TestTemplateContainerExtensionContext extends AbstractExtensionContext<TestTemplateTestDescriptor>
+final class TestTemplateContainerExtensionContext extends AbstractExtensionContext<TestTemplateTestDescriptor>
 		implements ContainerExtensionContext {
 
-	public TestTemplateContainerExtensionContext(ExtensionContext parent,
-			EngineExecutionListener engineExecutionListener, TestTemplateTestDescriptor testDescriptor) {
+	TestTemplateContainerExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
+			TestTemplateTestDescriptor testDescriptor) {
 		super(parent, engineExecutionListener, testDescriptor);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateContainerExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateContainerExtensionContext.java
@@ -35,7 +35,7 @@ final class TestTemplateContainerExtensionContext extends AbstractExtensionConte
 
 	@Override
 	public Optional<AnnotatedElement> getElement() {
-		return Optional.of(getTestDescriptor().getTemplateMethod());
+		return Optional.of(getTestDescriptor().getTestMethod());
 	}
 
 	@Override
@@ -45,7 +45,7 @@ final class TestTemplateContainerExtensionContext extends AbstractExtensionConte
 
 	@Override
 	public Optional<Method> getTestMethod() {
-		return Optional.of(getTestDescriptor().getTemplateMethod());
+		return Optional.of(getTestDescriptor().getTestMethod());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
@@ -30,7 +30,7 @@ import org.junit.platform.engine.UniqueId;
 @API(Internal)
 class TestTemplateInvocationTestDescriptor extends MethodTestDescriptor {
 
-	static final String SEGMENT_TYPE = "template-invocation";
+	static final String SEGMENT_TYPE = "test-template-invocation";
 
 	private TestTemplateInvocationContext invocationContext;
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
@@ -28,9 +28,9 @@ import org.junit.platform.engine.UniqueId;
  * @since 5.0
  */
 @API(Internal)
-class TestTemplateInvocationTestDescriptor extends MethodTestDescriptor {
+public class TestTemplateInvocationTestDescriptor extends MethodTestDescriptor {
 
-	static final String SEGMENT_TYPE = "test-template-invocation";
+	public static final String SEGMENT_TYPE = "test-template-invocation";
 
 	private TestTemplateInvocationContext invocationContext;
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
@@ -32,7 +32,7 @@ class TestTemplateInvocationTestDescriptor extends MethodTestDescriptor {
 
 	static final String SEGMENT_TYPE = "template-invocation";
 
-	private final TestTemplateInvocationContext invocationContext;
+	private TestTemplateInvocationContext invocationContext;
 
 	TestTemplateInvocationTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method templateMethod,
 			TestTemplateInvocationContext invocationContext, int index) {
@@ -46,5 +46,11 @@ class TestTemplateInvocationTestDescriptor extends MethodTestDescriptor {
 		invocationContext.getAdditionalExtensions().forEach(
 			extension -> registry.registerExtension(extension, invocationContext));
 		return registry;
+	}
+
+	@Override
+	public void after(JupiterEngineExecutionContext context) {
+		// forget invocationContext so it can be garbage collected
+		invocationContext = null;
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.junit.platform.commons.meta.API.Usage.Internal;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * {@link TestDescriptor} for a {@link org.junit.jupiter.api.TestTemplate @TestTemplate}
+ * invocation.
+ *
+ * @since 5.0
+ */
+@API(Internal)
+class TestTemplateInvocationTestDescriptor extends MethodTestDescriptor {
+
+	static final String SEGMENT_TYPE = "template-invocation";
+
+	private final TestTemplateInvocationContext invocationContext;
+
+	TestTemplateInvocationTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method templateMethod,
+			TestTemplateInvocationContext invocationContext, int index) {
+		super(uniqueId, invocationContext.getDisplayName(index), testClass, templateMethod);
+		this.invocationContext = invocationContext;
+	}
+
+	@Override
+	protected ExtensionRegistry populateNewExtensionRegistry(JupiterEngineExecutionContext context) {
+		ExtensionRegistry registry = super.populateNewExtensionRegistry(context);
+		invocationContext.getAdditionalExtensions().forEach(
+			extension -> registry.registerExtension(extension, invocationContext));
+		return registry;
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -19,11 +19,9 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ContainerExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
-import org.junit.jupiter.engine.execution.ConditionEvaluator;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.meta.API;
@@ -41,8 +39,6 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
  */
 @API(Internal)
 public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
-
-	private static final ConditionEvaluator conditionEvaluator = new ConditionEvaluator();
 
 	private final Class<?> testClass;
 	private final Method templateMethod;
@@ -113,13 +109,7 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public SkipResult shouldBeSkipped(JupiterEngineExecutionContext context) throws Exception {
-		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForContainer(
-			context.getExtensionRegistry(), context.getConfigurationParameters(),
-			(ContainerExtensionContext) context.getExtensionContext());
-		if (evaluationResult.isDisabled()) {
-			return SkipResult.skip(evaluationResult.getReason().orElse("<unknown>"));
-		}
-		return SkipResult.doNotSkip();
+		return shouldContainerBeSkipped(context);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.meta.API.Usage.Internal;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
@@ -57,8 +58,9 @@ public class TestTemplateTestDescriptor extends MethodTestDescriptor {
 	}
 
 	@Override
-	protected void invokeTestMethod(JupiterEngineExecutionContext context) {
-		// TODO #14 implement
+	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context) throws Exception {
+		throw new JUnitException(
+			"You need to register at least one TestTemplateInvocationContextProvider for this method");
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -126,7 +126,7 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 			Iterator<TestTemplateInvocationContext> contextIterator = provider.provide(containerExtensionContext);
 			contextIterator.forEachRemaining(invocationContext -> {
 				UniqueId uniqueId = getUniqueId().append("template-invocation",
-					"#" + invocationIndex.getAndIncrement());
+					"#" + invocationIndex.incrementAndGet());
 				MethodTestDescriptor methodTestDescriptor = new MethodTestDescriptor(uniqueId, this.testClass,
 					this.templateMethod);
 				context.getExecutionListener().dynamicTestRegistered(methodTestDescriptor);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.junit.platform.commons.meta.API.Usage.Internal;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * {@link TestDescriptor} for {@link org.junit.jupiter.api.TestTemplate @TestTemplate}
+ * methods.
+ *
+ * @since 5.0
+ */
+@API(Internal)
+public class TestTemplateTestDescriptor extends MethodTestDescriptor {
+
+	public TestTemplateTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod) {
+		super(uniqueId, testClass, testMethod);
+	}
+
+	// --- TestDescriptor ------------------------------------------------------
+
+	@Override
+	public boolean isTest() {
+		return false;
+	}
+
+	@Override
+	public boolean isContainer() {
+		return true;
+	}
+
+	@Override
+	public boolean hasTests() {
+		return true;
+	}
+
+	// --- Node ----------------------------------------------------------------
+
+	@Override
+	public boolean isLeaf() {
+		return true;
+	}
+
+	@Override
+	protected void invokeTestMethod(JupiterEngineExecutionContext context) {
+		// TODO #14 implement
+	}
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -124,10 +124,11 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 		providers.forEach(provider -> {
 			Iterator<TestTemplateInvocationContext> contextIterator = provider.provide(containerExtensionContext);
 			contextIterator.forEachRemaining(invocationContext -> {
-				UniqueId uniqueId = getUniqueId().append("template-invocation",
-					"#" + invocationIndex.incrementAndGet());
-				TestDescriptor invocationTestDescriptor = new MethodTestDescriptor(uniqueId, this.testClass,
-					this.templateMethod);
+				int index = invocationIndex.incrementAndGet();
+				UniqueId uniqueId = getUniqueId().append("template-invocation", "#" + index);
+				String displayName = "[" + index + "]";
+				TestDescriptor invocationTestDescriptor = new MethodTestDescriptor(uniqueId, displayName,
+					this.testClass, this.templateMethod);
 				addChild(invocationTestDescriptor);
 				dynamicTestExecutor.accept(invocationTestDescriptor);
 			});

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -126,7 +126,7 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 			contextIterator.forEachRemaining(invocationContext -> {
 				int index = invocationIndex.incrementAndGet();
 				UniqueId uniqueId = getUniqueId().append("template-invocation", "#" + index);
-				String displayName = "[" + index + "]";
+				String displayName = invocationContext.getDisplayName(index);
 				TestDescriptor invocationTestDescriptor = new MethodTestDescriptor(uniqueId, displayName,
 					this.testClass, this.templateMethod);
 				addChild(invocationTestDescriptor);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -128,6 +128,7 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 					"#" + invocationIndex.incrementAndGet());
 				TestDescriptor invocationTestDescriptor = new MethodTestDescriptor(uniqueId, this.testClass,
 					this.templateMethod);
+				addChild(invocationTestDescriptor);
 				dynamicTestExecutor.accept(invocationTestDescriptor);
 			});
 		});

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -19,9 +19,11 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ContainerExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.engine.execution.ConditionEvaluator;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.meta.API;
@@ -39,6 +41,8 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
  */
 @API(Internal)
 public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
+
+	private static final ConditionEvaluator conditionEvaluator = new ConditionEvaluator();
 
 	private final Class<?> testClass;
 	private final Method templateMethod;
@@ -109,7 +113,12 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public SkipResult shouldBeSkipped(JupiterEngineExecutionContext context) throws Exception {
-		// TODO #14 implement
+		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForContainer(
+			context.getExtensionRegistry(), context.getConfigurationParameters(),
+			(ContainerExtensionContext) context.getExtensionContext());
+		if (evaluationResult.isDisabled()) {
+			return SkipResult.skip(evaluationResult.getReason().orElse("<unknown>"));
+		}
 		return SkipResult.doNotSkip();
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -31,6 +31,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.opentest4j.TestAbortedException;
 
 /**
  * {@link TestDescriptor} for {@link org.junit.jupiter.api.TestTemplate @TestTemplate}
@@ -129,6 +130,7 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 				dynamicTestExecutor.accept(invocationTestDescriptor);
 			});
 		});
+		validateWasAtLeastInvokedOnce(invocationIndex);
 		return context;
 	}
 
@@ -149,6 +151,13 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 		UniqueId uniqueId = getUniqueId().append(TestTemplateInvocationTestDescriptor.SEGMENT_TYPE, "#" + index);
 		return new TestTemplateInvocationTestDescriptor(uniqueId, this.testClass, this.templateMethod,
 			invocationContext, index);
+	}
+
+	private void validateWasAtLeastInvokedOnce(AtomicInteger invocationIndex) {
+		if (invocationIndex.get() == 0) {
+			throw new TestAbortedException("No supporting "
+					+ TestTemplateInvocationContextProvider.class.getSimpleName() + " provided an invocation context");
+		}
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -18,7 +18,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 import org.junit.jupiter.api.extension.ContainerExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
@@ -116,7 +115,7 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
-			Consumer<TestDescriptor> dynamicTestExecutor) throws Exception {
+			DynamicTestExecutor dynamicTestExecutor) throws Exception {
 		ContainerExtensionContext containerExtensionContext = (ContainerExtensionContext) context.getExtensionContext();
 		List<TestTemplateInvocationContextProvider> providers = validateProviders(containerExtensionContext,
 			context.getExtensionRegistry());
@@ -127,7 +126,7 @@ public class TestTemplateTestDescriptor extends JupiterTestDescriptor {
 				int index = invocationIndex.incrementAndGet();
 				TestDescriptor invocationTestDescriptor = createInvocationTestDescriptor(invocationContext, index);
 				addChild(invocationTestDescriptor);
-				dynamicTestExecutor.accept(invocationTestDescriptor);
+				dynamicTestExecutor.execute(invocationTestDescriptor);
 			});
 		});
 		validateWasAtLeastInvokedOnce(invocationIndex);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractMethodResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractMethodResolver.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.discovery;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * @since 5.0
+ */
+@API(Experimental)
+abstract class AbstractMethodResolver implements ElementResolver {
+
+	private static final MethodFinder methodFinder = new MethodFinder();
+
+	private final String segmentType;
+	private final Predicate<Method> methodPredicate;
+
+	AbstractMethodResolver(String segmentType, Predicate<Method> methodPredicate) {
+		this.segmentType = segmentType;
+		this.methodPredicate = methodPredicate;
+	}
+
+	@Override
+	public Set<TestDescriptor> resolveElement(AnnotatedElement element, TestDescriptor parent) {
+		if (!(element instanceof Method))
+			return Collections.emptySet();
+
+		if (!(parent instanceof ClassTestDescriptor))
+			return Collections.emptySet();
+
+		Method method = (Method) element;
+		if (!isRelevantMethod(method))
+			return Collections.emptySet();
+
+		return Collections.singleton(createTestDescriptor(parent, method));
+	}
+
+	@Override
+	public Optional<TestDescriptor> resolveUniqueId(UniqueId.Segment segment, TestDescriptor parent) {
+		if (!segment.getType().equals(this.segmentType))
+			return Optional.empty();
+
+		if (!(parent instanceof ClassTestDescriptor))
+			return Optional.empty();
+
+		Optional<Method> optionalMethod = findMethod(segment, (ClassTestDescriptor) parent);
+		if (!optionalMethod.isPresent())
+			return Optional.empty();
+
+		Method method = optionalMethod.get();
+		if (!isRelevantMethod(method))
+			return Optional.empty();
+
+		return Optional.of(createTestDescriptor(parent, method));
+	}
+
+	private boolean isRelevantMethod(Method candidate) {
+		return methodPredicate.test(candidate);
+	}
+
+	private UniqueId createUniqueId(Method method, TestDescriptor parent) {
+		String methodId = String.format("%s(%s)", method.getName(),
+			StringUtils.nullSafeToString(method.getParameterTypes()));
+		return parent.getUniqueId().append(this.segmentType, methodId);
+	}
+
+	private Optional<Method> findMethod(UniqueId.Segment segment, ClassTestDescriptor parent) {
+		return methodFinder.findMethod(segment.getValue(), parent.getTestClass());
+	}
+
+	private TestDescriptor createTestDescriptor(TestDescriptor parent, Method method) {
+		UniqueId uniqueId = createUniqueId(method, parent);
+		Class<?> testClass = ((ClassTestDescriptor) parent).getTestClass();
+		return createTestDescriptor(uniqueId, testClass, method);
+	}
+
+	protected abstract TestDescriptor createTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method method);
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -73,6 +73,7 @@ public class DiscoverySelectorResolver {
 		resolvers.add(new NestedTestsResolver());
 		resolvers.add(new TestMethodResolver());
 		resolvers.add(new TestFactoryMethodResolver());
+		resolvers.add(new TestTemplateMethodResolver());
 		return new JavaElementsResolver(engineDescriptor, resolvers);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestFactoryMethodResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestFactoryMethodResolver.java
@@ -15,7 +15,6 @@ import static org.junit.platform.commons.meta.API.Usage.Experimental;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.TestFactory;
-import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsTestFactoryMethod;
 import org.junit.platform.commons.meta.API;
@@ -35,25 +34,17 @@ import org.junit.platform.engine.UniqueId;
  * @see TestFactoryTestDescriptor
  */
 @API(Experimental)
-class TestFactoryMethodResolver extends TestMethodResolver {
-
-	private static final IsTestFactoryMethod isTestFactoryMethod = new IsTestFactoryMethod();
+class TestFactoryMethodResolver extends AbstractMethodResolver {
 
 	static final String SEGMENT_TYPE = "test-factory";
 
 	TestFactoryMethodResolver() {
-		super(SEGMENT_TYPE);
+		super(SEGMENT_TYPE, new IsTestFactoryMethod());
 	}
 
 	@Override
-	protected boolean isTestMethod(Method candidate) {
-		return isTestFactoryMethod.test(candidate);
-	}
-
-	@Override
-	protected TestDescriptor resolveMethod(Method testMethod, ClassTestDescriptor parentClassDescriptor,
-			UniqueId uniqueId) {
-		return new TestFactoryTestDescriptor(uniqueId, parentClassDescriptor.getTestClass(), testMethod);
+	protected TestDescriptor createTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method method) {
+		return new TestFactoryTestDescriptor(uniqueId, testClass, method);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestMethodResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestMethodResolver.java
@@ -12,17 +12,11 @@ package org.junit.jupiter.engine.discovery;
 
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
-import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
 
-import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.MethodTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsTestMethod;
 import org.junit.platform.commons.meta.API;
-import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 
@@ -30,76 +24,16 @@ import org.junit.platform.engine.UniqueId;
  * @since 5.0
  */
 @API(Experimental)
-class TestMethodResolver implements ElementResolver {
-
-	private static final IsTestMethod isTestMethod = new IsTestMethod();
-	private static final MethodFinder methodFinder = new MethodFinder();
+class TestMethodResolver extends AbstractMethodResolver {
 
 	static final String SEGMENT_TYPE = "method";
 
-	private final String segmentType;
-
 	TestMethodResolver() {
-		this(SEGMENT_TYPE);
+		super(SEGMENT_TYPE, new IsTestMethod());
 	}
 
-	TestMethodResolver(String segmentType) {
-		this.segmentType = segmentType;
-	}
-
-	@Override
-	public Set<TestDescriptor> resolveElement(AnnotatedElement element, TestDescriptor parent) {
-		if (!(element instanceof Method))
-			return Collections.emptySet();
-
-		if (!(parent instanceof ClassTestDescriptor))
-			return Collections.emptySet();
-
-		Method testMethod = (Method) element;
-		if (!isTestMethod(testMethod))
-			return Collections.emptySet();
-
-		UniqueId uniqueId = createUniqueId(testMethod, parent);
-		return Collections.singleton(resolveMethod(testMethod, (ClassTestDescriptor) parent, uniqueId));
-	}
-
-	@Override
-	public Optional<TestDescriptor> resolveUniqueId(UniqueId.Segment segment, TestDescriptor parent) {
-		if (!segment.getType().equals(this.segmentType))
-			return Optional.empty();
-
-		if (!(parent instanceof ClassTestDescriptor))
-			return Optional.empty();
-
-		Optional<Method> optionalMethod = findMethod(segment, (ClassTestDescriptor) parent);
-		if (!optionalMethod.isPresent())
-			return Optional.empty();
-
-		Method testMethod = optionalMethod.get();
-		if (!isTestMethod(testMethod))
-			return Optional.empty();
-
-		UniqueId uniqueId = createUniqueId(testMethod, parent);
-		return Optional.of(resolveMethod(testMethod, (ClassTestDescriptor) parent, uniqueId));
-	}
-
-	protected boolean isTestMethod(Method candidate) {
-		return isTestMethod.test(candidate);
-	}
-
-	private UniqueId createUniqueId(Method testMethod, TestDescriptor parent) {
-		String methodId = String.format("%s(%s)", testMethod.getName(),
-			StringUtils.nullSafeToString(testMethod.getParameterTypes()));
-		return parent.getUniqueId().append(this.segmentType, methodId);
-	}
-
-	private Optional<Method> findMethod(UniqueId.Segment segment, ClassTestDescriptor parent) {
-		return methodFinder.findMethod(segment.getValue(), parent.getTestClass());
-	}
-
-	protected TestDescriptor resolveMethod(Method testMethod, ClassTestDescriptor parentClassDescriptor,
-			UniqueId uniqueId) {
-		return new MethodTestDescriptor(uniqueId, parentClassDescriptor.getTestClass(), testMethod);
+	protected TestDescriptor createTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method method) {
+		return new MethodTestDescriptor(uniqueId, testClass, method);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestTemplateMethodResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestTemplateMethodResolver.java
@@ -15,7 +15,6 @@ import static org.junit.platform.commons.meta.API.Usage.Experimental;
 import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsTestTemplateMethod;
 import org.junit.platform.commons.meta.API;
@@ -35,25 +34,17 @@ import org.junit.platform.engine.UniqueId;
  * @see TestTemplateTestDescriptor
  */
 @API(Experimental)
-class TestTemplateMethodResolver extends TestMethodResolver {
-
-	private static final IsTestTemplateMethod isTestTemplateMethod = new IsTestTemplateMethod();
+class TestTemplateMethodResolver extends AbstractMethodResolver {
 
 	static final String SEGMENT_TYPE = "test-template";
 
 	TestTemplateMethodResolver() {
-		super(SEGMENT_TYPE);
+		super(SEGMENT_TYPE, new IsTestTemplateMethod());
 	}
 
 	@Override
-	protected boolean isTestMethod(Method candidate) {
-		return isTestTemplateMethod.test(candidate);
-	}
-
-	@Override
-	protected TestDescriptor resolveMethod(Method testMethod, ClassTestDescriptor parentClassDescriptor,
-			UniqueId uniqueId) {
-		return new TestTemplateTestDescriptor(uniqueId, parentClassDescriptor.getTestClass(), testMethod);
+	protected TestDescriptor createTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method method) {
+		return new TestTemplateTestDescriptor(uniqueId, testClass, method);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestTemplateMethodResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestTemplateMethodResolver.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.discovery;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor;
+import org.junit.jupiter.engine.discovery.predicates.IsTestTemplateMethod;
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * {@code TestTemplateMethodResolver} is an {@link ElementResolver}
+ * that is able to resolve test factory methods annotated with
+ * {@link TestTemplate @TestTemplate}.
+ *
+ * <p>It will create {@link TestTemplateTestDescriptor} instances.
+ *
+ * @since 5.0
+ * @see ElementResolver
+ * @see TestTemplate
+ * @see TestTemplateTestDescriptor
+ */
+@API(Experimental)
+class TestTemplateMethodResolver extends TestMethodResolver {
+
+	private static final IsTestTemplateMethod isTestTemplateMethod = new IsTestTemplateMethod();
+
+	static final String SEGMENT_TYPE = "test-template";
+
+	TestTemplateMethodResolver() {
+		super(SEGMENT_TYPE);
+	}
+
+	@Override
+	protected boolean isTestMethod(Method candidate) {
+		return isTestTemplateMethod.test(candidate);
+	}
+
+	@Override
+	protected TestDescriptor resolveMethod(Method testMethod, ClassTestDescriptor parentClassDescriptor,
+			UniqueId uniqueId) {
+		return new TestTemplateTestDescriptor(uniqueId, parentClassDescriptor.getTestClass(), testMethod);
+	}
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -11,13 +11,6 @@
 package org.junit.jupiter.engine.discovery.predicates;
 
 import static org.junit.platform.commons.meta.API.Usage.Internal;
-import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
-import static org.junit.platform.commons.util.ReflectionUtils.isAbstract;
-import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
-import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
-
-import java.lang.reflect.Method;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.TestFactory;
 import org.junit.platform.commons.meta.API;
@@ -28,19 +21,10 @@ import org.junit.platform.commons.meta.API;
  * @since 5.0
  */
 @API(Internal)
-public class IsTestFactoryMethod implements Predicate<Method> {
+public class IsTestFactoryMethod extends IsTestableMethod {
 
-	@Override
-	public boolean test(Method candidate) {
-		//please do not collapse into single return
-		if (isStatic(candidate))
-			return false;
-		if (isPrivate(candidate))
-			return false;
-		if (isAbstract(candidate))
-			return false;
-
-		return isAnnotated(candidate, TestFactory.class);
+	public IsTestFactoryMethod() {
+		super(TestFactory.class);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethod.java
@@ -11,13 +11,6 @@
 package org.junit.jupiter.engine.discovery.predicates;
 
 import static org.junit.platform.commons.meta.API.Usage.Internal;
-import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
-import static org.junit.platform.commons.util.ReflectionUtils.isAbstract;
-import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
-import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
-
-import java.lang.reflect.Method;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.meta.API;
@@ -28,18 +21,10 @@ import org.junit.platform.commons.meta.API;
  * @since 5.0
  */
 @API(Internal)
-public class IsTestMethod implements Predicate<Method> {
+public class IsTestMethod extends IsTestableMethod {
 
-	@Override
-	public boolean test(Method candidate) {
-		//please do not collapse into single return
-		if (isStatic(candidate))
-			return false;
-		if (isPrivate(candidate))
-			return false;
-		if (isAbstract(candidate))
-			return false;
-		return isAnnotated(candidate, Test.class);
+	public IsTestMethod() {
+		super(Test.class);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethod.java
@@ -11,13 +11,6 @@
 package org.junit.jupiter.engine.discovery.predicates;
 
 import static org.junit.platform.commons.meta.API.Usage.Internal;
-import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
-import static org.junit.platform.commons.util.ReflectionUtils.isAbstract;
-import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
-import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
-
-import java.lang.reflect.Method;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.platform.commons.meta.API;
@@ -28,19 +21,10 @@ import org.junit.platform.commons.meta.API;
  * @since 5.0
  */
 @API(Internal)
-public class IsTestTemplateMethod implements Predicate<Method> {
+public class IsTestTemplateMethod extends IsTestableMethod {
 
-	@Override
-	public boolean test(Method candidate) {
-		//please do not collapse into single return
-		if (isStatic(candidate))
-			return false;
-		if (isPrivate(candidate))
-			return false;
-		if (isAbstract(candidate))
-			return false;
-
-		return isAnnotated(candidate, TestTemplate.class);
+	public IsTestTemplateMethod() {
+		super(TestTemplate.class);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethod.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.discovery.predicates;
+
+import static org.junit.platform.commons.meta.API.Usage.Internal;
+import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
+import static org.junit.platform.commons.util.ReflectionUtils.isAbstract;
+import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
+import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
+
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.platform.commons.meta.API;
+
+/**
+ * Test if a method is a JUnit Jupiter test template method.
+ *
+ * @since 5.0
+ */
+@API(Internal)
+public class IsTestTemplateMethod implements Predicate<Method> {
+
+	@Override
+	public boolean test(Method candidate) {
+		//please do not collapse into single return
+		if (isStatic(candidate))
+			return false;
+		if (isPrivate(candidate))
+			return false;
+		if (isAbstract(candidate))
+			return false;
+
+		return isAnnotated(candidate, TestTemplate.class);
+	}
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.discovery.predicates;
+
+import static org.junit.platform.commons.meta.API.Usage.Internal;
+import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
+import static org.junit.platform.commons.util.ReflectionUtils.isAbstract;
+import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
+import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import org.junit.platform.commons.meta.API;
+
+/**
+ * @since 5.0
+ */
+@API(Internal)
+class IsTestableMethod implements Predicate<Method> {
+
+	private final Class<? extends Annotation> annotationType;
+
+	IsTestableMethod(Class<? extends Annotation> annotationType) {
+		this.annotationType = annotationType;
+	}
+
+	@Override
+	public boolean test(Method candidate) {
+		//please do not collapse into single return
+		if (isStatic(candidate))
+			return false;
+		if (isPrivate(candidate))
+			return false;
+		if (isAbstract(candidate))
+			return false;
+		return isAnnotated(candidate, annotationType);
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.assertRecordedExecutionEventsContainsExactly;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.engine;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.event;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.finishedSuccessfully;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.finishedWithFailure;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.started;
+import static org.junit.platform.engine.test.event.TestExecutionResultConditions.message;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+
+public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void templateWithoutExtensionReportsError() {
+		LauncherDiscoveryRequest request = request().selectors(
+			selectMethod(MyTestTemplateTestCase.class, "templateWithoutRegisteredExtension")).build();
+
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(MyTestTemplateTestCase.class), started()), //
+			event(container("templateWithoutRegisteredExtension"), started()), //
+			event(container("templateWithoutRegisteredExtension"),
+				finishedWithFailure(message(
+					"You need to register at least one TestTemplateInvocationContextProvider for this method"))), //
+			event(container(MyTestTemplateTestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	private static class MyTestTemplateTestCase {
+
+		@TestTemplate
+		void templateWithoutRegisteredExtension() {
+		}
+
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
@@ -25,14 +26,19 @@ import static org.junit.platform.engine.test.event.ExecutionEventConditions.test
 import static org.junit.platform.engine.test.event.TestExecutionResultConditions.message;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ContainerExtensionContext;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 
@@ -46,14 +52,10 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		ExecutionEventRecorder eventRecorder = executeTests(request);
 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
-			event(engine(), started()), //
-			event(container(MyTestTemplateTestCase.class), started()), //
-			event(container("templateWithoutRegisteredExtension"), started()), //
-			event(container("templateWithoutRegisteredExtension"),
-				finishedWithFailure(message(
-					"You need to register at least one TestTemplateInvocationContextProvider for this method"))), //
-			event(container(MyTestTemplateTestCase.class), finishedSuccessfully()), //
-			event(engine(), finishedSuccessfully()));
+			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
+				event(container("templateWithoutRegisteredExtension"), started()), //
+				event(container("templateWithoutRegisteredExtension"), finishedWithFailure(message(
+					"You need to register at least one TestTemplateInvocationContextProvider for this method")))));
 	}
 
 	@Test
@@ -64,15 +66,63 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		ExecutionEventRecorder eventRecorder = executeTests(request);
 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
-			event(engine(), started()), //
-			event(container(MyTestTemplateTestCase.class), started()), //
-			event(container("templateWithSingleRegisteredExtension"), started()), //
-			event(dynamicTestRegistered("template-invocation:#0")), //
-			event(test("template-invocation:#0"), started()), //
-			event(test("template-invocation:#0"), finishedWithFailure(message("invocation is expected to fail"))), //
-			event(container("templateWithSingleRegisteredExtension"), finishedSuccessfully()), //
-			event(container(MyTestTemplateTestCase.class), finishedSuccessfully()), //
-			event(engine(), finishedSuccessfully()));
+			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
+				event(container("templateWithSingleRegisteredExtension"), started()), //
+				event(dynamicTestRegistered("template-invocation:#0")), //
+				event(test("template-invocation:#0"), started()), //
+				event(test("template-invocation:#0"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(container("templateWithSingleRegisteredExtension"), finishedSuccessfully())));
+	}
+
+	@Test
+	void templateWithTwoRegisteredExtensionsIsInvoked() {
+		LauncherDiscoveryRequest request = request().selectors(
+			selectMethod(MyTestTemplateTestCase.class, "templateWithTwoRegisteredExtensions")).build();
+
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
+				event(container("templateWithTwoRegisteredExtensions"), started()), //
+				event(dynamicTestRegistered("template-invocation:#0")), //
+				event(test("template-invocation:#0"), started()), //
+				event(test("template-invocation:#0"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("template-invocation:#1")), //
+				event(test("template-invocation:#1"), started()), //
+				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(container("templateWithTwoRegisteredExtensions"), finishedSuccessfully())));
+	}
+
+	@Test
+	void templateWithTwoInvocationsFromSingleExtensionIsInvoked() {
+		LauncherDiscoveryRequest request = request().selectors(
+			selectMethod(MyTestTemplateTestCase.class, "templateWithTwoInvocationsFromSingleExtension")).build();
+
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
+				event(container("templateWithTwoInvocationsFromSingleExtension"), started()), //
+				event(dynamicTestRegistered("template-invocation:#0")), //
+				event(test("template-invocation:#0"), started()), //
+				event(test("template-invocation:#0"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("template-invocation:#1")), //
+				event(test("template-invocation:#1"), started()), //
+				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(container("templateWithTwoInvocationsFromSingleExtension"), finishedSuccessfully())));
+	}
+
+	@SuppressWarnings({ "unchecked", "varargs", "rawtypes" })
+	@SafeVarargs
+	private final Condition<? super ExecutionEvent>[] wrappedInContainerEvents(Class<MyTestTemplateTestCase> clazz,
+			Condition<? super ExecutionEvent>... wrappedConditions) {
+		List<Condition<? super ExecutionEvent>> conditions = new ArrayList<>();
+		conditions.add(event(engine(), started()));
+		conditions.add(event(container(clazz), started()));
+		conditions.addAll(asList(wrappedConditions));
+		conditions.add(event(container(clazz), finishedSuccessfully()));
+		conditions.add(event(engine(), finishedSuccessfully()));
+		return conditions.toArray(new Condition[0]);
 	}
 
 	private static class MyTestTemplateTestCase {
@@ -87,18 +137,45 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 			fail("invocation is expected to fail");
 		}
 
+		@ExtendWith({ SingleInvocationContextProvider.class,
+				AnotherInvocationContextProviderWithASingleInvocation.class })
+		@TestTemplate
+		void templateWithTwoRegisteredExtensions() {
+			fail("invocation is expected to fail");
+		}
+
+		@ExtendWith(TwoInvocationsContextProvider.class)
+		@TestTemplate
+		void templateWithTwoInvocationsFromSingleExtension() {
+			fail("invocation is expected to fail");
+		}
+
 	}
 
 	private static class SingleInvocationContextProvider implements TestTemplateInvocationContextProvider {
-
 		@Override
 		public Iterator<TestTemplateInvocationContext> provide(ContainerExtensionContext context) {
-			return singleton(emptyContext()).iterator();
+			return singleton(emptyTestTemplateInvocationContext()).iterator();
 		}
+	}
 
-		private TestTemplateInvocationContext emptyContext() {
-			return new TestTemplateInvocationContext() {
-			};
+	private static class AnotherInvocationContextProviderWithASingleInvocation
+			implements TestTemplateInvocationContextProvider {
+		@Override
+		public Iterator<TestTemplateInvocationContext> provide(ContainerExtensionContext context) {
+			return singleton(emptyTestTemplateInvocationContext()).iterator();
 		}
+	}
+
+	private static class TwoInvocationsContextProvider implements TestTemplateInvocationContextProvider {
+		@Override
+		public Iterator<TestTemplateInvocationContext> provide(ContainerExtensionContext context) {
+			return asList(emptyTestTemplateInvocationContext(), emptyTestTemplateInvocationContext()).iterator();
+		}
+	}
+
+	private static TestTemplateInvocationContext emptyTestTemplateInvocationContext() {
+		return new TestTemplateInvocationContext() {
+		};
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -10,26 +10,36 @@
 
 package org.junit.jupiter.engine;
 
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.assertRecordedExecutionEventsContainsExactly;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.dynamicTestRegistered;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.engine;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.event;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.finishedSuccessfully;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.finishedWithFailure;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.started;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.test;
 import static org.junit.platform.engine.test.event.TestExecutionResultConditions.message;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
+import java.util.Iterator;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 
 public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 
 	@Test
-	void templateWithoutExtensionReportsError() {
+	void templateWithoutRegisteredExtensionReportsFailure() {
 		LauncherDiscoveryRequest request = request().selectors(
 			selectMethod(MyTestTemplateTestCase.class, "templateWithoutRegisteredExtension")).build();
 
@@ -46,11 +56,49 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 			event(engine(), finishedSuccessfully()));
 	}
 
+	@Test
+	void templateWithSingleRegisteredExtensionIsInvoked() {
+		LauncherDiscoveryRequest request = request().selectors(
+			selectMethod(MyTestTemplateTestCase.class, "templateWithSingleRegisteredExtension")).build();
+
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(MyTestTemplateTestCase.class), started()), //
+			event(container("templateWithSingleRegisteredExtension"), started()), //
+			event(dynamicTestRegistered("template-invocation:#0")), //
+			event(test("template-invocation:#0"), started()), //
+			event(test("template-invocation:#0"), finishedWithFailure(message("invocation is expected to fail"))), //
+			event(container("templateWithSingleRegisteredExtension"), finishedSuccessfully()), //
+			event(container(MyTestTemplateTestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
 	private static class MyTestTemplateTestCase {
 
 		@TestTemplate
 		void templateWithoutRegisteredExtension() {
 		}
 
+		@ExtendWith(SingleInvocationContextProvider.class)
+		@TestTemplate
+		void templateWithSingleRegisteredExtension() {
+			fail("invocation is expected to fail");
+		}
+
+	}
+
+	private static class SingleInvocationContextProvider implements TestTemplateInvocationContextProvider {
+
+		@Override
+		public Iterator<TestTemplateInvocationContext> provide(ContainerExtensionContext context) {
+			return singleton(emptyContext()).iterator();
+		}
+
+		private TestTemplateInvocationContext emptyContext() {
+			return new TestTemplateInvocationContext() {
+			};
+		}
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.assertRecordedExecutionEventsContainsExactly;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.displayName;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.dynamicTestRegistered;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.engine;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.event;
@@ -108,10 +109,10 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithTwoRegisteredExtensions"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1")), //
+				event(dynamicTestRegistered("template-invocation:#1"), displayName("[1]")), //
 				event(test("template-invocation:#1"), started()), //
 				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
-				event(dynamicTestRegistered("template-invocation:#2")), //
+				event(dynamicTestRegistered("template-invocation:#2"), displayName("[2]")), //
 				event(test("template-invocation:#2"), started()), //
 				event(test("template-invocation:#2"), finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithTwoRegisteredExtensions"), finishedSuccessfully())));
@@ -127,10 +128,10 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithTwoInvocationsFromSingleExtension"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1")), //
+				event(dynamicTestRegistered("template-invocation:#1"), displayName("[1]")), //
 				event(test("template-invocation:#1"), started()), //
 				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
-				event(dynamicTestRegistered("template-invocation:#2")), //
+				event(dynamicTestRegistered("template-invocation:#2"), displayName("[2]")), //
 				event(test("template-invocation:#2"), started()), //
 				event(test("template-invocation:#2"), finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithTwoInvocationsFromSingleExtension"), finishedSuccessfully())));
@@ -176,7 +177,11 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		return conditions.toArray(new Condition[0]);
 	}
 
-	private static class MyTestTemplateTestCase {
+	static class MyTestTemplateTestCase {
+
+		@Test
+		void foo() {
+		}
 
 		@TestTemplate
 		void templateWithoutRegisteredExtension() {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -98,9 +98,10 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithSingleRegisteredExtension"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1")), //
-				event(test("template-invocation:#1"), started()), //
-				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("test-template-invocation:#1")), //
+				event(test("test-template-invocation:#1"), started()), //
+				event(test("test-template-invocation:#1"),
+					finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithSingleRegisteredExtension"), finishedSuccessfully())));
 	}
 
@@ -113,7 +114,7 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 
 		TestDescriptor templateMethodDescriptor = findTestDescriptor(eventRecorder,
 			container("templateWithSingleRegisteredExtension"));
-		TestDescriptor invocationDescriptor = findTestDescriptor(eventRecorder, test("template-invocation:#1"));
+		TestDescriptor invocationDescriptor = findTestDescriptor(eventRecorder, test("test-template-invocation:#1"));
 		assertThat(invocationDescriptor.getParent()).hasValue(templateMethodDescriptor);
 		assertThat(templateMethodDescriptor.getChildren()).isEqualTo(singleton(invocationDescriptor));
 	}
@@ -139,12 +140,14 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithTwoRegisteredExtensions"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1"), displayName("[1]")), //
-				event(test("template-invocation:#1"), started()), //
-				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
-				event(dynamicTestRegistered("template-invocation:#2"), displayName("[2]")), //
-				event(test("template-invocation:#2"), started()), //
-				event(test("template-invocation:#2"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("test-template-invocation:#1"), displayName("[1]")), //
+				event(test("test-template-invocation:#1"), started()), //
+				event(test("test-template-invocation:#1"),
+					finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("test-template-invocation:#2"), displayName("[2]")), //
+				event(test("test-template-invocation:#2"), started()), //
+				event(test("test-template-invocation:#2"),
+					finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithTwoRegisteredExtensions"), finishedSuccessfully())));
 	}
 
@@ -158,12 +161,14 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithTwoInvocationsFromSingleExtension"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1"), displayName("[1]")), //
-				event(test("template-invocation:#1"), started()), //
-				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
-				event(dynamicTestRegistered("template-invocation:#2"), displayName("[2]")), //
-				event(test("template-invocation:#2"), started()), //
-				event(test("template-invocation:#2"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("test-template-invocation:#1"), displayName("[1]")), //
+				event(test("test-template-invocation:#1"), started()), //
+				event(test("test-template-invocation:#1"),
+					finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("test-template-invocation:#2"), displayName("[2]")), //
+				event(test("test-template-invocation:#2"), started()), //
+				event(test("test-template-invocation:#2"),
+					finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithTwoInvocationsFromSingleExtension"), finishedSuccessfully())));
 	}
 
@@ -177,8 +182,8 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithDisabledInvocations"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1")), //
-				event(test("template-invocation:#1"), skippedWithReason("tests are always disabled")), //
+				event(dynamicTestRegistered("test-template-invocation:#1")), //
+				event(test("test-template-invocation:#1"), skippedWithReason("tests are always disabled")), //
 				event(container("templateWithDisabledInvocations"), finishedSuccessfully())));
 	}
 
@@ -204,10 +209,11 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithCustomizedDisplayNames"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1"),
+				event(dynamicTestRegistered("test-template-invocation:#1"),
 					displayName("1 --> templateWithCustomizedDisplayNames()")), //
-				event(test("template-invocation:#1"), started()), //
-				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(test("test-template-invocation:#1"), started()), //
+				event(test("test-template-invocation:#1"),
+					finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithCustomizedDisplayNames"), finishedSuccessfully())));
 	}
 
@@ -221,12 +227,12 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithDynamicParameterResolver"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1"), displayName("[1] foo")), //
-				event(test("template-invocation:#1"), started()), //
-				event(test("template-invocation:#1"), finishedWithFailure(message("foo"))), //
-				event(dynamicTestRegistered("template-invocation:#2"), displayName("[2] bar")), //
-				event(test("template-invocation:#2"), started()), //
-				event(test("template-invocation:#2"), finishedWithFailure(message("bar"))), //
+				event(dynamicTestRegistered("test-template-invocation:#1"), displayName("[1] foo")), //
+				event(test("test-template-invocation:#1"), started()), //
+				event(test("test-template-invocation:#1"), finishedWithFailure(message("foo"))), //
+				event(dynamicTestRegistered("test-template-invocation:#2"), displayName("[2] bar")), //
+				event(test("test-template-invocation:#2"), started()), //
+				event(test("test-template-invocation:#2"), finishedWithFailure(message("bar"))), //
 				event(container("templateWithDynamicParameterResolver"), finishedSuccessfully())));
 	}
 
@@ -240,12 +246,12 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithDynamicTestInstancePostProcessor"), started()), //
-				event(dynamicTestRegistered("template-invocation:#1")), //
-				event(test("template-invocation:#1"), started()), //
-				event(test("template-invocation:#1"), finishedWithFailure(message("foo"))), //
-				event(dynamicTestRegistered("template-invocation:#2")), //
-				event(test("template-invocation:#2"), started()), //
-				event(test("template-invocation:#2"), finishedWithFailure(message("bar"))), //
+				event(dynamicTestRegistered("test-template-invocation:#1")), //
+				event(test("test-template-invocation:#1"), started()), //
+				event(test("test-template-invocation:#1"), finishedWithFailure(message("foo"))), //
+				event(dynamicTestRegistered("test-template-invocation:#2")), //
+				event(test("test-template-invocation:#2"), started()), //
+				event(test("test-template-invocation:#2"), finishedWithFailure(message("bar"))), //
 				event(container("templateWithDynamicTestInstancePostProcessor"), finishedSuccessfully())));
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -27,7 +27,6 @@ import static org.junit.platform.engine.test.event.TestExecutionResultConditions
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -68,9 +67,9 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithSingleRegisteredExtension"), started()), //
-				event(dynamicTestRegistered("template-invocation:#0")), //
-				event(test("template-invocation:#0"), started()), //
-				event(test("template-invocation:#0"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("template-invocation:#1")), //
+				event(test("template-invocation:#1"), started()), //
+				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithSingleRegisteredExtension"), finishedSuccessfully())));
 	}
 
@@ -84,12 +83,12 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithTwoRegisteredExtensions"), started()), //
-				event(dynamicTestRegistered("template-invocation:#0")), //
-				event(test("template-invocation:#0"), started()), //
-				event(test("template-invocation:#0"), finishedWithFailure(message("invocation is expected to fail"))), //
 				event(dynamicTestRegistered("template-invocation:#1")), //
 				event(test("template-invocation:#1"), started()), //
 				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("template-invocation:#2")), //
+				event(test("template-invocation:#2"), started()), //
+				event(test("template-invocation:#2"), finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithTwoRegisteredExtensions"), finishedSuccessfully())));
 	}
 
@@ -103,12 +102,12 @@ public class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithTwoInvocationsFromSingleExtension"), started()), //
-				event(dynamicTestRegistered("template-invocation:#0")), //
-				event(test("template-invocation:#0"), started()), //
-				event(test("template-invocation:#0"), finishedWithFailure(message("invocation is expected to fail"))), //
 				event(dynamicTestRegistered("template-invocation:#1")), //
 				event(test("template-invocation:#1"), started()), //
 				event(test("template-invocation:#1"), finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("template-invocation:#2")), //
+				event(test("template-invocation:#2"), started()), //
+				event(test("template-invocation:#2"), finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithTwoInvocationsFromSingleExtension"), finishedSuccessfully())));
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+
+class TestTemplateTestDescriptorTests {
+
+	@Test
+	void inheritsTagsFromParent() throws Exception {
+		UniqueId rootUniqueId = UniqueId.root("segment", "template");
+		UniqueId parentUniqueId = rootUniqueId.append("class", "myClass");
+		AbstractTestDescriptor parent = containerTestDescriptorWithTags(parentUniqueId,
+			singleton(TestTag.create("foo")));
+
+		TestTemplateTestDescriptor testDescriptor = new TestTemplateTestDescriptor(
+			parentUniqueId.append("tmp", "testTemplate()"), MyTestCase.class,
+			MyTestCase.class.getDeclaredMethod("testTemplate"));
+		parent.addChild(testDescriptor);
+
+		assertThat(testDescriptor.getTags()).containsExactlyInAnyOrder(TestTag.create("foo"), TestTag.create("bar"),
+			TestTag.create("baz"));
+	}
+
+	private AbstractTestDescriptor containerTestDescriptorWithTags(UniqueId uniqueId, Set<TestTag> tags) {
+		return new AbstractTestDescriptor(uniqueId, "testDescriptor with tags") {
+			@Override
+			public boolean isContainer() {
+				return true;
+			}
+
+			@Override
+			public boolean isTest() {
+				return false;
+			}
+
+			@Override
+			public Set<TestTag> getTags() {
+				return tags;
+			}
+		};
+	}
+
+	static class MyTestCase {
+		@Tag("bar")
+		@Tag("baz")
+		@TestTemplate
+		void testTemplate() {
+		}
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.engine.discovery.JupiterUniqueIdBuilder.engineId
 import static org.junit.jupiter.engine.discovery.JupiterUniqueIdBuilder.uniqueIdForClass;
 import static org.junit.jupiter.engine.discovery.JupiterUniqueIdBuilder.uniqueIdForMethod;
 import static org.junit.jupiter.engine.discovery.JupiterUniqueIdBuilder.uniqueIdForTestFactoryMethod;
+import static org.junit.jupiter.engine.discovery.JupiterUniqueIdBuilder.uniqueIdForTestTemplateMethod;
 import static org.junit.jupiter.engine.discovery.JupiterUniqueIdBuilder.uniqueIdForTopLevelClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClasspathRoots;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor;
 import org.junit.jupiter.engine.descriptor.subpackage.Class1WithTestCases;
@@ -522,6 +524,16 @@ public class DiscoverySelectorResolverTests {
 		assertThat(uniqueIds).contains(uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.class, "testB()"));
 	}
 
+	@Test
+	public void testTemplateMethodResolution() {
+		ClassSelector selector = selectClass(TestClassWithTemplate.class);
+
+		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
+
+		assertThat(engineDescriptor.getDescendants()).hasSize(2);
+		assertThat(uniqueIds()).contains(uniqueIdForTestTemplateMethod(TestClassWithTemplate.class, "testTemplate()"));
+	}
+
 	private TestDescriptor descriptorByUniqueId(UniqueId uniqueId) {
 		return engineDescriptor.getDescendants().stream().filter(
 			d -> d.getUniqueId().equals(uniqueId)).findFirst().get();
@@ -604,5 +616,11 @@ class TestCaseWithNesting {
 			void testC() {
 			}
 		}
+	}
+}
+
+class TestClassWithTemplate {
+	@TestTemplate
+	void testTemplate() {
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -75,10 +75,10 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(4, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test2()")));
-		assertTrue(uniqueIds.contains(uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(MyTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test1()"));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test2()"));
+		assertThat(uniqueIds).contains(uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()"));
 	}
 
 	@Test
@@ -90,10 +90,10 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(4, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test2()")));
-		assertTrue(uniqueIds.contains(uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(MyTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test1()"));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test2()"));
+		assertThat(uniqueIds).contains(uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()"));
 	}
 
 	@Test
@@ -105,13 +105,13 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(7, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test2()")));
-		assertTrue(uniqueIds.contains(uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()")));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(YourTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(YourTestClass.class, "test3()")));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(YourTestClass.class, "test4()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(MyTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test1()"));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test2()"));
+		assertThat(uniqueIds).contains(uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()"));
+		assertThat(uniqueIds).contains(uniqueIdForClass(YourTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(YourTestClass.class, "test3()"));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(YourTestClass.class, "test4()"));
 	}
 
 	@Test
@@ -122,9 +122,9 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(3, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()")));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test6()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()"));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test6()"));
 	}
 
 	@Test
@@ -136,8 +136,8 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(MyTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test1()"));
 	}
 
 	@Test
@@ -148,8 +148,8 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(HerTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(HerTestClass.class, "test1()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(HerTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(HerTestClass.class, "test1()"));
 	}
 
 	@Test
@@ -169,10 +169,10 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(4, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test2()")));
-		assertTrue(uniqueIds.contains(uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(MyTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test1()"));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test2()"));
+		assertThat(uniqueIds).contains(uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()"));
 	}
 
 	@Test
@@ -183,9 +183,9 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(3, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()")));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test6()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()"));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test6()"));
 	}
 
 	@Test
@@ -197,8 +197,8 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(OtherTestClass.NestedTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(OtherTestClass.NestedTestClass.class, "test5()"));
 	}
 
 	@Test
@@ -256,8 +256,8 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(MyTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test1()"));
 	}
 
 	@Test
@@ -269,8 +269,8 @@ public class DiscoverySelectorResolverTests {
 		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
 
-		assertTrue(uniqueIds.contains(uniqueIdForClass(HerTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(HerTestClass.class, "test1()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(HerTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(HerTestClass.class, "test1()"));
 	}
 
 	@Test
@@ -282,8 +282,8 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(2, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(HerTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(HerTestClass.class, "test7(java.lang.String)")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(HerTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(HerTestClass.class, "test7(java.lang.String)"));
 	}
 
 	@Test
@@ -306,9 +306,9 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(3, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(MyTestClass.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test1()")));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(MyTestClass.class, "test2()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(MyTestClass.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test1()"));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(MyTestClass.class, "test2()"));
 
 		TestDescriptor classFromMethod1 = descriptorByUniqueId(
 			uniqueIdForMethod(MyTestClass.class, "test1()")).getParent().get();
@@ -353,12 +353,12 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(6, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(Class1WithTestCases.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()")));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(Class2WithTestCases.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(Class2WithTestCases.class, "test2()")));
-		assertTrue(
-			uniqueIds.contains(uniqueIdForMethod(ClassWithStaticInnerTestCases.ShouldBeDiscovered.class, "test1()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(Class1WithTestCases.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()"));
+		assertThat(uniqueIds).contains(uniqueIdForClass(Class2WithTestCases.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(Class2WithTestCases.class, "test2()"));
+		assertThat(uniqueIds).contains(
+			uniqueIdForMethod(ClassWithStaticInnerTestCases.ShouldBeDiscovered.class, "test1()"));
 	}
 
 	@Test
@@ -370,12 +370,13 @@ public class DiscoverySelectorResolverTests {
 			"Too few test descriptors in classpath");
 
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(ReflectionUtils.loadClass("DefaultPackageTestCase").get())),
-			"Failed to pick up DefaultPackageTestCase via classpath scanning");
-		assertTrue(uniqueIds.contains(uniqueIdForClass(Class1WithTestCases.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()")));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(Class2WithTestCases.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(Class2WithTestCases.class, "test2()")));
+		assertThat(uniqueIds).contains(
+			uniqueIdForClass(ReflectionUtils.loadClass("DefaultPackageTestCase").get())).describedAs(
+				"Failed to pick up DefaultPackageTestCase via classpath scanning");
+		assertThat(uniqueIds).contains(uniqueIdForClass(Class1WithTestCases.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()"));
+		assertThat(uniqueIds).contains(uniqueIdForClass(Class2WithTestCases.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(Class2WithTestCases.class, "test2()"));
 	}
 
 	@Test
@@ -394,12 +395,12 @@ public class DiscoverySelectorResolverTests {
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertTrue(uniqueIds().contains(uniqueIdForClass(ReflectionUtils.loadClass("DefaultPackageTestCase").get())),
 			"Failed to pick up DefaultPackageTestCase via classpath scanning");
-		assertTrue(uniqueIds.contains(uniqueIdForClass(Class1WithTestCases.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()")));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(Class2WithTestCases.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(Class2WithTestCases.class, "test2()")));
-		assertTrue(
-			uniqueIds.contains(uniqueIdForMethod(ClassWithStaticInnerTestCases.ShouldBeDiscovered.class, "test1()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(Class1WithTestCases.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()"));
+		assertThat(uniqueIds).contains(uniqueIdForClass(Class2WithTestCases.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(Class2WithTestCases.class, "test2()"));
+		assertThat(uniqueIds).contains(
+			uniqueIdForMethod(ClassWithStaticInnerTestCases.ShouldBeDiscovered.class, "test1()"));
 	}
 
 	@Test
@@ -432,13 +433,13 @@ public class DiscoverySelectorResolverTests {
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertEquals(6, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(TestCaseWithNesting.class, "testA()")));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.class, "testB()")));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class)));
-		assertTrue(uniqueIds.contains(
-			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(TestCaseWithNesting.class, "testA()"));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.class, "testB()"));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class));
+		assertThat(uniqueIds).contains(
+			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()"));
 	}
 
 	@Test
@@ -450,12 +451,12 @@ public class DiscoverySelectorResolverTests {
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertEquals(5, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.class, "testB()")));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class)));
-		assertTrue(uniqueIds.contains(
-			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.class));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.class, "testB()"));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class));
+		assertThat(uniqueIds).contains(
+			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()"));
 	}
 
 	@Test
@@ -468,11 +469,11 @@ public class DiscoverySelectorResolverTests {
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertEquals(4, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class)));
-		assertTrue(uniqueIds.contains(
-			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.class));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class));
+		assertThat(uniqueIds).contains(
+			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()"));
 	}
 
 	@Test
@@ -484,11 +485,11 @@ public class DiscoverySelectorResolverTests {
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertEquals(4, uniqueIds.size());
 
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class)));
-		assertTrue(uniqueIds.contains(
-			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.class));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class));
+		assertThat(uniqueIds).contains(
+			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()"));
 	}
 
 	@Test
@@ -500,11 +501,11 @@ public class DiscoverySelectorResolverTests {
 
 		assertEquals(4, engineDescriptor.getDescendants().size());
 		List<UniqueId> uniqueIds = uniqueIds();
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class)));
-		assertTrue(uniqueIds.contains(
-			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.class));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class));
+		assertThat(uniqueIds).contains(
+			uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.DoubleNestedTestCase.class, "testC()"));
 	}
 
 	@Test
@@ -516,9 +517,9 @@ public class DiscoverySelectorResolverTests {
 
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertEquals(3, uniqueIds.size());
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class)));
-		assertTrue(uniqueIds.contains(uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.class, "testB()")));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.class));
+		assertThat(uniqueIds).contains(uniqueIdForClass(TestCaseWithNesting.NestedTestCase.class));
+		assertThat(uniqueIds).contains(uniqueIdForMethod(TestCaseWithNesting.NestedTestCase.class, "testB()"));
 	}
 
 	private TestDescriptor descriptorByUniqueId(UniqueId uniqueId) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestTemplateInvocationTestDescriptor;
 import org.junit.jupiter.engine.descriptor.subpackage.Class1WithTestCases;
 import org.junit.jupiter.engine.descriptor.subpackage.Class2WithTestCases;
 import org.junit.jupiter.engine.descriptor.subpackage.ClassWithStaticInnerTestCases;
@@ -532,6 +533,20 @@ public class DiscoverySelectorResolverTests {
 
 		assertThat(engineDescriptor.getDescendants()).hasSize(2);
 		assertThat(uniqueIds()).contains(uniqueIdForTestTemplateMethod(TestClassWithTemplate.class, "testTemplate()"));
+	}
+
+	@Test
+	public void resolvingTestTemplateInvocationByUniqueIdResolvesOnlyUpToParentTestTemplat() {
+		UniqueIdSelector selector = selectUniqueId(
+			uniqueIdForTestTemplateMethod(TestClassWithTemplate.class, "testTemplate()").append(
+				TestTemplateInvocationTestDescriptor.SEGMENT_TYPE, "#1"));
+
+		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
+
+		assertThat(engineDescriptor.getDescendants()).hasSize(2);
+
+		assertThat(uniqueIds()).containsSequence(uniqueIdForClass(TestClassWithTemplate.class),
+			uniqueIdForTestTemplateMethod(TestClassWithTemplate.class, "testTemplate()"));
 	}
 
 	private TestDescriptor descriptorByUniqueId(UniqueId uniqueId) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -325,7 +325,7 @@ public class DiscoverySelectorResolverTests {
 	public void resolvingDynamicTestByUniqueIdResolvesOnlyUpToParentTestFactory() {
 		UniqueIdSelector selector = selectUniqueId(
 			uniqueIdForTestFactoryMethod(MyTestClass.class, "dynamicTest()").append(
-				TestFactoryTestDescriptor.DYNAMIC_TEST_SEGMENT_TYPE, "%1"));
+				TestFactoryTestDescriptor.DYNAMIC_TEST_SEGMENT_TYPE, "#1"));
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engineDescriptor);
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.engine.discovery.JupiterUniqueIdBuilder.uniqueIdForTestTemplateMethod;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
@@ -24,6 +25,7 @@ import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.jupiter.engine.JupiterTestEngine;
 import org.junit.platform.engine.TestDescriptor;
@@ -105,6 +107,24 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		assertEquals(7, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
+	@Test
+	public void discoverTestTemplateMethodByUniqueId() {
+		LauncherDiscoveryRequest spec = request().selectors(
+			selectUniqueId(uniqueIdForTestTemplateMethod(TestTemplateClass.class, "testTemplate()"))).build();
+
+		TestDescriptor engineDescriptor = discoverTests(spec);
+		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
+	}
+
+	@Test
+	public void discoverTestTemplateMethodByMethodSelector() {
+		LauncherDiscoveryRequest spec = request().selectors(
+			selectMethod(TestTemplateClass.class, "testTemplate")).build();
+
+		TestDescriptor engineDescriptor = discoverTests(spec);
+		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
+	}
+
 	// -------------------------------------------------------------------
 
 	private static abstract class AbstractTestCase {
@@ -147,5 +167,13 @@ public class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	@Test
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface CustomTestAnnotation {
+	}
+
+	private static class TestTemplateClass {
+
+		@TestTemplate
+		void testTemplate() {
+		}
+
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/JupiterUniqueIdBuilder.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/JupiterUniqueIdBuilder.java
@@ -44,6 +44,10 @@ public class JupiterUniqueIdBuilder {
 		return uniqueIdForClass(clazz).append(TestFactoryMethodResolver.SEGMENT_TYPE, methodPart);
 	}
 
+	public static UniqueId uniqueIdForTestTemplateMethod(Class<?> clazz, String methodPart) {
+		return uniqueIdForClass(clazz).append(TestTemplateMethodResolver.SEGMENT_TYPE, methodPart);
+	}
+
 	public static UniqueId engineId() {
 		return UniqueId.forEngine(JupiterTestEngine.ENGINE_ID);
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethodTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.discovery.predicates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+public class IsTestTemplateMethodTests {
+
+	@Test
+	void publicTestMethodsEvaluatesToTrue() throws NoSuchMethodException {
+		Method templateMethod = ReflectionUtils.findMethod(AClassWithTestTemplate.class, "template").get();
+		assertThat(templateMethod).matches(new IsTestTemplateMethod());
+	}
+
+	private static class AClassWithTestTemplate {
+		@TestTemplate
+		void template() {
+		}
+	}
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
@@ -77,7 +77,11 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 			C context = preparedContext;
 			try {
 				context = node.before(context);
-				context = node.execute(context);
+				C dynamicTestContext = context;
+				context = node.execute(context, dynamicTestDescriptor -> {
+					this.listener.dynamicTestRegistered(dynamicTestDescriptor);
+					execute(dynamicTestDescriptor, dynamicTestContext);
+				});
 
 				// If a node is NOT a leaf, execute its children recursively.
 				// Note: executing children for a leaf could result in accidental

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -13,9 +13,11 @@ package org.junit.platform.engine.support.hierarchical;
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.commons.util.ToStringBuilder;
+import org.junit.platform.engine.TestDescriptor;
 
 /**
  * A <em>node</em> within the execution hierarchy.
@@ -78,13 +80,36 @@ public interface Node<C extends EngineExecutionContext> {
 	 * <p>Containers typically do not implement this method since the
 	 * {@link HierarchicalTestEngine} handles execution of their children.
 	 *
+	 * <p>The supplied {@code dynamicTestExecutor} may be used to submit
+	 * additional dynamic tests for immediate execution.
+	 *
 	 * @param context the context to execute in
+	 * @param dynamicTestExecutor the executor to submit dynamic tests to
 	 * @return the new context to be used for children of this node and for the
 	 * <em>after</em> behavior of the parent of this node, if any
 	 *
 	 * @see #before
 	 * @see #after
 	 */
+	default C execute(C context, Consumer<TestDescriptor> dynamicTestExecutor) throws Exception {
+		return execute(context);
+	}
+
+	/**
+	 * Execute the <em>behavior</em> of this node.
+	 *
+	 * <p>Containers typically do not implement this method since the
+	 * {@link HierarchicalTestEngine} handles execution of their children.
+	 *
+	 * @param context the context to execute in
+	 * @return the new context to be used for children of this node and for the
+	 * <em>after</em> behavior of the parent of this node, if any
+	 *
+	 * @see #before
+	 * @see #after
+	 * @deprecated Please use {@link #execute(EngineExecutionContext, Consumer)} instead.
+	 */
+	@Deprecated
 	default C execute(C context) throws Exception {
 		return context;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -13,7 +13,6 @@ package org.junit.platform.engine.support.hierarchical;
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.commons.util.ToStringBuilder;
@@ -91,7 +90,7 @@ public interface Node<C extends EngineExecutionContext> {
 	 * @see #before
 	 * @see #after
 	 */
-	default C execute(C context, Consumer<TestDescriptor> dynamicTestExecutor) throws Exception {
+	default C execute(C context, DynamicTestExecutor dynamicTestExecutor) throws Exception {
 		return execute(context);
 	}
 
@@ -107,7 +106,8 @@ public interface Node<C extends EngineExecutionContext> {
 	 *
 	 * @see #before
 	 * @see #after
-	 * @deprecated Please use {@link #execute(EngineExecutionContext, Consumer)} instead.
+	 * @deprecated Please use
+	 * {@link #execute(EngineExecutionContext, DynamicTestExecutor)} instead.
 	 */
 	@Deprecated
 	default C execute(C context) throws Exception {
@@ -195,6 +195,29 @@ public interface Node<C extends EngineExecutionContext> {
 					.toString();
 			// @formatter:on
 		}
+	}
+
+	/**
+	 * Executor for additional, dynamic test descriptors discovered during
+	 * execution of a {@link Node}.
+	 *
+	 * <p>The test descriptors will be executed by the same
+	 * {@link HierarchicalTestExecutor} that executes the submitting node.
+	 *
+	 * <p>This interface is not intended to be implemented by clients.
+	 *
+	 * @see Node#execute(EngineExecutionContext, DynamicTestExecutor)
+	 * @see HierarchicalTestExecutor
+	 */
+	interface DynamicTestExecutor {
+
+		/**
+		 * Submit a dynamic test descriptor for immediate execution.
+		 *
+		 * @param testDescriptor the test descriptor to be executed
+		 */
+		void execute(TestDescriptor testDescriptor);
+
 	}
 
 }

--- a/junit-platform-engine/src/test/java/org/junit/platform/engine/test/event/ExecutionEventConditions.java
+++ b/junit-platform-engine/src/test/java/org/junit/platform/engine/test/event/ExecutionEventConditions.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.test.event;
 
 import static java.util.function.Predicate.isEqual;
 import static org.assertj.core.api.Assertions.allOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Index.atIndex;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
@@ -49,7 +50,7 @@ public class ExecutionEventConditions {
 	public static void assertRecordedExecutionEventsContainsExactly(List<ExecutionEvent> executionEvents,
 			Condition<? super ExecutionEvent>... conditions) {
 		SoftAssertions softly = new SoftAssertions();
-		softly.assertThat(executionEvents).hasSize(conditions.length);
+		assertThat(executionEvents).hasSize(conditions.length);
 		for (int i = 0; i < conditions.length; i++) {
 			softly.assertThat(executionEvents).has(conditions[i], atIndex(i));
 		}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
@@ -13,6 +13,9 @@ package org.junit.platform.engine.support.hierarchical;
 import static org.junit.platform.engine.support.hierarchical.Node.SkipResult.doNotSkip;
 import static org.junit.platform.engine.support.hierarchical.Node.SkipResult.skip;
 
+import java.util.function.Consumer;
+
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
@@ -65,7 +68,8 @@ public class DemoHierarchicalTestDescriptor extends AbstractTestDescriptor imple
 	}
 
 	@Override
-	public DemoEngineExecutionContext execute(DemoEngineExecutionContext context) {
+	public DemoEngineExecutionContext execute(DemoEngineExecutionContext context,
+			Consumer<TestDescriptor> dynamicTestExecutor) {
 		if (this.executeBlock != null) {
 			this.executeBlock.run();
 		}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
@@ -69,7 +69,7 @@ public class DemoHierarchicalTestDescriptor extends AbstractTestDescriptor imple
 
 	@Override
 	public DemoEngineExecutionContext execute(DemoEngineExecutionContext context,
-			Consumer<TestDescriptor> dynamicTestExecutor) {
+			DynamicTestExecutor dynamicTestExecutor) {
 		if (this.executeBlock != null) {
 			this.executeBlock.run();
 		}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -35,6 +35,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.hierarchical.Node.DynamicTestExecutor;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.opentest4j.TestAbortedException;
@@ -337,8 +338,8 @@ public class HierarchicalTestExecutorTests {
 		MyLeaf dynamicTestDescriptor = spy(new MyLeaf(leafUniqueId.append("dynamic", "child")));
 
 		when(child.execute(any(), any())).thenAnswer(invocation -> {
-			Consumer<TestDescriptor> dynamicTestExecutor = invocation.getArgument(1);
-			dynamicTestExecutor.accept(dynamicTestDescriptor);
+			DynamicTestExecutor dynamicTestExecutor = invocation.getArgument(1);
+			dynamicTestExecutor.execute(dynamicTestDescriptor);
 			return invocation.getArgument(0);
 		});
 		root.addChild(child);
@@ -430,7 +431,7 @@ public class HierarchicalTestExecutorTests {
 
 		@Override
 		public MyEngineExecutionContext execute(MyEngineExecutionContext context,
-				Consumer<TestDescriptor> dynamicTestExecutor) throws Exception {
+				DynamicTestExecutor dynamicTestExecutor) throws Exception {
 			return context;
 		}
 


### PR DESCRIPTION
## Overview

This pull request introduces the concept of `@TestTemplate` methods. In contrast to `@Test` methods, a test template is not itself a test case but rather a template for test cases. As such, it is designed to be invoked multiple times depending on the number of `TestTemplateInvocationContexts` returned by the registered `TestTemplateInvocationContextProviders`.

Each invocation of a test template method, behaves like the execution of a regular @Test method, i.e. it supports the same lifecycle callbacks and extensions. Each context may provide a custom display name and provide additional extensions that will only be registered for the current invocation, e.g. a `ParameterResolver`, a `TestInstancePostProcessor` or both.

This extension point is a prerequisite for implementing support for parameterized tests as well as repeated tests.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
