### PR TITLE
Vintage stores multiple failures using MultipleFailuresError

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ assertJVersion = 3.6.0
 junit4Version  = 4.12
 log4jVersion   = 2.7
 mockitoVersion = 2.2.22
-ota4jVersion   = 1.0.0-M1
+ota4jVersion   = 1.0.0-SNAPSHOT
 degraphVersion = 0.1.4
 
 defaultBuiltBy = JUnit Team

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertAll.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertAll.java
@@ -10,7 +10,9 @@
 
 package org.junit.jupiter.api;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.function.Executable;
@@ -42,19 +44,21 @@ class AssertAll {
 
 	static void assertAll(String heading, Stream<Executable> executables) {
 		Preconditions.notNull(executables, "executables must not be null");
-		MultipleFailuresError multipleFailuresError = new MultipleFailuresError(heading);
 
+		List<Throwable> failures = new ArrayList<>();
 		executables.forEach(executable -> {
 			try {
 				executable.execute();
 			}
 			catch (AssertionError assertionError) {
-				multipleFailuresError.addFailure(assertionError);
+				failures.add(assertionError);
 			}
 			catch (Throwable t) {
 				ExceptionUtils.throwAsUncheckedException(t);
 			}
 		});
+
+		MultipleFailuresError multipleFailuresError = new MultipleFailuresError(heading, failures);
 
 		if (multipleFailuresError.hasFailures()) {
 			throw multipleFailuresError;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertAllTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertAllTests.java
@@ -90,7 +90,7 @@ public class AssertionsAssertAllTests {
 		// @formatter:on
 
 		assertTrue(multipleFailuresError != null);
-		List<AssertionError> failures = multipleFailuresError.getFailures();
+		List<Throwable> failures = multipleFailuresError.getFailures();
 		assertTrue(failures.size() == 2);
 		assertTrue(failures.get(0).getClass().equals(AssertionFailedError.class));
 	}
@@ -104,7 +104,7 @@ public class AssertionsAssertAllTests {
 		// @formatter:on
 
 		assertTrue(multipleFailuresError != null);
-		List<AssertionError> failures = multipleFailuresError.getFailures();
+		List<Throwable> failures = multipleFailuresError.getFailures();
 		assertTrue(failures.size() == 2);
 		assertTrue(failures.get(0).getClass().equals(AssertionFailedError.class));
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -14,8 +14,10 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Stream.concat;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
+import static org.junit.platform.engine.TestExecutionResult.failed;
 import static org.junit.platform.engine.TestExecutionResult.successful;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -23,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.platform.engine.TestDescriptor;
@@ -30,6 +33,7 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.runner.Description;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
 import org.junit.vintage.engine.descriptor.VintageTestDescriptor;
+import org.opentest4j.MultipleFailuresError;
 
 /**
  * @since 4.12
@@ -40,7 +44,7 @@ class TestRun {
 	private final Logger logger;
 	private final Set<? extends TestDescriptor> runnerDescendants;
 	private final Map<Description, List<VintageTestDescriptor>> descriptionToDescriptors;
-	private final Map<TestDescriptor, TestExecutionResult> executionResults = new LinkedHashMap<>();
+	private final Map<TestDescriptor, List<TestExecutionResult>> executionResults = new LinkedHashMap<>();
 	private final Set<TestDescriptor> skippedDescriptors = new LinkedHashSet<>();
 	private final Set<TestDescriptor> startedDescriptors = new LinkedHashSet<>();
 	private final Set<TestDescriptor> finishedDescriptors = new LinkedHashSet<>();
@@ -144,11 +148,29 @@ class TestRun {
 	}
 
 	void storeResult(TestDescriptor testDescriptor, TestExecutionResult result) {
-		executionResults.put(testDescriptor, result);
+		List<TestExecutionResult> testExecutionResults = executionResults.computeIfAbsent(testDescriptor,
+			td -> new ArrayList<>());
+		testExecutionResults.add(result);
 	}
 
 	TestExecutionResult getStoredResultOrSuccessful(TestDescriptor testDescriptor) {
-		return executionResults.getOrDefault(testDescriptor, successful());
-	}
+		List<TestExecutionResult> testExecutionResults = executionResults.get(testDescriptor);
 
+		if (testExecutionResults == null) {
+			return successful();
+		}
+		else if (testExecutionResults.size() == 1) {
+			return testExecutionResults.get(0);
+		}
+		else {
+			// @formatter:off
+			List<Throwable> failures = testExecutionResults
+					.stream()
+					.map(TestExecutionResult::getThrowable)
+					.map(Optional::get)
+					.collect(Collectors.toList());
+			// @formatter:on
+			return failed(new MultipleFailuresError("", failures));
+		}
+	}
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/Junit4TestCaseWithErrorCollectorStoringMultipleFailures.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/Junit4TestCaseWithErrorCollectorStoringMultipleFailures.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+
+public class Junit4TestCaseWithErrorCollectorStoringMultipleFailures {
+	@Rule
+	public ErrorCollector collector = new ErrorCollector();
+
+	@Test
+	public void example() {
+		collector.addError(new Throwable("first thing went wrong"));
+		collector.addError(new Throwable("second thing went wrong"));
+		collector.checkThat(getResult(), not(containsString("ERROR!")));
+		// all lines will run, and then a combined failure logged at the end.
+	}
+
+	private String getResult() {
+		return "This is an ERROR!";
+	}
+}


### PR DESCRIPTION
Change ota4jVersion to 1.0.0-SNAPSHOT because fix
ota4j-team/opentest4j#34 is required for this to build succesfully.

Fix Vintage engine only storing and reporting only one in case of many
failures as is the case when using JUnit4 ErrorCollector rule.

Use the new Immutable implementation of MultipleFailuresError to report
the multiple failures.

Also fix AssertAll to use the new immutable MFE.

Resolves: #659
See also: ota4j-team/opentest4j#30, ota4j-team/opentest4j#33


---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
