### PR TITLE
Add utility API to ExtensionContext.Util

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -12,11 +12,14 @@ package org.junit.jupiter.api.extension;
 
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -35,6 +38,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.0
  * @see Store
  * @see Namespace
+ * @see Util
  */
 @API(Experimental)
 public interface ExtensionContext {
@@ -340,6 +344,63 @@ public interface ExtensionContext {
 			return parts.hashCode();
 		}
 
+	}
+
+	/**
+	 * Get the {@link Util} instance providing access to commonly used helper methods.
+	 *
+	 * @return the util instance; never {@code null}
+	 */
+	Util getUtil();
+
+	/**
+	 * Groups commonly used helper methods used by extensions.
+	 */
+	interface Util {
+
+		/**
+		 * Determine if an annotation of {@code annotationType} is either <em>present</em> or <em>meta-present</em> on the
+		 * supplied {@code element}.
+		 *
+		 * @see org.junit.platform.commons.util.AnnotationUtils#isAnnotated(AnnotatedElement, Class)
+		 */
+		boolean isAnnotated(AnnotatedElement element, Class<? extends Annotation> annotationType);
+
+		/**
+		 * Find the first annotation of {@code annotationType} that is either <em>present</em> or <em>meta-present</em> on
+		 * the supplied {@code element}.
+		 *
+		 * @see org.junit.platform.commons.util.AnnotationUtils#findAnnotation(AnnotatedElement, Class)
+		 */
+		<A extends Annotation> Optional<A> findAnnotation(AnnotatedElement element, Class<A> annotationType);
+
+		/**
+		 * Find all <em>repeatable</em> {@linkplain Annotation annotations} of {@code annotationType} that are either
+		 * <em>present</em>, <em>indirectly present</em>, or <em>meta-present</em> on the supplied {@link AnnotatedElement}.
+		 *
+		 * @see org.junit.platform.commons.util.AnnotationUtils#findRepeatableAnnotations(AnnotatedElement, Class)
+		 */
+		<A extends Annotation> List<A> findRepeatableAnnotations(AnnotatedElement element, Class<A> annotationType);
+
+		/**
+		 * Find all {@code public} {@linkplain Field fields} of the supplied class or interface that are of the specified
+		 * {@code fieldType} and annotated or meta-annotated with the specified {@code annotationType}.
+		 *
+		 * @see org.junit.platform.commons.util.AnnotationUtils#findPublicAnnotatedFields(Class, Class, Class)
+		 */
+		List<Field> findPublicAnnotatedFields(Class<?> clazz, Class<?> fieldType,
+				Class<? extends Annotation> annotationType);
+
+		/**
+		 * Find all {@linkplain Method methods} of the supplied class or interface that are annotated or meta-annotated
+		 * with the specified {@code annotationType}.
+		 *
+		 * @param sortOrderHierarchyDown {@code true} translates to
+		 *   {@code ReflectionUtils.MethodSortOrder#HierarchyDown}, {@code false} is interpreted as
+		 *   {@code ReflectionUtils.MethodSortOrder#HierarchyUp}.
+		 */
+		List<Method> findAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType,
+				boolean sortOrderHierarchyDown);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -12,7 +12,12 @@ package org.junit.jupiter.engine.descriptor;
 
 import static java.util.stream.Collectors.toCollection;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -20,7 +25,9 @@ import java.util.Set;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.execution.ExtensionValuesStore;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
+import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils.MethodSortOrder;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
@@ -29,7 +36,7 @@ import org.junit.platform.engine.reporting.ReportEntry;
 /**
  * @since 5.0
  */
-abstract class AbstractExtensionContext<T extends TestDescriptor> implements ExtensionContext {
+abstract class AbstractExtensionContext<T extends TestDescriptor> implements ExtensionContext, ExtensionContext.Util {
 
 	private final ExtensionContext parent;
 	private final EngineExecutionListener engineExecutionListener;
@@ -75,6 +82,41 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 	@Override
 	public Set<String> getTags() {
 		return testDescriptor.getTags().stream().map(TestTag::getName).collect(toCollection(LinkedHashSet::new));
+	}
+
+	@Override
+	public Util getUtil() {
+		// The current implementation is done "in same instance".
+		// If more methods are added, consider creating a dedicated Util class.
+		return this;
+	}
+
+	@Override
+	public boolean isAnnotated(AnnotatedElement element, Class<? extends Annotation> annotationType) {
+		return AnnotationUtils.isAnnotated(element, annotationType);
+	}
+
+	@Override
+	public <A extends Annotation> Optional<A> findAnnotation(AnnotatedElement element, Class<A> annotationType) {
+		return AnnotationUtils.findAnnotation(element, annotationType);
+	}
+
+	@Override
+	public <A extends Annotation> List<A> findRepeatableAnnotations(AnnotatedElement element, Class<A> annotationType) {
+		return AnnotationUtils.findRepeatableAnnotations(element, annotationType);
+	}
+
+	@Override
+	public List<Field> findPublicAnnotatedFields(Class<?> clazz, Class<?> fieldType,
+			Class<? extends Annotation> annotationType) {
+		return AnnotationUtils.findPublicAnnotatedFields(clazz, fieldType, annotationType);
+	}
+
+	@Override
+	public List<Method> findAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType,
+			boolean sortOrderHierarchyDown) {
+		MethodSortOrder order = sortOrderHierarchyDown ? MethodSortOrder.HierarchyDown : MethodSortOrder.HierarchyUp;
+		return AnnotationUtils.findAnnotatedMethods(clazz, annotationType, order);
 	}
 
 }


### PR DESCRIPTION
## Overview

Fixes #246 by publishing useful internal helper methods via an API facade. At the moment, only annotation-related helpers are included. The `ExtensionContext.Util` interface might grow in the future.

## Discussion

1. Omit nested `Util` interface and pull helper methods up to `ExtensionContext`?
2. If nested interface is wanted, find a better name then `Util`?
3. Expose more helper methods, if yes, which?

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
