### PR TITLE
Gradle plugin improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ install: ./gradlew -version
 script:
   - java -version
   - ./gradlew -version
-  - ./gradlew --refresh-dependencies clean check -Dscan
+  - ./gradlew --refresh-dependencies clean check --scan

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ allprojects { subproj ->
 	}
 
 	checkstyle {
-		toolVersion = 6.11
+		toolVersion = '7.6'
 	}
 	checkstyleMain {
 		configFile = rootProject.file('src/checkstyle/checkstyleMain.xml')

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 }
 
 plugins {
-	id 'com.gradle.build-scan' version '1.3'
+	id 'com.gradle.build-scan' version '1.6'
 	id 'net.nemerosa.versioning' version '2.6.0'
 }
 

--- a/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
+++ b/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
@@ -1,14 +1,47 @@
 apply plugin: 'groovy'
 
+configurations {
+	functionalTestRuntimeTestCompile {
+		description = 'Local dependencies used for compiling tests source code inside of Gradle functional tests'
+	}
+	functionalTestRuntimeTestRuntime {
+		description = 'Local dependencies used for tests runtime inside of Gradle functional tests'
+	}
+}
+
+// Write the plugin's classpath to a file to share with the tests.
+// See https://docs.gradle.org/current/userguide/test_kit.html
+Task createClasspathManifests = tasks.create('createClasspathManifests') {
+	description = 'Generate classpath manifests for functional tests so that they can reference locally built libraries for use with Gradle Test Kit'
+	File functionalTestClasspathsDir = file("$buildDir/functionalTestClasspathManifests")
+
+	inputs.files sourceSets.main.runtimeClasspath
+	inputs.files configurations.functionalTestRuntimeTestCompile
+	inputs.files configurations.functionalTestRuntimeTestRuntime
+	outputs.dir functionalTestClasspathsDir
+
+	doLast {
+		functionalTestClasspathsDir.mkdirs()
+		file("$functionalTestClasspathsDir/plugin-classpath.txt").text = sourceSets.main.runtimeClasspath.join(System.lineSeparator())
+		file("$functionalTestClasspathsDir/test-compile-classpath.txt").text = configurations.functionalTestRuntimeTestCompile.join(System.lineSeparator())
+		file("$functionalTestClasspathsDir/test-runtime-classpath.txt").text = configurations.functionalTestRuntimeTestRuntime.join(System.lineSeparator())
+	}
+}
+
 dependencies {
 	implementation localGroovy()
 	implementation gradleApi()
 	api(project(path: ':junit-platform-console', configuration: 'shadow'))
 	api(project(':junit-platform-launcher'))
-	testImplementation('org.spockframework:spock-core:1.0-groovy-2.4') {
-		transitive = false
-	}
 	testRuntimeOnly("junit:junit:${junit4Version}")
+	testImplementation('org.spockframework:spock-core:1.0-groovy-2.4') {
+		exclude module: 'groovy-all'
+	}
+	testImplementation(gradleTestKit())
+	functionalTestRuntimeTestCompile(project(':junit-jupiter-api'))
+	functionalTestRuntimeTestRuntime(project(':junit-platform-console'))
+	functionalTestRuntimeTestRuntime(project(':junit-jupiter-engine'))
+	testRuntimeOnly(files(createClasspathManifests))
 }
 
 processResources {

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -52,8 +52,15 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 			deps.add(project.dependencies.create("org.junit.platform:junit-platform-console:${version}"))
 		}
 
+		JavaExec junitTask = project.tasks.create(TASK_NAME, JavaExec) {
+			it.with {
+				group = JavaBasePlugin.VERIFICATION_GROUP
+				description = 'Runs tests on the JUnit Platform.'
+			}
+		}
+
 		project.afterEvaluate {
-			configure(project, junitExtension)
+			configure(project, junitTask, junitExtension)
 		}
 	}
 
@@ -65,48 +72,46 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 		return properties.getProperty("version")
 	}
 
