### PR TITLE
Change Namespace equality to consider parts order.

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -82,6 +82,8 @@ on GitHub.
 ===== Deprecations and Breaking Changes
 
 * Removed deprecated `Assertions.expectThrows()` method in favor of `Assertions.assertThrows()`.
+* `ExtensionContext.Namespace`s with the same parts but in a different order are no longer considered
+  equal to each other.
 
 ===== New Features and Improvements
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -14,9 +14,10 @@ import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -307,9 +308,9 @@ public interface ExtensionContext {
 
 		/**
 		 * Create a namespace which restricts access to data to all extensions
-		 * which use the same {@code parts} for creating a namespace.
+		 * which use the same sequence of {@code parts} for creating a namespace.
 		 *
-		 * <p>The order of the {@code parts} is not significant.
+		 * <p>The order of the {@code parts} is significant.
 		 *
 		 * <p>Internally the {@code parts} are compared using {@link Object#equals(Object)}.
 		 */
@@ -319,10 +320,10 @@ public interface ExtensionContext {
 			return new Namespace(parts);
 		}
 
-		private final Set<?> parts;
+		private final List<?> parts;
 
 		private Namespace(Object... parts) {
-			this.parts = new HashSet<>(Arrays.asList(parts));
+			this.parts = new ArrayList<>(Arrays.asList(parts));
 		}
 
 		@Override

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionValuesStoreTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionValuesStoreTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -313,6 +314,22 @@ public class ExtensionValuesStoreTests {
 	class CompositeNamespaceTests {
 
 		@Test
+		void namespacesEqualForSamePartsSequence() {
+			Namespace ns1 = Namespace.create("part1", "part2");
+			Namespace ns2 = Namespace.create("part1", "part2");
+
+			assertEquals(ns1, ns2);
+		}
+
+		@Test
+		void orderOfNamespacePartsDoesMatter() {
+			Namespace ns1 = Namespace.create("part1", "part2");
+			Namespace ns2 = Namespace.create("part2", "part1");
+
+			assertNotEquals(ns1, ns2);
+		}
+
+		@Test
 		void additionNamespacePartMakesADifferenc() {
 
 			Namespace ns1 = Namespace.create("part1", "part2");
@@ -327,18 +344,6 @@ public class ExtensionValuesStoreTests {
 			assertEquals(value, store.get(ns1, key));
 			assertEquals(value, store.get(ns3, key));
 			assertEquals(value2, store.get(ns2, key));
-		}
-
-		@Test
-		void orderOfNamespacePartsDoesNotMatter() {
-
-			Namespace ns1 = Namespace.create("part1", "part2");
-			Namespace ns2 = Namespace.create("part2", "part1");
-
-			parentStore.put(ns1, key, value);
-
-			assertEquals(value, store.get(ns1, key));
-			assertEquals(value, store.get(ns2, key));
 		}
 
 	}


### PR DESCRIPTION
Not taking into account the order of parts made namespace behavior
non-intuitive.

Closes: #646

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
