### PR TITLE
Replace sout instruction with assertion

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
@@ -55,7 +55,7 @@ public class ConsoleLauncherIntegrationTests {
 		assertTrue(standardErr.isEmpty());
 
 		String standardOutText = new String(this.out.toByteArray());
-		System.out.println(standardOutText);
+		assertThat(standardOutText).isNotBlank();
 		return standardOutText;
 	}
 


### PR DESCRIPTION
## Overview

Replace `System.out.println` instruction with actual assertion.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
