### PR TITLE
Test-Coverage FilePosition

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FilePositionTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FilePositionTests.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Created by Dustin on 4/28/2017.
  */
-class TestFilePosition {
+class FilePositionTests {
 
 	@Test
 	void Test_FilePosition_Start_getLine() {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/TestFilePosition.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/TestFilePosition.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.support.descriptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Created by Dustin on 4/28/2017.
+ */
+class TestFilePosition {
+
+	@Test
+	void Test_FilePosition_Start_getLine() {
+		FilePosition fp = new FilePosition(0, 0);
+		assertEquals(0, fp.getLine(), "check the getLine() method");
+	}
+
+	@Test
+	void Test_FilePosition_Start_getColumn() {
+		FilePosition fp = new FilePosition(0, 0);
+		assertEquals(0, fp.getColumn(), "check the getCoumn() method");
+	}
+
+	@Test
+	void Test_FilePosition_Equals_Itself() {
+		FilePosition fp = new FilePosition(0, 0);
+		assertTrue(fp.equals(fp), "Same FilePosition Object");
+	}
+
+	@Test
+	void Test_FilePosition_Equals() {
+		FilePosition fp = new FilePosition(1, 1);
+		FilePosition fp2 = new FilePosition(1, 1);
+		assertTrue(fp.equals(fp2), "Different FilePositions but same line and column numbers");
+	}
+
+	@Test
+	void Test_FilePosition_Equals_FalseCase() {
+		FilePosition fp = new FilePosition(1, 1);
+		FilePosition fp2 = new FilePosition(0, 1);
+		FilePosition fp3 = new FilePosition(1, 0);
+		assertFalse(fp.equals(fp2));
+		assertFalse(fp.equals(fp3));
+		assertFalse(fp2.equals(fp3));
+	}
+}


### PR DESCRIPTION
## Overview

I have written tests that cover the getLine, getColumn, and equals methods in the FilePosition.java class.  The tests for getLine and getColumn check to make sure the line and columns received are the same as what were entered into the FilePosition instantiation.  To test the equals method I check that it will equal itself, it will equal another filePosition with the same line and column.  Then I check to make sure it returns false where the line or column number do not match.
---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
