### PR TITLE
String#isEmpty() usage

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
@@ -48,7 +48,7 @@ public final class StringUtils {
 	 * @see #isNotBlank(String)
 	 */
 	public static boolean isBlank(String str) {
-		return (str == null || str.trim().length() == 0);
+		return (str == null || str.trim().isEmpty());
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -251,7 +251,7 @@ public final class DiscoverySelectors {
 	 */
 	public static PackageSelector selectPackage(String packageName) {
 		Preconditions.notNull(packageName, "Package name must not be null");
-		Preconditions.condition(packageName.equals("") || packageName.trim().length() != 0,
+		Preconditions.condition(packageName.isEmpty() || packageName.trim().length() != 0,
 			"Package name must not contain only whitespace");
 		return new PackageSelector(packageName.trim());
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -251,7 +251,7 @@ public final class DiscoverySelectors {
 	 */
 	public static PackageSelector selectPackage(String packageName) {
 		Preconditions.notNull(packageName, "Package name must not be null");
-		Preconditions.condition(packageName.isEmpty() || packageName.trim().length() != 0,
+		Preconditions.condition(packageName.isEmpty() || !packageName.trim().isEmpty(),
 			"Package name must not contain only whitespace");
 		return new PackageSelector(packageName.trim());
 	}


### PR DESCRIPTION
## Overview

This PR uses the `String#isEmpty()` method to clean up the code and make it easier to read. The patches contained in it replace usages of `someString.equals("")` and `someString.length() == 0`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---
