### PR TITLE
Reduce log level for detected test engines

### DIFF
--- a/junit-platform-console/junit-platform-console.gradle
+++ b/junit-platform-console/junit-platform-console.gradle
@@ -107,6 +107,7 @@ artifacts {
 task standaloneExec(type: JavaExec, dependsOn: [standaloneJar, testClasses]) {
 	ignoreExitValue = true
 	workingDir = "$buildDir/libs"
+	jvmArgs = ['-ea', "-Djava.util.logging.config.file=$buildDir/resources/test/logging.properties"]
 	main = '-jar'
 	args = [
 			"$standaloneJar.archiveName",

--- a/junit-platform-console/src/test/resources/logging.properties
+++ b/junit-platform-console/src/test/resources/logging.properties
@@ -1,0 +1,9 @@
+#
+# Logging properties used by :junit-platform-console:standaloneExec task to
+# verify the successful registration of both test engines, namely Jupiter and
+# Vintage engine.
+#
+
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=CONFIG
+org.junit.level=CONFIG

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
@@ -28,7 +28,7 @@ class ServiceLoaderTestEngineRegistry {
 	public Iterable<TestEngine> loadTestEngines() {
 		Iterable<TestEngine> testEngines = ServiceLoader.load(TestEngine.class,
 			ReflectionUtils.getDefaultClassLoader());
-		LOG.info(() -> createDiscoveredTestEnginesMessage(testEngines));
+		LOG.config(() -> createDiscoveredTestEnginesMessage(testEngines));
 		return testEngines;
 	}
 


### PR DESCRIPTION
## Overview

Fixes #513 by using log level CONFIG instead of DEBUG.

If you want to see the information which engines were detected, use "-Djava.util.logging.config.file=LOG" with the content of LOG something similar to:

```
  handlers=java.util.logging.ConsoleHandler
  java.util.logging.ConsoleHandler.level=CONFIG
  org.junit.level=CONFIG
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
