### PR TITLE
Publish maintained utilities to dedicated support package

### DIFF
--- a/documentation/src/docs/asciidoc/extensions.adoc
+++ b/documentation/src/docs/asciidoc/extensions.adoc
@@ -251,3 +251,11 @@ put values into a store for later retrieval.  See the
 `ContainerExtensionContext`. Since `ContainerExtensionContexts` may be nested, the scope of inner
 contexts may also be limited. Consult the corresponding Javadoc for details on the methods
 available for storing and retrieving values via the `{ExtensionContext_Store}`.
+
+[[extensions-supported-utilities]]
+=== Supported Utilities in Extensions
+
+The JUnit Platform Commons artifact exposes package `{junit-platform-support-package}` which
+contains maintained utility methods handling `Annotation`, reflection and classpath scanning tasks.
+Extension authors are encouraged to use these supported methods to align expected the behaviour
+with the JUnit Platform.

--- a/documentation/src/docs/asciidoc/index.adoc
+++ b/documentation/src/docs/asciidoc/index.adoc
@@ -15,6 +15,7 @@ Stefan Bechtold; Sam Brannen; Johannes Link; Matthias Merdes; Marc Philipp
 :junit-platform-console:            {javadoc-root}/org/junit/platform/console/package-summary.html[junit-platform-console]
 :junit-platform-engine:             {javadoc-root}/org/junit/platform/engine/package-summary.html[junit-platform-engine]
 :junit-platform-launcher:           {javadoc-root}/org/junit/platform/launcher/package-summary.html[junit-platform-launcher]
+:junit-platform-support-package:    {javadoc-root}/org/junit/platform/commons/support/package-summary.html[org.junit.platform.commons.support]
 :API:                               {javadoc-root}/org/junit/platform/commons/meta/API.html[@API]
 :Launcher:                          {javadoc-root}/org/junit/platform/launcher/Launcher.html[Launcher]
 :ConsoleLauncher:                   {javadoc-root}/org/junit/platform/console/ConsoleLauncher.html[ConsoleLauncher]

--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -64,6 +64,10 @@ on GitHub.
 * New `--exclude-classname` (`--N`) option added to the `ConsoleLauncher` accepting a regular
   expression to exclude those classes whose fully qualified names match. When this option is
   repeated, all patterns will be combined using OR semantics.
