### PR TITLE
Apply IntelliJ-suggested code changes

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ToStringBuilder.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ToStringBuilder.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.commons.util;
 
-import static java.util.stream.Collectors.joining;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
 import java.util.ArrayList;
@@ -98,13 +97,7 @@ public class ToStringBuilder {
 
 	@Override
 	public String toString() {
-		// @formatter:off
-		return new StringBuilder(this.type.getSimpleName()).append(" ")
-			.append("[")
-			.append(this.values.stream().collect(joining(", ")))
-			.append("]")
-			.toString();
-		// @formatter:on
+		return this.type.getSimpleName() + " [" + String.join(", ", this.values) + "]";
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/XmlReportWriter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/XmlReportWriter.java
@@ -245,8 +245,8 @@ class XmlReportWriter {
 	}
 
 	private String buildReportEntryDescription(ReportEntry reportEntry, int entryNumber) {
-		StringBuilder builder = new StringBuilder((format("Report Entry #{0} (timestamp: {1})\n", entryNumber,
-			ISO_LOCAL_DATE_TIME.format(reportEntry.getTimestamp()))));
+		StringBuilder builder = new StringBuilder(format("Report Entry #{0} (timestamp: {1})\n", entryNumber,
+			ISO_LOCAL_DATE_TIME.format(reportEntry.getTimestamp())));
 
 		reportEntry.getKeyValuePairs().entrySet().forEach(
 			entry -> builder.append(format("\t- {0}: {1}\n", entry.getKey(), entry.getValue())));
@@ -274,12 +274,11 @@ class XmlReportWriter {
 	private void writeNonStandardAttributesToSystemOutElement(TestIdentifier testIdentifier, XMLStreamWriter writer)
 			throws XMLStreamException {
 
-		StringBuilder builder = new StringBuilder("\n");
-		builder.append("unique-id: ").append(testIdentifier.getUniqueId()).append("\n");
-		builder.append("display-name: ").append(testIdentifier.getDisplayName()).append("\n");
+		String cData = "\nunique-id: " + testIdentifier.getUniqueId() //
+				+ "\ndisplay-name: " + testIdentifier.getDisplayName() + "\n";
 
 		writer.writeStartElement("system-out");
-		writer.writeCData(builder.toString());
+		writer.writeCData(cData);
 		writer.writeEndElement();
 		newLine(writer);
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestExecutionListenerRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestExecutionListenerRegistry.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.launcher.core;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -32,9 +33,7 @@ class TestExecutionListenerRegistry {
 	}
 
 	void registerListeners(TestExecutionListener... listeners) {
-		for (TestExecutionListener listener : listeners) {
-			this.testExecutionListeners.add(listener);
-		}
+		Collections.addAll(this.testExecutionListeners, listeners);
 	}
 
 	private void notifyTestExecutionListeners(Consumer<TestExecutionListener> consumer) {


### PR DESCRIPTION
## Overview

`ToStringBuilder.java` was unnecessarily creating both a `StringBuilder` and a `Stream` within `toString()`, where regular string concatenation and `String.join()` would have been equally performant and probably more readable.

`XmlReportWriter.java` was also creating a `StringBuilder` where regular string concatenation would have worked just as well. Whether it is more readable though is up for debate.

`TestExecutionListenerRegistry.java` was adding things to a collection via manual looping, where calling `Collections.addAll` would have been shorter and probably more readable.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
