### PR TITLE
Close dynamic test streams, fixes #683

### DIFF
--- a/documentation/src/docs/asciidoc/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/writing-tests.adoc
@@ -394,6 +394,9 @@ Technically speaking, a `@TestFactory` method must return a `Stream`,
 These `DynamicTest` instances will then be executed lazily,
 enabling dynamic and even non-deterministic generation of test cases.
 
+any Stream returned by a {@code @TestFactory} will be properly closed,
+making it safe to use a resource for example Files.lines().
+
 As with `@Test` methods, `@TestFactory` methods must not be `private` or `static`
 and may optionally declare parameters to be resolved by `ParameterResolvers`.
 

--- a/documentation/src/docs/asciidoc/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/writing-tests.adoc
@@ -394,8 +394,8 @@ Technically speaking, a `@TestFactory` method must return a `Stream`,
 These `DynamicTest` instances will then be executed lazily,
 enabling dynamic and even non-deterministic generation of test cases.
 
-any Stream returned by a {@code @TestFactory} will be properly closed,
-making it safe to use a resource for example Files.lines().
+Any `Stream` returned by a `@TestFactory` will be properly closed by calling `stream.close()`,
+making it safe to use a resource such as `Files.lines()`.
 
 As with `@Test` methods, `@TestFactory` methods must not be `private` or `static`
 and may optionally declare parameters to be resolved by `ParameterResolvers`.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestFactory.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestFactory.java
@@ -34,6 +34,9 @@ import org.junit.platform.commons.meta.API;
  * will then be executed lazily, enabling dynamic and even non-deterministic
  * generation of test cases.
  *
+ * any Stream returned by a {@code @TestFactory} will be properly closed,
+ * making it safe to use a resource for example {@code Files.lines()}.
+ *
  * <p>{@code @TestFactory} methods may optionally declare parameters to be
  * resolved by {@link org.junit.jupiter.api.extension.ParameterResolver
  * ParameterResolvers}.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestFactory.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestFactory.java
@@ -34,8 +34,8 @@ import org.junit.platform.commons.meta.API;
  * will then be executed lazily, enabling dynamic and even non-deterministic
  * generation of test cases.
  *
