### PR TITLE
Implementation of legacyreporting for the surefire provider using getLegacyName

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -22,6 +22,9 @@ on GitHub.
 * All `findMethods()` implementations in `ReflectionUtils` no longer return synthetic methods.
   Shadowed https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2[override-equal]
   methods are also no longer included in the result collection.
+* Introduced `getLegacyName()` in `TestIdentifier`.
+  This allows the JUnit Platform Surefire provider to resolve the class and method names
+  through `getLegacyName()` instead of using the source location.
 
 ===== Deprecations and Breaking Changes
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -111,6 +111,11 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 		return true;
 	}
 
+	@Override
+	public String getLegacyReportingName() {
+		return testClass.getName();
+	}
+
 	private static String generateDefaultDisplayName(Class<?> testClass) {
 		String name = testClass.getName();
 		int index = name.lastIndexOf('.');

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -57,6 +57,11 @@ abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
 		return this.testMethod;
 	}
 
+	@Override
+	public String getLegacyReportingName() {
+		return generateDefaultDisplayName(testMethod);
+	}
+
 	private static String generateDefaultDisplayName(Method testMethod) {
 		return String.format("%s(%s)", testMethod.getName(),
 			StringUtils.nullSafeToString(Class::getSimpleName, testMethod.getParameterTypes()));

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -53,6 +53,10 @@ public interface TestDescriptor {
 	 */
 	String getDisplayName();
 
+	default String getLegacyReportingName() {
+		return getDisplayName();
+	}
+
 	/**
 	 * Get the set of {@linkplain TestTag tags} associated with this descriptor.
 	 *

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -46,6 +46,7 @@ public final class TestIdentifier implements Serializable {
 	private final Set<TestTag> tags;
 	private final boolean test;
 	private final boolean container;
+	private final String legacyReportingName;
 
 	/**
 	 * Factory for creating a new {@link TestIdentifier} from a {@link TestDescriptor}.
@@ -61,11 +62,12 @@ public final class TestIdentifier implements Serializable {
 		boolean container = !test || !testDescriptor.getChildren().isEmpty();
 		Optional<String> parentId = testDescriptor.getParent().map(
 			parentDescriptor -> parentDescriptor.getUniqueId().toString());
-		return new TestIdentifier(uniqueId, displayName, source, tags, test, container, parentId);
+		String legacyReportingName = testDescriptor.getLegacyReportingName();
+		return new TestIdentifier(uniqueId, displayName, source, tags, test, container, parentId, legacyReportingName);
 	}
 
 	TestIdentifier(String uniqueId, String displayName, Optional<TestSource> source, Set<TestTag> tags, boolean test,
-			boolean container, Optional<String> parentId) {
+			boolean container, Optional<String> parentId, String legacyReportingName) {
 		this.uniqueId = uniqueId;
 		this.parentId = parentId.orElse(null);
 		this.displayName = displayName;
@@ -73,6 +75,7 @@ public final class TestIdentifier implements Serializable {
 		this.tags = unmodifiableSet(new LinkedHashSet<>(tags));
 		this.test = test;
 		this.container = container;
+		this.legacyReportingName = legacyReportingName;
 	}
 
 	/**
@@ -153,6 +156,10 @@ public final class TestIdentifier implements Serializable {
 		return this.tags;
 	}
 
+	public String getLegacyReportingName() {
+		return legacyReportingName;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof TestIdentifier) {
@@ -174,6 +181,7 @@ public final class TestIdentifier implements Serializable {
 				.append("uniqueId", this.uniqueId)
 				.append("parentId", this.parentId)
 				.append("displayName", this.displayName)
+				.append("legacyReportingName", this.legacyReportingName)
 				.append("source", this.source)
 				.append("tags", this.tags)
 				.append("test", this.test)

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/JUnitPlatformProviderTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/JUnitPlatformProviderTests.java
@@ -21,7 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import org.apache.maven.surefire.report.ReportEntry;
 import org.apache.maven.surefire.report.RunListener;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.MethodTestDescriptor;
@@ -182,6 +183,22 @@ class RunListenerAdapterTests {
 		assertEquals(parentDisplay, entryCaptor.getValue().getSourceName());
 	}
 
+	@Test
+	void displayNamesIgnoredInReport() throws NoSuchMethodException {
+		MethodTestDescriptor descriptor = new MethodTestDescriptor(newId(), MyTestClass.class,
+			MyTestClass.class.getDeclaredMethod("myNamedTestMethod"));
+
+		TestIdentifier factoryIdentifier = TestIdentifier.from(descriptor);
+		ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+
+		adapter.executionSkipped(factoryIdentifier, "");
+		verify(listener).testSkipped(entryCaptor.capture());
+
+		ReportEntry value = entryCaptor.getValue();
+
+		assertEquals("myNamedTestMethod()", value.getName());
+	}
+
 	private static TestIdentifier newMethodIdentifier() throws Exception {
 		return TestIdentifier.from(newMethodDescriptor());
 	}
@@ -253,6 +270,11 @@ class RunListenerAdapterTests {
 	private static class MyTestClass {
 		@Test
 		void myTestMethod() {
+		}
+
+		@DisplayName("name")
+		@Test
+		void myNamedTestMethod() {
 		}
 	}
 }

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
@@ -16,7 +16,10 @@
 
 package org.junit.platform.surefire.provider;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
@@ -44,10 +44,11 @@ class TestIdentifierTests {
 	void serialization() throws Exception {
 		TestIdentifier identifier = serializeAndDeserialize(//
 			new TestIdentifier("uniqueId", "displayName", Optional.of(new ClassSource(TestIdentifierTests.class)),
-				singleton(TestTag.create("aTag")), true, false, Optional.of("parentId")));
+				singleton(TestTag.create("aTag")), true, false, Optional.of("parentId"), "reportingName"));
 
 		assertEquals("uniqueId", identifier.getUniqueId());
 		assertEquals("displayName", identifier.getDisplayName());
+		assertEquals("reportingName", identifier.getLegacyReportingName());
 		assertThat(identifier.getSource()).contains(new ClassSource(TestIdentifierTests.class));
 		assertEquals(singleton(TestTag.create("aTag")), identifier.getTags());
 		assertTrue(identifier.isTest());


### PR DESCRIPTION
## Overview

Please describe your changes here and list any open questions you might have.
An alternative Implementation of #616 corresponding to the suggestion in the discussion in #654 
---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
