### PR TITLE
Update documentation regarding exclude classname option

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -56,6 +56,9 @@ on GitHub.
   similar to the
   https://github.com/junit-team/junit4/wiki/Download-and-Install#plain-old-jar[plain-old JAR]
   known from JUnit 4.
+* New `--exclude-classname` (`--N`) option added to the `ConsoleLauncher` accepting a regular
+  expression to exclude those classes whose fully qualified names match. When this option is
+  repeated, all patterns will be combined using OR semantics.
 
 [[release-notes-5.0.0-m4-junit-jupiter]]
 ==== JUnit Jupiter

--- a/documentation/src/docs/asciidoc/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/running-tests.adoc
@@ -530,6 +530,11 @@ Option                                        Description
                                                 "Test" or "Tests". When this option is
                                                 repeated, all patterns will be combined
                                                 using OR semantics. (default: ^.*Tests?$)
+-N, --exclude-classname <String>              Provide a regular expression to exclude
+                                                those classes whose fully qualified
+                                                names match. When this option is
+                                                repeated, all patterns will be combined
+                                                using OR semantics.
 --include-package <String>                    Provide a package to be included in the
                                                 test run. This option can be repeated.
 --exclude-package <String>                    Provide a package to be excluded from the


### PR DESCRIPTION
## Overview

After-math of https://github.com/junit-team/junit5/pull/630 adding information regarding `--exclude-classname` option  to the user documentation and release notes.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
