### PR TITLE
Invoke lifecycle hooks around each dynamic test

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -108,6 +109,12 @@ public class MethodTestDescriptor extends MethodBasedTestDescriptor {
 	@Override
 	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
 			DynamicTestExecutor dynamicTestExecutor) throws Exception {
+		executeTestBetweenBeforeAndAfterHooks(context, c -> invokeTestMethod(c, dynamicTestExecutor));
+		return context;
+	}
+
+	protected void executeTestBetweenBeforeAndAfterHooks(JupiterEngineExecutionContext context,
+			Consumer<JupiterEngineExecutionContext> testExecutor) {
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 
 		// @formatter:off
@@ -117,7 +124,7 @@ public class MethodTestDescriptor extends MethodBasedTestDescriptor {
 				if (throwableCollector.isEmpty()) {
 					invokeBeforeTestExecutionCallbacks(context);
 					if (throwableCollector.isEmpty()) {
-						invokeTestMethod(context, dynamicTestExecutor);
+						testExecutor.accept(context);
 					}
 					invokeAfterTestExecutionCallbacks(context);
 				}
@@ -127,8 +134,6 @@ public class MethodTestDescriptor extends MethodBasedTestDescriptor {
 		// @formatter:on
 
 		throwableCollector.assertEmpty();
-
-		return context;
 	}
 
 	private void invokeBeforeEachCallbacks(JupiterEngineExecutionContext context) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.extension.TestExtensionContext;
 import org.junit.jupiter.engine.execution.ExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.jupiter.engine.execution.ThrowableCollector;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.commons.util.CollectionUtils;
@@ -69,6 +70,18 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 	}
 
 	@Override
+	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
+			DynamicTestExecutor dynamicTestExecutor) throws Exception {
+		ThrowableCollector throwableCollector = context.getThrowableCollector();
+
+		invokeTestMethod(context, dynamicTestExecutor);
+
+		throwableCollector.assertEmpty();
+
+		return context;
+	}
+
+	@Override
 	protected void invokeTestMethod(JupiterEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) {
 		TestExtensionContext testExtensionContext = (TestExtensionContext) context.getExtensionContext();
 
@@ -80,8 +93,8 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 			try (Stream<DynamicTest> dynamicTestStream = toDynamicTestStream(testExtensionContext,
 				testFactoryMethodResult)) {
 				AtomicInteger index = new AtomicInteger();
-				dynamicTestStream.forEach(
-					dynamicTest -> registerAndExecute(dynamicTest, index.incrementAndGet(), dynamicTestExecutor));
+				dynamicTestStream.forEach(dynamicTest -> executeTestBetweenBeforeAndAfterHooks(context,
+					c -> registerAndExecute(dynamicTest, index.incrementAndGet(), dynamicTestExecutor)));
 			}
 			catch (ClassCastException ex) {
 				throw invalidReturnTypeException(ex);


### PR DESCRIPTION
## Overview

`@BeforeEach`, `@AfterEach` and associated callback extensions run once around `@TestFactory` methods.

The proposition here is to run these hooks **around each dynamic tests** created by the factory method.

Hooks are not invoked around the factory method, because it is a container and type (container or test) cannot be determined from a hook implementation.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.