### PR TITLE
Get jdk-9 back to build JUnit 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,16 @@ matrix:
     - jdk: oraclejdk8
       addons: {apt: {packages: [oracle-java8-installer]}}
     - jdk: oraclejdk9
-      addons: {apt: {packages: [oracle-java9-installer]}}
-# With jdk-9-b163(or higher) available on Travis, env: JDK_JAVA_OPTIONS='--permit-illegal-access'
+      install:
+        - cd ..
+        - wget http://download.java.net/java/jdk9/archive/168/binaries/jdk-9-ea+168_linux-x64_bin.tar.gz
+        - tar -xzf jdk-9-ea+168_linux-x64_bin.tar.gz
+        - export JAVA_HOME=$PWD/jdk-9
+        - PATH=$JAVA_HOME/bin:$PATH
+        - cd -
+        - ./gradlew -version
       env: JDK_JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED'
+           #JDK_JAVA_OPTIONS='--permit-illegal-access'
 
 # Display Gradle version instead of letting Travis execute './gradlew assemble' by default
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: java
 sudo: false
 dist: trusty
 
-jdk:
-  - oraclejdk8
-
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+matrix:
+  include:
+    - jdk: oraclejdk8
+      addons: {apt: {packages: [oracle-java8-installer]}}
+    - jdk: oraclejdk9
+      addons: {apt: {packages: [oracle-java9-installer]}}
+# With jdk-9-b163(or higher) available on Travis, env: JDK_JAVA_OPTIONS='--permit-illegal-access'
+      env: JDK_JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED'
 
 # Display Gradle version instead of letting Travis execute './gradlew assemble' by default
 install:

--- a/junit-jupiter-migration-support/src/main/java/org/junit/jupiter/migrationsupport/rules/member/TestRuleAnnotatedField.java
+++ b/junit-jupiter-migration-support/src/main/java/org/junit/jupiter/migrationsupport/rules/member/TestRuleAnnotatedField.java
@@ -24,6 +24,7 @@ class TestRuleAnnotatedField extends AbstractTestRuleAnnotatedMember {
 		super(retrieveTestRule(testInstance, field));
 	}
 
+	@SuppressWarnings("deprecation") // "AccessibleObject.isAccessible()" is deprecated in Java 9
 	private static TestRule retrieveTestRule(Object testInstance, Field field) {
 		try {
 			if (!field.isAccessible()) {

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -41,7 +41,7 @@ class ParameterizedTestNameFormatterTests {
 		// @formatter:off
 		assertEquals("42, 99, enigma, null, [1, 2, 3], [foo, bar], [[2, 4], [3, 9]]",
 			formatter.format(1,
-				new Integer(42),
+				Integer.valueOf(42),
 				99,
 				"enigma",
 				null,

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -935,6 +935,7 @@ public final class ReflectionUtils {
 		return type instanceof TypeVariable || type instanceof GenericArrayType;
 	}
 
+	@SuppressWarnings("deprecation") // "AccessibleObject.isAccessible()" is deprecated in Java 9
 	private static <T extends AccessibleObject> T makeAccessible(T object) {
 		if (!object.isAccessible()) {
 			object.setAccessible(true);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
@@ -13,8 +13,6 @@ package org.junit.platform.launcher.core;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.logging.Logger;
 
 import org.junit.platform.commons.util.ClassLoaderUtils;
@@ -31,19 +29,7 @@ class ServiceLoaderTestEngineRegistry {
 		Iterable<TestEngine> testEngines = ServiceLoader.load(TestEngine.class,
 			ClassLoaderUtils.getDefaultClassLoader());
 		LOG.config(() -> createDiscoveredTestEnginesMessage(testEngines));
-
-		// filter duplicates, jdk-9 bug: https://bugs.openjdk.java.net/browse/JDK-8177139
-		List<TestEngine> pruned = new ArrayList<>();
-		Set<String> set = new TreeSet<>();
-		for (TestEngine engine : testEngines) {
-			String className = engine.getClass().getName();
-			if (set.contains(className)) {
-				continue;
-			}
-			set.add(className);
-			pruned.add(engine);
-		}
-		return pruned;
+		return testEngines;
 	}
 
 	private String createDiscoveredTestEnginesMessage(Iterable<TestEngine> testEngines) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
@@ -13,6 +13,8 @@ package org.junit.platform.launcher.core;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Logger;
 
 import org.junit.platform.commons.util.ClassLoaderUtils;
@@ -29,7 +31,19 @@ class ServiceLoaderTestEngineRegistry {
 		Iterable<TestEngine> testEngines = ServiceLoader.load(TestEngine.class,
 			ClassLoaderUtils.getDefaultClassLoader());
 		LOG.config(() -> createDiscoveredTestEnginesMessage(testEngines));
-		return testEngines;
+
+		// filter duplicates, jdk-9 bug: https://bugs.openjdk.java.net/browse/JDK-8177139
+		List<TestEngine> pruned = new ArrayList<>();
+		Set<String> set = new TreeSet<>();
+		for (TestEngine engine : testEngines) {
+			String className = engine.getClass().getName();
+			if (set.contains(className)) {
+				continue;
+			}
+			set.add(className);
+			pruned.add(engine);
+		}
+		return pruned;
 	}
 
 	private String createDiscoveredTestEnginesMessage(Iterable<TestEngine> testEngines) {


### PR DESCRIPTION
## Overview

Current state of getting jdk-9 back to build JUnit 5 - not only on Travis CI.

With https://github.com/junit-team/junit5/commit/4e401dd72f2157cb6dc8a9db615e491007dba4cf the `'-Werror'` compiler option is untouched, i.e. remains activated.

Fixes #775 

### Note

Travis CI (debian trusty) is still on JDK9-B162, due to [webupd8team](https://launchpad.net/~webupd8team/+archive/ubuntu/java?field.series_filter=trusty) is on 162.

Using a manually installed JDK9-B168 with https://github.com/junit-team/junit5/pull/842/commits/d0443a35b8700cee1a2b28493981e99efb3b1591 for now.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [na] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [na] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [na] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
