### PR TITLE
Allow Assertions.fail methods to be used as expressions

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -43,7 +43,7 @@ on GitHub.
 
 ===== New Features and Improvements
 
-* ❓
+* All `fail` methods in `Assertions` can now be used as an expression.
 
 
 [[release-notes-5.0.0-m6-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -50,32 +50,56 @@ public final class Assertions {
 
 	/**
 	 * <em>Fails</em> a test with the given failure {@code message}.
+	 *
+	 * <p>The generic return type {@code V} allows this method to be used directly
+	 * as an expression value. As an {@link org.opentest4j.AssertionFailedError}
+	 * is created and thrown before the final return statement, this method never
+	 * returns a value to its caller.
 	 */
-	public static void fail(String message) {
+	public static <V> V fail(String message) {
 		AssertionUtils.fail(message);
+		return null; // appeasing the compiler: this line will never be executed.
 	}
 
 	/**
 	 * <em>Fails</em> a test with the given failure {@code message} as well
 	 * as the underlying {@code cause}.
+	 *
+	 * <p>The generic return type {@code V} allows this method to be used directly
+	 * as an expression value. As an {@link org.opentest4j.AssertionFailedError}
+	 * is created and thrown before the final return statement, this method never
+	 * returns a value to its caller.
 	 */
-	public static void fail(String message, Throwable cause) {
+	public static <V> V fail(String message, Throwable cause) {
 		AssertionUtils.fail(message, cause);
+		return null; // appeasing the compiler: this line will never be executed.
 	}
 
 	/**
 	 * <em>Fails</em> a test with the given underlying {@code cause}.
+	 *
+	 * <p>The generic return type {@code V} allows this method to be used directly
+	 * as an expression value. As an {@link org.opentest4j.AssertionFailedError}
+	 * is created and thrown before the final return statement, this method never
+	 * returns a value to its caller.
 	 */
-	public static void fail(Throwable cause) {
+	public static <V> V fail(Throwable cause) {
 		AssertionUtils.fail(cause);
+		return null; // appeasing the compiler: this line will never be executed.
 	}
 
 	/**
 	 * <em>Fails</em> a test with the failure message retrieved from the
 	 * given {@code messageSupplier}.
+	 *
+	 * <p>The generic return type {@code V} allows this method to be used directly
+	 * as an expression value. As an {@link org.opentest4j.AssertionFailedError}
+	 * is created and thrown before the final return statement, this method never
+	 * returns a value to its caller.
 	 */
-	public static void fail(Supplier<String> messageSupplier) {
+	public static <V> V fail(Supplier<String> messageSupplier) {
 		AssertionUtils.fail(messageSupplier);
+		return null; // appeasing the compiler: this line will never be executed.
 	}
 
 	// --- assertTrue ----------------------------------------------------------

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsFailTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsFailTests.java
@@ -13,8 +13,10 @@ package org.junit.jupiter.api;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import org.opentest4j.AssertionFailedError;
@@ -121,6 +123,19 @@ class AssertionsFailTests {
 			Throwable cause = ex.getCause();
 			assertMessageContains(cause, "cause");
 		}
+	}
+
+	@Test
+	void failUsableAsAnExpression() {
+		// @formatter:off
+		long count = Collections.emptySet().stream()
+				.peek(element -> fail("peek should never be called"))
+				.filter(element -> fail("filter should never be called", new Throwable("cause")))
+				.map(element -> fail(new Throwable("map should never be called")))
+				.sorted((e1, e2) -> fail(() -> "sorted should never be called"))
+				.count();
+		// @formatter:on
+		assertEquals(0L, count);
 	}
 
 }


### PR DESCRIPTION
## Overview

Prior to this commit the return type `void` prevented the use of a `fail`-method as an expression. For example, the user has to wrap the `fail` call in a lambda like:

```java
  Stream.of().map(entry -> { fail("should not be called"); return ""; })
```

Now, the line can be written more clearly as:

```java
  Stream.of().map(entry -> fail("should not be called"))
```

Addresses #845

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
