### PR TITLE
Applying spotless groovy support on groovy file format checks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 	}
 	dependencies {
-		classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.2.0'
+		classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.4.0'
 		classpath 'org.ajoberstar:gradle-git:1.7.0'
 		classpath 'org.ajoberstar:gradle-git-publish:0.2.1'
 		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-SNAPSHOT'
@@ -91,10 +91,10 @@ allprojects { subproj ->
 	apply plugin: 'com.github.ben-manes.versions' // gradle dependencyUpdates
 	apply from: "$rootDir/gradle/degraph.gradle"
 
-	repositories {
-		// mavenLocal()
-		mavenCentral()
-		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+	buildscript {
+		repositories {
+			mavenCentral()
+		}
 	}
 
 	tasks.withType(Test) { task ->
@@ -391,12 +391,15 @@ subprojects { subproj ->
 	}
 
 	spotless {
-		def headerFile = rootProject.file('src/spotless/' + licenseHeaderFileProvider.call(project))
+		def headerText = rootProject.file('src/spotless/' + licenseHeaderFileProvider.call(project))
+		def importOrderConfig = rootProject.file('src/eclipse/junit-eclipse.importorder')
+		def formatterJavaConfig= rootProject.file('src/eclipse/junit-eclipse-formatter-settings.xml')
+		def formatterGroovyConfig = rootProject.file('src/eclipse/junit-greclipse-formatter-settings.prefs')
 
 		java {
-			licenseHeaderFile headerFile, '(package|import) '
-			importOrderFile rootProject.file('src/eclipse/junit-eclipse.importorder')
-			eclipseFormatFile rootProject.file('src/eclipse/junit-eclipse-formatter-settings.xml')
+			licenseHeaderFile headerText, '(package|import) '
+			importOrderFile importOrderConfig
+			eclipse().configFile formatterJavaConfig
 			if (org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8) {
 				removeUnusedImports()
 			}
@@ -405,15 +408,14 @@ subprojects { subproj ->
 			endWithNewline()
 		}
 
-		format 'groovy', {
+		groovy {
 			target 'src/**/*.groovy'
-			indentWithTabs()
+			licenseHeaderFile headerText, "package "
+			importOrderFile importOrderConfig
+			greclipse().configFile formatterJavaConfig, formatterGroovyConfig
+
 			trimTrailingWhitespace()
 			endWithNewline()
-			licenseHeaderFile headerFile, "package "
-
-			replaceRegex 'class-level Javadoc indentation fix', /^\*/, ' *'
-			replaceRegex 'nested Javadoc indentation fix', /\t\*/, '\t *'
 		}
 	}
 

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/EnginesExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/EnginesExtension.groovy
@@ -39,5 +39,4 @@ class EnginesExtension {
 	void exclude(String... engineIds) {
 		this.exclude.addAll engineIds
 	}
-
 }

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/FiltersExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/FiltersExtension.groovy
@@ -41,7 +41,7 @@ class FiltersExtension {
 	List<String> excludeClassNamePatterns
 
 	protected List<String> getIncludeClassNamePatterns() {
-		return includeClassNamePatterns ?: [ ClassNameFilter.STANDARD_INCLUDE_PATTERN ];
+		return includeClassNamePatterns ?: [ClassNameFilter.STANDARD_INCLUDE_PATTERN]
 	}
 
 	protected List<String> getExcludeClassNamePatterns() {
@@ -81,5 +81,4 @@ class FiltersExtension {
 		}
 		excludeClassNamePatterns.addAll(patterns)
 	}
-
 }

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -150,10 +150,10 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 			args.addAll(['-N', pattern])
 		}
 		filters.packages.include.each { includedPackage ->
-			args.addAll(['--include-package',includedPackage])
+			args.addAll(['--include-package', includedPackage])
 		}
 		filters.packages.exclude.each { excludedPackage ->
-			args.addAll(['--exclude-package',excludedPackage])
+			args.addAll(['--exclude-package', excludedPackage])
 		}
 		filters.tags.include.each { tag ->
 			args.addAll(['-t', tag])

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/PackagesExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/PackagesExtension.groovy
@@ -39,5 +39,4 @@ class PackagesExtension {
 	void exclude(String... packages) {
 		this.exclude.addAll packages
 	}
-
 }

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/TagsExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/TagsExtension.groovy
@@ -39,5 +39,4 @@ class TagsExtension {
 	void exclude(String... tags) {
 		this.exclude.addAll tags
 	}
-
 }

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
@@ -12,6 +12,7 @@ package org.junit.platform.gradle.plugin
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -51,10 +52,10 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
 		BuildResult result = GradleRunner.create()
-			.withProjectDir(testProjectDir.root)
-			.withPluginClasspath(pluginClasspath)
-			.withArguments('build')
-			.build()
+				.withProjectDir(testProjectDir.root)
+				.withPluginClasspath(pluginClasspath)
+				.withArguments('build')
+				.build()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
@@ -70,10 +71,10 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
 		BuildResult result = GradleRunner.create()
-			.withProjectDir(testProjectDir.root)
-			.withPluginClasspath(pluginClasspath)
-			.withArguments('build')
-			.build()
+				.withProjectDir(testProjectDir.root)
+				.withPluginClasspath(pluginClasspath)
+				.withArguments('build')
+				.build()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
@@ -89,10 +90,10 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
 		BuildResult result = GradleRunner.create()
-			.withProjectDir(testProjectDir.root)
-			.withPluginClasspath(pluginClasspath)
-			.withArguments('build')
-			.buildAndFail()
+				.withProjectDir(testProjectDir.root)
+				.withPluginClasspath(pluginClasspath)
+				.withArguments('build')
+				.buildAndFail()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.FAILED
@@ -107,10 +108,10 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
 		BuildResult result = GradleRunner.create()
-			.withProjectDir(testProjectDir.root)
-			.withPluginClasspath(pluginClasspath)
-			.withArguments('build')
-			.buildAndFail()
+				.withProjectDir(testProjectDir.root)
+				.withPluginClasspath(pluginClasspath)
+				.withArguments('build')
+				.buildAndFail()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.FAILED
@@ -119,9 +120,9 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 	private static String splitClasspath(List<File> dependencies) {
 		return dependencies
-			.collect { it.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
-			.collect { "'$it'" }
-			.join(', ')
+				.collect { it.absolutePath.replace('\\', '\\\\') } // escape backslashes in Windows paths
+				.collect { "'$it'" }
+				.join(', ')
 	}
 
 	private void javaPlugin() {
@@ -177,7 +178,7 @@ junitPlatform {
 		Files.createDirectories(javaFile.parent)
 		javaFile.withWriter {
 			it.write(
-				'''
+					'''
 package org.junit.gradletest;
 
 public class Adder {
@@ -208,7 +209,7 @@ class AdderTest {
 		}
 }
 '''
-			)
+					)
 		}
 	}
 
@@ -220,20 +221,20 @@ class AdderTest {
 
 		when:
 		BuildResult result = GradleRunner.create()
-			.withProjectDir(testProjectDir.root)
-			.withPluginClasspath(pluginClasspath)
-			.withArguments('test')
-			.build()
+				.withProjectDir(testProjectDir.root)
+				.withPluginClasspath(pluginClasspath)
+				.withArguments('test')
+				.build()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
 
 		when:
 		result = GradleRunner.create()
-			.withProjectDir(testProjectDir.root)
-			.withPluginClasspath(pluginClasspath)
-			.withArguments('test')
-			.build()
+				.withProjectDir(testProjectDir.root)
+				.withPluginClasspath(pluginClasspath)
+				.withArguments('test')
+				.build()
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.UP_TO_DATE
@@ -242,8 +243,7 @@ class AdderTest {
 	private void succeedingTestFile() {
 		Path testPath = Paths.get(testProjectDir.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
 		Files.createDirectories(testPath.parent)
-		testPath.withWriter {
-			it.write('''
+		testPath.withWriter { it.write('''
 package org.junit.gradletest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -257,8 +257,7 @@ class AdderTest {
 				assertEquals(10, adder.add(5, 5), "This should succeed!");
 		}
 }
-''')
-		}
+''') }
 	}
 
 	private List<File> loadClassPathManifestResource(String name) {

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.platform.console.ConsoleLauncher
 import org.junit.platform.engine.discovery.ClassNameFilter
+
 import spock.lang.Issue
 import spock.lang.Specification
 
@@ -132,8 +133,8 @@ class JUnitPlatformPluginSpec extends Specification {
 		junitTask.args.containsAll('-E', 'bar')
 		junitTask.args.containsAll('--reports-dir', new File('/any').getCanonicalFile().toString())
 		def classpathToBeScanned = ['build/classes/main', 'build/resources/main', 'build/classes/test', 'build/resources/test']
-				.collect { path -> project.file(path).absolutePath }
-				.join(File.pathSeparator)
+		.collect { path -> project.file(path).absolutePath }
+		.join(File.pathSeparator)
 		junitTask.args.containsAll('--scan-class-path', classpathToBeScanned)
 
 		Task testTask = project.tasks.findByName('test')
@@ -186,9 +187,7 @@ class JUnitPlatformPluginSpec extends Specification {
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
-		project.junitPlatform {
-			reportsDir = "$project.buildDir/foo/bar/baz"
-		}
+		project.junitPlatform { reportsDir = "$project.buildDir/foo/bar/baz" }
 		project.evaluate()
 
 		then:
@@ -241,9 +240,7 @@ class JUnitPlatformPluginSpec extends Specification {
 		project.apply plugin: 'org.junit.platform.gradle.plugin'
 
 		when:
-		project.junitPlatform {
-			platformVersion '1.0.0'
-		}
+		project.junitPlatform { platformVersion '1.0.0' }
 		project.evaluate()
 
 		then:
@@ -252,11 +249,11 @@ class JUnitPlatformPluginSpec extends Specification {
 
 		configuration.getAllDependencies().contains(
 				project.dependencies.create("org.junit.platform:junit-platform-launcher:1.0.0"),
-		)
+				)
 
 		configuration.getAllDependencies().contains(
 				project.dependencies.create("org.junit.platform:junit-platform-console:1.0.0")
-		)
+				)
 	}
 
 	def "adds dependencies with fixed version when not explicitly configured"() {
@@ -271,10 +268,10 @@ class JUnitPlatformPluginSpec extends Specification {
 		configuration.triggerWhenEmptyActionsIfNecessary()
 
 		configuration.getAllDependencies()
-			.findAll { dependency -> "org.junit.platform" == dependency.getGroup() }
-			.collect { dependency -> dependency.getVersion() }
-			.findAll { version -> version.startsWith("1.") && !version.contains("+")}
-			.size() == 2
+				.findAll { dependency -> "org.junit.platform" == dependency.getGroup() }
+				.collect { dependency -> dependency.getVersion() }
+				.findAll { version -> version.startsWith("1.") && !version.contains("+")}
+				.size() == 2
 	}
 
 	@Issue('https://github.com/junit-team/junit5/issues/708')

--- a/src/eclipse/junit-greclipse-formatter-settings.prefs
+++ b/src/eclipse/junit-greclipse-formatter-settings.prefs
@@ -1,0 +1,6 @@
+#Remove unnecessary semicolons. The default value is 'false'.
+groovy.formatter.remove.unnecessary.semicolons=true
+
+#Length after which list are considered too long. These will be wrapped.
+#The default value is 30.
+groovy.formatter.longListLength=140


### PR DESCRIPTION
## Overview

Replaces  custom formatting config for Groovy source files by GrEclipse formatting.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
