### PR TITLE
Move to java-library plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ ext {
 
 allprojects { subproj ->
 
-	apply plugin: 'java'
+	apply plugin: 'java-library'
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
 	apply plugin: 'com.diffplug.gradle.spotless'

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -30,18 +30,18 @@ test {
 */
 
 dependencies {
-	testCompile(project(':junit-jupiter-api'))
-	testCompile(project(':junit-platform-runner'))
-	testCompile(project(':junit-platform-launcher'))
+	testImplementation(project(':junit-jupiter-api'))
+	testImplementation(project(':junit-platform-runner'))
+	testImplementation(project(':junit-platform-launcher'))
 
 	// Include junit-platform-console so that the JUnit Gradle plugin
 	// uses the local version of the ConsoleLauncher.
-	testRuntime(project(path: ':junit-platform-console', configuration: 'shadow'))
+	testRuntimeOnly(project(path: ':junit-platform-console', configuration: 'shadow'))
 
-	testRuntime(project(':junit-vintage-engine'))
-	testRuntime(project(':junit-jupiter-engine'))
-	testRuntime("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-	testRuntime("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
+	testRuntimeOnly(project(':junit-vintage-engine'))
+	testRuntimeOnly(project(':junit-jupiter-engine'))
+	testRuntimeOnly("org.apache.logging.log4j:log4j-core:${log4jVersion}")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 }
 
 asciidoctorj {

--- a/junit-jupiter-api/junit-jupiter-api.gradle
+++ b/junit-jupiter-api/junit-jupiter-api.gradle
@@ -1,4 +1,4 @@
 dependencies {
-	compile("org.opentest4j:opentest4j:${ota4jVersion}")
-	compile(project(':junit-platform-commons'))
+	api("org.opentest4j:opentest4j:${ota4jVersion}")
+	api(project(':junit-platform-commons'))
 }

--- a/junit-jupiter-engine/junit-jupiter-engine.gradle
+++ b/junit-jupiter-engine/junit-jupiter-engine.gradle
@@ -18,19 +18,19 @@ test {
 */
 
 dependencies {
-	compile(project(':junit-platform-engine'))
-	compile(project(':junit-jupiter-api'))
+	api(project(':junit-platform-engine'))
+	api(project(':junit-jupiter-api'))
 
-	testCompile(project(':junit-platform-launcher'))
-	testCompile(project(':junit-platform-runner'))
-	testCompile(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))
-	testCompile("org.assertj:assertj-core:${assertJVersion}")
-	testCompile("org.mockito:mockito-core:${mockitoVersion}")
+	testImplementation(project(':junit-platform-launcher'))
+	testImplementation(project(':junit-platform-runner'))
+	testImplementation(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))
+	testImplementation("org.assertj:assertj-core:${assertJVersion}")
+	testImplementation("org.mockito:mockito-core:${mockitoVersion}")
 
 	// Include junit-platform-console so that the JUnit Gradle plugin
 	// uses the local version of the ConsoleLauncher.
-	testRuntime(project(path: ':junit-platform-console', configuration: 'shadow'))
+	testRuntimeOnly(project(path: ':junit-platform-console', configuration: 'shadow'))
 
-	testRuntime("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-	testRuntime("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-core:${log4jVersion}")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 }

--- a/junit-jupiter-migration-support/junit-jupiter-migration-support.gradle
+++ b/junit-jupiter-migration-support/junit-jupiter-migration-support.gradle
@@ -18,20 +18,20 @@ test {
 */
 
 dependencies {
-	compile("junit:junit:${junit4Version}")
-	compile(project(':junit-jupiter-api'))
+	api("junit:junit:${junit4Version}")
+	api(project(':junit-jupiter-api'))
 
-	testCompile(project(':junit-jupiter-engine'))
-	testCompile(project(':junit-platform-launcher'))
-	testCompile(project(':junit-platform-runner'))
-	testCompile(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))
-	testCompile("org.assertj:assertj-core:${assertJVersion}")
-	testCompile("org.mockito:mockito-core:${mockitoVersion}")
+	testImplementation(project(':junit-jupiter-engine'))
+	testImplementation(project(':junit-platform-launcher'))
+	testImplementation(project(':junit-platform-runner'))
+	testImplementation(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))
+	testImplementation("org.assertj:assertj-core:${assertJVersion}")
+	testImplementation("org.mockito:mockito-core:${mockitoVersion}")
 
 	// Include junit-platform-console so that the JUnit Gradle plugin
 	// uses the local version of the ConsoleLauncher.
-	testRuntime(project(path: ':junit-platform-console', configuration: 'shadow'))
-	testRuntime(project(':junit-jupiter-engine'))
-	testRuntime("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-	testRuntime("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
+	testRuntimeOnly(project(path: ':junit-platform-console', configuration: 'shadow'))
+	testRuntimeOnly(project(':junit-jupiter-engine'))
+	testRuntimeOnly("org.apache.logging.log4j:log4j-core:${log4jVersion}")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 }

--- a/junit-platform-console/junit-platform-console.gradle
+++ b/junit-platform-console/junit-platform-console.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 buildscript {
@@ -16,9 +16,9 @@ configurations {
 }
 
 dependencies {
-	compile(project(':junit-platform-launcher'))
-	testCompile(project(':junit-jupiter-api'))
-	testCompile("junit:junit:${junit4Version}")
+	api(project(':junit-platform-launcher'))
+	testImplementation(project(':junit-jupiter-api'))
+	testImplementation("junit:junit:${junit4Version}")
 
 	shadowed('net.sf.jopt-simple:jopt-simple:5.0.3')
 

--- a/junit-platform-engine/junit-platform-engine.gradle
+++ b/junit-platform-engine/junit-platform-engine.gradle
@@ -12,8 +12,8 @@ artifacts {
 }
 
 dependencies {
-	compile(project(':junit-platform-commons'))
-	compile("org.opentest4j:opentest4j:${ota4jVersion}")
+	api(project(':junit-platform-commons'))
+	api("org.opentest4j:opentest4j:${ota4jVersion}")
 
-	testCompile("org.assertj:assertj-core:${assertJVersion}")
+	testImplementation("org.assertj:assertj-core:${assertJVersion}")
 }

--- a/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
+++ b/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'groovy'
 
 dependencies {
-	compile localGroovy()
-	compile gradleApi()
-	compile(project(path: ':junit-platform-console', configuration: 'shadow'))
-	compile(project(':junit-platform-launcher'))
-	testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
+	implementation localGroovy()
+	implementation gradleApi()
+	api(project(path: ':junit-platform-console', configuration: 'shadow'))
+	api(project(':junit-platform-launcher'))
+	testImplementation('org.spockframework:spock-core:1.0-groovy-2.4') {
 		transitive = false
 	}
-	testRuntime("junit:junit:${junit4Version}")
+	testRuntimeOnly("junit:junit:${junit4Version}")
 }
 
 processResources {

--- a/junit-platform-launcher/junit-platform-launcher.gradle
+++ b/junit-platform-launcher/junit-platform-launcher.gradle
@@ -1,3 +1,3 @@
 dependencies {
-	compile(project(':junit-platform-engine'))
+	api(project(':junit-platform-engine'))
 }

--- a/junit-platform-runner/junit-platform-runner.gradle
+++ b/junit-platform-runner/junit-platform-runner.gradle
@@ -1,4 +1,4 @@
 dependencies {
-	compile(project(':junit-platform-launcher'))
-	compile("junit:junit:${junit4Version}")
+	api(project(':junit-platform-launcher'))
+	api("junit:junit:${junit4Version}")
 }

--- a/junit-platform-surefire-provider/junit-platform-surefire-provider.gradle
+++ b/junit-platform-surefire-provider/junit-platform-surefire-provider.gradle
@@ -11,19 +11,19 @@ junitPlatform {
 }
 
 dependencies {
-	compile(project(':junit-platform-launcher'))
-	compile('org.apache.maven.surefire:surefire-api:2.19.1')
-	compile('org.apache.maven.surefire:common-java5:2.19.1')
+	api(project(':junit-platform-launcher'))
+	implementation('org.apache.maven.surefire:surefire-api:2.19.1')
+	implementation('org.apache.maven.surefire:common-java5:2.19.1')
 
-	testCompile(project(':junit-jupiter-api'))
-	testCompile(project(':junit-platform-runner'))
-	testCompile(project(':junit-jupiter-engine'))
-	testCompile("org.mockito:mockito-core:${mockitoVersion}")
-	testCompile("org.assertj:assertj-core:${assertJVersion}")
+	testImplementation(project(':junit-jupiter-api'))
+	testImplementation(project(':junit-platform-runner'))
+	testImplementation(project(':junit-jupiter-engine'))
+	testImplementation("org.mockito:mockito-core:${mockitoVersion}")
+	testImplementation("org.assertj:assertj-core:${assertJVersion}")
 
 	// Include junit-platform-console so that the JUnit Gradle plugin
 	// uses the local version of the ConsoleLauncher.
-	testRuntime(project(path: ':junit-platform-console', configuration: 'shadow'))
-	testRuntime("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-	testRuntime("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
+	testRuntimeOnly(project(path: ':junit-platform-console', configuration: 'shadow'))
+	testRuntimeOnly("org.apache.logging.log4j:log4j-core:${log4jVersion}")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 }

--- a/junit-vintage-engine/junit-vintage-engine.gradle
+++ b/junit-vintage-engine/junit-vintage-engine.gradle
@@ -18,21 +18,21 @@ test {
 */
 
 dependencies {
-	compile(project(':junit-platform-engine'))
-	compile("junit:junit:${junit4Version}")
+	api(project(':junit-platform-engine'))
+	implementation("junit:junit:${junit4Version}")
 
-	testCompile(project(':junit-platform-launcher'))
-	testCompile(project(':junit-jupiter-api'))
-	testCompile(project(':junit-platform-runner'))
-	testCompile(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))
-	testCompile("org.assertj:assertj-core:${assertJVersion}")
-	testCompile("org.mockito:mockito-core:${mockitoVersion}")
+	testImplementation(project(':junit-platform-launcher'))
+	testImplementation(project(':junit-jupiter-api'))
+	testImplementation(project(':junit-platform-runner'))
+	testImplementation(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))
+	testImplementation("org.assertj:assertj-core:${assertJVersion}")
+	testImplementation("org.mockito:mockito-core:${mockitoVersion}")
 
 	// Include junit-platform-console so that the JUnit Gradle plugin
 	// uses the local version of the ConsoleLauncher.
-	testRuntime(project(path: ':junit-platform-console', configuration: 'shadow'))
+	testRuntimeOnly(project(path: ':junit-platform-console', configuration: 'shadow'))
 
-	testRuntime(project(':junit-jupiter-engine'))
-	testRuntime("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-	testRuntime("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
+	testRuntimeOnly(project(':junit-jupiter-engine'))
+	testRuntimeOnly("org.apache.logging.log4j:log4j-core:${log4jVersion}")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 }

--- a/platform-tests/platform-tests.gradle
+++ b/platform-tests/platform-tests.gradle
@@ -12,21 +12,21 @@ junitPlatform {
 
 dependencies {
 	// --- Things we are testing --------------------------------------------------
-	testCompile(project(':junit-platform-commons'))
-	testCompile(project(path: ':junit-platform-console', configuration: 'shadow'))
-	testRuntime(project(path: ':junit-platform-console', configuration: 'shadowed'))
-	testCompile(project(':junit-platform-engine'))
-	testCompile(project(':junit-platform-launcher'))
+	testImplementation(project(':junit-platform-commons'))
+	testImplementation(project(path: ':junit-platform-console', configuration: 'shadow'))
+	testRuntimeOnly(project(path: ':junit-platform-console', configuration: 'shadowed'))
+	testImplementation(project(':junit-platform-engine'))
+	testImplementation(project(':junit-platform-launcher'))
 
 	// --- Things we are testing with ---------------------------------------------
-	testCompile(project(':junit-jupiter-api'))
-	testCompile(project(':junit-platform-runner'))
-	testCompile(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))
-	testCompile("org.assertj:assertj-core:${assertJVersion}")
-	testCompile("org.mockito:mockito-core:${mockitoVersion}")
+	testImplementation(project(':junit-jupiter-api'))
+	testImplementation(project(':junit-platform-runner'))
+	testImplementation(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))
+	testImplementation("org.assertj:assertj-core:${assertJVersion}")
+	testImplementation("org.mockito:mockito-core:${mockitoVersion}")
 
 	// --- Test run-time dependencies ---------------------------------------------
-	testRuntime(project(':junit-jupiter-engine'))
-	testRuntime("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-	testRuntime("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
+	testRuntimeOnly(project(':junit-jupiter-engine'))
+	testRuntimeOnly("org.apache.logging.log4j:log4j-core:${log4jVersion}")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 }


### PR DESCRIPTION
## Overview

Modify existing configuration names by `api` or `implementation`.

See gh-691

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [X] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
