### PR TITLE
revise Asciidoctor task configuration

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -2,21 +2,15 @@ buildscript {
 	dependencies {
 		// classpath 'org.asciidoctor:asciidoctorj-epub3:1.5.0-alpha.6'
 		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.14'
+		classpath 'org.asciidoctor:asciidoctorj-diagram:1.5.4'
 	}
 }
 
 plugins {
 	id 'org.asciidoctor.convert' version '1.5.3'
-	// for asciidoctor-diagram support
-	id 'com.github.jruby-gradle.base' version '1.4.0'
 }
 
-apply plugin: 'org.asciidoctor.convert'
 apply plugin: 'org.junit.platform.gradle.plugin'
-
-dependencies {
-	gems 'rubygems:asciidoctor-diagram:1.5.4'
-}
 
 junitPlatform {
 	details 'tree'
@@ -53,31 +47,14 @@ dependencies {
 }
 
 asciidoctorj {
-	version = '1.5.4.1'
-}
-
-// "Catalog" of static images plus images generated via asciidoctor-diagram.
-ext.imagesCatalogDir = new File(buildDir, 'asciidoc/images')
-
-// Copy static images to the "Catalog" directory so that the catalog
-// directory can be used as both the "source" and "target" directory
-// while generating a PDF of the User Guide. If we do not do this,
-// the PDF will NOT contain any generated diagrams!
-task copyStaticImagesToCatalogDir(type: Copy) {
-	from 'src/docs/asciidoc/images'
-	into imagesCatalogDir
+	version = '1.5.5'
 }
 
 asciidoctor {
+	// enable the Asciidoctor Diagram extension
+	requires 'asciidoctor-diagram'
 
-	dependsOn copyStaticImagesToCatalogDir
-
-	// for asciidoctor-diagram support
-	dependsOn jrubyPrepare
-	requires = ['asciidoctor-diagram']
-	gemPath = jrubyPrepare.outputDir
-
-	separateOutputDirs = false
+	separateOutputDirs false
 	sources { include 'index.adoc' }
 
 	backends 'html5', 'pdf' // , 'epub3'
@@ -93,12 +70,9 @@ asciidoctor {
 				'testResourcesDir': project.sourceSets.test.resources.srcDirs[0],
 				'source-highlighter': 'coderay@', // TODO switch to 'rouge' once supported by the html5 backend
 				'tabsize': '4',
-				'imagesoutdir': imagesCatalogDir,
-				'imagesdir': imagesCatalogDir,
 				'toc': 'left',
 				'icons': 'font',
-				'setanchors': 'true',
+				'sectanchors': true,
 				'idprefix': '',
-				'idseparator': '-',
-				'docinfo1': 'true'
+				'idseparator': '-'
 }

--- a/documentation/src/docs/asciidoc/index.adoc
+++ b/documentation/src/docs/asciidoc/index.adoc
@@ -1,7 +1,8 @@
 [[user-guide]]
 = JUnit 5 User Guide
 Stefan Bechtold; Sam Brannen; Johannes Link; Matthias Merdes; Marc Philipp; Christian Stein
-
+:imagesdir: images
+ifdef::backend-pdf[:imagesdir: {docdir}/{imagesdir}]
 ifdef::backend-pdf[:source-highlighter: rouge]
 
 :sectnums:


### PR DESCRIPTION
## Overview

Revise the Asciidoctor build task configuration / setup in the following ways:

- remove dedicated task to copy images as this is built into the plugin
- use AsciidoctorJ Diagram instead of low-level asciidoctor-diagram gem dependency
- don't set imagesoutdir as it defaults to destination dir + imagesdir
- set imagesdir in document instead of build configuration to avoid breaking HTML
- no need to activate Gradle plugin defined using plugins clause
- correct a few bad AsciiDoc attribute declarations

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---