### PR TITLE
Fix loading of classes from Spring Boot executable jars.

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
@@ -157,7 +157,7 @@ class ClasspathScanner {
 		// @formatter:off
 		return Stream.of(
 					basePackageName,
-					determineSubpackageName(baseDir, classFile),
+					determineSubpackageName(baseDir, basePackageName, classFile),
 					determineSimpleClassName(classFile)
 				)
 				.filter(value -> !value.isEmpty()) // Handle default package appropriately.
@@ -170,10 +170,16 @@ class ClasspathScanner {
 		return fileName.substring(0, fileName.length() - CLASS_FILE_SUFFIX.length());
 	}
 
-	private String determineSubpackageName(Path baseDir, Path classFile) {
+	private String determineSubpackageName(Path baseDir, String basePackageName, Path classFile) {
 		Path relativePath = baseDir.relativize(classFile.getParent());
 		String pathSeparator = baseDir.getFileSystem().getSeparator();
 		String subpackageName = relativePath.toString().replace(pathSeparator, PACKAGE_SEPARATOR_STRING);
+
+		if (StringUtils.isNotBlank(basePackageName) && subpackageName.startsWith(basePackageName)) {
+			subpackageName = subpackageName.length() == basePackageName.length() ? ""
+					: subpackageName.substring(basePackageName.length() + 1);
+		}
+
 		if (subpackageName.endsWith(pathSeparator)) {
 			// Workaround for JDK bug: https://bugs.openjdk.java.net/browse/JDK-8153248
 			subpackageName = subpackageName.substring(0, subpackageName.length() - pathSeparator.length());


### PR DESCRIPTION
Fix classpath scanning for Spring Boot jars

## Overview

I am writing a service that handles integration testing, and it makes use of Spring Boot to create executable jars.  The classpath scanning algorithm doesn't properly handle this jar format and results in mangled classnames.

This change introduces a test case that reproduces the issue, as well as a fix.  I am not 100% sure that this is correct (with respect to the design of the ClasspathScanner class).

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
