### PR TITLE
Classes containing @TestTemplate methods are detected as Test classes

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestClassWithTests.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestClassWithTests.java
@@ -31,7 +31,10 @@ public class IsTestClassWithTests implements Predicate<Class<?>> {
 
 	private static final IsTestFactoryMethod isTestFactoryMethod = new IsTestFactoryMethod();
 
-	private static final Predicate<Method> isTestOrTestFactoryMethod = isTestMethod.or(isTestFactoryMethod);
+	private static final IsTestTemplateMethod isTestTemplateMethod = new IsTestTemplateMethod();
+
+	private static final Predicate<Method> isTestOrTestFactoryOrTestTemplateMethod = isTestMethod.or(
+		isTestFactoryMethod).or(isTestTemplateMethod);
 
 	private static final IsPotentialTestContainer isPotentialTestContainer = new IsPotentialTestContainer();
 
@@ -43,11 +46,11 @@ public class IsTestClassWithTests implements Predicate<Class<?>> {
 		if (!isPotentialTestContainer.test(candidate)) {
 			return false;
 		}
-		return hasTestOrTestFactoryMethods(candidate) || hasNestedTests(candidate);
+		return hasTestOrTestFactoryOrTestTemplateMethods(candidate) || hasNestedTests(candidate);
 	}
 
-	private boolean hasTestOrTestFactoryMethods(Class<?> candidate) {
-		return !ReflectionUtils.findMethods(candidate, isTestOrTestFactoryMethod).isEmpty();
+	private boolean hasTestOrTestFactoryOrTestTemplateMethods(Class<?> candidate) {
+		return !ReflectionUtils.findMethods(candidate, isTestOrTestFactoryOrTestTemplateMethod).isEmpty();
 	}
 
 	private boolean hasNestedTests(Class<?> candidate) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestClassWithTestsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestClassWithTestsTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestTemplate;
 
 public class IsTestClassWithTestsTests {
 
@@ -40,6 +41,10 @@ public class IsTestClassWithTestsTests {
 		assertTrue(isTestClassWithTests.test(ClassWithNestedTestCases.class));
 	}
 
+	@Test
+	void classWithTestTemplateEvaluatesToTrue() {
+		assertTrue(isTestClassWithTests.test(ClassWithTestTemplate.class));
+	}
 }
 
 //class name must not end with 'Tests', otherwise it would be picked up by the suite
@@ -80,4 +85,13 @@ class ClassWithNestedTestCases {
 		}
 
 	}
+}
+
+//class name must not end with 'Tests', otherwise it would be picked up by the suite
+class ClassWithTestTemplate {
+
+	@TestTemplate
+	void first(int a) {
+	}
+
 }


### PR DESCRIPTION
## Overview

`@TestTemplate` methods are now recognized as **test** ones by the Discovery phase (see `DiscoverySelectorResolver`).

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---