### PR TITLE
Add Launcher.execute(Request, Listener…) overload

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -48,6 +48,11 @@ on GitHub.
   by an executable standalone JAR distribution. For details, see the "New Features" section below.
 * The `MethodSortOrder` enum in `ReflectionUtils` has been renamed to `HierarchyTraversalMode`. Those
   affected should now use `ReflectionSupport` instead of `ReflectionUtils`.
+* The method `execute(LauncherDiscoveryRequest launcherDiscoveryRequest)` in `Launcher` has been
+  deprecated and will be removed in milestone M5. Instead use the following new method that registers
+  supplied ``TestExecutionListener``s in addition to already registered listeners but only for the
+  supplied `LauncherDiscoveryRequest`:
+  `execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners)`
 
 ===== New Features
 

--- a/documentation/src/test/java/example/UsingTheLauncherDemo.java
+++ b/documentation/src/test/java/example/UsingTheLauncherDemo.java
@@ -66,7 +66,7 @@ class UsingTheLauncherDemo {
 		TestExecutionListener listener = new SummaryGeneratingListener();
 		launcher.registerTestExecutionListeners(listener);
 
-		launcher.execute(request);
+		launcher.execute(request, new TestExecutionListener[0]);
 		// end::execution[]
 		// @formatter:on
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -62,7 +62,7 @@ public class ConsoleTestExecutor {
 		SummaryGeneratingListener summaryListener = registerListeners(out, launcher);
 
 		LauncherDiscoveryRequest discoveryRequest = new DiscoveryRequestCreator().toDiscoveryRequest(options);
-		launcher.execute(discoveryRequest);
+		launcher.execute(discoveryRequest, new TestExecutionListener[0]);
 
 		TestExecutionSummary summary = summaryListener.getSummary();
 		printSummary(summary, out);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
@@ -81,8 +81,29 @@ public interface Launcher {
 	 * collecting their results, and notify {@linkplain #registerTestExecutionListeners
 	 * registered listeners} about the progress and results of the execution.
 	 *
-	 * @param launcherDiscoveryRequest the launcher discovery request; never {@code null}
+	 * <p>The <em>deprecated</em> default implementation delegates to
+	 * {@link #execute(LauncherDiscoveryRequest, TestExecutionListener...)} with no
+	 * additional listeners.
+	 *
+	 * <p>The method will be removed in milestone M5.
+	 * @deprecated Use {@link #execute(LauncherDiscoveryRequest, TestExecutionListener...)} instead.
 	 */
-	void execute(LauncherDiscoveryRequest launcherDiscoveryRequest);
+	@Deprecated
+	default void execute(LauncherDiscoveryRequest launcherDiscoveryRequest) {
+		execute(launcherDiscoveryRequest, new TestExecutionListener[0]);
+	}
 
+	/**
+	 * Execute a {@link TestPlan} which is built according to the supplied
+	 * {@link LauncherDiscoveryRequest} by querying all registered engines and
+	 * collecting their results, and notify {@linkplain #registerTestExecutionListeners
+	 * registered listeners} about the progress and results of the execution.
+	 *
+	 * <p>Supplied test execution listeners are registered in addition to already
+	 * registered listeners but only for the supplied launcher discovery request.
+	 *
+	 * @param launcherDiscoveryRequest the launcher discovery request; never {@code null}
+	 * @param listeners additional test execution listeners; never {@code null}
+	 */
+	void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners);
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestExecutionListenerRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestExecutionListenerRegistry.java
@@ -10,8 +10,8 @@
 
 package org.junit.platform.launcher.core;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -26,7 +26,18 @@ import org.junit.platform.launcher.TestPlan;
  */
 class TestExecutionListenerRegistry {
 
-	private final List<TestExecutionListener> testExecutionListeners = new LinkedList<>();
+	private final List<TestExecutionListener> testExecutionListeners;
+
+	TestExecutionListenerRegistry() {
+		this(null);
+	}
+
+	TestExecutionListenerRegistry(TestExecutionListenerRegistry source) {
+		this.testExecutionListeners = new ArrayList<>();
+		if (source != null) {
+			this.testExecutionListeners.addAll(source.testExecutionListeners);
+		}
+	}
 
 	List<TestExecutionListener> getTestExecutionListeners() {
 		return testExecutionListeners;

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
@@ -37,6 +37,7 @@ import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
@@ -128,7 +129,7 @@ public class JUnitPlatform extends Runner implements Filterable {
 	public void run(RunNotifier notifier) {
 		JUnitPlatformRunnerListener listener = new JUnitPlatformRunnerListener(this.testTree, notifier);
 		this.launcher.registerTestExecutionListeners(listener);
-		this.launcher.execute(this.discoveryRequest);
+		this.launcher.execute(this.discoveryRequest, new TestExecutionListener[0]);
 	}
 
 	private JUnitPlatformTestTree generateTestTree() {

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/JUnitPlatformProvider.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/JUnitPlatformProvider.java
@@ -41,6 +41,7 @@ import org.junit.platform.engine.Filter;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TagFilter;
+import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.core.LauncherFactory;
 
 /**
@@ -124,7 +125,7 @@ public class JUnitPlatformProvider extends AbstractProvider {
 
 		LauncherDiscoveryRequest discoveryRequest = request().selectors(selectClass(testClass)).filters(
 			includeAndExcludeFilters).build();
-		launcher.execute(discoveryRequest);
+		launcher.execute(discoveryRequest, new TestExecutionListener[0]);
 
 		runListener.testSetCompleted(classEntry);
 	}

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/XmlReportsWritingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/XmlReportsWritingListenerTests.java
@@ -52,6 +52,7 @@ import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestDescri
 import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestEngine;
 import org.junit.platform.engine.test.TestDescriptorStub;
 import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.opentest4j.AssertionFailedError;
@@ -414,7 +415,8 @@ class XmlReportsWritingListenerTests {
 		XmlReportsWritingListener reportListener = new XmlReportsWritingListener(tempDirectory.toString(), out, clock);
 		Launcher launcher = createLauncher(engine);
 		launcher.registerTestExecutionListeners(reportListener);
-		launcher.execute(request().selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))).build());
+		launcher.execute(request().selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))).build(),
+			new TestExecutionListener[0]);
 	}
 
 	private String readValidXmlFile(Path xmlFile) throws Exception {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -40,6 +40,7 @@ import org.junit.platform.launcher.PostDiscoveryFilterStub;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 
 /**
  * @since 1.0
@@ -299,7 +300,7 @@ class DefaultLauncherTests {
 		TestEngineSpy engine = new TestEngineSpy();
 
 		DefaultLauncher launcher = createLauncher(engine);
-		launcher.execute(request().build());
+		launcher.execute(request().build(), new TestExecutionListener[0]);
 
 		ConfigurationParameters configurationParameters = engine.requestForExecution.getConfigurationParameters();
 		assertThat(configurationParameters.get("key").isPresent()).isFalse();
@@ -311,7 +312,7 @@ class DefaultLauncherTests {
 		TestEngineSpy engine = new TestEngineSpy();
 
 		DefaultLauncher launcher = createLauncher(engine);
-		launcher.execute(request().configurationParameter("key", "value").build());
+		launcher.execute(request().configurationParameter("key", "value").build(), new TestExecutionListener[0]);
 
 		ConfigurationParameters configurationParameters = engine.requestForExecution.getConfigurationParameters();
 		assertThat(configurationParameters.size()).isEqualTo(1);
@@ -327,7 +328,7 @@ class DefaultLauncherTests {
 			TestEngineSpy engine = new TestEngineSpy();
 
 			DefaultLauncher launcher = createLauncher(engine);
-			launcher.execute(request().build());
+			launcher.execute(request().build(), new TestExecutionListener[0]);
 
 			ConfigurationParameters configurationParameters = engine.requestForExecution.getConfigurationParameters();
 			assertThat(configurationParameters.size()).isEqualTo(0);
@@ -340,4 +341,16 @@ class DefaultLauncherTests {
 		}
 	}
 
+	@Test
+	void withAdditionalListener() {
+		TestEngineSpy engine = new TestEngineSpy();
+		SummaryGeneratingListener listener = new SummaryGeneratingListener();
+
+		DefaultLauncher launcher = createLauncher(engine);
+		launcher.execute(request().build(), listener);
+
+		assertThat(listener.getSummary()).isNotNull();
+		assertThat(listener.getSummary().getContainersFoundCount()).isEqualTo(1);
+		assertThat(listener.getSummary().getTestsFoundCount()).isEqualTo(1);
+	}
 }


### PR DESCRIPTION
## Overview

Addresses #628 by adding an overloaded execute(LauncherDiscoveryRequest, TestExecutionListener) method that uses the supplied TestExecutionListeners in addition to already registered listeners but only for the supplied LauncherDiscoveryRequest.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
