### PR TITLE
Fix regression for class hierarchies without synthetic methods

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/bridge/AbstractNonGenericTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/bridge/AbstractNonGenericTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.bridge;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @since 5.0
+ */
+@ExtendWith(NumberResolver.class)
+abstract class AbstractNonGenericTests {
+
+	@Test
+	void mA() {
+		BridgeMethodTests.sequence.add("mA()");
+	}
+
+	@Test
+	void test(Number value) {
+		BridgeMethodTests.sequence.add("A.test(Number)");
+		Assertions.assertEquals(42, value);
+	}
+
+	static class B extends AbstractNonGenericTests {
+
+		@Test
+		void mB() {
+			BridgeMethodTests.sequence.add("mB()");
+		}
+
+		@Test
+		void test(Byte value) {
+			BridgeMethodTests.sequence.add("B.test(Byte)");
+			Assertions.assertEquals(123, value.intValue());
+		}
+
+	}
+
+	static class C extends B {
+
+		@Test
+		void mC() {
+			BridgeMethodTests.sequence.add("mC()");
+		}
+
+		@Override
+		@Test
+		void test(Byte value) {
+			BridgeMethodTests.sequence.add("C.test(Byte)");
+			Assertions.assertEquals(123, value.intValue());
+		}
+
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/bridge/NumberResolver.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/bridge/NumberResolver.java
@@ -32,6 +32,9 @@ class NumberResolver implements ParameterResolver {
 			throws ParameterResolutionException {
 
 		Class<?> type = parameterContext.getParameter().getType();
+		if (type == Number.class) {
+			return 42;
+		}
 		try {
 			return type.getMethod("valueOf", String.class).invoke(null, "123");
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -21,10 +21,13 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -716,7 +719,11 @@ public final class ReflectionUtils {
 		if (lower.getParameterCount() != upper.getParameterCount()) {
 			return false;
 		}
-		// Check for method sub-signatures.
+		// trivial case: parameter types exactly match
+		if (Arrays.equals(lower.getParameterTypes(), upper.getParameterTypes())) {
+			return true;
+		}
+		// param count is equal, but types do not match exactly: check for method sub-signatures
 		// https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2
 		for (int i = 0; i < lower.getParameterCount(); i++) {
 			Class<?> lowerType = lower.getParameterTypes()[i];
@@ -725,7 +732,27 @@ public final class ReflectionUtils {
 				return false;
 			}
 		}
-		return true;
+		// lower is sub-signature of upper: check for generics in upper method
+		if (isGeneric(upper)) {
+			return true;
+		}
+		return false;
+	}
+
+	static boolean isGeneric(Method method) {
+		if (isGeneric(method.getGenericReturnType())) {
+			return true;
+		}
+		for (Type type : method.getGenericParameterTypes()) {
+			if (isGeneric(type)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isGeneric(Type type) {
+		return type instanceof TypeVariable || type instanceof GenericArrayType;
 	}
 
 	private static <T extends AccessibleObject> T makeAccessible(T object) {

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -673,10 +673,32 @@ public class ReflectionUtilsTests {
 		assertTrue(methods.stream().filter(Method::isBridge).count() == 0);
 	}
 
+	@Test
+	void isGeneric() throws Exception {
+		for (Method method : Generic.class.getMethods()) {
+			assertTrue(ReflectionUtils.isGeneric(method));
+		}
+		for (Method method : PublicClass.class.getMethods()) {
+			assertFalse(ReflectionUtils.isGeneric(method));
+		}
+	}
+
 	private static void createDirectories(Path... paths) throws IOException {
 		for (Path path : paths) {
 			Files.createDirectory(path);
 		}
+	}
+
+	interface Generic<A, B, C extends A> {
+		A foo();
+
+		B foo(A a, B b);
+
+		C foo(C[][] cs);
+
+		<X> int foo(X x);
+
+		<X> X foo(int i);
 	}
 
 	class ClassWithSyntheticMethod {


### PR DESCRIPTION
## Overview

Code introduced by https://github.com/junit-team/junit5/commit/82174c15aba026a52a2566ee8643af89917fc1a1 broke standard support for test class hierarchies without bridge or synthetic methods present.

This commit fixes the regression by comparing the default and generic string representation of the upper method. If they are equal, the upper method does not shadow the lower one.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
