### PR TITLE
Do not execute abstract tests in VintageTestEngine

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
@@ -57,3 +57,5 @@ on GitHub.
 
 * Fixed a bug where static member classes were incorrectly being filtered out.
   They are now considered valid JUnit Vintage test classes.
+* Fixed a bug where JUnit Vintage would incorrectly try to run abstract classes.
+  They will now not be run, but will log a warning that they are being excluded.

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
@@ -410,13 +410,14 @@ class VintageTestEngineExecutionTests {
 
 	}
 
+	@RunWith(MisbehavingSuiteRunner.class)
+	public static class MisBehavingSuiteTestClass {
+
+	}
+
 	@Test
 	void ignoreEventsForUnknownDescriptionsByMisbehavingSuiteRunner() {
-		@RunWith(MisbehavingSuiteRunner.class)
-		class TestClass {
-
-		}
-		Class<?> testClass = TestClass.class;
+		Class<?> testClass = MisBehavingSuiteTestClass.class;
 
 		List<ExecutionEvent> executionEvents = execute(testClass);
 
@@ -447,13 +448,14 @@ class VintageTestEngineExecutionTests {
 
 	}
 
+	@RunWith(MisbehavingChildlessRunner.class)
+	public static class MisbehavingChildTestClass {
+
+	}
+
 	@Test
 	void ignoreEventsForUnknownDescriptionsByMisbehavingChildlessRunner() {
-		@RunWith(MisbehavingChildlessRunner.class)
-		class TestClass {
-
-		}
-		Class<?> testClass = TestClass.class;
+		Class<?> testClass = MisbehavingChildTestClass.class;
 
 		List<ExecutionEvent> executionEvents = execute(testClass);
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscoveryRequestResolverTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscoveryRequestResolverTests.java
@@ -25,7 +25,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.vintage.engine.RecordCollectingLogger;
+import org.junit.vintage.engine.samples.junit4.AbstractJunit4TestCaseWithConstructorParameter;
 
 /**
  * @since 4.12
@@ -71,6 +73,24 @@ class VintageDiscoveryRequestResolverTests {
 		public void test() {
 		}
 
+	}
+
+	@Test
+	void doesNotResolveAbstractClasses() {
+		EngineDescriptor engineDescriptor = new EngineDescriptor(engineId(), "JUnit Vintage");
+		Class<?> testClass = AbstractJunit4TestCaseWithConstructorParameter.class;
+		LauncherDiscoveryRequest request = request().selectors(selectClass(testClass)).build();
+
+		RecordCollectingLogger logger = new RecordCollectingLogger();
+
+		JUnit4DiscoveryRequestResolver resolver = new JUnit4DiscoveryRequestResolver(engineDescriptor, logger);
+		resolver.resolve(request);
+
+		assertThat(engineDescriptor.getChildren()).isEmpty();
+
+		LogRecord logRecord = getOnlyElement(logger.getLogRecords());
+		assertThat(logRecord.getLevel()).isEqualTo(Level.WARNING);
+		assertThat(logRecord.getMessage()).isEqualTo("Class " + testClass.getName() + " could not be resolved");
 	}
 
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/AbstractJunit4TestCaseWithConstructorParameter.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/AbstractJunit4TestCaseWithConstructorParameter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import org.junit.Test;
+
+public abstract class AbstractJunit4TestCaseWithConstructorParameter {
+
+	public AbstractJunit4TestCaseWithConstructorParameter(int parameter) {
+
+	}
+
+	@Test
+	public void test() {
+	}
+}


### PR DESCRIPTION
## Overview

The Junit4DiscoveryRequestResolver did not take the isPotentialJunit4TestClass
predicate in consideration. This is now added in the TestClassCollector, so
Abstract classes are properly filtered.

Multiple tests however used non-JUnit 4 compliant classes as test input.
These are now moved to make them proper JUnit 4 test classes.

Perhaps some of these test classes should be given better names, since they are now on the top level.

The logging follows the output maven generated for the same class when it was being
run from the jupiter engine.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