- * any Stream returned by a {@code @TestFactory} will be properly closed,
- * making it safe to use a resource for example {@code Files.lines()}.
+ * <p>Any {@code Stream} returned by a {@code @TestFactory} will be properly closed by calling {@code stream.close()},
+ * making it safe to use a resource such as {@code Files.lines()}.
  *
  * <p>{@code @TestFactory} methods may optionally declare parameters to be
  * resolved by {@link org.junit.jupiter.api.extension.ParameterResolver

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -81,9 +81,10 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 			Object testFactoryMethodResult = executableInvoker.invoke(method, instance, testExtensionContext,
 				context.getExtensionRegistry());
 
-			try {
+			try (Stream<DynamicTest> dynamicTestStream = toDynamicTestStream(testExtensionContext,
+				testFactoryMethodResult)) {
 				AtomicInteger index = new AtomicInteger();
-				toDynamicTestStream(testExtensionContext, testFactoryMethodResult).forEach(
+				dynamicTestStream.forEach(
 					dynamicTest -> registerAndExecute(dynamicTest, index.incrementAndGet(), dynamicTestExecutor));
 			}
 			catch (ClassCastException ex) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/DynamicTestStreamClosedTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/DynamicTestStreamClosedTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.extension.TestExtensionContext;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.jupiter.engine.execution.ThrowableCollector;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.Node;
+
+public class DynamicTestStreamClosedTests {
+	@SuppressWarnings("unchecked")
+	private static final Stream<DynamicTest> mockStream = mock(Stream.class);
+	private JupiterEngineExecutionContext context;
+	private Method testMethod;
+
+	@Before
+	public void before() throws NoSuchMethodException {
+		TestExtensionContext testExtensionContext = mock(TestExtensionContext.class);
+
+		testMethod = DynamicCloseHookedStreamTest.class.getMethod("customStream");
+		when(testExtensionContext.getTestMethod()).thenReturn(Optional.of(testMethod));
+		when(testExtensionContext.getTestInstance()).thenReturn(new DynamicCloseHookedStreamTest());
+
+		context = new JupiterEngineExecutionContext(null, null).extend().withThrowableCollector(
+			new ThrowableCollector()).withExtensionContext(testExtensionContext).build();
+	}
+
+	@Test
+	public void streamsFromTestFactoriesShouldBeClosed() {
+		TestFactoryTestDescriptor descriptor = new TestFactoryTestDescriptor(UniqueId.forEngine("engine"),
+			DynamicCloseHookedStreamTest.class, testMethod);
+		descriptor.invokeTestMethod(context, mock(Node.DynamicTestExecutor.class));
+		verify(mockStream).close();
+	}
+
+	public static class DynamicCloseHookedStreamTest {
+
+		@TestFactory
+		public Stream<DynamicTest> customStream() {
+			return mockStream;
+		}
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/DynamicTestStreamClosedTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/DynamicTestStreamClosedTests.java
@@ -48,8 +48,9 @@ class DynamicTestStreamClosedTests {
 		testMethod = DynamicCloseHookedStreamTest.class.getMethod("customStream");
 		when(testExtensionContext.getTestMethod()).thenReturn(Optional.of(testMethod));
 
-		Stream<DynamicTest> stream = Stream.<DynamicTest> of().onClose(() -> isClosed = true);
-		when(testExtensionContext.getTestInstance()).thenReturn(new DynamicCloseHookedStreamTest(stream));
+		Stream<DynamicTest> stream = Stream.empty();
+		Stream<DynamicTest> onCloseStream = stream.onClose(() -> isClosed = true);
+		when(testExtensionContext.getTestInstance()).thenReturn(new DynamicCloseHookedStreamTest(onCloseStream));
 
 		TestFactoryTestDescriptor descriptor = new TestFactoryTestDescriptor(UniqueId.forEngine("engine"),
 			DynamicCloseHookedStreamTest.class, testMethod);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/DynamicTestStreamClosedTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/DynamicTestStreamClosedTests.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
@@ -29,14 +28,14 @@ import org.junit.jupiter.engine.execution.ThrowableCollector;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.hierarchical.Node;
 
-public class DynamicTestStreamClosedTests {
+class DynamicTestStreamClosedTests {
 	private JupiterEngineExecutionContext context;
 	private Method testMethod;
 	private TestExtensionContext testExtensionContext;
 	private boolean isClosed;
 
 	@BeforeEach
-	public void before() {
+	void before() {
 		testExtensionContext = mock(TestExtensionContext.class);
 		isClosed = false;
 
@@ -45,7 +44,7 @@ public class DynamicTestStreamClosedTests {
 	}
 
 	@Test
-	public void streamsFromTestFactoriesShouldBeClosed() throws NoSuchMethodException {
+	void streamsFromTestFactoriesShouldBeClosed() throws NoSuchMethodException {
 		testMethod = DynamicCloseHookedStreamTest.class.getMethod("customStream");
 		when(testExtensionContext.getTestMethod()).thenReturn(Optional.of(testMethod));
 
@@ -60,7 +59,7 @@ public class DynamicTestStreamClosedTests {
 	}
 
 	@Test
-	public void streamsFromTestFactoriesShouldBeClosedWhenTheyThrow() throws NoSuchMethodException {
+	void streamsFromTestFactoriesShouldBeClosedWhenTheyThrow() throws NoSuchMethodException {
 		testMethod = StreamOfIntClosedTest.class.getMethod("customStream");
 		when(testExtensionContext.getTestMethod()).thenReturn(Optional.of(testMethod));
 
@@ -74,11 +73,10 @@ public class DynamicTestStreamClosedTests {
 		assertTrue(isClosed);
 	}
 
-	@Disabled
-	public static class DynamicCloseHookedStreamTest {
+	private static class DynamicCloseHookedStreamTest {
 		private Stream<DynamicTest> mockStream;
 
-		public DynamicCloseHookedStreamTest(Stream<DynamicTest> mockStream) {
+		DynamicCloseHookedStreamTest(Stream<DynamicTest> mockStream) {
 			this.mockStream = mockStream;
 		}
 
@@ -88,11 +86,10 @@ public class DynamicTestStreamClosedTests {
 		}
 	}
 
-	@Disabled
-	public static class StreamOfIntClosedTest {
+	private static class StreamOfIntClosedTest {
 		private Stream<Integer> mockStream;
 
-		public StreamOfIntClosedTest(Stream<Integer> mockStream) {
+		StreamOfIntClosedTest(Stream<Integer> mockStream) {
 			this.mockStream = mockStream;
 		}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/DynamicTestStreamClosedTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/DynamicTestStreamClosedTests.java
@@ -35,7 +35,6 @@ public class DynamicTestStreamClosedTests {
 	private TestExtensionContext testExtensionContext;
 	private boolean isClosed;
 
-	@SuppressWarnings("unchecked")
 	@BeforeEach
 	public void before() {
 		testExtensionContext = mock(TestExtensionContext.class);


### PR DESCRIPTION
## Overview
Added a call to close for dynamic test streams #683 .

I decided to put the test in it's own test file, due to the considerable amount of setup.
Is there any other place this test might belong to?

### Documentation

I'm not sure where the right place would be to document this, My guess is in: https://github.com/junit-team/junit5/blob/master/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestFactory.java#L32

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
