### PR TITLE
Include "inherited" nested classes in findNestedClasses()

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -29,6 +29,8 @@ on GitHub.
   method names through `getLegacyName()` instead of using the source location.
 * JAR files that contain spaces in their paths (`%20`) are now properly decoded before being
   used in classpath scanning routines.
+* Updated `findNestedClasses()` in `ReflectionUtils` so that searches for nested classes also
+  return inherited nested classes (regardless of whether they are static or not).
 
 ===== Deprecations and Breaking Changes
 
@@ -90,6 +92,7 @@ on GitHub.
 ===== Bug Fixes
 
 * Fixed bug that prevented discovery of two or more methods of the same class.
+* Fixed bug that prevented discovery of `@Nested` non-static test classes declared in super classes.
 * The correct execution order of overridden `@BeforeEach`/`@AfterEach` methods is now enforced when declared
   at multiple levels within a class hierarchy. It's now always `super.before`, `this.before`, `this.test`,
   `this.after`, and `super.after`, even if the compiler adds synthetic methods.

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -81,6 +81,18 @@ public class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 
 	}
 
+	@Test
+	public void inheritedNestedTestsAreExecuted() {
+		ExecutionEventRecorder eventRecorder = executeTestsForClass(TestCaseWithInheritedNested.class);
+
+		assertEquals(2, eventRecorder.getTestStartedCount(), "# tests started");
+		assertEquals(1, eventRecorder.getTestSuccessfulCount(), "# tests succeeded");
+		assertEquals(1, eventRecorder.getTestFailedCount(), "# tests failed");
+
+		assertEquals(3, eventRecorder.getContainerStartedCount(), "# containers started");
+		assertEquals(3, eventRecorder.getContainerFinishedCount(), "# containers finished");
+	}
+
 	// -------------------------------------------------------------------
 
 	private static class TestCaseWithNesting {
@@ -172,6 +184,39 @@ public class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 				}
 			}
 		}
+	}
+
+	interface InterfaceWithNestedClass {
+
+		@Nested
+		class NestedInInterface {
+
+			@Test
+			void notExecutedByImplementingClass() {
+				Assertions.fail("class in interface is static and should have been filtered out");
+			}
+		}
+
+	}
+
+	static abstract class AbstractSuperClass implements InterfaceWithNestedClass {
+
+		@Nested
+		class NestedInAbstractClass {
+
+			@Test
+			void successful() {
+			}
+
+			@Test
+			void failing() {
+				Assertions.fail("something went wrong");
+			}
+		}
+	}
+
+	static class TestCaseWithInheritedNested extends AbstractSuperClass {
+		// empty on purpose
 	}
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -528,7 +528,21 @@ public final class ReflectionUtils {
 		Preconditions.notNull(clazz, "Class must not be null");
 		Preconditions.notNull(predicate, "predicate must not be null");
 
-		return Arrays.stream(clazz.getDeclaredClasses()).filter(predicate).collect(toList());
+		Set<Class<?>> candidates = findNestedClasses(clazz, new LinkedHashSet<>());
+		return candidates.stream().filter(predicate).collect(toList());
+	}
+
+	private static Set<Class<?>> findNestedClasses(Class<?> clazz, Set<Class<?>> candidates) {
+		for (Class<?> candidate = clazz; candidate != null; candidate = candidate.getSuperclass()) {
+			Class<?>[] declaredClasses = candidate.getDeclaredClasses();
+			candidates.addAll(Arrays.asList(declaredClasses));
+			for (Class<?> interfaceType : candidate.getInterfaces()) {
+				declaredClasses = interfaceType.getDeclaredClasses();
+				candidates.addAll(Arrays.asList(declaredClasses));
+				findNestedClasses(interfaceType, candidates);
+			}
+		}
+		return candidates;
 	}
 
 	/**

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -42,6 +42,8 @@ import org.junit.jupiter.extensions.TempDirectory.Root;
 import org.junit.platform.commons.util.ReflectionUtilsTests.ClassWithNestedClasses.Nested1;
 import org.junit.platform.commons.util.ReflectionUtilsTests.ClassWithNestedClasses.Nested2;
 import org.junit.platform.commons.util.ReflectionUtilsTests.ClassWithNestedClasses.Nested3;
+import org.junit.platform.commons.util.ReflectionUtilsTests.Interface45.Nested5;
+import org.junit.platform.commons.util.ReflectionUtilsTests.InterfaceWithNestedClass.Nested4;
 
 /**
  * Unit tests for {@link ReflectionUtils}.
@@ -409,6 +411,9 @@ public class ReflectionUtilsTests {
 
 		assertThat(ReflectionUtils.findNestedClasses(ClassWithNestedClasses.class, ReflectionUtils::isStatic))
 			.containsExactly(Nested3.class);
+
+		assertThat(ReflectionUtils.findNestedClasses(ClassExtendingClassWithNestedClasses.class, clazz -> true))
+			.containsOnly(Nested1.class, Nested2.class, Nested3.class, Nested4.class, Nested5.class);
 		// @formatter:on
 	}
 
@@ -863,6 +868,21 @@ public class ReflectionUtilsTests {
 
 		static class Nested3 {
 		}
+	}
+
+	interface InterfaceWithNestedClass {
+
+		class Nested4 {
+		}
+	}
+
+	interface Interface45 extends InterfaceWithNestedClass {
+
+		class Nested5 {
+		}
+	}
+
+	static class ClassExtendingClassWithNestedClasses extends ClassWithNestedClasses implements Interface45 {
 	}
 
 	static class GrandparentClass {


### PR DESCRIPTION
## Overview

Fixes #717 by traversing superclasses to find all declared classes in the hierarchy of the class to scan. Declared classes of implemented (super-) interfaces are also included.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