+* Introduce JUnit Platform support package `org.junit.platform.commons.support` which contains
+  maintained utility methods handling `Annotation`, reflection and classpath scanning tasks.
+  `TestEngine` and `Extension` authors are encouraged to use these supported methods
+  to align the behaviour with the JUnit Platform.
 
 [[release-notes-5.0.0-m4-junit-jupiter]]
 ==== JUnit Jupiter

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.commons.support;
+
+import static org.junit.platform.commons.meta.API.Usage.Maintained;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+/**
+ * Common annotation support.
+ *
+ * @since 1.0
+ */
+@API(Maintained)
+public final class AnnotationSupport {
+
+	///CLOVER:OFF
+	private AnnotationSupport() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
+	/**
+	 * Determine if an annotation of {@code annotationType} is either
+	 * <em>present</em> or <em>meta-present</em> on the supplied
+	 * {@code element}.
+	 *
+	 * @see #findAnnotation(AnnotatedElement, Class)
+	 */
+	public static boolean isAnnotated(AnnotatedElement element, Class<? extends Annotation> annotationType) {
+		return AnnotationUtils.isAnnotated(element, annotationType);
+	}
+
+	/**
+	 * Find the first annotation of {@code annotationType} that is either
+	 * <em>present</em> or <em>meta-present</em> on the supplied
+	 * {@code element}.
+	 */
+	public static <A extends Annotation> Optional<A> findAnnotation(AnnotatedElement element, Class<A> annotationType) {
+		return AnnotationUtils.findAnnotation(element, annotationType);
+	}
+
+	/**
+	 * Find all <em>repeatable</em> {@linkplain Annotation annotations} of
+	 * {@code annotationType} that are either <em>present</em>, <em>indirectly
+	 * present</em>, or <em>meta-present</em> on the supplied {@link AnnotatedElement}.
+	 *
+	 * <p>This method extends the functionality of
+	 * {@link java.lang.reflect.AnnotatedElement#getAnnotationsByType(Class)}
+	 * with additional support for meta-annotations.
+	 *
+	 * <p>In addition, if the element is a class and the repeatable annotation
+	 * is {@link java.lang.annotation.Inherited @Inherited}, this method will
+	 * search on superclasses first in order to support top-down semantics.
+	 * The result is that this algorithm finds repeatable annotations that
+	 * would be <em>shadowed</em> and therefore not visible according to Java's
+	 * standard semantics for inherited, repeatable annotations, but most
+	 * developers will naturally assume that all repeatable annotations in JUnit
+	 * are discovered regardless of whether they are declared stand-alone, in a
+	 * container, or as a meta-annotation (e.g., multiple declarations of
+	 * {@code @ExtendWith} within a test class hierarchy).
+	 *
+	 * <p>If the supplied {@code element} is {@code null}, this method simply
+	 * returns an empty list.
+	 *
+	 * @param element the element to search on, potentially {@code null}
+	 * @param annotationType the repeatable annotation type to search for; never {@code null}
+	 * @return the list of all such annotations found; never {@code null}
+	 * @see java.lang.annotation.Repeatable
+	 * @see java.lang.annotation.Inherited
+	 */
+	public static <A extends Annotation> List<A> findRepeatableAnnotations(AnnotatedElement element,
+			Class<A> annotationType) {
+		return AnnotationUtils.findRepeatableAnnotations(element, annotationType);
+	}
+
+	/**
+	 * Find all {@code public} {@linkplain Field fields} of the supplied class
+	 * or interface that are of the specified {@code fieldType} and annotated
+	 * or <em>meta-annotated</em> with the specified {@code annotationType}.
+	 *
+	 * <p>Consult the Javadoc for {@link Class#getFields()} for details on
+	 * inheritance and ordering.
+	 *
+	 * @param clazz the class or interface in which to find the fields; never {@code null}
+	 * @param fieldType the type of field to find; never {@code null}
+	 * @param annotationType the annotation type to search for; never {@code null}
+	 * @return the list of all such fields found; never {@code null}
+	 * @see Class#getFields()
+	 */
+	public static List<Field> findPublicAnnotatedFields(Class<?> clazz, Class<?> fieldType,
+			Class<? extends Annotation> annotationType) {
+		return AnnotationUtils.findPublicAnnotatedFields(clazz, fieldType, annotationType);
+	}
+
+	/**
+	 * Find all {@linkplain Method methods} of the supplied class or interface
+	 * that are annotated or <em>meta-annotated</em> with the specified
+	 * {@code annotationType}.
+	 *
+	 * @param clazz the class or interface in which to find the methods; never {@code null}
+	 * @param annotationType the annotation type to search for; never {@code null}
+	 * @param sortOrder the method sort order
+	 * @return the list of all such methods found; never {@code null}
+	 */
+	public static List<Method> findAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType,
+			MethodSortOrder sortOrder) {
+		return AnnotationUtils.findAnnotatedMethods(clazz, annotationType,
+			ReflectionUtils.MethodSortOrder.valueOf(sortOrder.name()));
+	}
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/MethodSortOrder.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/MethodSortOrder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.commons.support;
+
+import static org.junit.platform.commons.meta.API.Usage.Maintained;
+
+import org.junit.platform.commons.meta.API;
+
+/**
+ * @since 1.0
+ */
+@API(Maintained)
+public enum MethodSortOrder {
+	/**
+	 * Sort methods from top to bottom.
+	 */
+	HierarchyDown,
+
+	/**
+	 * Sort methods from bottom to top.
+	 */
+	HierarchyUp
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.commons.support;
+
+import static org.junit.platform.commons.meta.API.Usage.Maintained;
+
+import java.net.URI;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+/**
+ * Common reflection and classpath scanning support.
+ *
+ * @since 1.0
+ */
+@API(Maintained)
+public final class ReflectionSupport {
+
+	///CLOVER:OFF
+	private ReflectionSupport() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
+	/**
+	 * Find all {@linkplain Class classes} of the supplied {@code root}
+	 * {@linkplain URI} that match the specified {@code classTester} and
+	 * {@code classNameFilter} predicates.
+	 *
+	 * @param root the root URI to start scanning
+	 * @param classTester the class type filter; never {@code null}
+	 * @param classNameFilter the class name filter; never {@code null}
+	 * @return the list of all such classes found; never {@code null}
+	 */
+	public static List<Class<?>> findAllClassesInClasspathRoot(URI root, Predicate<Class<?>> classTester,
+			Predicate<String> classNameFilter) {
+		return ReflectionUtils.findAllClassesInClasspathRoot(root, classTester, classNameFilter);
+	}
+
+	/**
+	 * Find all {@linkplain Class classes} of the supplied {@code basePackageName}
+	 * that match the specified {@code classTester} and {@code classNameFilter}
+	 * predicates.
+	 *
+	 * @param basePackageName the base package name to start scanning
+	 * @param classTester the class type filter; never {@code null}
+	 * @param classNameFilter the class name filter; never {@code null}
+	 * @return the list of all such classes found; never {@code null}
+	 */
+	public static List<Class<?>> findAllClassesInPackage(String basePackageName, Predicate<Class<?>> classTester,
+			Predicate<String> classNameFilter) {
+		return ReflectionUtils.findAllClassesInPackage(basePackageName, classTester, classNameFilter);
+	}
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/package-info.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Maintained common support API provided by the JUnit Platform.
+ *
+ * <p>The purpose of this package is to provide {@code TestEngine} and
+ * {@code Extension} authors convenient access to a subset of internal utility
+ * methods helping with their implementation. This prevents re-inventing the
+ * wheel and ensures that common tasks are handled in the same way as within
+ * the JUnit Platform.
+ */
+
+package org.junit.platform.commons.support;

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -45,9 +45,13 @@ import org.junit.platform.commons.util.ReflectionUtils.MethodSortOrder;
  * itself. <strong>Any usage by external parties is not supported.</strong>
  * Use at your own risk!
  *
+ * <p>Some utilities are published via the maintained {@code AnnotationSupport}
+ * class.
+ *
  * @since 1.0
  * @see Annotation
  * @see AnnotatedElement
+ * @see org.junit.platform.commons.support.AnnotationSupport
  */
 @API(Internal)
 public final class AnnotationUtils {
@@ -61,10 +65,7 @@ public final class AnnotationUtils {
 	private static final Map<AnnotationCacheKey, Annotation> annotationCache = new ConcurrentHashMap<>(256);
 
 	/**
-	 * Determine if an annotation of {@code annotationType} is either <em>present</em> or <em>meta-present</em> on the
-	 * supplied {@code element}.
-	 *
-	 * @see #findAnnotation(AnnotatedElement, Class)
+	 * @see org.junit.platform.commons.support.AnnotationSupport#isAnnotated(AnnotatedElement, Class)
 	 */
 	public static boolean isAnnotated(AnnotatedElement element, Class<? extends Annotation> annotationType) {
 		return findAnnotation(element, annotationType).isPresent();
@@ -87,8 +88,7 @@ public final class AnnotationUtils {
 	}
 
 	/**
-	 * Find the first annotation of {@code annotationType} that is either <em>present</em> or <em>meta-present</em> on
-	 * the supplied {@code element}.
+	 * @see org.junit.platform.commons.support.AnnotationSupport#findAnnotation(AnnotatedElement, Class)
 	 */
 	public static <A extends Annotation> Optional<A> findAnnotation(AnnotatedElement element, Class<A> annotationType) {
 		return findAnnotation(element, annotationType, new HashSet<>());
@@ -158,33 +158,7 @@ public final class AnnotationUtils {
 	}
 
 	/**
-	 * Find all <em>repeatable</em> {@linkplain Annotation annotations} of
-	 * {@code annotationType} that are either <em>present</em>, <em>indirectly
-	 * present</em>, or <em>meta-present</em> on the supplied {@link AnnotatedElement}.
-	 *
-	 * <p>This method extends the functionality of
-	 * {@link java.lang.reflect.AnnotatedElement#getAnnotationsByType(Class)}
-	 * with additional support for meta-annotations.
-	 *
-	 * <p>In addition, if the element is a class and the repeatable annotation
-	 * is {@link Inherited @Inherited}, this method will search on superclasses
-	 * first in order to support top-down semantics. The result is that this
-	 * algorithm finds repeatable annotations that would be <em>shadowed</em>
-	 * and therefore not visible according to Java's standard semantics for
-	 * inherited, repeatable annotations, but most developers will naturally
-	 * assume that all repeatable annotations in JUnit are discovered regardless
-	 * of whether they are declared stand-alone, in a container, or as a
-	 * meta-annotation (e.g., multiple declarations of {@code @ExtendWith}
-	 * within a test class hierarchy).
-	 *
-	 * <p>If the supplied {@code element} is {@code null}, this method simply
-	 * returns an empty list.
-	 *
-	 * @param element the element to search on, potentially {@code null}
-	 * @param annotationType the repeatable annotation type to search for; never {@code null}
-	 * @return the list of all such annotations found; never {@code null}
-	 * @see Repeatable
-	 * @see Inherited
+	 * @see org.junit.platform.commons.support.AnnotationSupport#findRepeatableAnnotations(AnnotatedElement, Class)
 	 */
 	public static <A extends Annotation> List<A> findRepeatableAnnotations(AnnotatedElement element,
 			Class<A> annotationType) {
@@ -268,18 +242,7 @@ public final class AnnotationUtils {
 	}
 
 	/**
-	 * Find all {@code public} {@linkplain Field fields} of the supplied class
-	 * or interface that are of the specified {@code fieldType} and annotated
-	 * or meta-annotated with the specified {@code annotationType}.
-	 *
-	 * <p>Consult the Javadoc for {@link Class#getFields()} for details on
-	 * inheritance and ordering.
-	 *
-	 * @param clazz the class or interface in which to find the fields; never {@code null}
-	 * @param fieldType the type of field to find; never {@code null}
-	 * @param annotationType the annotation type to search for; never {@code null}
-	 * @return the list of all such fields found; never {@code null}
-	 * @see Class#getFields()
+	 * @see org.junit.platform.commons.support.AnnotationSupport#findPublicAnnotatedFields(Class, Class, Class)
 	 */
 	public static List<Field> findPublicAnnotatedFields(Class<?> clazz, Class<?> fieldType,
 			Class<? extends Annotation> annotationType) {
@@ -295,6 +258,9 @@ public final class AnnotationUtils {
 		// @formatter:on
 	}
 
+	/**
+	 * @see org.junit.platform.commons.support.AnnotationSupport#findAnnotatedMethods(Class, Class, org.junit.platform.commons.support.MethodSortOrder)
+	 */
 	public static List<Method> findAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType,
 			MethodSortOrder sortOrder) {
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -52,7 +52,11 @@ import org.junit.platform.commons.meta.API;
  * itself. <strong>Any usage by external parties is not supported.</strong>
  * Use at your own risk!
  *
+ * <p>Some utilities are published via the maintained {@code ReflectionSupport}
+ * class.
+ *
  * @since 1.0
+ * @see org.junit.platform.commons.support.ReflectionSupport
  */
 @API(Internal)
 public final class ReflectionUtils {
@@ -464,11 +468,17 @@ public final class ReflectionUtils {
 		return findAllClassesInClasspathRoot(root.toUri(), classTester, classNameFilter);
 	}
 
+	/**
+	 * @see org.junit.platform.commons.support.ReflectionSupport#findAllClassesInClasspathRoot(URI, Predicate, Predicate)
+	 */
 	public static List<Class<?>> findAllClassesInClasspathRoot(URI root, Predicate<Class<?>> classTester,
 			Predicate<String> classNameFilter) {
 		return classpathScanner.scanForClassesInClasspathRoot(root, classTester, classNameFilter);
 	}
 
+	/**
+	 * @see org.junit.platform.commons.support.ReflectionSupport#findAllClassesInPackage(String, Predicate, Predicate)
+	 */
 	public static List<Class<?>> findAllClassesInPackage(String basePackageName, Predicate<Class<?>> classTester,
 			Predicate<String> classNameFilter) {
 		return classpathScanner.scanForClassesInPackage(basePackageName, classTester, classNameFilter);

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/AnnotationSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/AnnotationSupportTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.commons.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.junit.platform.commons.util.PreconditionViolationException;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+/**
+ * @since 1.0
+ */
+class AnnotationSupportTests {
+
+	@Test
+	void isAnnotatedDelegates() throws Throwable {
+		assertEquals(AnnotationUtils.isAnnotated(Probe.class, Tag.class),
+			AnnotationSupport.isAnnotated(Probe.class, Tag.class));
+		assertEquals(AnnotationUtils.isAnnotated(Probe.class, Override.class),
+			AnnotationSupport.isAnnotated(Probe.class, Override.class));
+	}
+
+	@Test
+	void findAnnotationDelegates() throws Throwable {
+		assertEquals(AnnotationUtils.findAnnotation(Probe.class, Tag.class),
+			AnnotationSupport.findAnnotation(Probe.class, Tag.class));
+		assertEquals(AnnotationUtils.findAnnotation(Probe.class, Override.class),
+			AnnotationSupport.findAnnotation(Probe.class, Override.class));
+	}
+
+	@Test
+	void findRepeatableAnnotationsDelegates() throws Throwable {
+		Method bMethod = Probe.class.getDeclaredMethod("bMethod");
+		assertEquals(AnnotationUtils.findRepeatableAnnotations(bMethod, Tag.class),
+			AnnotationSupport.findRepeatableAnnotations(bMethod, Tag.class));
+		Object expected = assertThrows(PreconditionViolationException.class,
+			() -> AnnotationUtils.findRepeatableAnnotations(bMethod, Override.class));
+		Object actual = assertThrows(PreconditionViolationException.class,
+			() -> AnnotationSupport.findRepeatableAnnotations(bMethod, Override.class));
+		assertSame(expected.getClass(), actual.getClass(), "expected same exception class");
+		assertEquals(expected.toString(), actual.toString(), "expected equal exception toString representation");
+	}
+
+	@Test
+	void findAnnotatedMethodsDelegates() throws Throwable {
+		assertEquals(
+			AnnotationUtils.findAnnotatedMethods(Probe.class, Tag.class, ReflectionUtils.MethodSortOrder.HierarchyDown),
+			AnnotationSupport.findAnnotatedMethods(Probe.class, Tag.class, MethodSortOrder.HierarchyDown));
+		assertEquals(
+			AnnotationUtils.findAnnotatedMethods(Probe.class, Tag.class, ReflectionUtils.MethodSortOrder.HierarchyUp),
+			AnnotationSupport.findAnnotatedMethods(Probe.class, Tag.class, MethodSortOrder.HierarchyUp));
+
+		assertEquals(
+			AnnotationUtils.findAnnotatedMethods(Probe.class, Override.class,
+				ReflectionUtils.MethodSortOrder.HierarchyDown),
+			AnnotationSupport.findAnnotatedMethods(Probe.class, Override.class, MethodSortOrder.HierarchyDown));
+		assertEquals(
+			AnnotationUtils.findAnnotatedMethods(Probe.class, Override.class,
+				ReflectionUtils.MethodSortOrder.HierarchyUp),
+			AnnotationSupport.findAnnotatedMethods(Probe.class, Override.class, MethodSortOrder.HierarchyUp));
+	}
+
+	@Test
+	void findPublicAnnotatedFieldsDelegates() throws Throwable {
+		assertEquals(AnnotationUtils.findPublicAnnotatedFields(Probe.class, String.class, FieldMarker.class),
+			AnnotationSupport.findPublicAnnotatedFields(Probe.class, String.class, FieldMarker.class));
+		assertEquals(AnnotationUtils.findPublicAnnotatedFields(Probe.class, Throwable.class, Override.class),
+			AnnotationSupport.findPublicAnnotatedFields(Probe.class, Throwable.class, Override.class));
+	}
+
+	@Target({ ElementType.FIELD })
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface FieldMarker {
+	}
+
+	@Tag("class-tag")
+	static class Probe {
+
+		@FieldMarker
+		public static String publicStaticAnnotatedField = "static";
+
+		@FieldMarker
+		public String publicNormalAnnotatedField = "normal";
+
+		@Tag("method-tag")
+		void aMethod() {
+		}
+
+		@Tag("method-tag-1")
+		@Tag("method-tag-2")
+		void bMethod() {
+		}
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.commons.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+/**
+ * @since 1.0
+ */
+class ReflectionSupportTests {
+
+	private final Predicate<Class<?>> allTypes = type -> true;
+	private final Predicate<String> allNames = name -> true;
+
+	@TestFactory
+	List<DynamicTest> findAllClassesInClasspathRootDelegates() throws Throwable {
+		List<DynamicTest> tests = new ArrayList<>();
+		List<Path> paths = new ArrayList<>();
+		paths.add(Paths.get(".").toRealPath());
+		paths.addAll(ReflectionUtils.getAllClasspathRootDirectories());
+		for (Path path : paths) {
+			URI root = path.toUri();
+			String displayName = root.getPath();
+			if (displayName.length() > 42) {
+				displayName = "..." + displayName.substring(displayName.length() - 42);
+			}
+			tests.add(DynamicTest.dynamicTest(displayName,
+				() -> assertEquals(ReflectionUtils.findAllClassesInClasspathRoot(root, allTypes, allNames),
+					ReflectionSupport.findAllClassesInClasspathRoot(root, allTypes, allNames))));
+		}
+		return tests;
+	}
+
+	@Test
+	void findAllClassesInPackageDelegates() {
+		assertEquals(0, ReflectionSupport.findAllClassesInPackage("illegal package name", allTypes, allNames).size());
+		assertEquals(ReflectionUtils.findAllClassesInPackage("illegal package name", allTypes, allNames),
+			ReflectionSupport.findAllClassesInPackage("illegal package name", allTypes, allNames));
+		assertNotEquals(0, ReflectionSupport.findAllClassesInPackage("org.junit", allTypes, allNames).size());
+		assertEquals(ReflectionUtils.findAllClassesInPackage("org.junit", allTypes, allNames),
+			ReflectionSupport.findAllClassesInPackage("org.junit", allTypes, allNames));
+	}
+
+}


### PR DESCRIPTION
## Overview

Fixes #246 and #352 by publishing useful internal helper methods via an API facade. Members of the support package are maintained, which is reflected by the `@API(Maintained)` annotation. The current support facade only delegates to the internal utility methods.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
