### PR TITLE
Introduce tests for Theme class

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/console/options/ThemeTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/ThemeTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.console.options;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestExecutionResult;
+
+class ThemeTests {
+
+	@Test
+	void givenUtf8ShouldReturnUnicode() {
+		assertEquals(Theme.valueOf(StandardCharsets.UTF_8), Theme.UNICODE);
+	}
+
+	@Test
+	void givenAnythingElseShouldReturnAscii() {
+		assertAll("All character sets that are not UTF-8 should return Theme.ASCII", () -> {
+			assertEquals(Theme.valueOf(StandardCharsets.ISO_8859_1), Theme.ASCII);
+			assertEquals(Theme.valueOf(StandardCharsets.US_ASCII), Theme.ASCII);
+			assertEquals(Theme.valueOf(StandardCharsets.UTF_16), Theme.ASCII);
+		});
+	}
+
+	@Test
+	void givenSuccessfulTestExecutionResultShouldReturnAsciiSuccessfulElement() {
+		TestExecutionResult successful = TestExecutionResult.successful();
+		assertEquals(Theme.ASCII.successful(), Theme.ASCII.status(successful));
+	}
+
+	@Test
+	void givenSuccessfulTestExecutionResultShouldReturnUnicodeSuccessfulElement() {
+		TestExecutionResult successful = TestExecutionResult.successful();
+		assertEquals(Theme.UNICODE.successful(), Theme.UNICODE.status(successful));
+	}
+
+	@Test
+	void givenAbortedTestExecutionResultShouldReturnAsciiAbortedElement() {
+		TestExecutionResult aborted = TestExecutionResult.aborted(new Throwable());
+		assertEquals(Theme.ASCII.aborted(), Theme.ASCII.status(aborted));
+	}
+
+	@Test
+	void givenAbortedTestExecutionResultShouldReturnUnicodeAbortedElement() {
+		TestExecutionResult aborted = TestExecutionResult.aborted(new Throwable());
+		assertEquals(Theme.UNICODE.aborted(), Theme.UNICODE.status(aborted));
+	}
+
+	@Test
+	void givenFailedTestExecutionResultShouldReturnAsciiFailedElement() {
+		TestExecutionResult failed = TestExecutionResult.failed(new Throwable());
+		assertEquals(Theme.ASCII.failed(), Theme.ASCII.status(failed));
+	}
+
+	@Test
+	void givenFailedTestExecutionResultShouldReturnUnicodeFailedElement() {
+		TestExecutionResult failed = TestExecutionResult.failed(new Throwable());
+		assertEquals(Theme.UNICODE.failed(), Theme.UNICODE.status(failed));
+	}
+}


### PR DESCRIPTION
## Overview

I have created tests for the enum Theme. The tests verify that the correct Theme be given for a certain character set. The tests also verify that for each Theme, the correct result string be given from Theme.status() based on a TestExecutionResult.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
