### PR TITLE
Replace Node.isLeaf() with explicit tracking of executed descriptors

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
@@ -29,6 +29,8 @@ on GitHub.
   - `junit-platform-commons`: `ReflectionUtils.findAllClassesInClasspathRoot(Path, Predicate, Predicate)`
 * The `junit-platform-surefire-provider` now requires `maven-surefire-plugin` version
   2.20 or higher.
+* The `isLeaf()` method of the `org.junit.platform.engine.support.hierarchical.Node`
+  interface has been removed.
 
 ===== New Features and Improvements
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -94,11 +94,6 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 
 	// --- Node ----------------------------------------------------------------
 
-	@Override
-	public boolean isLeaf() {
-		return !isContainer();
-	}
-
 	protected SkipResult shouldContainerBeSkipped(JupiterEngineExecutionContext context) {
 		ConditionEvaluationResult evaluationResult = conditionEvaluator.evaluateForContainer(
 			context.getExtensionRegistry(), context.getConfigurationParameters(),

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -59,11 +59,6 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 	// --- Node ----------------------------------------------------------------
 
 	@Override
-	public boolean isLeaf() {
-		return true;
-	}
-
-	@Override
 	protected void invokeTestMethod(JupiterEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) {
 		TestExtensionContext testExtensionContext = (TestExtensionContext) context.getExtensionContext();
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -54,11 +54,6 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor {
 	// --- Node ----------------------------------------------------------------
 
 	@Override
-	public boolean isLeaf() {
-		return true;
-	}
-
-	@Override
 	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) throws Exception {
 		ExtensionRegistry registry = populateNewExtensionRegistryFromExtendWith(getTestMethod(),
 			context.getExtensionRegistry());

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExecutionTracker.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExecutionTracker.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.support.hierarchical;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * @since 1.0
+ */
+class ExecutionTracker {
+
+	private final Set<UniqueId> executedUniqueIds = new HashSet<>();
+
+	void markExecuted(TestDescriptor testDescriptor) {
+		executedUniqueIds.add(testDescriptor.getUniqueId());
+	}
+
+	boolean wasAlreadyExecuted(TestDescriptor testDescriptor) {
+		return executedUniqueIds.contains(testDescriptor.getUniqueId());
+	}
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
@@ -86,8 +86,11 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 				});
 
 				C contextForStaticChildren = context;
-				testDescriptor.getChildren().stream().filter(child -> !tracker.wasAlreadyExecuted(child)).forEach(
-					child -> execute(child, contextForStaticChildren, tracker));
+				// @formatter:off
+				testDescriptor.getChildren().stream()
+						.filter(child -> !tracker.wasAlreadyExecuted(child))
+						.forEach(child -> execute(child, contextForStaticChildren, tracker));
+				// @formatter:on
 			}
 			finally {
 				node.after(context);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -30,15 +30,6 @@ import org.junit.platform.engine.TestDescriptor;
 public interface Node<C extends EngineExecutionContext> {
 
 	/**
-	 * Determine if this {@code Node} is a leaf in the hierarchy.
-	 *
-	 * <p>The default implementation returns {@code false}.
-	 */
-	default boolean isLeaf() {
-		return false;
-	}
-
-	/**
 	 * Prepare the supplied {@code context} prior to execution.
 	 *
 	 * <p>The default implementation returns the supplied {@code context} unmodified.

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
@@ -47,11 +47,6 @@ public class DemoHierarchicalContainerDescriptor extends AbstractTestDescriptor
 	}
 
 	@Override
-	public boolean isLeaf() {
-		return false;
-	}
-
-	@Override
 	public boolean hasTests() {
 		return true;
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalEngineDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalEngineDescriptor.java
@@ -50,9 +50,4 @@ public class DemoHierarchicalEngineDescriptor extends EngineDescriptor implement
 		return context;
 	}
 
-	@Override
-	public boolean isLeaf() {
-		return false;
-	}
-
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
@@ -44,11 +44,6 @@ public class DemoHierarchicalTestDescriptor extends AbstractTestDescriptor imple
 		return this.executeBlock != null ? Type.TEST : Type.CONTAINER;
 	}
 
-	@Override
-	public boolean isLeaf() {
-		return isTest();
-	}
-
 	public void markSkipped(String reason) {
 		this.skipped = true;
 		this.skippedReason = reason;

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -407,12 +407,6 @@ public class HierarchicalTestExecutorTests {
 		public Type getType() {
 			return Type.CONTAINER;
 		}
-
-		@Override
-		public boolean isLeaf() {
-			return isTest();
-		}
-
 	}
 
 	private static class MyLeaf extends AbstractTestDescriptor implements Node<MyEngineExecutionContext> {
@@ -430,11 +424,6 @@ public class HierarchicalTestExecutorTests {
 		@Override
 		public Type getType() {
 			return Type.TEST;
-		}
-
-		@Override
-		public boolean isLeaf() {
-			return isTest();
 		}
 	}
 


### PR DESCRIPTION
Fixes #812.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
