### PR TITLE
Remove semicolons at the end of enums

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/HierarchyTraversalMode.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/HierarchyTraversalMode.java
@@ -33,6 +33,6 @@ public enum HierarchyTraversalMode {
 	/**
 	 * Traverse the hierarchy using bottom-up semantics.
 	 */
-	BOTTOM_UP;
+	BOTTOM_UP
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -87,7 +87,7 @@ public final class ReflectionUtils {
 		/**
 		 * Traverse the hierarchy using bottom-up semantics.
 		 */
-		BOTTOM_UP;
+		BOTTOM_UP
 	}
 
 	// Pattern: [fully qualified class name]#[methodName]((comma-separated list of parameter type names))


### PR DESCRIPTION
## Overview

This patch removes redundant semicolons in the end of enum constants
lists.
While these semicolons aren't technically wrong, they're redundant.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---