### PR TITLE
Provide informative error message if parameterized test name pattern is invalid

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -15,6 +15,7 @@ import static java.util.stream.Collectors.joining;
 import java.text.MessageFormat;
 import java.util.stream.IntStream;
 
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.StringUtils;
 
 /**
@@ -48,7 +49,13 @@ class ParameterizedTestNameFormatter {
 			humanReadableArguments[i] = StringUtils.nullSafeToString(arguments[i]);
 		}
 
-		return MessageFormat.format(result, humanReadableArguments);
+		try {
+			return MessageFormat.format(result, humanReadableArguments);
+		}
+		catch (IllegalArgumentException ex) {
+			String message = "The naming pattern defined for the parameterized tests is invalid: " + ex.getMessage();
+			throw new JUnitException(message, ex);
+		}
 	}
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -53,7 +53,8 @@ class ParameterizedTestNameFormatter {
 			return MessageFormat.format(result, humanReadableArguments);
 		}
 		catch (IllegalArgumentException ex) {
-			String message = "The naming pattern defined for the parameterized tests is invalid: " + ex.getMessage();
+			String message = "The naming pattern defined for the parameterized tests is invalid. "
+					+ "The nested exception contains more details.";
 			throw new JUnitException(message, ex);
 		}
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -12,10 +12,13 @@ package org.junit.jupiter.params;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.JUnitException;
 
 /**
  * @since 5.0
@@ -72,6 +75,15 @@ class ParameterizedTestNameFormatterTests {
 		Object[] expected = Arrays.copyOf(actual, actual.length);
 		assertEquals("1, two, -128, [[2, 4], [3, 9]]", formatter.format(1, actual));
 		assertArrayEquals(expected, actual);
+	}
+
+	@Test
+	void throwsReadableExceptionForInvalidPattern() {
+		ParameterizedTestNameFormatter formatter = new ParameterizedTestNameFormatter("{index");
+
+		JUnitException exception = assertThrows(JUnitException.class, () -> formatter.format(1));
+		assertNotNull(exception.getCause());
+		assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
 	}
 
 }


### PR DESCRIPTION
Without this change an invalid test name pattern results in an error message that does not immediately point to the problem.

Before:

```
java.lang.IllegalArgumentException: Unmatched braces in the pattern.

	at java.text.MessageFormat.applyPattern(MessageFormat.java:508)
	at java.text.MessageFormat.<init>(MessageFormat.java:362)
	at java.text.MessageFormat.format(MessageFormat.java:840)
	at org.junit.jupiter.params.ParameterizedTestNameFormatter.format(ParameterizedTestNameFormatter.java:39)
	at org.junit.jupiter.params.ParameterizedTestInvocationContext.getDisplayName(ParameterizedTestInvocationContext.java:35)
	at org.junit.jupiter.engine.descriptor.TestTemplateInvocationTestDescriptor.<init>(TestTemplateInvocationTestDescriptor.java:39)
	at org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor.createInvocationTestDescriptor(TestTemplateTestDescriptor.java:117)
	at org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor.lambda$execute$1(TestTemplateTestDescriptor.java:92)
```

After:

```
org.junit.platform.commons.JUnitException: The naming pattern defined for the parameterized tests is invalid: Unmatched braces in the pattern.

	at org.junit.jupiter.params.ParameterizedTestNameFormatter.format(ParameterizedTestNameFormatter.java:54)
	at org.junit.jupiter.params.ParameterizedTestInvocationContext.getDisplayName(ParameterizedTestInvocationContext.java:35)
	at org.junit.jupiter.engine.descriptor.TestTemplateInvocationTestDescriptor.<init>(TestTemplateInvocationTestDescriptor.java:39)
	at org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor.createInvocationTestDescriptor(TestTemplateTestDescriptor.java:112)
	at org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor.lambda$execute$1(TestTemplateTestDescriptor.java:87)
	... more
Caused by: java.lang.IllegalArgumentException: Unmatched braces in the pattern.
	at java.text.MessageFormat.applyPattern(MessageFormat.java:508)
	at java.text.MessageFormat.<init>(MessageFormat.java:362)
	at java.text.MessageFormat.format(MessageFormat.java:840)
	at org.junit.jupiter.params.ParameterizedTestNameFormatter.format(ParameterizedTestNameFormatter.java:50)
	... 79 more
```

Closes #861.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
