### PR TITLE
Replace AtomicInteger with int in TestTemplateTestDescriptor.execute()

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -14,8 +14,9 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
 import java.lang.reflect.Method;
+import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ContainerExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
@@ -89,13 +90,18 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor {
 		ContainerExtensionContext containerExtensionContext = (ContainerExtensionContext) context.getExtensionContext();
 		List<TestTemplateInvocationContextProvider> providers = validateProviders(containerExtensionContext,
 			context.getExtensionRegistry());
-		AtomicInteger invocationIndex = new AtomicInteger();
-		// @formatter:off
-		providers.stream()
-				.flatMap(provider -> provider.provide(containerExtensionContext))
-				.map(invocationContext -> createInvocationTestDescriptor(invocationContext, invocationIndex.incrementAndGet()))
-				.forEach(invocationTestDescriptor -> execute(dynamicTestExecutor, invocationTestDescriptor));
-		// @formatter:on
+
+		int invocationIndex = 0;
+		for (TestTemplateInvocationContextProvider provider : providers) {
+			Stream<TestTemplateInvocationContext> invocationContextStream = provider.provide(containerExtensionContext);
+			Iterator<TestTemplateInvocationContext> contextIterator = invocationContextStream.iterator();
+			while (contextIterator.hasNext()) {
+				TestDescriptor invocationTestDescriptor = createInvocationTestDescriptor(contextIterator.next(),
+					++invocationIndex);
+				execute(dynamicTestExecutor, invocationTestDescriptor);
+			}
+			invocationContextStream.close();
+		}
 		validateWasAtLeastInvokedOnce(invocationIndex);
 		return context;
 	}
@@ -127,8 +133,8 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor {
 		dynamicTestExecutor.execute(testDescriptor);
 	}
 
-	private void validateWasAtLeastInvokedOnce(AtomicInteger invocationIndex) {
-		if (invocationIndex.get() == 0) {
+	private void validateWasAtLeastInvokedOnce(int invocationIndex) {
+		if (invocationIndex == 0) {
 			throw new TestAbortedException("No supporting "
 					+ TestTemplateInvocationContextProvider.class.getSimpleName() + " provided an invocation context");
 		}


### PR DESCRIPTION
An atomic integer is not really required to count the invocationIndex.
A local int variable should shuffice. Rewrite using java5 for-each and
while loop instead of lambdas to remove the need for an effectively
final mutable number.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
