### PR TITLE
TestIdentifier now uses TestDescriptor.Type

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M4.adoc
@@ -131,7 +131,10 @@ on GitHub.
   only delegate to `TestDescriptor.Type` constants now.
 * Introduced `TestDescriptor.prune()` and `TestDescriptor.pruneTree()` which allow engine authors
   to customize what happens when pruning is triggered by the JUnit Platform.
-
+* `TestIdentifier` now also uses the new enumeration `TestDescriptor.Type` to store the
+  underlying type. It can be retrieved via the new `TestIdentifier.getType()` getter and
+  `TestIdentifier.isTest()` and `TestIdentifier.isContainer()` only delegate to
+  `TestDescriptor.Type` constants now.
 
 [[release-notes-5.0.0-m4-junit-vintage]]
 ==== JUnit Vintage

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
@@ -222,12 +222,13 @@ class RunListenerAdapterTests {
 		when(parent.getUniqueId()).thenReturn(newId());
 		when(parent.getDisplayName()).thenReturn(parentDisplay);
 		when(parent.getLegacyReportingName()).thenReturn(parentDisplay);
+		when(parent.getType()).thenReturn(TestDescriptor.Type.CONTAINER);
 		TestIdentifier parentId = TestIdentifier.from(parent);
 
 		// The (child) test case that is to be executed as part of a test plan.
 		TestDescriptor child = mock(TestDescriptor.class);
 		when(child.getUniqueId()).thenReturn(newId());
-		when(child.isTest()).thenReturn(true);
+		when(child.getType()).thenReturn(TestDescriptor.Type.TEST);
 
 		// Ensure the child source is null yet that there is a parent -- the special case to be tested.
 		when(child.getSource()).thenReturn(Optional.empty());


### PR DESCRIPTION
## Overview

This PR addresses part of #407 by using the new `TestDescriptor.Type` enum as new property of `TestIdentifier`. `TestIdentifier.isContainer()` and `TestIdentifier.isTest()` now also only delegate their work to `TestDescriptor.Type#isContainer()/isTest()`.

This PR also removes unnecessary Optional-wrapper usages within the creation of `TestIdentifier`s.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
