### PR TITLE
Ignore all synthetic methods in ReflectionUtils#findMethod(s)

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -19,7 +19,7 @@ on GitHub.
 * The JUnit Platform Gradle plugin now adds its dependencies with a fixed version (same as plugin
   version) instead of a dynamic versioning scheme (was `1.+`) by default to ensure reproducible
   builds.
-* All `findMethods()` implementations in `ReflectionUtils` no longer return bridge methods.
+* All `findMethods()` implementations in `ReflectionUtils` no longer return synthetic methods.
   Shadowed https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2[override-equal]
   methods are also no longer included in the result collection.
 
@@ -77,7 +77,7 @@ on GitHub.
 * Fix bug that prevented discovery of two or more methods of the same class.
 * Enforce correct execution order of overridden `@BeforeEach`/`@AfterEach` methods when declared
   at multiple class hierarchy levels. It's now always `super.before`, `this.before`, `this.test`,
-  `this.after` and `super.after`, even when the compiler added bridge methods.
+  `this.after` and `super.after`, even when the compiler added synthetic methods.
 
 ===== Deprecations and Breaking Changes
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -585,17 +585,11 @@ public final class ReflectionUtils {
 
 		// @formatter:off
 		List<Method> localMethods = Arrays.stream(clazz.getDeclaredMethods())
-				.filter(method -> !method.isBridge()) // [#333] don't collect bridge methods
+				.filter(method -> !method.isSynthetic())
 				.collect(toList());
-		// @formatter:on
-
-		// @formatter:off
 		List<Method> superclassMethods = getSuperclassMethods(clazz, sortOrder).stream()
 				.filter(method -> !isMethodShadowedByLocalMethods(method, localMethods))
 				.collect(toList());
-		// @formatter:on
-
-		// @formatter:off
 		List<Method> interfaceMethods = getInterfaceMethods(clazz, sortOrder).stream()
 				.filter(method -> !isMethodShadowedByLocalMethods(method, localMethods))
 				.collect(toList());

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -556,6 +556,13 @@ public class ReflectionUtilsTests {
 	}
 
 	@Test
+	void findMethodsIgnoresSyntheticMethods() {
+		List<Method> methods = ReflectionUtils.findMethods(ClassWithSyntheticMethod.class, method -> true);
+		assertNotNull(methods);
+		assertEquals(0, methods.size());
+	}
+
+	@Test
 	void findMethodsUsingHierarchyUpMode() throws Exception {
 		assertThat(ReflectionUtils.findMethods(ChildClass.class, method -> method.getName().contains("method"),
 			HierarchyUp)).containsExactly(ChildClass.class.getMethod("method4"), ParentClass.class.getMethod("method3"),
@@ -670,6 +677,12 @@ public class ReflectionUtilsTests {
 		for (Path path : paths) {
 			Files.createDirectory(path);
 		}
+	}
+
+	class ClassWithSyntheticMethod {
+		Runnable foo = InterfaceWithStaticMethod::foo;
+		Runnable bar = StaticClass::staticMethod;
+		Comparable<Number> synthetic = number -> 0;
 	}
 
 	interface InterfaceWithOneDeclaredMethod {


### PR DESCRIPTION
## Overview

`ReflectionUtils#findMethods` did already filter bridge methods, but
let other synthetic methods through. For example a field like:

  Predicate<String> allNames = name -> true;

may yield a synthetic method to be declared in the encapsulating class.
Now, all synthetic methods (including bridge methods) are filtered.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
