### PR TITLE
Explicitly catch RuntimeExceptions

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ConditionEvaluator.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ConditionEvaluator.java
@@ -116,7 +116,7 @@ public class ConditionEvaluator {
 			logResult(condition.getClass(), result);
 			return result;
 		}
-		catch (Exception ex) {
+		catch (RuntimeException ex) {
 			throw evaluationException(condition.getClass(), ex);
 		}
 	}
@@ -127,7 +127,7 @@ public class ConditionEvaluator {
 			logResult(condition.getClass(), result);
 			return result;
 		}
-		catch (Exception ex) {
+		catch (RuntimeException ex) {
 			throw evaluationException(condition.getClass(), ex);
 		}
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
@@ -20,6 +20,7 @@ import static org.junit.platform.commons.util.ClassFileVisitor.CLASS_FILE_SUFFIX
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -78,7 +79,7 @@ class ClasspathScanner {
 			return packageName.isEmpty() // default package
 					|| getClassLoader().getResources(packagePath(packageName.trim())).hasMoreElements();
 		}
-		catch (Exception ex) {
+		catch (IOException | RuntimeException ex) {
 			return false;
 		}
 	}
@@ -127,7 +128,7 @@ class ClasspathScanner {
 		catch (PreconditionViolationException ex) {
 			throw ex;
 		}
-		catch (Exception ex) {
+		catch (URISyntaxException | IOException | RuntimeException ex) {
 			logWarning(ex, () -> "Error scanning files for URI " + baseUri);
 			return emptyList();
 		}
@@ -256,7 +257,7 @@ class ClasspathScanner {
 			}
 			return uris;
 		}
-		catch (Exception ex) {
+		catch (URISyntaxException | IOException | RuntimeException ex) {
 			logWarning(ex, () -> "Error reading URIs from class loader for base package " + basePackageName);
 			return emptyList();
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
@@ -13,6 +13,8 @@ package org.junit.platform.commons.util;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.CodeSource;
 import java.util.Optional;
@@ -102,7 +104,7 @@ public final class PackageUtils {
 				return Optional.ofNullable(mainAttributes.getValue(name));
 			}
 		}
-		catch (Exception e) {
+		catch (URISyntaxException | IOException | RuntimeException e) {
 			return Optional.empty();
 		}
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -407,7 +407,7 @@ public final class ReflectionUtils {
 			try {
 				return findMethod(classOptional.get(), methodName.trim(), parameterTypeNames);
 			}
-			catch (Exception ex) {
+			catch (RuntimeException ex) {
 				/* ignore */
 			}
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -37,7 +37,7 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 			try {
 				value = System.getProperty(key);
 			}
-			catch (Exception ex) {
+			catch (RuntimeException ex) {
 				/* ignore */
 			}
 		}


### PR DESCRIPTION
## Overview 
I noticed several instances where `Exception` was caught, but was not sure if this was done intentionally to also catch `RuntimeException` or not.

I decided to dig a bit deeper and found that this was indeed intentional. Since this was not clear (to me) from the start I thought it might be a good idea to make it explicit.

In `platform.commons.util.ClasspathScanner.java` I was unsure whether or not `RuntimeException` was a possibility, and therefore I included it to prevent accidentally changing behaviour.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
