### PR TITLE
Adds the disableOnDebug member to @ExtendWith.  Resolves 668.

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -80,7 +80,9 @@ on GitHub.
 * `Assertions.assertThrows()` now uses canonical names for exception types when
   generating assertion failure messages.
 * `TestInstancePostProcessors` registered on test methods are now invoked.
-
+* `@ExtendWith` now supports a `disabledOnDebug` flag with a default value of false so that
+  one or more `Extensions` can be disabled when the JVM is in debug mode.  This function
+  mimics the `DisableOnDebug` rule wrapper in JUnit 4.
 
 [[release-notes-5.0.0-m4-junit-vintage]]
 ==== JUnit Vintage

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
@@ -58,4 +58,10 @@ public @interface ExtendWith {
 	 */
 	Class<? extends Extension>[] value();
 
+	/**
+	 * Indicates that this {@link Extension} should not be registered if the
+	 * JVM was launched in debug mode.
+	 */
+	boolean disableOnDebug() default false;
+
 }


### PR DESCRIPTION
## Overview

This PR adds code to disable extensions when the JVM is running in debug mode in order to support the equivalent functionality that exists in JUnit 4.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [ ] ~~Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc~~
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [X] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
