### PR TITLE
Clean up and encourage immutability within the codebase

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -76,9 +76,9 @@ public class ConditionEvaluationResult {
 	public String toString() {
 		// @formatter:off
 		return new ToStringBuilder(this)
-			.append("enabled", this.enabled)
-			.append("reason", this.reason.orElse("<unknown>"))
-			.toString();
+				.append("enabled", this.enabled)
+				.append("reason", this.reason.orElse("<unknown>"))
+				.toString();
 		// @formatter:on
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -110,8 +110,11 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor {
 			TestTemplateInvocationContextProvider.class);
 		Preconditions.notEmpty(providers, "You must register at least one "
 				+ TestTemplateInvocationContextProvider.class.getSimpleName() + " for this method");
-		providers = providers.stream().filter(provider -> provider.supports(containerExtensionContext)).collect(
-			toList());
+		// @formatter:off
+		providers = providers.stream()
+				.filter(provider -> provider.supports(containerExtensionContext))
+				.collect(toList());
+		// @formatter:on
 		Preconditions.notEmpty(providers, "You must register at least one "
 				+ TestTemplateInvocationContextProvider.class.getSimpleName() + " that supports this method");
 		return providers;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/JavaElementsResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/JavaElementsResolver.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.discovery;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethods;
 import static org.junit.platform.commons.util.ReflectionUtils.findNestedClasses;
@@ -25,7 +26,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsInnerClass;
@@ -125,9 +125,7 @@ class JavaElementsResolver {
 
 	private Set<TestDescriptor> resolveForAllParents(AnnotatedElement element, Set<TestDescriptor> potentialParents) {
 		Set<TestDescriptor> resolvedDescriptors = new HashSet<>();
-		potentialParents.forEach(parent -> {
-			resolvedDescriptors.addAll(resolve(element, parent));
-		});
+		potentialParents.forEach(parent -> resolvedDescriptors.addAll(resolve(element, parent)));
 		return resolvedDescriptors;
 	}
 
@@ -156,7 +154,7 @@ class JavaElementsResolver {
 				.map(resolver -> tryToResolveWithResolver(element, parent, resolver)) //
 				.filter(testDescriptors -> !testDescriptors.isEmpty()) //
 				.flatMap(Collection::stream) //
-				.collect(Collectors.toSet());
+				.collect(toSet());
 	}
 
 	private Set<TestDescriptor> tryToResolveWithResolver(AnnotatedElement element, TestDescriptor parent,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java
@@ -76,11 +76,11 @@ class TestInfoParameterResolver implements ParameterResolver {
 		public String toString() {
 			// @formatter:off
 			return new ToStringBuilder(this)
-				.append("displayName", this.displayName)
-				.append("tags", this.tags)
-				.append("testClass", this.testClass)
-				.append("testMethod", this.testMethod)
-				.toString();
+					.append("displayName", this.displayName)
+					.append("tags", this.tags)
+					.append("testClass", this.testClass)
+					.append("testMethod", this.testMethod)
+					.toString();
 			// @formatter:on
 		}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -82,7 +82,7 @@ public final class AnnotationSupport {
 	 *
 	 * @param element the element to search on, potentially {@code null}
 	 * @param annotationType the repeatable annotation type to search for; never {@code null}
-	 * @return the list of all such annotations found; never {@code null}
+	 * @return the list of all such annotations found; neither {@code null} nor mutable
 	 * @see java.lang.annotation.Repeatable
 	 * @see java.lang.annotation.Inherited
 	 */
@@ -103,7 +103,7 @@ public final class AnnotationSupport {
 	 * @param clazz the class or interface in which to find the fields; never {@code null}
 	 * @param fieldType the type of field to find; never {@code null}
 	 * @param annotationType the annotation type to search for; never {@code null}
-	 * @return the list of all such fields found; never {@code null}
+	 * @return the list of all such fields found; neither {@code null} nor mutable
 	 * @see Class#getFields()
 	 */
 	public static List<Field> findPublicAnnotatedFields(Class<?> clazz, Class<?> fieldType,
@@ -120,7 +120,7 @@ public final class AnnotationSupport {
 	 * @param clazz the class or interface in which to find the methods; never {@code null}
 	 * @param annotationType the annotation type to search for; never {@code null}
 	 * @param traversalMode the hierarchy traversal mode; never {@code null}
-	 * @return the list of all such methods found; never {@code null}
+	 * @return the list of all such methods found; neither {@code null} nor mutable
 	 */
 	public static List<Method> findAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType,
 			HierarchyTraversalMode traversalMode) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -42,7 +42,7 @@ public final class ReflectionSupport {
 	 * @param root the root URI to start scanning
 	 * @param classTester the class type filter; never {@code null}
 	 * @param classNameFilter the class name filter; never {@code null}
-	 * @return the list of all such classes found; never {@code null}
+	 * @return the list of all such classes found; neither {@code null} nor mutable
 	 */
 	public static List<Class<?>> findAllClassesInClasspathRoot(URI root, Predicate<Class<?>> classTester,
 			Predicate<String> classNameFilter) {
@@ -57,7 +57,7 @@ public final class ReflectionSupport {
 	 * @param basePackageName the base package name to start scanning
 	 * @param classTester the class type filter; never {@code null}
 	 * @param classNameFilter the class name filter; never {@code null}
-	 * @return the list of all such classes found; never {@code null}
+	 * @return the list of all such classes found; neither {@code null} nor mutable
 	 */
 	public static List<Class<?>> findAllClassesInPackage(String basePackageName, Predicate<Class<?>> classTester,
 			Predicate<String> classNameFilter) {
@@ -74,7 +74,7 @@ public final class ReflectionSupport {
 	 * @param clazz the class or interface in which to find the methods; never {@code null}
 	 * @param predicate the method filter; never {@code null}
 	 * @param traversalMode the hierarchy traversal mode; never {@code null}
-	 * @return the list of all such methods found; never {@code null}
+	 * @return the list of all such methods found; neither {@code null} nor mutable
 	 */
 	public static List<Method> findMethods(Class<?> clazz, Predicate<Method> predicate,
 			HierarchyTraversalMode traversalMode) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -11,8 +11,8 @@
 package org.junit.platform.commons.util;
 
 import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toCollection;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
+import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
@@ -178,7 +178,8 @@ public final class AnnotationUtils {
 		// duplicates, but we need to maintain the original order.
 		Set<A> found = new LinkedHashSet<>(16);
 		findRepeatableAnnotations(element, annotationType, containerType, inherited, found, new HashSet<>(16));
-		return new ArrayList<>(found);
+		// unmodifiable since returned from public, non-internal method(s)
+		return Collections.unmodifiableList(new ArrayList<>(found));
 	}
 
 	private static <A extends Annotation> void findRepeatableAnnotations(AnnotatedElement element,
@@ -255,7 +256,7 @@ public final class AnnotationUtils {
 		// @formatter:off
 		return Arrays.stream(clazz.getFields())
 				.filter(field -> fieldType.isAssignableFrom(field.getType()) && isAnnotated(field, annotationType))
-				.collect(toCollection(ArrayList::new));
+				.collect(toUnmodifiableList());
 		// @formatter:on
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
@@ -10,9 +10,14 @@
 
 package org.junit.platform.commons.util;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collector;
 
 import org.junit.platform.commons.meta.API;
 
@@ -49,6 +54,28 @@ public final class CollectionUtils {
 		Preconditions.condition(collection.size() == 1,
 			() -> "collection must contain exactly one element: " + collection);
 		return collection.iterator().next();
+	}
+
+	/**
+	 * Returns a {@code Collector} that accumulates the input elements into a
+	 * new unmodifiable list, in encounter order.
+	 *
+	 * <p>There are no guarantees on the type or serializability of the list
+	 * returned, so if more control over the returned list is required,
+	 * consider creating a new {@code Collector} implementation like the
+	 * following:
+	 * <pre>{@code
+	 *     public static <T> Collector<T, ?, List<T>> toUnmodifiableList(Supplier<List<T>> listSupplier) {
+	 *         return collectingAndThen(toCollection(listSupplier), Collections::unmodifiableList);
+	 *     }
+	 * }</pre>
+	 *
+	 * @param <T> the type of the input elements
+	 * @return a {@code Collector} which collects all the input elements into
+	 * an unmodifiable list, in encounter order
+	 */
+	public static <T> Collector<T, ?, List<T>> toUnmodifiableList() {
+		return collectingAndThen(toList(), Collections::unmodifiableList);
 	}
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -13,6 +13,7 @@ package org.junit.platform.commons.util;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
+import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.BOTTOM_UP;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
 
@@ -505,7 +506,9 @@ public final class ReflectionUtils {
 	 */
 	public static List<Class<?>> findAllClassesInClasspathRoot(URI root, Predicate<Class<?>> classTester,
 			Predicate<String> classNameFilter) {
-		return classpathScanner.scanForClassesInClasspathRoot(root, classTester, classNameFilter);
+		// unmodifiable since returned by public, non-internal method(s)
+		return Collections.unmodifiableList(
+			classpathScanner.scanForClassesInClasspathRoot(root, classTester, classNameFilter));
 	}
 
 	/**
@@ -513,7 +516,9 @@ public final class ReflectionUtils {
 	 */
 	public static List<Class<?>> findAllClassesInPackage(String basePackageName, Predicate<Class<?>> classTester,
 			Predicate<String> classNameFilter) {
-		return classpathScanner.scanForClassesInPackage(basePackageName, classTester, classNameFilter);
+		// unmodifiable since returned by public, non-internal method(s)
+		return Collections.unmodifiableList(
+			classpathScanner.scanForClassesInPackage(basePackageName, classTester, classNameFilter));
 	}
 
 	public static List<Class<?>> findNestedClasses(Class<?> clazz, Predicate<Class<?>> predicate) {
@@ -609,7 +614,8 @@ public final class ReflectionUtils {
 		// @formatter:off
 		return findAllMethodsInHierarchy(clazz, traversalMode).stream()
 				.filter(predicate)
-				.collect(toList());
+				// unmodifiable since returned by public, non-internal method(s)
+				.collect(toUnmodifiableList());
 		// @formatter:on
 	}
 
@@ -677,10 +683,11 @@ public final class ReflectionUtils {
 		List<Method> allInterfaceMethods = new ArrayList<>();
 		for (Class<?> ifc : clazz.getInterfaces()) {
 
-			List<Method> localMethods = Arrays.stream(ifc.getDeclaredMethods()).filter(m -> !isAbstract(m)).collect(
-				toList());
-
 			// @formatter:off
+			List<Method> localMethods = Arrays.stream(ifc.getDeclaredMethods())
+					.filter(m -> !isAbstract(m))
+					.collect(toList());
+
 			List<Method> subInterfaceMethods = getInterfaceMethods(ifc, traversalMode).stream()
 					.filter(method -> !isMethodShadowedByLocalMethods(method, localMethods))
 					.collect(toList());

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/FilterResult.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/FilterResult.java
@@ -104,9 +104,9 @@ public class FilterResult {
 	public String toString() {
 		// @formatter:off
 		return new ToStringBuilder(this)
-			.append("included", this.included)
-			.append("reason", this.reason.orElse("<unknown>"))
-			.toString();
+				.append("included", this.included)
+				.append("reason", this.reason.orElse("<unknown>"))
+				.toString();
 		// @formatter:on
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine;
 
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -87,16 +88,16 @@ public interface TestDescriptor {
 	void setParent(TestDescriptor parent);
 
 	/**
-	 * Get the set of <em>children</em> of this descriptor.
+	 * Get the immutable set of <em>children</em> of this descriptor.
 	 *
-	 * @return the set of children of this descriptor; never {@code null}
-	 * but potentially empty
+	 * @return the set of children of this descriptor; neither {@code null}
+	 * nor mutable, but potentially empty
 	 * @see #getDescendants()
 	 */
 	Set<? extends TestDescriptor> getChildren();
 
 	/**
-	 * Get the set of all <em>descendants</em> of this descriptor.
+	 * Get the immutable set of all <em>descendants</em> of this descriptor.
 	 *
 	 * <p>A <em>descendant</em> is a child of this descriptor or a child of one of
 	 * its children, recursively.
@@ -109,7 +110,7 @@ public interface TestDescriptor {
 		for (TestDescriptor child : getChildren()) {
 			descendants.addAll(child.getDescendants());
 		}
-		return descendants;
+		return Collections.unmodifiableSet(descendants);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestExecutionResult.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestExecutionResult.java
@@ -110,10 +110,12 @@ public class TestExecutionResult {
 
 	@Override
 	public String toString() {
-		ToStringBuilder builder = new ToStringBuilder(this);
-		builder.append("status", status);
-		builder.append("throwable", throwable);
-		return builder.toString();
+		// @formatter:off
+		return new ToStringBuilder(this)
+				.append("status", status)
+				.append("throwable", throwable)
+				.toString();
+		// @formatter:on
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -239,9 +239,9 @@ public class UniqueId implements Cloneable, Serializable {
 		public String toString() {
 			// @formatter:off
 			return new ToStringBuilder(this)
-				.append("type", this.type)
-				.append("value", this.value)
-				.toString();
+					.append("type", this.type)
+					.append("value", this.value)
+					.toString();
 			// @formatter:on
 		}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -10,8 +10,8 @@
 
 package org.junit.platform.engine.discovery;
 
-import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
+import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +46,8 @@ import org.junit.platform.engine.UniqueId;
 @API(Experimental)
 public final class DiscoverySelectors {
 
-	private static Pattern fullyQualifiedMethodNamePattern = Pattern.compile("([^#]+)#([^(]+)(?:\\((.*)\\))?");
+	private static final Pattern FULLY_QUALIFIED_METHOD_NAME_PATTERN = Pattern.compile(
+		"([^#]+)#([^(]+)(?:\\((.*)\\))?");
 
 	///CLOVER:OFF
 	private DiscoverySelectors() {
@@ -207,7 +208,8 @@ public final class DiscoverySelectors {
 				.filter(Files::exists)
 				.map(Path::toUri)
 				.map(ClasspathRootSelector::new)
-				.collect(toList());
+				// unmodifiable since selectClasspathRoots is a public, non-internal method
+				.collect(toUnmodifiableList());
 		// @formatter:on
 	}
 
@@ -310,7 +312,7 @@ public final class DiscoverySelectors {
 	public static MethodSelector selectMethod(String fullyQualifiedMethodName) throws PreconditionViolationException {
 		Preconditions.notBlank(fullyQualifiedMethodName, "fullyQualifiedMethodName must not be null or blank");
 
-		Matcher matcher = fullyQualifiedMethodNamePattern.matcher(fullyQualifiedMethodName);
+		Matcher matcher = FULLY_QUALIFIED_METHOD_NAME_PATTERN.matcher(fullyQualifiedMethodName);
 		Preconditions.condition(matcher.matches(),
 			fullyQualifiedMethodName + " is not a valid fully qualified method name");
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
@@ -10,12 +10,14 @@
 
 package org.junit.platform.launcher.listeners;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
@@ -192,13 +194,13 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 
 	@Override
 	public List<Failure> getFailures() {
-		return new ArrayList<>(failures);
+		return Collections.unmodifiableList(failures);
 	}
 
 	private String describeTest(TestIdentifier testIdentifier) {
 		List<String> descriptionParts = new ArrayList<>();
 		collectTestDescription(Optional.of(testIdentifier), descriptionParts);
-		return descriptionParts.stream().collect(Collectors.joining(":"));
+		return descriptionParts.stream().collect(joining(":"));
 	}
 
 	private void collectTestDescription(Optional<TestIdentifier> optionalIdentifier, List<String> descriptionParts) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
@@ -130,7 +130,7 @@ public interface TestExecutionSummary {
 	void printFailuresTo(PrintWriter writer);
 
 	/**
-	 * Get a list of the failures of the test plan execution.
+	 * Get an immutable list of the failures of the test plan execution.
 	 */
 	List<Failure> getFailures();
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
@@ -16,6 +16,10 @@ import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
+
+import java.util.List;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +59,14 @@ class CollectionUtilsTests {
 			CollectionUtils.getOnlyElement(asList("foo", "bar"));
 		});
 		assertEquals("collection must contain exactly one element: [foo, bar]", exception.getMessage());
+	}
+
+	@Test
+	void toUnmodifiableListThrowsOnMutation() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			List<Integer> numbers = IntStream.range(0, 10).mapToObj(Integer::valueOf).collect(toUnmodifiableList());
+			numbers.set(0, 1);
+		});
 	}
 
 }


### PR DESCRIPTION
## Overview

I've made a number of cleanup- and immutability-related changes to the JUnit 5 codebase in my spare time, mainly for fun, but also in the hope that it makes things a little easier to maintain in the future. However, it's not clear to me if all the changes I've made are actually desirable for backwards-compatibility or other reasons.

Are all the changes I've made here OK? If not, I wonder if someone on the JUnit 5 team would kindly let me know either where I can improve or where I've overstepped my boundaries. :)

Here's a summary of the main changes I've made, as I've written in my commit message:
```
    Clean up and encourage immutability within the codebase

    - `Collections::unmodifiable*` has been used more for the return values
      of public, non-internal, collection-returning methods, with the
      intention of making them a bit easier to use and understand for
      external users (since their mutability (or lack thereof) is now more
      clearly defined and enforced).
    - Code blocks between `// formatter:{off|on}` comments have been
      manually formatted for consistenty.
    - The methods of `Collectors` are statically imported more for
      consistency.
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
