### PR TITLE
Add integration test

### DIFF
--- a/junit-platform-console/junit-platform-console.gradle
+++ b/junit-platform-console/junit-platform-console.gradle
@@ -17,6 +17,9 @@ configurations {
 
 dependencies {
 	compile(project(':junit-platform-launcher'))
+	testCompile(project(':junit-jupiter-api'))
+	testCompile("junit:junit:${junit4Version}")
+
 	shadowed('net.sf.jopt-simple:jopt-simple:5.0.3')
 
 	standalone(project(':junit-platform-console'))
@@ -51,6 +54,7 @@ javadoc {
 }
 
 jar.enabled = false
+test.enabled = false // prevent supposed-to-fail integration tests from failing the build
 
 shadowJar {
 	// Generate shadow jar only if the underlying manifest was regenerated.
@@ -100,25 +104,55 @@ artifacts {
 	archives standaloneJar
 }
 
-task standaloneExec(type: JavaExec) {
-	dependsOn(standaloneJar)
-	workingDir "$buildDir/libs"
+task standaloneExec(type: JavaExec, dependsOn: [standaloneJar, testClasses]) {
+	ignoreExitValue = true
+	workingDir = "$buildDir/libs"
 	main = '-jar'
 	args = [
 			"$standaloneJar.archiveName",
 			'--scan-classpath',
-			'--details', 'none'
+			'--include-classname', '.*',
+			'--classpath', "$buildDir/classes/test",
+			'--details', 'tree'
 	]
 	standardOutput = new ByteArrayOutputStream()
 	errorOutput = new ByteArrayOutputStream()
 }
 
-task standaloneCheck {
-	dependsOn(standaloneExec)
+task standaloneCheck(dependsOn: standaloneExec) {
 	doLast {
 		String text = standaloneExec.errorOutput.toString() + standaloneExec.standardOutput.toString()
+		// engines -- output depends on default logging configuration
 		assert text.contains("junit-jupiter (group ID: org.junit.jupiter, artifact ID: junit-jupiter-engine, version: $rootProject.version)")
 		assert text.contains("junit-vintage (group ID: org.junit.vintage, artifact ID: junit-vintage-engine, version: $vintageVersion)")
+		// tree node names
+		assert text.contains("JUnit Jupiter")
+		assert text.contains("JupiterIntegration")
+		assert text.contains("abort()") && text.contains("Assumption failed: integration-test-abort")
+		assert text.contains("successful()")
+		assert text.contains("disabled()") && text.contains("integration-test-disabled")
+		assert text.contains("fail()") && text.contains("integration-test-fail")
+		assert text.contains("JUnit Vintage")
+		assert text.contains("VintageIntegration")
+		assert text.contains("ignored") && text.contains("integr4tion test")
+		assert text.contains("f4il") && text.contains("f4iled")
+		assert text.contains("succ3ssful")
+		// summary
+		assert text.contains("Test run finished after")
+		// container summary
+		assert text.contains("4 containers found")
+		assert text.contains("0 containers skipped")
+		assert text.contains("4 containers started")
+		assert text.contains("0 containers aborted")
+		assert text.contains("4 containers successful")
+		assert text.contains("0 containers failed")
+		// tests summary
+		assert text.contains("7 tests found")
+		assert text.contains("2 tests skipped")
+		assert text.contains("5 tests started")
+		assert text.contains("1 tests aborted")
+		assert text.contains("2 tests successful")
+		assert text.contains("2 tests failed")
 	}
 }
 

--- a/junit-platform-console/src/test/java/integration/JupiterIntegration.java
+++ b/junit-platform-console/src/test/java/integration/JupiterIntegration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package integration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+class JupiterIntegration {
+
+	@Test
+	void successful() {
+	}
+
+	@Test
+	@Disabled("integration-test-disabled")
+	void disabled() {
+	}
+
+	@Test
+	void abort() {
+		Assumptions.assumeTrue(false, "integration-test-abort");
+	}
+
+	@Test
+	void fail() {
+		Assertions.fail("integration-test-fail");
+	}
+}

--- a/junit-platform-console/src/test/java/integration/VintageIntegration.java
+++ b/junit-platform-console/src/test/java/integration/VintageIntegration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.runners.MethodSorters.NAME_ASCENDING;
+
+import org.junit.FixMethodOrder;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@FixMethodOrder(NAME_ASCENDING)
+public class VintageIntegration {
+
+	@Test
+	@Ignore("integr4tion test")
+	public void ignored() {
+		fail("this test should be ignored");
+	}
+
+	@Test
+	public void succ3ssful() {
+		assertEquals(3, 1 + 2);
+	}
+
+	@Test
+	public void f4il() {
+		fail("f4iled");
+	}
+}


### PR DESCRIPTION
## Overview

Fixes #648 by running some sample tests (which includes failing and passing tests)
reads the output, and ensures that we get the expected result. This integration test
relies on external test plan execution using the standalone jar.

When the something similar to the incorrect usage of a Stream's filter() method
that removed all tests from being run happens, this integration test will fail.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
