### PR TITLE
Apply the 'java' plugin when the `JunitPlatformPlugin` is applied

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -19,6 +19,8 @@ on GitHub.
 * The JUnit Platform Gradle plugin now adds its dependencies with a fixed version (same as plugin
   version) instead of a dynamic versioning scheme (was `1.+`) by default to ensure reproducible
   builds.
+* The JUnit Platform Gradle plugin explicitly applies the Gradle built-in `java` plugin as
+  it has an implicit dependency on it being applied.
 * All `findMethods()` implementations in `ReflectionUtils` no longer return synthetic methods.
   Shadowed https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2[override-equal]
   methods are also no longer included in the result collection.

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -21,10 +21,11 @@ import org.junit.platform.console.ConsoleLauncher
  */
 class JUnitPlatformPlugin implements Plugin<Project> {
 
-	private static final String EXTENSION_NAME = 'junitPlatform';
-	private static final String TASK_NAME      = 'junitPlatformTest';
+	private static final String EXTENSION_NAME = 'junitPlatform'
+	private static final String TASK_NAME      = 'junitPlatformTest'
 
 	void apply(Project project) {
+		project.pluginManager.apply('java')
 		def junitExtension = project.extensions.create(EXTENSION_NAME, JUnitPlatformExtension, project)
 		junitExtension.extensions.create('selectors', SelectorsExtension)
 		junitExtension.extensions.create('filters', FiltersExtension)

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -14,6 +14,7 @@ import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testfixtures.ProjectBuilder
@@ -32,11 +33,20 @@ class JUnitPlatformPluginSpec extends Specification {
 		project = ProjectBuilder.builder().build()
 	}
 
+	def "plugin does not fail when it is the only plugin applied"() {
+		when:
+		project.apply plugin: 'org.junit.platform.gradle.plugin'
+		project.evaluate()
+
+		then:
+		noExceptionThrown()
+	}
 
 	def "applying the plugin"() {
 		when:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 		then:
+		project.plugins.hasPlugin(JavaPlugin)
 		project.plugins.hasPlugin(JUnitPlatformPlugin)
 		project.plugins.getPlugin(JUnitPlatformPlugin) instanceof JUnitPlatformPlugin
 		project.extensions.findByName('junitPlatform') instanceof JUnitPlatformExtension
@@ -44,7 +54,6 @@ class JUnitPlatformPluginSpec extends Specification {
 
 	def "setting junitPlatform properties"() {
 
-		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -76,7 +85,6 @@ class JUnitPlatformPluginSpec extends Specification {
 
 	def "creating junitPlatformTest task"() {
 
-		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -136,7 +144,6 @@ class JUnitPlatformPluginSpec extends Specification {
 
 	def "uses standard class name pattern"() {
 
-		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -149,7 +156,6 @@ class JUnitPlatformPluginSpec extends Specification {
 
 	def "enableStandardTestTask set to true"() {
 
-		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -176,7 +182,6 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "users can set buildDir to be a GString, and it will be converted to file"() {
-		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -192,7 +197,6 @@ class JUnitPlatformPluginSpec extends Specification {
 
 	def "selectors can be specified"() {
 
-		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -233,7 +237,6 @@ class JUnitPlatformPluginSpec extends Specification {
 
 	def "adds dependencies to configuration"() {
 
-		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -255,9 +258,8 @@ class JUnitPlatformPluginSpec extends Specification {
 		)
 	}
 
-	def "adds dependencies with fixed version when not explicity configured"() {
+	def "adds dependencies with fixed version when not explicitly configured"() {
 
-		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -80,7 +80,7 @@ class JUnitPlatformPluginSpec extends Specification {
 			details 'NONE'
 		}
 		then:
-		true == true
+		noExceptionThrown()
 	}
 
 	def "creating junitPlatformTest task"() {


### PR DESCRIPTION
Currently, the `JUnitPlatformPlugin` makes assumptions that the `'java'` plugin has been applied by looking at `sourceSets` and tasks that are created by it.
If the `'java'` plugin is not applied, the configuration will fail during the `afterEvaluate`

This change makes it so that the `'java'` plugin is also applied.

## Overview

* I'm not sure how this should be documented in the release notes

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
