### PR TITLE
Demonstrate that a static class is a member class

### DIFF
--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/MemberClassTest.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/MemberClassTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.vintage.engine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MemberClassTest {
+
+	@Test
+	void staticClassIsMemberClass() {
+		assertTrue(Foo.class.isMemberClass());
+	}
+
+	public static class Foo {
+
+	}
+}


### PR DESCRIPTION
## Overview

In the discussion https://github.com/junit-team/junit5/pull/776/files#r110263870 the concept of a member class was discussed. This pr demonstrates that static nested classes are also considered member classes.

Furthermore in the [java 8 specification](https://docs.oracle.com/javase/specs/jls/se8/jls8.pdf) section 8.5 page 256 is mentioned.
>A member class is a class whose declaration is directly enclosed in the body of
another class or interface declaration (§8.1.6, §9.1.4).

If JUnit 4 does indeed consider static nested classes as valid, this means there is probably a bug in the implementation of https://github.com/junit-team/junit5/blob/master/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/IsPotentialJUnit4TestClass.java#L30

CC @sbrannen 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
