### PR TITLE
set outdir instead of imagesoutdir

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -54,8 +54,6 @@ asciidoctor {
 	// enable the Asciidoctor Diagram extension
 	requires 'asciidoctor-diagram'
 
-	def buildImagesDir = new File(buildDir, 'asciidoc/images')
-
 	separateOutputDirs false
 	sources { include 'index.adoc' }
 
@@ -70,7 +68,7 @@ asciidoctor {
 				'mainDir': project.sourceSets.main.java.srcDirs[0],
 				'testDir': project.sourceSets.test.java.srcDirs[0],
 				'testResourcesDir': project.sourceSets.test.resources.srcDirs[0],
-				'imagesoutdir': buildImagesDir,
+				'outdir': outputDir.absolutePath,
 				'source-highlighter': 'coderay@', // TODO switch to 'rouge' once supported by the html5 backend
 				'tabsize': '4',
 				'toc': 'left',

--- a/documentation/src/docs/asciidoc/index.adoc
+++ b/documentation/src/docs/asciidoc/index.adoc
@@ -2,7 +2,7 @@
 = JUnit 5 User Guide
 Stefan Bechtold; Sam Brannen; Johannes Link; Matthias Merdes; Marc Philipp; Christian Stein
 :imagesdir: images
-ifdef::backend-pdf[:imagesdir: {imagesoutdir}]
+ifdef::backend-pdf[:imagesdir: {outdir}/{imagesdir}]
 ifdef::backend-pdf[:source-highlighter: rouge]
 //
 // Blank lines are not permitted in the doc-header: http://asciidoctor.org/docs/user-manual/#doc-header


### PR DESCRIPTION
## Overview

- set outdir instead of imagesoutdir
- allows imagesdir for PDF can be derived from default imagesdir

You want to avoid setting imagesoutdir in the plugin configuration because then you have to remember to update it if you change the imagesdir in the document. Instead, you want to set the outdir attribute based on the plugin setting. That way, you can build the imagesdir for PDF based on the outdir and the default imagesdir. This mimics what Asciidoctor Diagram does internally.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---