### PR TITLE
Assertions.assertLinesMatch(List<String>, List<String>) proposal

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -104,7 +104,10 @@ on GitHub.
 * `TestInstancePostProcessors` registered on test methods are now invoked.
 * There are two new signatures for `Assertions.fail`: `Assertions.fail(Throwable cause)` and
   `Assertions.fail(String message, Throwable cause)`.
-
+* New `Assertions.assertLinesMatch()` comparing lists of `String` featuring `Object::equals` and
+  regular expression checks. It also provides a fast-forward mechanism to skip actual lines that
+  are expected to change in each invocation, e.g. duration, timestamps and stack traces.
+  Consult the Javadoc for `{Assertions}` for details.
 
 [[release-notes-5.0.0-m4-junit-vintage]]
 ==== JUnit Vintage

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -118,7 +118,7 @@ class AssertLinesMatch {
 			}
 
 			int number = expectedLines.size() - expectedDeque.size(); // 1-based line number
-			fail(expectedLines, actualLines, "expected line #%d:`%s` don't match", number, snippet(expectedLine));
+			fail(expectedLines, actualLines, "expected line #%d:`%s` doesn't match", number, snippet(expectedLine));
 		}
 
 		// after math
@@ -156,7 +156,7 @@ class AssertLinesMatch {
 		String text = fastForwardLine.trim().substring(2, fastForwardLine.length() - 2).trim();
 		try {
 			int limit = Integer.parseInt(text);
-			condition(limit > 0, "fast-forward limit must be greater than zero, it is: " + limit);
+			condition(limit > 0, () -> format("fast-forward(%d) limit must be greater than zero", limit));
 			return limit;
 		}
 		catch (NumberFormatException e) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -16,11 +16,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.commons.util.Preconditions.condition;
 import static org.junit.platform.commons.util.Preconditions.notNull;
 
+import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
@@ -43,7 +41,7 @@ class AssertLinesMatch {
 		int expectedSize = expectedLines.size();
 		int actualSize = actualLines.size();
 
-		// trivial case: when expecting more then actual lines available, something is wrong
+		// trivial case: when expecting more than actual lines available, something is wrong
 		if (expectedSize > actualSize) {
 			// use standard assertEquals(Object, Object, message) to let IDEs present the textual difference
 			String expected = String.join(System.lineSeparator(), expectedLines);
@@ -71,8 +69,8 @@ class AssertLinesMatch {
 	}
 
 	private static void assertLinesMatchWithFastForward(List<String> expectedLines, List<String> actualLines) {
-		Deque<String> expectedDeque = new LinkedList<>(expectedLines);
-		Deque<String> actualDeque = new LinkedList<>(actualLines);
+		Deque<String> expectedDeque = new ArrayDeque<>(expectedLines);
+		Deque<String> actualDeque = new ArrayDeque<>(actualLines);
 
 		while (!expectedDeque.isEmpty()) {
 			String expectedLine = expectedDeque.pop();
@@ -132,16 +130,16 @@ class AssertLinesMatch {
 		}
 	}
 
-	private static boolean isFastForwardLine(String line) {
+	static boolean isFastForwardLine(String line) {
 		line = line.trim();
-		return line.startsWith(">>") && line.endsWith(">>");
+		return line.length() >= 4 && line.startsWith(">>") && line.endsWith(">>");
 	}
 
-	private static int parseFastForwardLimit(String fastForwardLine) {
+	static int parseFastForwardLimit(String fastForwardLine) {
 		String text = fastForwardLine.trim().substring(2, fastForwardLine.length() - 2).trim();
 		try {
 			int limit = Integer.parseInt(text);
-			condition(limit > 0, "fast-forward must greater than zero, it is: " + limit);
+			condition(limit > 0, "fast-forward limit must be greater than zero, it is: " + limit);
 			return limit;
 		}
 		catch (NumberFormatException e) {
@@ -149,14 +147,12 @@ class AssertLinesMatch {
 		}
 	}
 
-	private static boolean matches(String expectedLine, String actualLine) {
+	static boolean matches(String expectedLine, String actualLine) {
 		if (expectedLine.equals(actualLine)) {
 			return true;
 		}
 		try {
-			Pattern pattern = Pattern.compile(expectedLine);
-			Matcher matcher = pattern.matcher(actualLine);
-			return matcher.matches();
+			return actualLine.matches(expectedLine);
 		}
 		catch (PatternSyntaxException ignore) {
 			return false;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * {@code AssertLinesMatch} is a collection of utility methods that support asserting
+ * lines of {@link String} equality or {@link java.util.regex.Pattern}-match in tests.
+ *
+ * @since 5.0
+ */
+class AssertLinesMatch {
+
+	static void assertLinesMatch(List<String> expectedLines, List<String> actualLines) {
+		Preconditions.notNull(expectedLines, "expectedLines must not be null");
+		Preconditions.notNull(actualLines, "actualLines must not be null");
+
+		// trivial case: same list instance
+		if (expectedLines == actualLines) {
+			return;
+		}
+
+		int expectedSize = expectedLines.size();
+		int actualSize = actualLines.size();
+
+		// trivial case: when expecting more then actual lines available, something is wrong
+		if (expectedSize > actualSize) {
+			// use standard assertEquals(Object, Object, message) to let IDEs present the textual difference
+			String expected = String.join(System.lineSeparator(), expectedLines);
+			String actual = String.join(System.lineSeparator(), actualLines);
+			assertEquals(expected, actual, "expected " + expectedSize + " lines, but only got " + actualSize);
+			fail("should not happen as expected != actual was asserted");
+		}
+
+		// simple case: both list are equally sized, compare them line-by-line
+		if (expectedSize == actualSize) {
+			for (int i = 0; i < expectedSize; i++) {
+				assertMatches(expectedLines.get(i), actualLines.get(i), i, i);
+			}
+			return;
+		}
+
+		assertLinesMatchWithDSL(expectedLines, actualLines);
+	}
+
+	private static void assertLinesMatchWithDSL(List<String> expectedLines, List<String> actualLines) {
+		assert expectedLines.size() < actualLines.size() : "unexpected lines sizes";
+
+		for (int e = 0, a = 0; e < expectedLines.size() && a < actualLines.size(); e++, a++) {
+			String expectedLine = expectedLines.get(e);
+			String actualLine = actualLines.get(a);
+			// trivial case: take the fast path when both lines are equal
+			if (expectedLine.equals(actualLine)) {
+				continue;
+			}
+			// fast forward markers found in expected line: fast forward actual line until next match
+			if (isFastForwardLine(expectedLine.trim())) {
+				int nextExpectedIndex = e + 1;
+				if (nextExpectedIndex >= expectedLines.size()) {
+					// trivial case: marker was last line in expected list
+					return;
+				}
+				expectedLine = expectedLines.get(nextExpectedIndex);
+				int ahead = a;
+				while (!matches(expectedLine, actualLine, false)) {
+					actualLine = actualLines.get(ahead++);
+					if (ahead > actualLines.size()) {
+						fail("ran out of actual bounds");
+					}
+				}
+				a = ahead - 2; // "side-effect" assignment to for-loop variable on purpose
+				continue;
+			}
+			// now, assert equality of expect and actual line
+			assertMatches(expectedLine, actualLine, e, a);
+		}
+	}
+
+	private static boolean isFastForwardLine(String line) {
+		return line.equals("S T A C K T R A C E") || line.startsWith("{{") && line.endsWith("}}");
+	}
+
+	private static int getUpperLimit(String fastForwardLine) {
+		// TODO implement and use
+		return Integer.MAX_VALUE;
+	}
+
+	private static void assertMatches(String expectedLine, String actualLine, int expectedIndex, int actualIndex) {
+		assertTrue(matches(expectedLine, actualLine, true), //
+			() -> format("%nexpected:%d = %s%nactual:%d = %s", expectedIndex, expectedLine, actualIndex, actualLine));
+	}
+
+	private static boolean matches(String expectedLine, String actualLine, boolean failOnPatternSyntaxException) {
+		if (expectedLine.equals(actualLine)) {
+			return true;
+		}
+		try {
+			Pattern pattern = Pattern.compile(expectedLine);
+			Matcher matcher = pattern.matcher(actualLine);
+			return matcher.matches();
+		}
+		catch (PatternSyntaxException exception) {
+			if (failOnPatternSyntaxException) {
+				fail("expected line is not a valid regex pattern" + expectedLine, exception);
+			}
+			return false;
+		}
+	}
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -878,7 +878,7 @@ public final class Assertions {
 	 * list.
 	 *
 	 * <p>This method differs from other assertions that effectively only check {@link String#equals(Object)},
-	 * in that it uses the following staged match-making algorithm:
+	 * in that it uses the following staged matching algorithm:
 	 *
 	 * <p>For each pair of expected and actual lines do
 	 * <ol>

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -873,8 +873,47 @@ public final class Assertions {
 
 	// --- assertLinesMatch ----------------------------------------------------
 
-	public static void assertLinesMatch(List<String> expected, List<String> actual) {
-		AssertLinesMatch.assertLinesMatch(expected, actual);
+	/**
+	 * <em>Asserts</em> that {@code expected} list of {@linkplain String}s matches {@code actual}
+	 * list.
+	 *
+	 * <p>This method differs from other assertions that effectively only check {@link String#equals(Object)},
+	 * in that it uses the following staged match-making algorithm:
+	 *
+	 * <p>For each pair of expected and actual lines do
+	 * <ol>
+	 *   <li>check if {@code expected.equals(actual)} - if yes, continue with next pair</li>
+	 *   <li>otherwise treat {@code expected} as a regular expression and check via
+	 *   {@link String#matches(String)} - if yes, continue with next pair</li>
+	 *   <li>otherwise check if {@code expected} line is a fast-forward marker, if yes apply
+	 *   fast-forward actual lines accordingly (see below) and goto 1.</li>
+	 * </ol>
+	 *
+	 * <p>A valid fast-forward marker is an expected line that starts and ends with the literal
+	 * {@code >>} and contains at least 4 characters. Examples:
+	 * <ul>
+	 *   <li>{@code >>>>}<br>{@code >> stacktrace >>}<br>{@code >> single line, non Integer.parse()-able comment >>}
+	 *   <br>Skip arbitrary number of actual lines, until first matching subsequent expected line is found. Any
+	 *   character between the fast-forward literals are discarded.</li>
+	 *   <li>{@code ">> 21 >>"}
+	 *   <br>Skip strictly 21 lines. If they can't be skipped for any reason, an assertion error is raised.</li>
+	 * </ul>
+	 *
+	 * <p>Example showing all three kinds of expected line formats:
+	 * <pre>{@code
+	 * │  │  │     caught: AssertionFailedError: single line fail message
+	 * >> S T A C K T R A C E >>
+	 * │  │  │   duration: [\d]+ ms
+	 * │  │  │     status: ✘ FAILED
+	 * │  └─ test() finished after [\d]+ ms\.
+	 * └─ JUnit Jupiter finished after [\d]+ ms\.
+	 * Test plan execution finished. Number of all tests: 1
+	 *
+	 * Test run finished after [\d]+ ms
+	 * }</pre>
+	 */
+	public static void assertLinesMatch(List<String> expectedLines, List<String> actualLines) {
+		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines);
 	}
 
 	// --- assertNotEquals -----------------------------------------------------

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.meta.API.Usage.Maintained;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -868,6 +869,12 @@ public final class Assertions {
 	public static void assertIterableEquals(Iterable<?> expected, Iterable<?> actual,
 			Supplier<String> messageSupplier) {
 		AssertIterableEquals.assertIterableEquals(expected, actual, messageSupplier);
+	}
+
+	// --- assertLinesMatch ----------------------------------------------------
+
+	public static void assertLinesMatch(List<String> expected, List<String> actual) {
+		AssertLinesMatch.assertLinesMatch(expected, actual);
 	}
 
 	// --- assertNotEquals -----------------------------------------------------

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for JUnit Jupiter {@link Assertions}.
+ *
+ * @since 5.0
+ */
+public class AssertionsAssertLinesMatchTests {
+
+	@Test
+	void assertLinesMatchesToSelf() {
+		List<String> list = Arrays.asList("first line", "second line", "third line", "last line");
+		AssertLinesMatch.assertLinesMatch(list, list);
+	}
+
+	@Test
+	void assertLinesMatchesPlainEqualLists() {
+		List<String> expected = Arrays.asList("first line", "second line", "third line", "last line");
+		List<String> actual = Arrays.asList("first line", "second line", "third line", "last line");
+		AssertLinesMatch.assertLinesMatch(expected, actual);
+	}
+
+	@Test
+	void assertLinesMatchesUsingRegexPatterns() {
+		List<String> expected = Arrays.asList("^first.+line", "second\\s*line", "th.rd l.ne", "last line$");
+		List<String> actual = Arrays.asList("first line", "second line", "third line", "last line");
+		AssertLinesMatch.assertLinesMatch(expected, actual);
+	}
+
+	@Test
+	void assertLinesMatchesUsingFastForwardCommand() {
+		List<String> expected = Arrays.asList("first line", "{{ skip lines until next matches }}", "last line");
+		List<String> actual = Arrays.asList("first line", "second line", "third line", "last line");
+		AssertLinesMatch.assertLinesMatch(expected, actual);
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java
@@ -42,9 +42,15 @@ public class AssertionsAssertLinesMatchTests {
 
 	@Test
 	void assertLinesMatchesUsingFastForwardCommand() {
-		List<String> expected = Arrays.asList("first line", "{{ skip lines until next matches }}", "last line");
+		List<String> expected = Arrays.asList("first line", ">> skip lines until next matches >>", "last line");
 		List<String> actual = Arrays.asList("first line", "second line", "third line", "last line");
 		AssertLinesMatch.assertLinesMatch(expected, actual);
 	}
 
+	@Test
+	void assertLinesMatchesUsingFastForwardCommandWithLimit() {
+		List<String> expected = Arrays.asList("first line", ">> 1 >>", "last line");
+		List<String> actual = Arrays.asList("first line", "skipped", "last line");
+		AssertLinesMatch.assertLinesMatch(expected, actual);
+	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java
@@ -13,7 +13,6 @@ package org.junit.jupiter.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -77,11 +76,19 @@ public class AssertionsAssertLinesMatchTests {
 	}
 
 	@Test
+	void assertLinesMatchMoreActualLinesThenExpectedFails() {
+		List<String> expected = Arrays.asList("first line", "second line", "third line");
+		List<String> actual = Arrays.asList("first line", "second line", "third line", "last line");
+		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
+		assertEquals("more actual lines than expected: 1", error.getMessage());
+	}
+
+	@Test
 	void assertLinesMatchUsingFastForwardMarkerWithTooLowLimitFails() {
 		List<String> expected = Arrays.asList("first line", ">> 1 >>");
 		List<String> actual = Arrays.asList("first line", "skipped", "last line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
-		assertTrue(error.getMessage().contains("wrong number of actual lines remaining"));
+		assertEquals("terminal fast-forward(1) error: fast-forward(2) expected", error.getMessage());
 	}
 
 	@Test
@@ -89,6 +96,6 @@ public class AssertionsAssertLinesMatchTests {
 		List<String> expected = Arrays.asList("first line", ">> 100 >>");
 		List<String> actual = Arrays.asList("first line", "skipped", "last line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
-		assertEquals("fast-forward 100 lines failed, only 2 lines left", error.getMessage());
+		assertEquals("terminal fast-forward(100) error: fast-forward(2) expected", error.getMessage());
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java
@@ -10,9 +10,13 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertLinesMatch.isFastForwardLine;
+import static org.junit.jupiter.api.AssertLinesMatch.parseFastForwardLimit;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -97,5 +101,34 @@ public class AssertionsAssertLinesMatchTests {
 		List<String> actual = Arrays.asList("first line", "skipped", "last line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
 		assertEquals("terminal fast-forward(100) error: fast-forward(2) expected", error.getMessage());
+	}
+
+	@Test
+	void assertLinesMatchIsFastForwardLine() {
+		assertAll("valid fast-forward lines", //
+			() -> assertTrue(isFastForwardLine(">>>>")), () -> assertTrue(isFastForwardLine(">> >>")),
+			() -> assertTrue(isFastForwardLine(">> stacktrace >>")),
+			() -> assertTrue(isFastForwardLine(">> single line, non Integer.parse()-able comment >>")),
+			() -> assertTrue(isFastForwardLine(">>9>>")), () -> assertTrue(isFastForwardLine(">> 9 >>")),
+			() -> assertTrue(isFastForwardLine(">> -9 >>")));
+	}
+
+	@Test
+	void assertLinesMatchParseFastForwardLimit() {
+		assertAll("valid fast-forward limits", //
+			() -> assertEquals(Integer.MAX_VALUE, parseFastForwardLimit(">>>>")),
+			() -> assertEquals(Integer.MAX_VALUE, parseFastForwardLimit(">> >>")),
+			() -> assertEquals(Integer.MAX_VALUE, parseFastForwardLimit(">> stacktrace >>")),
+			() -> assertEquals(Integer.MAX_VALUE, parseFastForwardLimit(">> non Integer.parse()-able comment >>")),
+			() -> assertEquals(9, parseFastForwardLimit(">>9>>")),
+			() -> assertEquals(9, parseFastForwardLimit(">> 9 >>")));
+	}
+
+	@Test
+	void assertLinesMatchMatches() {
+		assertAll("valid fast-forward lines", //
+			() -> assertTrue(AssertLinesMatch.matches("123", "123")),
+			() -> assertTrue(AssertLinesMatch.matches(".*", "123")),
+			() -> assertTrue(AssertLinesMatch.matches("\\d+", "123")));
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
@@ -13,6 +13,7 @@ package org.junit.platform.console;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethods;
@@ -29,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -208,7 +208,7 @@ class ConsoleDetailsTests {
 			List<String> expectedLines = Files.readAllLines(path, UTF_8);
 			List<String> actualLines = asList(result.out.split("\\R"));
 
-			Assertions.assertLinesMatch(expectedLines, actualLines);
+			assertLinesMatch(expectedLines, actualLines);
 		}
 	}
 }

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-flat-ascii.out.txt
@@ -7,7 +7,7 @@ Finished:    failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit
              line
              fail
              message
-S T A C K T R A C E
+>> S T A C K T R A C E >>
 Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-flat-unicode.out.txt
@@ -7,7 +7,7 @@ Finished:    failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit
              line
              fail
              message
-S T A C K T R A C E
+>> S T A C K T R A C E >>
 Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-verbose-ascii.out.txt
@@ -11,7 +11,7 @@ Test plan execution started. Number of static tests: 1
 | | |              line
 | | |              fail
 | | |              message
-S T A C K T R A C E
+>> S T A C K T R A C E >>
 \| \| \|  duration: [\d]+ ms
 | | |    status: [X] FAILED
 \| '-- Fail finished after [\d]+ ms\.

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-verbose-unicode.out.txt
@@ -11,7 +11,7 @@ Test plan execution started. Number of static tests: 1
 │  │  │               line
 │  │  │               fail
 │  │  │               message
-S T A C K T R A C E
+>> S T A C K T R A C E >>
 │  │  │   duration: [\d]+ ms
 │  │  │     status: ✘ FAILED
 │  └─ Fail finished after [\d]+ ms\.

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-flat-ascii.out.txt
@@ -4,7 +4,7 @@ Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.Cons
 Started:     failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()])
 Finished:    failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()])
              => Exception: org.opentest4j.AssertionFailedError: single line fail message
-S T A C K T R A C E
+>> S T A C K T R A C E >>
 Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-flat-unicode.out.txt
@@ -4,7 +4,7 @@ Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.Cons
 Started:     failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()])
 Finished:    failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()])
              => Exception: org.opentest4j.AssertionFailedError: single line fail message
-S T A C K T R A C E
+>> S T A C K T R A C E >>
 Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-verbose-ascii.out.txt
@@ -8,7 +8,7 @@ Test plan execution started. Number of static tests: 1
 | | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
 | | |    caught: org.opentest4j.AssertionFailedError: single line fail message
-S T A C K T R A C E
+>> S T A C K T R A C E >>
 \| \| \|  duration: [\d]+ ms
 | | |    status: [X] FAILED
 \| '-- Fail finished after [\d]+ ms\.

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-verbose-unicode.out.txt
@@ -8,7 +8,7 @@ Test plan execution started. Number of static tests: 1
 │  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
 │  │  │     caught: org.opentest4j.AssertionFailedError: single line fail message
-S T A C K T R A C E
+>> S T A C K T R A C E >>
 │  │  │   duration: [\d]+ ms
 │  │  │     status: ✘ FAILED
 │  └─ Fail finished after [\d]+ ms\.


### PR DESCRIPTION
## Overview

This is PR promotes an assertion utility developed for internal `List<String>` comparsion to the public Jupiter API as `org.junit.jupiter.api.Assertions.assertLinesMatch(List<String> expected, List<String> actual)`

Simple example:
```
List<String> expected = Arrays.asList("^first.+line", ".[[oO)", "last line$");
List<String> actual = Arrays.asList("first line", ".[[oO)", "last line");
assertLinesMatch(expected, actual);
```
File/System.out-based [example](https://github.com/junit-team/junit5/blob/assert_lines_match/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java#L207):
```
List<String> expectedLines = Files.readAllLines(path, UTF_8);
List<String> actualLines = asList(result.out.split("\\R"));

assertLinesMatch(expectedLines, actualLines);
```

## Motivation

The new assertion enhances the already existing `assertIterableEquals(Iterable<?> expected, Iterable<?> actual)` by supporting the following "match outline" in sequence:

1. test simple `String` equality fur current expected and actual line
2. treat the expected line as a regular expression pattern and match the actual line
3. interpret fast-forward marker `>> [limit | or some arbitrary comment ] >>` to skip a (limited) block of actual lines. If the fast-forward limit is not given, the skipped block grows until the next expected line is found.

See [AssertionsAssertLinesMatchTests.java](https://github.com/junit-team/junit5/blob/assert_lines_match/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertLinesMatchTests.java) for more usage examples.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
