### PR TITLE
Invoke TestExecutionExceptionHandlers in reversed order, analogous to After*Callbacks

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodTestDescriptor.java
@@ -180,7 +180,8 @@ public class MethodTestDescriptor extends MethodBasedTestDescriptor {
 	private void invokeTestExecutionExceptionHandlers(ExtensionRegistry registry, TestExtensionContext context,
 			Throwable ex) {
 
-		invokeTestExecutionExceptionHandlers(ex, registry.getExtensions(TestExecutionExceptionHandler.class), context);
+		invokeTestExecutionExceptionHandlers(ex, registry.getReversedExtensions(TestExecutionExceptionHandler.class),
+			context);
 	}
 
 	private void invokeTestExecutionExceptionHandlers(Throwable ex, List<TestExecutionExceptionHandler> handlers,

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestExecutionExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestExecutionExceptionHandlerTests.java
@@ -155,10 +155,10 @@ class TestExecutionExceptionHandlerTests extends AbstractJupiterTestEngineTests 
 		}
 
 		@Test
-		@ExtendWith(ConvertException.class)
-		@ExtendWith(RethrowException.class)
-		@ExtendWith(SwallowException.class)
 		@ExtendWith(ShouldNotBeCalled.class)
+		@ExtendWith(SwallowException.class)
+		@ExtendWith(RethrowException.class)
+		@ExtendWith(ConvertException.class)
 		void testSeveral() {
 			throw new RuntimeException("unchecked");
 		}


### PR DESCRIPTION
## Overview

I think extensions should behave consistently whenever the test method is exited. This requires calling exception handlers in reversed order, the same way as after callbacks are called. In particular, if two extensions a and b implement before and exception handling callbacks, one would expect

- before-a
- before-b
- handle-exception-b
- handle-exception-a

to provide an around like behavior (same as JUnit 4 rule chains).

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
