### PR TITLE
Consider static nested classes as potential JUnit4 tests

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
@@ -54,4 +54,5 @@ on GitHub.
 
 ===== Bug Fixes
 
-* ❓
+* Fixed a bug where static member classes were incorrectly being filtered out.
+  They are now considered valid JUnit Vintage test classes.

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/IsPotentialJUnit4TestClass.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/IsPotentialJUnit4TestClass.java
@@ -12,6 +12,7 @@ package org.junit.vintage.engine.discovery;
 
 import static org.junit.platform.commons.util.ReflectionUtils.isAbstract;
 import static org.junit.platform.commons.util.ReflectionUtils.isPublic;
+import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
 
 import java.util.function.Predicate;
 
@@ -27,7 +28,14 @@ class IsPotentialJUnit4TestClass implements Predicate<Class<?>> {
 			return false;
 		if (!isPublic(candidate))
 			return false;
-		return !candidate.isMemberClass();
+		if (isNonStaticMemberClass(candidate))
+			return false;
+
+		return true;
+	}
+
+	private boolean isNonStaticMemberClass(Class<?> candidate) {
+		return candidate.isMemberClass() && !isStatic(candidate);
 	}
 
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/IsPotentialJUnit4TestClassTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/IsPotentialJUnit4TestClassTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.vintage.engine.discovery;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class IsPotentialJUnit4TestClassTests {
+
+	private IsPotentialJUnit4TestClass isPotentialJUnit4TestClass = new IsPotentialJUnit4TestClass();
+
+	@Test
+	void staticMemberClass() {
+		assertTrue(isPotentialJUnit4TestClass.test(Foo.class));
+	}
+
+	public static class Foo {
+
+	}
+
+	@Test
+	void nonPublicClass() {
+		assertFalse(isPotentialJUnit4TestClass.test(Bar.class));
+	}
+
+	static class Bar {
+
+	}
+
+	@Test
+	void abstractClass() {
+		assertFalse(isPotentialJUnit4TestClass.test(Baz.class));
+	}
+
+	public static abstract class Baz {
+
+	}
+
+	@Test
+	void anonymousClass() {
+		Foo foo = new Foo() {
+
+		};
+
+		assertFalse(isPotentialJUnit4TestClass.test(foo.getClass()));
+	}
+
+	public class FooBaz {
+
+	}
+
+	@Test
+	void publicInnerClass() {
+		assertFalse(isPotentialJUnit4TestClass.test(FooBaz.class));
+	}
+}


### PR DESCRIPTION
## Overview

The IsPotentialJunit4TestClass now checks if a memberclass is declared static.
If so it lets it through the filter.

Also includes unit tests for the IsPotentialJUnit4TestClass. It might be nice to use the
parameters support for these tests.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
