### PR TITLE
Redesign isTest() and isContainer() in TestDescriptor

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -111,6 +111,15 @@ on GitHub.
   regular expression checks. It also provides a fast-forward mechanism to skip actual lines that
   are expected to change in each invocation, e.g. duration, timestamps and stack traces.
   Consult the Javadoc for `{Assertions}` for details.
+* Squashed logic behind `TestDescriptor.isTest()` and `TestDescriptor.isContainer()` from two
+  independent boolean properties into a single enumeration, namely `TestDescriptor.Type`. See
+  next bullet point for details.
+* Introduced `TestDescriptor.Type` enumeration with `TestDescriptor.getType()` accessor defining
+  all possible descriptor types. `TestDescriptor.isTest()` and `TestDescriptor.isContainer()`
+  only delegate to `TestDescriptor.Type` constants now.
+* Introduced `TestDescriptor.prune()` and `TestDescriptor.pruneTree()` which allows engine writers
+  customize what happens when pruning is triggered by the JUnit Platform.
+
 
 [[release-notes-5.0.0-m4-junit-vintage]]
 ==== JUnit Vintage

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -102,13 +102,8 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	@Override
-	public final boolean isTest() {
-		return false;
-	}
-
-	@Override
-	public final boolean isContainer() {
-		return true;
+	public Type getType() {
+		return Type.CONTAINER;
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
@@ -32,13 +32,8 @@ class DynamicTestTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	@Override
-	public boolean isTest() {
-		return true;
-	}
-
-	@Override
-	public boolean isContainer() {
-		return false;
+	public Type getType() {
+		return Type.TEST;
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -68,13 +68,8 @@ public class MethodTestDescriptor extends MethodBasedTestDescriptor {
 	}
 
 	@Override
-	public boolean isTest() {
-		return true;
-	}
-
-	@Override
-	public boolean isContainer() {
-		return false;
+	public Type getType() {
+		return Type.TEST;
 	}
 
 	// --- Node ----------------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -47,13 +47,8 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 	// --- TestDescriptor ------------------------------------------------------
 
 	@Override
-	public boolean isTest() {
-		return false;
-	}
-
-	@Override
-	public boolean isContainer() {
-		return true;
+	public Type getType() {
+		return Type.CONTAINER;
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -42,13 +42,8 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor {
 	}
 
 	@Override
-	public boolean isTest() {
-		return false;
-	}
-
-	@Override
-	public boolean isContainer() {
-		return true;
+	public Type getType() {
+		return Type.CONTAINER;
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -64,7 +64,7 @@ public class DiscoverySelectorResolver {
 		request.getSelectorsByType(UniqueIdSelector.class).forEach(selector -> {
 			javaElementsResolver.resolveUniqueId(selector.getUniqueId());
 		});
-		pruneTree(engineDescriptor);
+		engineDescriptor.pruneTree();
 	}
 
 	private JavaElementsResolver createJavaElementsResolver(TestDescriptor engineDescriptor) {
@@ -75,15 +75,6 @@ public class DiscoverySelectorResolver {
 		resolvers.add(new TestFactoryMethodResolver());
 		resolvers.add(new TestTemplateMethodResolver());
 		return new JavaElementsResolver(engineDescriptor, resolvers);
-	}
-
-	private void pruneTree(TestDescriptor root) {
-		TestDescriptor.Visitor removeChildrenWithoutTests = (descriptor) -> {
-			if (!descriptor.isRoot() && !descriptor.hasTests()) {
-				descriptor.removeFromHierarchy();
-			}
-		};
-		root.accept(removeChildrenWithoutTests);
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
@@ -42,14 +42,10 @@ class TestTemplateTestDescriptorTests {
 
 	private AbstractTestDescriptor containerTestDescriptorWithTags(UniqueId uniqueId, Set<TestTag> tags) {
 		return new AbstractTestDescriptor(uniqueId, "testDescriptor with tags") {
-			@Override
-			public boolean isContainer() {
-				return true;
-			}
 
 			@Override
-			public boolean isTest() {
-				return false;
+			public Type getType() {
+				return Type.CONTAINER;
 			}
 
 			@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/EngineDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/EngineDescriptor.java
@@ -13,13 +13,11 @@ package org.junit.platform.engine.support.descriptor;
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
 import org.junit.platform.commons.meta.API;
-import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
 
 /**
- * An {@code EngineDescriptor} is a {@link TestDescriptor} for a specific
- * {@link TestEngine}.
+ * An {@code EngineDescriptor} is a {@link org.junit.platform.engine.TestDescriptor} for a specific
+ * {@link org.junit.platform.engine.TestEngine}.
  *
  * @since 1.0
  */
@@ -34,33 +32,21 @@ public class EngineDescriptor extends AbstractTestDescriptor {
 	 * never {@code null}
 	 * @param displayName the display name for the described {@code TestEngine};
 	 * never {@code null} or blank
-	 * @see TestEngine#getId()
-	 * @see TestDescriptor#getDisplayName()
+	 * @see org.junit.platform.engine.TestEngine#getId()
+	 * @see org.junit.platform.engine.TestDescriptor#getDisplayName()
 	 */
 	public EngineDescriptor(UniqueId uniqueId, String displayName) {
 		super(uniqueId, displayName);
 	}
 
 	/**
-	 * Always returns {@code false}: a {@link TestEngine} is never a test.
+	 * Always returns {@link org.junit.platform.engine.TestDescriptor.Type#ENGINE}.
 	 *
+	 * @see org.junit.platform.engine.TestDescriptor#isContainer() Test2()
 	 * @see org.junit.platform.engine.TestDescriptor#isTest()
-	 * @see #isContainer()
 	 */
 	@Override
-	public final boolean isTest() {
-		return false;
+	public final Type getType() {
+		return Type.ENGINE;
 	}
-
-	/**
-	 * Always returns {@code true}: a {@link TestEngine} is always a container.
-	 *
-	 * @see org.junit.platform.engine.TestDescriptor#isContainer()
-	 * @see #isTest()
-	 */
-	@Override
-	public final boolean isContainer() {
-		return true;
-	}
-
 }

--- a/junit-platform-engine/src/test/java/org/junit/platform/engine/test/TestDescriptorStub.java
+++ b/junit-platform-engine/src/test/java/org/junit/platform/engine/test/TestDescriptorStub.java
@@ -23,13 +23,7 @@ public class TestDescriptorStub extends AbstractTestDescriptor {
 	}
 
 	@Override
-	public boolean isTest() {
-		return getChildren().isEmpty();
+	public Type getType() {
+		return getChildren().isEmpty() ? Type.TEST : Type.CONTAINER;
 	}
-
-	@Override
-	public boolean isContainer() {
-		return !isTest();
-	}
-
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -59,7 +59,7 @@ public final class TestIdentifier implements Serializable {
 		Optional<TestSource> source = testDescriptor.getSource();
 		Set<TestTag> tags = testDescriptor.getTags();
 		boolean test = testDescriptor.isTest();
-		boolean container = !test || !testDescriptor.getChildren().isEmpty();
+		boolean container = testDescriptor.isContainer();
 		Optional<String> parentId = testDescriptor.getParent().map(
 			parentDescriptor -> parentDescriptor.getUniqueId().toString());
 		String legacyReportingName = testDescriptor.getLegacyReportingName();

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
@@ -29,12 +29,6 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
  */
 class Root {
 
-	private static final TestDescriptor.Visitor REMOVE_DESCRIPTORS_WITHOUT_TESTS = descriptor -> {
-		if (!descriptor.isRoot() && !descriptor.hasTests()) {
-			descriptor.removeFromHierarchy();
-		}
-	};
-
 	private final Map<TestEngine, TestDescriptor> testEngineDescriptors = new LinkedHashMap<>(4);
 
 	/**
@@ -74,7 +68,7 @@ class Root {
 	 * pruning, it will <strong>not</strong> be removed.
 	 */
 	void prune() {
-		acceptInAllTestEngines(REMOVE_DESCRIPTORS_WITHOUT_TESTS);
+		acceptInAllTestEngines(TestDescriptor::prune);
 	}
 
 	private boolean isExcluded(TestDescriptor descriptor, Filter<TestDescriptor> postDiscoveryFilter) {

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -77,13 +77,8 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 	}
 
 	@Override
-	public boolean isTest() {
-		return description.isTest();
-	}
-
-	@Override
-	public boolean isContainer() {
-		return description.isSuite();
+	public Type getType() {
+		return description.isTest() ? Type.TEST : Type.CONTAINER;
 	}
 
 	@Override

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/TreePrinterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/TreePrinterTests.java
@@ -74,13 +74,8 @@ class TreePrinterTests {
 	private TestIdentifier createEngineId(String uniqueId, String displayName) {
 		return TestIdentifier.from(new AbstractTestDescriptor(UniqueId.forEngine(uniqueId), displayName) {
 			@Override
-			public boolean isContainer() {
-				return false;
-			}
-
-			@Override
-			public boolean isTest() {
-				return false;
+			public Type getType() {
+				return Type.ENGINE;
 			}
 		});
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
@@ -102,14 +102,10 @@ class GroupDescriptor extends AbstractTestDescriptor {
 	}
 
 	@Override
-	public boolean isTest() {
-		return false;
+	public Type getType() {
+		return Type.CONTAINER;
 	}
 
-	@Override
-	public boolean isContainer() {
-		return true;
-	}
 }
 
 class LeafDescriptor extends AbstractTestDescriptor {
@@ -119,12 +115,8 @@ class LeafDescriptor extends AbstractTestDescriptor {
 	}
 
 	@Override
-	public boolean isTest() {
-		return true;
+	public Type getType() {
+		return Type.TEST;
 	}
 
-	@Override
-	public boolean isContainer() {
-		return false;
-	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoClassTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoClassTestDescriptor.java
@@ -46,18 +46,9 @@ public class DemoClassTestDescriptor extends AbstractTestDescriptor {
 		// @formatter:on
 	}
 
-	public final Class<?> getTestClass() {
-		return this.testClass;
-	}
-
 	@Override
-	public final boolean isTest() {
-		return false;
-	}
-
-	@Override
-	public final boolean isContainer() {
-		return true;
+	public Type getType() {
+		return Type.CONTAINER;
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoMethodTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoMethodTestDescriptor.java
@@ -64,13 +64,8 @@ public class DemoMethodTestDescriptor extends AbstractTestDescriptor {
 	}
 
 	@Override
-	public boolean isTest() {
-		return true;
-	}
-
-	@Override
-	public boolean isContainer() {
-		return false;
+	public Type getType() {
+		return Type.TEST;
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
@@ -42,8 +42,8 @@ public class DemoHierarchicalContainerDescriptor extends AbstractTestDescriptor
 	}
 
 	@Override
-	public boolean isTest() {
-		return false;
+	public Type getType() {
+		return Type.CONTAINER;
 	}
 
 	@Override
@@ -53,11 +53,6 @@ public class DemoHierarchicalContainerDescriptor extends AbstractTestDescriptor
 
 	@Override
 	public boolean hasTests() {
-		return true;
-	}
-
-	@Override
-	public boolean isContainer() {
 		return true;
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
@@ -40,13 +40,8 @@ public class DemoHierarchicalTestDescriptor extends AbstractTestDescriptor imple
 	}
 
 	@Override
-	public boolean isTest() {
-		return !isContainer();
-	}
-
-	@Override
-	public boolean isContainer() {
-		return this.executeBlock == null;
+	public Type getType() {
+		return this.executeBlock != null ? Type.TEST : Type.CONTAINER;
 	}
 
 	@Override

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -404,18 +404,13 @@ public class HierarchicalTestExecutorTests {
 		}
 
 		@Override
-		public boolean isTest() {
-			return false;
-		}
-
-		@Override
-		public boolean isContainer() {
-			return true;
+		public Type getType() {
+			return Type.CONTAINER;
 		}
 
 		@Override
 		public boolean isLeaf() {
-			return !isContainer();
+			return isTest();
 		}
 
 	}
@@ -433,18 +428,13 @@ public class HierarchicalTestExecutorTests {
 		}
 
 		@Override
-		public boolean isTest() {
-			return true;
-		}
-
-		@Override
-		public boolean isContainer() {
-			return false;
+		public Type getType() {
+			return Type.TEST;
 		}
 
 		@Override
 		public boolean isLeaf() {
-			return !isContainer();
+			return isTest();
 		}
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listener/SummaryGenerationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listener/SummaryGenerationTests.java
@@ -195,13 +195,8 @@ class SummaryGenerationTests {
 			new TestDescriptorStub(UniqueId.root("container", uniqueId), uniqueId) {
 
 				@Override
-				public boolean isContainer() {
-					return true;
-				}
-
-				@Override
-				public boolean isTest() {
-					return false;
+				public Type getType() {
+					return Type.CONTAINER;
 				}
 			});
 		testPlan.add(identifier);

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -732,13 +732,8 @@ class JUnitPlatformRunnerTests {
 		}
 
 		@Override
-		public boolean isContainer() {
-			return true;
-		}
-
-		@Override
-		public boolean isTest() {
-			return false;
+		public Type getType() {
+			return Type.CONTAINER;
 		}
 	}
 
@@ -749,13 +744,8 @@ class JUnitPlatformRunnerTests {
 		}
 
 		@Override
-		public boolean isContainer() {
-			return false;
-		}
-
-		@Override
-		public boolean isTest() {
-			return true;
+		public Type getType() {
+			return Type.TEST;
 		}
 	}
 


### PR DESCRIPTION
## Overview

Fixes #508 by replacing logic behind `isTest()` and `isContainer()` from two independent boolean properties into an enumeration based one:

```java
enum TestDescriptor.Type {

	ENGINE, CONTAINER, TEST, CONTAINER_AND_TEST;

	public boolean isContainer() {
		return this == ENGINE || this == CONTAINER || this == CONTAINER_AND_TEST;
	}

	public boolean isTest() {
		return this == TEST || this == CONTAINER_AND_TEST;
	}
}
```

Convenient and code duplicate remover methods `TestDescriptor.prune()` and `TestDescriptor.pruneTree()` are introduced.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x]  All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
