### PR TITLE
Add ClassLoaderUtils and log the location from which an engine was loaded

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
@@ -20,9 +20,6 @@ on GitHub.
 
 ===== Deprecations and Breaking Changes
 
-* The deprecated `execute(LauncherDiscoveryRequest)` method has been removed from the
-  `org.junit.platform.launcher.Launcher` API; use
-  `execute(LauncherDiscoveryRequest, TestExecutionListener...)` instead.
 * The deprecated `--hide-details` option of the `ConsoleLauncher` has been removed; use
   `--details none` instead.
 
@@ -47,7 +44,9 @@ on GitHub.
 
 ===== New Features and Improvements
 
-* ❓
+* Added internal utility method to provide information about the location from which
+  the engine class was loaded. When the location URL is available, it is logged at
+  configuration-level by the service loading mechanism.
 
 
 [[release-notes-5.0.0-m5-junit-vintage]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.engine.Constants;
 import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.util.ClassLoaderUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.engine.ConfigurationParameters;
@@ -88,7 +89,7 @@ public class ExtensionRegistry {
 	}
 
 	private static void registerAutoDetectedExtensions(ExtensionRegistry extensionRegistry) {
-		Iterable<Extension> extensions = ServiceLoader.load(Extension.class, ReflectionUtils.getDefaultClassLoader());
+		Iterable<Extension> extensions = ServiceLoader.load(Extension.class, ClassLoaderUtils.getDefaultClassLoader());
 
 		// @formatter:off
 		LOG.config(() -> "Registering auto-detected extensions: "

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassLoaderUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassLoaderUtils.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.junit.platform.commons.meta.API.Usage.Internal;
+
+import java.net.URL;
+import java.security.CodeSource;
+import java.util.Optional;
+
+import org.junit.platform.commons.meta.API;
+
+/**
+ * Collection of utilities for working with {@linkplain ClassLoader} and associated tasks.
+ *
+ * <h3>DISCLAIMER</h3>
+ *
+ * <p>These utilities are intended solely for usage within the JUnit framework
+ * itself. <strong>Any usage by external parties is not supported.</strong>
+ * Use at your own risk!
+ *
+ * @since 1.0
+ */
+@API(Internal)
+public final class ClassLoaderUtils {
+
+	///CLOVER:OFF
+	private ClassLoaderUtils() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
+	public static ClassLoader getDefaultClassLoader() {
+		try {
+			ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+			if (contextClassLoader != null) {
+				return contextClassLoader;
+			}
+		}
+		catch (Throwable ex) {
+			/* ignore */
+		}
+		return ClassLoader.getSystemClassLoader();
+	}
+
+	/**
+	 * Get the location from which the supplied object's class was loaded.
+	 *
+	 * @param object the object for whose class the location should be retrieved
+	 * @return an {@code Optional} containing the URL of the class' location; never
+	 * {@code null} but potentially empty
+	 */
+	public static Optional<URL> getLocation(Object object) {
+		Preconditions.notNull(object, "object must not be null");
+		// determine class loader
+		ClassLoader loader = object.getClass().getClassLoader();
+		if (loader == null) {
+			loader = ClassLoader.getSystemClassLoader();
+			while (loader != null && loader.getParent() != null) {
+				loader = loader.getParent();
+			}
+		}
+		// try finding resource by name
+		if (loader != null) {
+			String name = object.getClass().getName();
+			name = name.replace(".", "/") + ".class";
+			try {
+				return Optional.ofNullable(loader.getResource(name));
+			}
+			catch (Throwable ignore) {
+				/* ignore */
+			}
+		}
+		// try protection domain
+		try {
+			CodeSource codeSource = object.getClass().getProtectionDomain().getCodeSource();
+			if (codeSource != null) {
+				return Optional.ofNullable(codeSource.getLocation());
+			}
+		}
+		catch (SecurityException ignore) {
+			/* ignore */
+		}
+		return Optional.empty();
+	}
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -96,7 +96,7 @@ public final class ReflectionUtils {
 	private static final Class<?>[] EMPTY_CLASS_ARRAY = new Class<?>[0];
 
 	private static final ClasspathScanner classpathScanner = new ClasspathScanner(
-		ReflectionUtils::getDefaultClassLoader, ReflectionUtils::loadClass);
+		ClassLoaderUtils::getDefaultClassLoader, ReflectionUtils::loadClass);
 
 	private static final Map<String, Class<?>> primitiveNameToTypeMap;
 
@@ -137,19 +137,6 @@ public final class ReflectionUtils {
 		primitiveToWrapper.put(double.class, Double.class);
 
 		primitiveToWrapperMap = Collections.unmodifiableMap(primitiveToWrapper);
-	}
-
-	public static ClassLoader getDefaultClassLoader() {
-		try {
-			ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-			if (contextClassLoader != null) {
-				return contextClassLoader;
-			}
-		}
-		catch (Throwable ex) {
-			/* ignore */
-		}
-		return ClassLoader.getSystemClassLoader();
 	}
 
 	public static boolean isPublic(Class<?> clazz) {
@@ -327,7 +314,7 @@ public final class ReflectionUtils {
 	 * @see #loadClass(String, ClassLoader)
 	 */
 	public static Optional<Class<?>> loadClass(String name) {
-		return loadClass(name, getDefaultClassLoader());
+		return loadClass(name, ClassLoaderUtils.getDefaultClassLoader());
 	}
 
 	/**

--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle
@@ -104,8 +104,8 @@ task standaloneCheck(dependsOn: standaloneExec) {
 	doLast {
 		String text = standaloneExec.errorOutput.toString() + standaloneExec.standardOutput.toString()
 		// engines -- output depends on default logging configuration
-		assert text.contains("junit-jupiter (group ID: org.junit.jupiter, artifact ID: junit-jupiter-engine, version: $rootProject.version)")
-		assert text.contains("junit-vintage (group ID: org.junit.vintage, artifact ID: junit-vintage-engine, version: $vintageVersion)")
+		assert text.contains("junit-jupiter (group ID: org.junit.jupiter, artifact ID: junit-jupiter-engine, version: $rootProject.version")
+		assert text.contains("junit-vintage (group ID: org.junit.vintage, artifact ID: junit-vintage-engine, version: $vintageVersion")
 		// tree node names
 		assert text.contains("JUnit Jupiter")
 		assert text.contains("JupiterIntegration")

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.meta.API;
-import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.ClassLoaderUtils;
 import org.junit.platform.console.options.CommandLineOptions;
 import org.junit.platform.console.options.Details;
 import org.junit.platform.console.options.Theme;
@@ -74,7 +74,7 @@ public class ConsoleTestExecutor {
 		List<Path> additionalClasspathEntries = options.getAdditionalClasspathEntries();
 		if (!additionalClasspathEntries.isEmpty()) {
 			URL[] urls = additionalClasspathEntries.stream().map(this::toURL).toArray(URL[]::new);
-			ClassLoader parentClassLoader = ReflectionUtils.getDefaultClassLoader();
+			ClassLoader parentClassLoader = ClassLoaderUtils.getDefaultClassLoader();
 			ClassLoader customClassLoader = URLClassLoader.newInstance(urls, parentClassLoader);
 			return Optional.of(customClassLoader);
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.logging.Logger;
 
-import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.ClassLoaderUtils;
 import org.junit.platform.engine.TestEngine;
 
 /**
@@ -27,7 +27,7 @@ class ServiceLoaderTestEngineRegistry {
 
 	public Iterable<TestEngine> loadTestEngines() {
 		Iterable<TestEngine> testEngines = ServiceLoader.load(TestEngine.class,
-			ReflectionUtils.getDefaultClassLoader());
+			ClassLoaderUtils.getDefaultClassLoader());
 		LOG.config(() -> createDiscoveredTestEnginesMessage(testEngines));
 		return testEngines;
 	}
@@ -48,6 +48,7 @@ class ServiceLoaderTestEngineRegistry {
 		engine.getGroupId().ifPresent(groupId -> attributes.add("group ID: " + groupId));
 		engine.getArtifactId().ifPresent(artifactId -> attributes.add("artifact ID: " + artifactId));
 		engine.getVersion().ifPresent(version -> attributes.add("version: " + version));
+		ClassLoaderUtils.getLocation(engine).ifPresent(location -> attributes.add("location: " + location));
 		return attributes;
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestExecutionListenerRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestExecutionListenerRegistry.java
@@ -16,7 +16,7 @@ import static java.util.stream.StreamSupport.stream;
 import java.util.ServiceLoader;
 import java.util.logging.Logger;
 
-import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.ClassLoaderUtils;
 import org.junit.platform.launcher.TestExecutionListener;
 
 /**
@@ -28,7 +28,7 @@ class ServiceLoaderTestExecutionListenerRegistry {
 
 	Iterable<TestExecutionListener> loadListeners() {
 		Iterable<TestExecutionListener> listeners = ServiceLoader.load(TestExecutionListener.class,
-			ReflectionUtils.getDefaultClassLoader());
+			ClassLoaderUtils.getDefaultClassLoader());
 		LOG.config(() -> "Loaded TestExecutionListener instances: "
 				+ stream(listeners.spliterator(), false).map(Object::toString).collect(toList()));
 		return listeners;

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ClassLoaderUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ClassLoaderUtilsTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ClassLoaderUtils}.
+ *
+ * @since 1.0
+ */
+class ClassLoaderUtilsTests {
+
+	@Test
+	void getLocationFromNullFails() {
+		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
+			() -> ClassLoaderUtils.getLocation(null));
+		assertEquals("object must not be null", exception.getMessage());
+	}
+
+	@Test
+	void getLocationFromVariousObjectsArePresent() {
+		assertTrue(ClassLoaderUtils.getLocation(void.class).isPresent());
+		assertTrue(ClassLoaderUtils.getLocation(byte.class).isPresent());
+		assertTrue(ClassLoaderUtils.getLocation(this).isPresent());
+		assertTrue(ClassLoaderUtils.getLocation("").isPresent());
+		assertTrue(ClassLoaderUtils.getLocation(0).isPresent());
+		assertTrue(ClassLoaderUtils.getLocation(Thread.State.RUNNABLE).isPresent());
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ClasspathScannerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ClasspathScannerTests.java
@@ -51,7 +51,7 @@ class ClasspathScannerTests {
 		loadedClass.ifPresent(loadedClasses::add);
 		return loadedClass;
 	};
-	private final ClasspathScanner classpathScanner = new ClasspathScanner(ReflectionUtils::getDefaultClassLoader,
+	private final ClasspathScanner classpathScanner = new ClasspathScanner(ClassLoaderUtils::getDefaultClassLoader,
 		trackingClassLoader);
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -58,7 +58,7 @@ public class ReflectionUtilsTests {
 		ClassLoader mock = mock(ClassLoader.class);
 		Thread.currentThread().setContextClassLoader(mock);
 		try {
-			assertSame(mock, ReflectionUtils.getDefaultClassLoader());
+			assertSame(mock, ClassLoaderUtils.getDefaultClassLoader());
 		}
 		finally {
 			Thread.currentThread().setContextClassLoader(original);
@@ -70,7 +70,7 @@ public class ReflectionUtilsTests {
 		ClassLoader original = Thread.currentThread().getContextClassLoader();
 		Thread.currentThread().setContextClassLoader(null);
 		try {
-			assertSame(ClassLoader.getSystemClassLoader(), ReflectionUtils.getDefaultClassLoader());
+			assertSame(ClassLoader.getSystemClassLoader(), ClassLoaderUtils.getDefaultClassLoader());
 		}
 		finally {
 			Thread.currentThread().setContextClassLoader(original);

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/ConsoleTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/ConsoleTestExecutorTests.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.platform.commons.util.ReflectionUtils.getDefaultClassLoader;
+import static org.junit.platform.commons.util.ClassLoaderUtils.getDefaultClassLoader;
 import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
 
 import java.io.PrintWriter;


### PR DESCRIPTION
## Overview

This commit enhances the configuration-level log statement with the location URL from where the classloader loaded the engine class.

Also introduce dedicated `ClassLoaderUtils` class that encapsulates static class-related helper methods. As a first action, this commit moves `getDefaultClassLoader()` to `ClassLoaderUtils` helper.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
