### PR TITLE
Introduce extension point before test instantiation

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/BeforeTestInstantiationCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/BeforeTestInstantiationCallback.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import org.junit.platform.commons.meta.API;
+
+/**
+ * {@code BeforeTestInstantiationCallback} defines the API for {@link Extension
+ * Extensions} that wish to provide additional behavior to tests immediately
+ * before each test instance is created.
+ *
+ * <p>Implementations must provide a no-args constructor.
+ *
+ * @since 5.0
+ * @see org.junit.jupiter.api.Test
+ * @see BeforeTestExecutionCallback
+ * @see AfterTestExecutionCallback
+ * @see BeforeEachCallback
+ * @see AfterEachCallback
+ * @see BeforeAllCallback
+ * @see AfterAllCallback
+ */
+@FunctionalInterface
+@API(Experimental)
+public interface BeforeTestInstantiationCallback extends Extension {
+
+	/**
+	 * Callback that is invoked <em>immediately before</em> each test instance is created.
+	 *
+	 * @param context the current extension context; never {@code null}
+	 */
+	void beforeTestInstantiation(ContainerExtensionContext context) throws Exception;
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeTestInstantiationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeTestInstantiationTests.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeTestInstantiationCallback;
+import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.engine.JupiterTestEngine;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+
+/**
+ * Integration tests that verify support for {@link BeforeTestInstantiationCallback} in the
+ * {@link JupiterTestEngine}.
+ *
+ * @since 5.0
+ */
+public class BeforeTestInstantiationTests extends AbstractJupiterTestEngineTests {
+
+	private static final List<String> callSequence = new ArrayList<>();
+
+	@Test
+	void beforeTestInstantiationCallback() {
+		// @formatter:off
+		assertBeforeTestInstantiationCallback(TopLevelTestCase.class,
+				"fooBeforeAllCallback",
+				"barBeforeAllCallback",
+					"beforeAllMethod-1",
+						"fooBeforeTestInstantiationCallback",
+						"barBeforeTestInstantiationCallback",
+							"constructor-1"
+		);
+		// @formatter:on
+	}
+
+	@Test
+	void beforeTestInstantiationCallbackInSubclass() {
+		// @formatter:off
+		assertBeforeTestInstantiationCallback(SecondLevelTestCase.class,
+				"fooBeforeAllCallback",
+				"barBeforeAllCallback",
+				"bazBeforeAllCallback",
+					"beforeAllMethod-1",
+					"beforeAllMethod-2",
+						"fooBeforeTestInstantiationCallback",
+						"barBeforeTestInstantiationCallback",
+						"bazBeforeTestInstantiationCallback",
+							"constructor-1",
+							"constructor-2",
+					"afterAllMethod-2"
+		);
+		// @formatter:on
+	}
+
+	@Test
+	void beforeAllMethodThrowsAnException() {
+		// @formatter:off
+		assertBeforeTestInstantiationCallback(ExceptionInBeforeTestInstantiationTestCase.class, 0,
+				"fooBeforeAllCallback",
+					"fooBeforeTestInstantiationCallback",
+						"exceptionThrowingBeforeTestInstantiationCallback",  // throws an exception.
+							// test should not get invoked.
+				"afterAllMethod"
+		);
+		// @formatter:on
+	}
+
+	private void assertBeforeTestInstantiationCallback(Class<?> testClass, String... expectedCalls) {
+		assertBeforeTestInstantiationCallback(testClass, 1, expectedCalls);
+	}
+
+	private void assertBeforeTestInstantiationCallback(Class<?> testClass, int testsSuccessful,
+			String... expectedCalls) {
+		callSequence.clear();
+		LauncherDiscoveryRequest request = request().selectors(selectClass(testClass)).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertEquals(1, eventRecorder.getTestStartedCount(), "# tests started");
+		assertEquals(testsSuccessful, eventRecorder.getTestSuccessfulCount(), "# tests succeeded");
+
+		assertEquals(asList(expectedCalls), callSequence, () -> "wrong call sequence for " + testClass.getName());
+	}
+
+	// -------------------------------------------------------------------------
+
+	// Must NOT be private; otherwise, the @Test method gets discovered but never executed.
+	@ExtendWith({ FooClassLevelCallbacks.class, BarClassLevelCallbacks.class })
+	static class TopLevelTestCase {
+
+		public TopLevelTestCase() {
+			callSequence.add("constructor-1");
+		}
+
+		@BeforeAll
+		static void beforeAll1() {
+			callSequence.add("beforeAllMethod-1");
+		}
+
+		@Test
+		void test() {
+		}
+	}
+
+	// Must NOT be private; otherwise, the @Test method gets discovered but never executed.
+	@ExtendWith(BazClassLevelCallbacks.class)
+	static class SecondLevelTestCase extends TopLevelTestCase {
+
+		public SecondLevelTestCase() {
+			callSequence.add("constructor-2");
+		}
+
+		@BeforeAll
+		static void beforeAll2() {
+			callSequence.add("beforeAllMethod-2");
+		}
+
+		@AfterAll
+		static void afterAll2() {
+			callSequence.add("afterAllMethod-2");
+		}
+	}
+
+	@ExtendWith({ FooClassLevelCallbacks.class, ExceptionThrowingBeforeTestInstantiationCallback.class })
+	private static class ExceptionInBeforeTestInstantiationTestCase {
+
+		@Test
+		void test() {
+			callSequence.add("test");
+		}
+
+		@AfterAll
+		static void afterAll() {
+			callSequence.add("afterAllMethod");
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	private static class FooClassLevelCallbacks implements BeforeAllCallback, BeforeTestInstantiationCallback {
+
+		@Override
+		public void beforeAll(ContainerExtensionContext testExecutionContext) {
+			callSequence.add("fooBeforeAllCallback");
+		}
+
+		@Override
+		public void beforeTestInstantiation(ContainerExtensionContext context) throws Exception {
+			callSequence.add("fooBeforeTestInstantiationCallback");
+		}
+	}
+
+	private static class BarClassLevelCallbacks implements BeforeAllCallback, BeforeTestInstantiationCallback {
+
+		@Override
+		public void beforeAll(ContainerExtensionContext testExecutionContext) {
+			callSequence.add("barBeforeAllCallback");
+		}
+
+		@Override
+		public void beforeTestInstantiation(ContainerExtensionContext context) throws Exception {
+			callSequence.add("barBeforeTestInstantiationCallback");
+		}
+	}
+
+	private static class BazClassLevelCallbacks implements BeforeAllCallback, BeforeTestInstantiationCallback {
+
+		@Override
+		public void beforeAll(ContainerExtensionContext testExecutionContext) {
+			callSequence.add("bazBeforeAllCallback");
+		}
+
+		@Override
+		public void beforeTestInstantiation(ContainerExtensionContext context) throws Exception {
+			callSequence.add("bazBeforeTestInstantiationCallback");
+		}
+	}
+
+	private static class ExceptionThrowingBeforeTestInstantiationCallback implements BeforeTestInstantiationCallback {
+
+		@Override
+		public void beforeTestInstantiation(ContainerExtensionContext context) throws Exception {
+			callSequence.add("exceptionThrowingBeforeTestInstantiationCallback");
+			throw new RuntimeException("BeforeTestInstantiationCallback");
+		}
+	}
+
+}


### PR DESCRIPTION
To migrate our existing framework to JUnit 5 I'd like to hook into the lifecycle of JUnit 5 test execution before any test instance is created.

We want to configure the test environment for each test right before the test instance is created.

 * TestInstancePostProcessor is too late, as instance fields have already been initialized.
 * BeforeAll is not appropriate, as we need to configure the environment for each test run.

 ---
 I hereby agree to the terms of the JUnit Contributor License Agreement.

## Overview

Please describe your changes here and list any open questions you might have.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
