### PR TITLE
Introduce engine-level ExtensionContext

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
@@ -96,6 +96,8 @@ on GitHub.
 * If a `@ParameterizedTest` accepts an array as an argument, the string representation of
   the array will now be converted to a human readable format when generating the display
   name for invocations of the parameterized test.
+* Extensions may now share state across top-level test classes by using the `Store` of the
+  newly introduced engine-level `ExtensionContext`.
 
 
 [[release-notes-5.0.0-m5-junit-vintage]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
@@ -13,9 +13,11 @@ package org.junit.jupiter.engine.descriptor;
 import static org.junit.jupiter.engine.extension.ExtensionRegistry.createRegistryWithDefaultExtensions;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
+import org.junit.jupiter.api.extension.ContainerExtensionContext;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.meta.API;
+import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.engine.support.hierarchical.Node;
@@ -31,12 +33,15 @@ public class JupiterEngineDescriptor extends EngineDescriptor implements Node<Ju
 	}
 
 	@Override
-	public JupiterEngineExecutionContext before(JupiterEngineExecutionContext context) {
+	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) throws Exception {
 		ExtensionRegistry extensionRegistry = createRegistryWithDefaultExtensions(context.getConfigurationParameters());
+		EngineExecutionListener executionListener = context.getExecutionListener();
+		ContainerExtensionContext extensionContext = new JupiterEngineExtensionContext(executionListener, this);
 
 		// @formatter:off
 		return context.extend()
 				.withExtensionRegistry(extensionRegistry)
+				.withExtensionContext(extensionContext)
 				.build();
 		// @formatter:on
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineExtensionContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.junit.platform.commons.meta.API.Usage.Internal;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.engine.EngineExecutionListener;
+
+/**
+ * @since 5.0
+ */
+@API(Internal)
+public final class JupiterEngineExtensionContext extends AbstractExtensionContext<JupiterEngineDescriptor>
+		implements ContainerExtensionContext {
+
+	public JupiterEngineExtensionContext(EngineExecutionListener engineExecutionListener,
+			JupiterEngineDescriptor testDescriptor) {
+		super(null, engineExecutionListener, testDescriptor);
+	}
+
+	@Override
+	public Optional<AnnotatedElement> getElement() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<Class<?>> getTestClass() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<Method> getTestMethod() {
+		return Optional.empty();
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionContextExecutionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionContextExecutionTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ContainerExtensionContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestExtensionContext;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+
+class ExtensionContextExecutionTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	@ExtendWith(ExtensionContextParameterResolver.class)
+	void extensionContextHierarchy(ExtensionContext testExtensionContext) {
+		assertThat(testExtensionContext).isInstanceOf(TestExtensionContext.class);
+
+		Optional<ExtensionContext> classExtensionContext = testExtensionContext.getParent();
+		assertThat(classExtensionContext).containsInstanceOf(ContainerExtensionContext.class);
+
+		Optional<ExtensionContext> engineExtensionContext = classExtensionContext.orElse(null).getParent();
+		assertThat(engineExtensionContext).containsInstanceOf(ContainerExtensionContext.class);
+
+		assertThat(engineExtensionContext.orElse(null).getParent()).isEmpty();
+	}
+
+	static class ExtensionContextParameterResolver implements ParameterResolver {
+		@Override
+		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			return ExtensionContext.class.equals(parameterContext.getParameter().getType());
+		}
+
+		@Override
+		public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			return extensionContext;
+		}
+	}
+
+	@Test
+	void twoTestClassesCanShareStateViaEngineExtensionContext() {
+		Parent.counter.set(0);
+
+		ExecutionEventRecorder eventRecorder = executeTests(
+			request().selectors(selectClass(A.class), selectClass(B.class)).build());
+
+		assertThat(eventRecorder.getTestFinishedCount()).isEqualTo(2);
+		assertThat(Parent.counter).hasValue(1);
+	}
+
+	@ExtendWith(OnlyIncrementCounterOnce.class)
+	static class Parent {
+		static final AtomicInteger counter = new AtomicInteger(0);
+
+		@Test
+		void test() {
+		}
+	}
+
+	static class A extends Parent {
+	}
+
+	static class B extends Parent {
+	}
+
+	static class OnlyIncrementCounterOnce implements BeforeAllCallback {
+		@Override
+		public void beforeAll(ContainerExtensionContext context) throws Exception {
+			getRoot(context).getStore().getOrComputeIfAbsent("counter", key -> Parent.counter.incrementAndGet());
+		}
+
+		private ExtensionContext getRoot(ExtensionContext context) {
+			return context.getParent().map(this::getRoot).orElse(context);
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes #671.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [X] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
