### PR TITLE
Add dynamic container support in @TestFactory methods

### DIFF
--- a/documentation/src/test/java/example/DynamicTestsDemo.java
+++ b/documentation/src/test/java/example/DynamicTestsDemo.java
@@ -13,8 +13,10 @@ package example;
 //tag::user_guide[]
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -24,9 +26,11 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 
 class DynamicTestsDemo {
@@ -38,6 +42,28 @@ class DynamicTestsDemo {
 	@TestFactory
 	List<String> dynamicTestsWithInvalidReturnType() {
 		return Arrays.asList("Hello");
+	}
+
+	@TestFactory
+	List<DynamicNode> dynamicTestsWithContainers() {
+		Executable alwaysTrue = () -> assertTrue(true);
+
+		List<DynamicNode> nestedOne = new ArrayList<>();
+		nestedOne.add(dynamicTest("nested-1", alwaysTrue));
+		nestedOne.add(dynamicTest("nested-2", alwaysTrue));
+		List<DynamicNode> nestedTwo = new ArrayList<>();
+		nestedTwo.add(dynamicTest("nested-3", alwaysTrue));
+		nestedTwo.add(dynamicContainer("2nd level", dynamicTestsFromIterable()));
+		nestedTwo.add(dynamicTest("nested-4", alwaysTrue));
+		nestedTwo.add(dynamicContainer("level II", dynamicTestsFromStream()));
+
+		List<DynamicNode> nodes = new ArrayList<>();
+		nodes.add(dynamicTest("begin", alwaysTrue));
+		nodes.add(dynamicContainer("container one", nestedOne));
+		nodes.add(dynamicTest("middle", alwaysTrue));
+		nodes.add(dynamicContainer("container two", nestedTwo));
+		nodes.add(dynamicTest("end", alwaysTrue));
+		return nodes;
 	}
 
 	@TestFactory

--- a/documentation/src/test/java/example/DynamicTestsDemo.java
+++ b/documentation/src/test/java/example/DynamicTestsDemo.java
@@ -12,11 +12,12 @@ package example;
 
 //tag::user_guide[]
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -30,7 +31,6 @@ import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestFactory;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 
 class DynamicTestsDemo {
@@ -45,25 +45,21 @@ class DynamicTestsDemo {
 	}
 
 	@TestFactory
-	List<DynamicNode> dynamicTestsWithContainers() {
-		Executable alwaysTrue = () -> assertTrue(true);
-
-		List<DynamicNode> nestedOne = new ArrayList<>();
-		nestedOne.add(dynamicTest("nested-1", alwaysTrue));
-		nestedOne.add(dynamicTest("nested-2", alwaysTrue));
-		List<DynamicNode> nestedTwo = new ArrayList<>();
-		nestedTwo.add(dynamicTest("nested-3", alwaysTrue));
-		nestedTwo.add(dynamicContainer("2nd level", dynamicTestsFromIterable()));
-		nestedTwo.add(dynamicTest("nested-4", alwaysTrue));
-		nestedTwo.add(dynamicContainer("level II", dynamicTestsFromStream()));
-
-		List<DynamicNode> nodes = new ArrayList<>();
-		nodes.add(dynamicTest("begin", alwaysTrue));
-		nodes.add(dynamicContainer("container one", nestedOne));
-		nodes.add(dynamicTest("middle", alwaysTrue));
-		nodes.add(dynamicContainer("container two", nestedTwo));
-		nodes.add(dynamicTest("end", alwaysTrue));
-		return nodes;
+	Stream<DynamicNode> dynamicTestsWithContainers() {
+		// end::user_guide[]
+		// @formatter:off
+		// tag::user_guide[]
+		return Stream.of("A", "B", "C")
+			.map(input -> dynamicContainer("Container " + input, Stream.of(
+				dynamicTest("not null", () -> assertNotNull(input)),
+				dynamicContainer("properties", Stream.of(
+					dynamicTest("length > 0", () -> assertTrue(input.length() > 0)),
+					dynamicTest("not empty", () -> assertFalse(input.isEmpty()))
+				))
+			)));
+		// end::user_guide[]
+		// @formatter:on
+		// tag::user_guide[]
 	}
 
 	@TestFactory
@@ -113,8 +109,8 @@ class DynamicTestsDemo {
 		// end::user_guide[]
 		// @formatter:off
 		// tag::user_guide[]
-		return Stream.of("A", "B", "C").map(
-			str -> dynamicTest("test" + str, () -> { /* ... */ }));
+		return Stream.of("A", "B", "C")
+			.map(str -> dynamicTest("test" + str, () -> { /* ... */ }));
 		// end::user_guide[]
 		// @formatter:on
 		// tag::user_guide[]
@@ -126,8 +122,8 @@ class DynamicTestsDemo {
 		// @formatter:off
 		// tag::user_guide[]
 		// Generates tests for the first 10 even integers.
-		return IntStream.iterate(0, n -> n + 2).limit(10).mapToObj(
-			n -> dynamicTest("test" + n, () -> assertTrue(n % 2 == 0)));
+		return IntStream.iterate(0, n -> n + 2).limit(10)
+			.mapToObj(n -> dynamicTest("test" + n, () -> assertTrue(n % 2 == 0)));
 		// end::user_guide[]
 		// @formatter:on
 		// tag::user_guide[]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicContainer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicContainer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.util.CollectionUtils;
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * A {@code DynamicContainer} is a container generated at runtime.
+ *
+ * @since 5.0
+ */
+@API(Experimental)
+public class DynamicContainer extends DynamicNode {
+
+	public static DynamicContainer dynamicContainer(String displayName, Iterable<? extends DynamicNode> dynamicNodes) {
+		return new DynamicContainer(displayName, StreamSupport.stream(dynamicNodes.spliterator(), false));
+	}
+
+	public static DynamicContainer dynamicContainer(String displayName, Stream<? extends DynamicNode> dynamicNodes) {
+		return new DynamicContainer(displayName, dynamicNodes);
+	}
+
+	private final List<DynamicNode> dynamicNodes;
+
+	private DynamicContainer(String displayName, Stream<? extends DynamicNode> dynamicNodes) {
+		super(displayName);
+		Preconditions.notNull(dynamicNodes, "dynamicNodes must not be null");
+		this.dynamicNodes = dynamicNodes.collect(CollectionUtils.toUnmodifiableList());
+		Preconditions.containsNoNullElements(this.dynamicNodes, "individual dynamic node must not be null");
+	}
+
+	public Iterable<DynamicNode> getDynamicNodes() {
+		return dynamicNodes;
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicNode.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicNode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ToStringBuilder;
+
+/**
+ * A {@code DynamicNode} is the abstract basis class for a container or a test
+ * case generated at runtime.
+ *
+ * @since 5.0
+ */
+@API(Experimental)
+public abstract class DynamicNode {
+
+	private final String displayName;
+
+	DynamicNode(String displayName) {
+		this.displayName = Preconditions.notBlank(displayName, "displayName must not be null or blank");
+	}
+
+	/**
+	 * Get the display name of this {@code DynamicTest}.
+	 */
+	public String getDisplayName() {
+		return this.displayName;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).append("displayName", displayName).toString();
+	}
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
  * A {@code DynamicTest} is a test case generated at runtime.
@@ -46,7 +45,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @see Executable
  */
 @API(Experimental)
-public class DynamicTest {
+public class DynamicTest extends DynamicNode {
 
 	/**
 	 * Factory for creating a new {@code DynamicTest} for the supplied display
@@ -99,19 +98,11 @@ public class DynamicTest {
 		// @formatter:on
 	}
 
-	private final String displayName;
 	private final Executable executable;
 
 	private DynamicTest(String displayName, Executable executable) {
-		this.displayName = Preconditions.notBlank(displayName, "displayName must not be null or blank");
+		super(displayName);
 		this.executable = Preconditions.notNull(executable, "executable must not be null");
-	}
-
-	/**
-	 * Get the display name of this {@code DynamicTest}.
-	 */
-	public String getDisplayName() {
-		return this.displayName;
 	}
 
 	/**
@@ -120,10 +111,4 @@ public class DynamicTest {
 	public Executable getExecutable() {
 		return this.executable;
 	}
-
-	@Override
-	public String toString() {
-		return new ToStringBuilder(this).append("displayName", displayName).toString();
-	}
-
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -42,11 +42,6 @@ class DynamicContainerTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	@Override
-	public boolean isLeaf() {
-		return true;
-	}
-
-	@Override
 	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
 			DynamicTestExecutor dynamicTestExecutor) throws Exception {
 		int index = 1;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor.createDynamicDescriptor;
+
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * {@link TestDescriptor} for a {@link DynamicContainer}.
+ *
+ * @since 5.0
+ */
+class DynamicContainerTestDescriptor extends JupiterTestDescriptor {
+
+	private final DynamicContainer dynamicContainer;
+	private final TestSource testSource;
+
+	DynamicContainerTestDescriptor(UniqueId uniqueId, DynamicContainer dynamicContainer, TestSource testSource) {
+		super(uniqueId, dynamicContainer.getDisplayName());
+		this.dynamicContainer = dynamicContainer;
+		this.testSource = testSource;
+		setSource(testSource);
+	}
+
+	@Override
+	public Type getType() {
+		return Type.CONTAINER;
+	}
+
+	@Override
+	public boolean isLeaf() {
+		return true;
+	}
+
+	@Override
+	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
+			DynamicTestExecutor dynamicTestExecutor) throws Exception {
+		int index = 1;
+		for (DynamicNode childNode : dynamicContainer.getDynamicNodes()) {
+			dynamicTestExecutor.execute(createDynamicDescriptor(this, childNode, index++, testSource));
+		}
+		return context;
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
@@ -25,7 +25,7 @@ class DynamicTestTestDescriptor extends JupiterTestDescriptor {
 
 	private final DynamicTest dynamicTest;
 
-	public DynamicTestTestDescriptor(UniqueId uniqueId, DynamicTest dynamicTest, TestSource source) {
+	DynamicTestTestDescriptor(UniqueId uniqueId, DynamicTest dynamicTest, TestSource source) {
 		super(uniqueId, dynamicTest.getDisplayName());
 		this.dynamicTest = dynamicTest;
 		setSource(source);


### PR DESCRIPTION
## Overview

Addresses #695 and #604 

Add dynamic container support in @TestFactory methods.

https://travis-ci.org/junit-team/junit5/builds/228235319#L596 is generated by:

```java
Stream.of("A", "B", "C")
	.map(input -> dynamicContainer("Container " + input, Stream.of(
		dynamicTest("not null", () -> assertNotNull(input)),
		dynamicContainer("properties", Stream.of(
			dynamicTest("length > 0", () -> assertTrue(input.length() > 0)),
			dynamicTest("not empty", () -> assertFalse(input.isEmpty()))
		))
	)));
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Review and polish introduced methods
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