-	private void configure(Project project, JUnitPlatformExtension junitExtension) {
-		project.tasks.create(TASK_NAME, JavaExec) { junitTask ->
-			junitTask.with {
-				group = JavaBasePlugin.VERIFICATION_GROUP
-				description = 'Runs tests on the JUnit Platform.'
-				inputs.property('enableStandardTestTask', junitExtension.enableStandardTestTask)
-				inputs.property('selectors.uris', junitExtension.selectors.uris)
-				inputs.property('selectors.files', junitExtension.selectors.files)
-				inputs.property('selectors.directories', junitExtension.selectors.directories)
-				inputs.property('selectors.packages', junitExtension.selectors.packages)
-				inputs.property('selectors.classes', junitExtension.selectors.classes)
-				inputs.property('selectors.methods', junitExtension.selectors.methods)
-				inputs.property('selectors.resources', junitExtension.selectors.resources)
-				inputs.property('filters.engines.include', junitExtension.filters.engines.include)
-				inputs.property('filters.engines.exclude', junitExtension.filters.engines.exclude)
-				inputs.property('filters.tags.include', junitExtension.filters.tags.include)
-				inputs.property('filters.tags.exclude', junitExtension.filters.tags.exclude)
-				inputs.property('filters.includeClassNamePatterns', junitExtension.filters.includeClassNamePatterns)
-				inputs.property('filters.packages.include', junitExtension.filters.packages.include)
-				inputs.property('filters.packages.exclude', junitExtension.filters.packages.exclude)
+	private void configure(Project project, JavaExec junitTask, JUnitPlatformExtension junitExtension) {
+		junitTask.with {
+			group = JavaBasePlugin.VERIFICATION_GROUP
+			description = 'Runs tests on the JUnit Platform.'
+			inputs.property('enableStandardTestTask', junitExtension.enableStandardTestTask)
+			inputs.property('selectors.uris', junitExtension.selectors.uris)
+			inputs.property('selectors.files', junitExtension.selectors.files)
+			inputs.property('selectors.directories', junitExtension.selectors.directories)
+			inputs.property('selectors.packages', junitExtension.selectors.packages)
+			inputs.property('selectors.classes', junitExtension.selectors.classes)
+			inputs.property('selectors.methods', junitExtension.selectors.methods)
+			inputs.property('selectors.resources', junitExtension.selectors.resources)
+			inputs.property('filters.engines.include', junitExtension.filters.engines.include)
+			inputs.property('filters.engines.exclude', junitExtension.filters.engines.exclude)
+			inputs.property('filters.tags.include', junitExtension.filters.tags.include)
+			inputs.property('filters.tags.exclude', junitExtension.filters.tags.exclude)
+			inputs.property('filters.includeClassNamePatterns', junitExtension.filters.includeClassNamePatterns)
+			inputs.property('filters.packages.include', junitExtension.filters.packages.include)
+			inputs.property('filters.packages.exclude', junitExtension.filters.packages.exclude)
 
-				def reportsDir = junitExtension.reportsDir ?: project.file("$project.buildDir/test-results/junit-platform")
-				outputs.dir reportsDir
+			def reportsDir = junitExtension.reportsDir ?: project.file("$project.buildDir/test-results/junit-platform")
+			outputs.dir reportsDir
 
-				if (junitExtension.logManager) {
-					systemProperty 'java.util.logging.manager', junitExtension.logManager
-				}
-
-				configureTaskDependencies(project, it, junitExtension)
-
-				// Build the classpath from the user's test runtime classpath and the JUnit
-				// Platform modules.
-				//
-				// Note: the user's test runtime classpath must come first; otherwise, code
-				// instrumented by Clover in JUnit's build will be shadowed by JARs pulled in
-				// via the junitPlatform configuration... leading to zero code coverage for
-				// the respective modules.
-				classpath = project.sourceSets.test.runtimeClasspath + project.configurations.junitPlatform
-
-				main = ConsoleLauncher.class.getName()
-				args buildArgs(project, junitExtension, reportsDir)
+			if (junitExtension.logManager) {
+				systemProperty 'java.util.logging.manager', junitExtension.logManager
 			}
+
+			configureTaskDependencies(project, it, junitExtension)
+
+			// Build the classpath from the user's test runtime classpath and the JUnit
+			// Platform modules.
+			//
+			// Note: the user's test runtime classpath must come first; otherwise, code
+			// instrumented by Clover in JUnit's build will be shadowed by JARs pulled in
+			// via the junitPlatform configuration... leading to zero code coverage for
+			// the respective modules.
+			classpath = project.sourceSets.test.runtimeClasspath + project.configurations.junitPlatform
+
+			main = ConsoleLauncher.class.getName()
+			args buildArgs(project, junitExtension, reportsDir)
 		}
 	}
 

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.junit.platform.gradle.plugin
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class JUnitPlatformPluginFunctionalSpec extends Specification {
+
+	@Rule
+	final TemporaryFolder testProjectDir = new TemporaryFolder()
+	private File buildFile
+	private List<File> pluginClasspath
+	private List<File> testCompileClasspath
+	private List<File> testRuntimeClasspath
+
+	def setup() {
+		pluginClasspath = loadClassPathManifestResource('plugin-classpath.txt')
+		testCompileClasspath = loadClassPathManifestResource('test-compile-classpath.txt')
+		testRuntimeClasspath = loadClassPathManifestResource('test-runtime-classpath.txt')
+		buildFile = testProjectDir.newFile('build.gradle')
+		buildFile << """
+buildscript {
+	dependencies {
+		classpath files(${splitClasspath(pluginClasspath)})
+	}
+}
+apply plugin: 'org.junit.platform.gradle.plugin'
+"""
+	}
+
+	def "can be used with 'java' plugin"() {
+		given:
+		javaPlugin()
+		javaFile()
+		succeedingTestFile()
+
+		when:
+		BuildResult result = GradleRunner.create()
+																		.withProjectDir(testProjectDir.root)
+																		.withPluginClasspath(pluginClasspath)
+																		.withArguments('build')
+																		.build()
+
+		then:
+		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
+		result.task(':build').outcome == TaskOutcome.SUCCESS
+		result.output.contains('1 tests successful')
+	}
+
+	def "can be used with 'java-library' plugin"() {
+		given:
+		javaFile()
+		succeedingTestFile()
+		javaLibraryPlugin()
+
+		when:
+		BuildResult result = GradleRunner.create()
+																		.withProjectDir(testProjectDir.root)
+																		.withPluginClasspath(pluginClasspath)
+																		.withArguments('build')
+																		.build()
+
+		then:
+		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
+		result.task(':build').outcome == TaskOutcome.SUCCESS
+		result.output.contains('1 tests successful')
+	}
+
+
+	def "failing test fails build with 'java' plugin"() {
+		given:
+		javaFile()
+		failingTestFile()
+		javaPlugin()
+
+		when:
+		BuildResult result = GradleRunner.create()
+																		.withProjectDir(testProjectDir.root)
+																		.withPluginClasspath(pluginClasspath)
+																		.withArguments('build')
+																		.buildAndFail()
+
+		then:
+		result.task(':junitPlatformTest').outcome == TaskOutcome.FAILED
+		result.output.contains('1 tests failed')
+	}
+
+	def "failing test fails build with 'java-library' plugin"() {
+		given:
+		javaFile()
+		failingTestFile()
+		javaLibraryPlugin()
+
+		when:
+		BuildResult result = GradleRunner.create()
+																		.withProjectDir(testProjectDir.root)
+																		.withPluginClasspath(pluginClasspath)
+																		.withArguments('build')
+																		.buildAndFail()
+
+		then:
+		result.task(':junitPlatformTest').outcome == TaskOutcome.FAILED
+		result.output.contains('1 tests failed')
+	}
+
+	private static String splitClasspath(List<File> dependencies) {
+		return dependencies
+			.collect { it.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+			.collect { "'$it'" }
+			.join(', ')
+	}
+
+	private void javaPlugin() {
+		buildFile << """
+apply plugin: 'java'
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+dependencies {
+	testCompile files(${splitClasspath(testCompileClasspath)})
+	testRuntime files(${splitClasspath(testRuntimeClasspath)})
+	// Use local dependencies so that defaultDependencies are not used
+	junitPlatform files(${splitClasspath(testRuntimeClasspath)})
+}
+
+junitPlatform {
+	filters {
+		engines {
+			include 'junit-jupiter'
+		}
+	}
+}
+"""
+	}
+
+	private void javaLibraryPlugin() {
+		buildFile << """
+apply plugin: 'java-library'
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+dependencies {
+	testImplementation files(${splitClasspath(testCompileClasspath)})
+	testRuntimeOnly files(${splitClasspath(testRuntimeClasspath)})
+	// Use local dependencies so that defaultDependencies are not used
+	junitPlatform files(${splitClasspath(testRuntimeClasspath)})
+}
+
+junitPlatform {
+	filters {
+		engines {
+			include 'junit-jupiter'
+		}
+	}
+}
+"""
+	}
+
+	private void javaFile() {
+		Path javaFile = Paths.get(testProjectDir.root.toString(), 'src', 'main', 'java', 'org', 'junit', 'gradletest', 'Adder.java')
+		Files.createDirectories(javaFile.parent)
+		// @formatter:off
+		javaFile.withWriter {
+			it.write(
+				'''
+package org.junit.gradletest;
+
+public class Adder {
+		public int add(int a, int b) {
+				return a + b;
+		}
+}
+''')
+		}
+		// @formatter:on
+	}
+
+	private void failingTestFile() {
+		Path testPath = Paths.get(testProjectDir.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
+		Files.createDirectories(testPath.parent)
+		// @formatter:off
+		testPath.withWriter {
+			it.write('''
+package org.junit.gradletest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class AdderTest {
+		@Test
+		void failingTest() {
+				Adder adder = new Adder();
+				assertEquals(5, adder.add(3, 3), "This should fail!");
+		}
+}
+'''
+			)
+		}
+	}
+
+	private void succeedingTestFile() {
+		Path testPath = Paths.get(testProjectDir.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
+		Files.createDirectories(testPath.parent)
+		// @formatter:off
+		testPath.withWriter {
+			it.write(
+		'''
+package org.junit.gradletest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class AdderTest {
+		@Test
+		void succeedingTest() {
+				Adder adder = new Adder();
+				assertEquals(10, adder.add(5, 5), "This should succeed!");
+		}
+}
+''')
+		}
+	}
+
+	private List<File> loadClassPathManifestResource(String name) {
+		InputStream classpathResource = getClass().classLoader.getResourceAsStream(name)
+		if (classpathResource == null) {
+			throw new IllegalStateException("Did not find required resource with name ${name}")
+		}
+		return classpathResource.readLines().collect { new File(it) }
+	}
+}

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
@@ -51,10 +51,10 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
 		BuildResult result = GradleRunner.create()
-																		.withProjectDir(testProjectDir.root)
-																		.withPluginClasspath(pluginClasspath)
-																		.withArguments('build')
-																		.build()
+			.withProjectDir(testProjectDir.root)
+			.withPluginClasspath(pluginClasspath)
+			.withArguments('build')
+			.build()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
@@ -70,10 +70,10 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
 		BuildResult result = GradleRunner.create()
-																		.withProjectDir(testProjectDir.root)
-																		.withPluginClasspath(pluginClasspath)
-																		.withArguments('build')
-																		.build()
+			.withProjectDir(testProjectDir.root)
+			.withPluginClasspath(pluginClasspath)
+			.withArguments('build')
+			.build()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
@@ -89,10 +89,10 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
 		BuildResult result = GradleRunner.create()
-																		.withProjectDir(testProjectDir.root)
-																		.withPluginClasspath(pluginClasspath)
-																		.withArguments('build')
-																		.buildAndFail()
+			.withProjectDir(testProjectDir.root)
+			.withPluginClasspath(pluginClasspath)
+			.withArguments('build')
+			.buildAndFail()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.FAILED
@@ -107,10 +107,10 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
 		BuildResult result = GradleRunner.create()
-																		.withProjectDir(testProjectDir.root)
-																		.withPluginClasspath(pluginClasspath)
-																		.withArguments('build')
-																		.buildAndFail()
+			.withProjectDir(testProjectDir.root)
+			.withPluginClasspath(pluginClasspath)
+			.withArguments('build')
+			.buildAndFail()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.FAILED
@@ -175,7 +175,6 @@ junitPlatform {
 	private void javaFile() {
 		Path javaFile = Paths.get(testProjectDir.root.toString(), 'src', 'main', 'java', 'org', 'junit', 'gradletest', 'Adder.java')
 		Files.createDirectories(javaFile.parent)
-		// @formatter:off
 		javaFile.withWriter {
 			it.write(
 				'''
@@ -188,13 +187,11 @@ public class Adder {
 }
 ''')
 		}
-		// @formatter:on
 	}
 
 	private void failingTestFile() {
 		Path testPath = Paths.get(testProjectDir.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
 		Files.createDirectories(testPath.parent)
-		// @formatter:off
 		testPath.withWriter {
 			it.write('''
 package org.junit.gradletest;
@@ -223,10 +220,10 @@ class AdderTest {
 
 		when:
 		BuildResult result = GradleRunner.create()
-																		.withProjectDir(testProjectDir.root)
-																		.withPluginClasspath(pluginClasspath)
-																		.withArguments('test')
-																		.build()
+			.withProjectDir(testProjectDir.root)
+			.withPluginClasspath(pluginClasspath)
+			.withArguments('test')
+			.build()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
@@ -245,7 +242,6 @@ class AdderTest {
 	private void succeedingTestFile() {
 		Path testPath = Paths.get(testProjectDir.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
 		Files.createDirectories(testPath.parent)
-		// @formatter:off
 		testPath.withWriter {
 			it.write(
 		'''

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
@@ -81,7 +81,6 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 		result.output.contains('1 tests successful')
 	}
 
-
 	def "failing test fails build with 'java' plugin"() {
 		given:
 		javaFile()
@@ -214,6 +213,33 @@ class AdderTest {
 '''
 			)
 		}
+	}
+
+	def "when tests are executed again after no changes then the junitPlatformTest task is UP-TO-DATE"() {
+		given:
+		javaPlugin()
+		javaFile()
+		succeedingTestFile()
+
+		when:
+		BuildResult result = GradleRunner.create()
+																		.withProjectDir(testProjectDir.root)
+																		.withPluginClasspath(pluginClasspath)
+																		.withArguments('test')
+																		.build()
+
+		then:
+		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
+
+		when:
+		result = GradleRunner.create()
+												.withProjectDir(testProjectDir.root)
+												.withPluginClasspath(pluginClasspath)
+												.withArguments('test')
+												.build()
+
+		then:
+		result.task(':junitPlatformTest').outcome == TaskOutcome.UP_TO_DATE
 	}
 
 	private void succeedingTestFile() {

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
@@ -230,10 +230,10 @@ class AdderTest {
 
 		when:
 		result = GradleRunner.create()
-												.withProjectDir(testProjectDir.root)
-												.withPluginClasspath(pluginClasspath)
-												.withArguments('test')
-												.build()
+			.withProjectDir(testProjectDir.root)
+			.withPluginClasspath(pluginClasspath)
+			.withArguments('test')
+			.build()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.UP_TO_DATE
@@ -243,8 +243,7 @@ class AdderTest {
 		Path testPath = Paths.get(testProjectDir.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
 		Files.createDirectories(testPath.parent)
 		testPath.withWriter {
-			it.write(
-		'''
+			it.write('''
 package org.junit.gradletest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -51,7 +51,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "setting junitPlatform properties"() {
-
+		given:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -82,7 +82,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "creating junitPlatformTest task"() {
-
+		given:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -141,7 +141,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "uses standard class name pattern"() {
-
+		given:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -153,7 +153,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "enableStandardTestTask set to true"() {
-
+		given:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -167,6 +167,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "when buildDir is set to non-standard location, it will be honored"() {
+		given:
 		project.apply plugin: 'java'
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
@@ -180,6 +181,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "users can set buildDir to be a GString, and it will be converted to file"() {
+		given:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -194,7 +196,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "selectors can be specified"() {
-
+		given:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -234,7 +236,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "adds dependencies to configuration"() {
-
+		given:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -257,7 +259,7 @@ class JUnitPlatformPluginSpec extends Specification {
 	}
 
 	def "adds dependencies with fixed version when not explicitly configured"() {
-
+		given:
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
@@ -273,5 +275,4 @@ class JUnitPlatformPluginSpec extends Specification {
 			.findAll { version -> version.startsWith("1.") && !version.contains("+")}
 			.size() == 2
 	}
-
 }

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.platform.console.ConsoleLauncher
 import org.junit.platform.engine.discovery.ClassNameFilter
+import spock.lang.Issue
 import spock.lang.Specification
 
 /**
@@ -25,7 +26,7 @@ import spock.lang.Specification
  */
 class JUnitPlatformPluginSpec extends Specification {
 
-	Project project
+	private Project project
 
 	def setup() {
 		project = ProjectBuilder.builder().build()
@@ -274,5 +275,19 @@ class JUnitPlatformPluginSpec extends Specification {
 			.collect { dependency -> dependency.getVersion() }
 			.findAll { version -> version.startsWith("1.") && !version.contains("+")}
 			.size() == 2
+	}
+
+	@Issue('https://github.com/junit-team/junit5/issues/708')
+	def "can configure the junitPlatformTest task during the configuration phase"() {
+		given:
+		String customDescription = 'My custom description'
+		project.apply plugin: 'org.junit.platform.gradle.plugin'
+
+		when:
+		final junitPlatformTest = project.tasks.getByName('junitPlatformTest')
+		junitPlatformTest.description = customDescription
+
+		then:
+		junitPlatformTest.description == customDescription
 	}
 }

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -12,8 +12,6 @@ package org.junit.platform.gradle.plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.testing.Test


### PR DESCRIPTION
## Overview

Fixes https://github.com/junit-team/junit5/issues/708 and adds functional tests for validating Gradle plugin until the Gradle team can start implementing built-in support.

- No changelog updated yet, wasn't sure if this would get in.
- Testing Uses locally built components by providing the classpath of those components as dependencies
- Does not currently use the [`java-gradle-plugin`](https://docs.gradle.org/current/userguide/javaGradle_plugin.html) - I wasn't sure how that would fare with the current signing and other components used right now, so I didn't add that in (can be done later)

*Questions*

- Should we run the functional tests on every build?
- Should we run the functional tests with multiple Gradle versions (very easy to add)?
- Is the formatting for writing build files, java files, etc. in the functional test acceptable? 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
