### PR TITLE
Include junit-jupiter-params in standalone JAR

### DIFF
--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle
@@ -13,9 +13,11 @@ buildscript {
 dependencies {
 	shadow(project(':junit-platform-console'))
 	shadow(project(':junit-jupiter-engine'))
+	shadow(project(':junit-jupiter-params'))
 	shadow(project(':junit-vintage-engine'))
 
 	testCompileOnly(project(':junit-jupiter-api'))
+	testCompileOnly(project(path: ':junit-jupiter-params', configuration: 'shadow'))
 	testCompileOnly("junit:junit:${junit4Version}")
 }
 
@@ -43,7 +45,10 @@ shadowJar {
 		(project.generateManifest || !shadowJar.archivePath.exists())
 	}
 
-	dependsOn(project(':junit-platform-console').shadowJar)
+	dependsOn(
+		project(':junit-platform-console').shadowJar,
+		project(':junit-jupiter-params').shadowJar
+	)
 
 	classifier = null
 	configurations = [project.configurations.shadow]
@@ -100,21 +105,23 @@ task standaloneCheck(dependsOn: standaloneExec) {
 		assert text.contains("ignored") && text.contains("integr4tion test")
 		assert text.contains("f4il") && text.contains("f4iled")
 		assert text.contains("succ3ssful")
+		assert text.contains("JupiterParamsIntegration")
+		assert text.contains("[1] argument=test")
 		// summary
 		assert text.contains("Test run finished after")
 		// container summary
-		assert text.contains("4 containers found")
+		assert text.contains("6 containers found")
 		assert text.contains("0 containers skipped")
-		assert text.contains("4 containers started")
+		assert text.contains("6 containers started")
 		assert text.contains("0 containers aborted")
-		assert text.contains("4 containers successful")
+		assert text.contains("6 containers successful")
 		assert text.contains("0 containers failed")
 		// tests summary
-		assert text.contains("7 tests found")
+		assert text.contains("8 tests found")
 		assert text.contains("2 tests skipped")
-		assert text.contains("5 tests started")
+		assert text.contains("6 tests started")
 		assert text.contains("1 tests aborted")
-		assert text.contains("2 tests successful")
+		assert text.contains("3 tests successful")
 		assert text.contains("2 tests failed")
 	}
 }

--- a/junit-platform-console-standalone/src/test/java/standalone/JupiterParamsIntegration.java
+++ b/junit-platform-console-standalone/src/test/java/standalone/JupiterParamsIntegration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package standalone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class JupiterParamsIntegration {
+
+	@ParameterizedTest(name = "[{index}] argument={0}")
+	@ValueSource(strings = "test")
+	void parameterizedTest(String argument) {
+		assertEquals("test", argument);
+	}
+}


### PR DESCRIPTION
Fixes #759.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] ~~Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc~~
- [X] ~~[Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed~~
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] ~~Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)~~
- [X] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [X] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
