### PR TITLE
Adds fail() methods that pass Throwables - closes #656.

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -80,6 +80,8 @@ on GitHub.
 * `Assertions.assertThrows()` now uses canonical names for exception types when
   generating assertion failure messages.
 * `TestInstancePostProcessors` registered on test methods are now invoked.
+* There are two new signatures `Assertions.fail` - `Assertions.fail(Throwable cause)` and
+  `Assertions.fail(String message, Throwable cause)`.
 
 
 [[release-notes-5.0.0-m4-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -36,6 +36,14 @@ class AssertionUtils {
 		fail(() -> message);
 	}
 
+	static void fail(String message, Throwable cause) {
+		throw new AssertionFailedError(message, cause);
+	}
+
+	static void fail(Throwable cause) {
+		throw new AssertionFailedError(null, cause);
+	}
+
 	static void fail(Supplier<String> messageSupplier) {
 		throw new AssertionFailedError(nullSafeGet(messageSupplier));
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -56,6 +56,21 @@ public final class Assertions {
 	}
 
 	/**
+	 * <em>Fails</em> a test with the given failure {@code message} as well
+	 * as the underlying {@code cause}.
+	 */
+	public static void fail(String message, Throwable cause) {
+		AssertionUtils.fail(message, cause);
+	}
+
+	/**
+	 * <em>Fails</em> a test with the given underlying {@code cause}.
+	 */
+	public static void fail(Throwable cause) {
+		AssertionUtils.fail(cause);
+	}
+
+	/**
 	 * <em>Fails</em> a test with the failure message retrieved from the
 	 * given {@code messageSupplier}.
 	 */

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsFailTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsFailTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -66,6 +67,59 @@ public class AssertionsFailTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "");
+		}
+	}
+
+	@Test
+	void failWithStringAndThrowable() {
+		try {
+			fail("message", new Throwable("cause"));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "message");
+			Throwable cause = ex.getCause();
+			assertMessageContains(cause, "cause");
+		}
+	}
+
+	@Test
+	void failWithThrowable() {
+		try {
+			fail((String) null, new Throwable("cause"));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "");
+			Throwable cause = ex.getCause();
+			assertMessageContains(cause, "cause");
+		}
+	}
+
+	@Test
+	void failWithStringAndNullThrowable() {
+		try {
+			fail("message", (Throwable) null);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "message");
+			if (ex.getCause() != null) {
+				throw new AssertionError("Cause should have been null");
+			}
+		}
+	}
+
+	@Test
+	void failWithNullStringAndThrowable() {
+		try {
+			fail((String) null, new Throwable("cause"));
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "");
+			Throwable cause = ex.getCause();
+			assertMessageContains(cause, "cause");
 		}
 	}
 


### PR DESCRIPTION
## Overview

This PR adds two additional signatures for the ```Assertions.fail()``` methods:

-   ```Assertions.fail(String message, Throwable cause)```
-   ```Assertions.fail(Throwable cause)```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [ ] ~~Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc~~
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the ~~[User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and~~  [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [X] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
