### PR TITLE
Add findMethods to reflection support API

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -117,7 +117,7 @@ public final class AnnotationSupport {
 	 *
 	 * @param clazz the class or interface in which to find the methods; never {@code null}
 	 * @param annotationType the annotation type to search for; never {@code null}
-	 * @param sortOrder the method sort order
+	 * @param sortOrder the method sort order; never {@code null}
 	 * @return the list of all such methods found; never {@code null}
 	 */
 	public static List<Method> findAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType,

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -12,6 +12,7 @@ package org.junit.platform.commons.support;
 
 import static org.junit.platform.commons.meta.API.Usage.Maintained;
 
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.List;
 import java.util.function.Predicate;
@@ -62,4 +63,21 @@ public final class ReflectionSupport {
 			Predicate<String> classNameFilter) {
 		return ReflectionUtils.findAllClassesInPackage(basePackageName, classTester, classNameFilter);
 	}
+
+	/**
+	 * Find all {@linkplain Method methods} of the supplied class or interface
+	 * that match the specified {@code predicate}.
+	 *
+	 * <p>If you're are looking for methods annotated with a certain annotation
+	 * type, consider using {@linkplain AnnotationSupport#findAnnotatedMethods(Class, Class, MethodSortOrder)}.
+	 *
+	 * @param clazz the class or interface in which to find the methods; never {@code null}
+	 * @param predicate the method filter; never {@code null}
+	 * @param sortOrder the method sort order; never {@code null}
+	 * @return the list of all such methods found; never {@code null}
+	 */
+	public static List<Method> findMethods(Class<?> clazz, Predicate<Method> predicate, MethodSortOrder sortOrder) {
+		return ReflectionUtils.findMethods(clazz, predicate, ReflectionUtils.MethodSortOrder.valueOf(sortOrder.name()));
+	}
+
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -564,6 +564,9 @@ public final class ReflectionUtils {
 		return findMethods(clazz, predicate, MethodSortOrder.HierarchyDown);
 	}
 
+	/**
+	 * @see org.junit.platform.commons.support.ReflectionSupport#findMethods(Class, Predicate, org.junit.platform.commons.support.MethodSortOrder)
+	 */
 	public static List<Method> findMethods(Class<?> clazz, Predicate<Method> predicate, MethodSortOrder sortOrder) {
 		Preconditions.notNull(clazz, "Class must not be null");
 		Preconditions.notNull(predicate, "predicate must not be null");

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
@@ -13,6 +13,7 @@ package org.junit.platform.commons.support;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,6 +33,7 @@ class ReflectionSupportTests {
 
 	private final Predicate<Class<?>> allTypes = type -> true;
 	private final Predicate<String> allNames = name -> true;
+	private final Predicate<Method> allMethods = name -> true;
 
 	@TestFactory
 	List<DynamicTest> findAllClassesInClasspathRootDelegates() throws Throwable {
@@ -62,4 +64,15 @@ class ReflectionSupportTests {
 			ReflectionSupport.findAllClassesInPackage("org.junit", allTypes, allNames));
 	}
 
+	@Test
+	void findMethodsDelegates() {
+		assertEquals(
+			ReflectionUtils.findMethods(ReflectionSupportTests.class, allMethods,
+				ReflectionUtils.MethodSortOrder.HierarchyUp),
+			ReflectionSupport.findMethods(ReflectionSupportTests.class, allMethods, MethodSortOrder.HierarchyUp));
+		assertEquals(
+			ReflectionUtils.findMethods(ReflectionSupportTests.class, allMethods,
+				ReflectionUtils.MethodSortOrder.HierarchyDown),
+			ReflectionSupport.findMethods(ReflectionSupportTests.class, allMethods, MethodSortOrder.HierarchyDown));
+	}
 }


### PR DESCRIPTION
## Overview

This commit publishes method ReflectionSupport#findMethods which in turn delegates to the internal utility performing hierarchical method searches.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
