### PR TITLE
Issues/810 encode unique id segments

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ArrayTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ArrayTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine.execution;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.engine.execution.injection.sample.PrimitiveArrayParameterResolver;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.test.event.ExecutionEvent;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+
+/**
+ * Unit tests for UniqueId.parse for methods with array type parameters.
+ *
+ * @see <a href="https://github.com/junit-team/junit5/issues/810">#810</a>
+ *
+ * @since 5.0
+ */
+class ArrayTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void executeTestsForPrimitiveArrayMethodInjectionCases() {
+		ExecutionEventRecorder eventRecorder = executeTestsForClass(PrimitiveArrayMethodInjectionTestCase.class);
+
+		assertEquals(1, eventRecorder.getTestStartedCount(), "# tests started");
+		assertEquals(1, eventRecorder.getTestSuccessfulCount(), "# tests succeeded");
+		assertEquals(0, eventRecorder.getTestFailedCount(), "# tests failed");
+
+		eventRecorder.getExecutionEvents().stream().map(ExecutionEvent::getTestDescriptor).distinct().skip(2).map(
+			TestDescriptor::getUniqueId).forEach(id -> UniqueId.parse(id.toString()));
+	}
+
+	@ExtendWith(PrimitiveArrayParameterResolver.class)
+	private static class PrimitiveArrayMethodInjectionTestCase {
+
+		@Test
+		void primitiveArray(int... ints) {
+			assertArrayEquals(new int[] { 1, 2, 3 }, ints);
+		}
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
@@ -14,6 +14,9 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -71,8 +74,8 @@ class UniqueIdFormat implements Serializable {
 		if (!segmentMatcher.matches()) {
 			throw new JUnitException(String.format("'%s' is not a well-formed UniqueId segment", segmentString));
 		}
-		String type = checkAllowed(segmentMatcher.group(1));
-		String value = checkAllowed(segmentMatcher.group(2));
+		String type = decode(checkAllowed(segmentMatcher.group(1)));
+		String value = decode(checkAllowed(segmentMatcher.group(2)));
 		return new Segment(type, value);
 	}
 
@@ -101,12 +104,29 @@ class UniqueIdFormat implements Serializable {
 	}
 
 	private String describe(Segment segment) {
-		return String.format("%s%s%s%s%s", this.openSegment, segment.getType(), this.typeValueSeparator,
-			segment.getValue(), this.closeSegment);
+		String body = encode(segment.getType()) + typeValueSeparator + encode(segment.getValue());
+		return openSegment + body + closeSegment;
 	}
 
 	private static String quote(char c) {
 		return Pattern.quote(String.valueOf(c));
 	}
 
+	private String encode(String s) {
+		try {
+			return URLEncoder.encode(s, "UTF-8");
+		}
+		catch (UnsupportedEncodingException e) {
+			throw new JUnitException("UTF-8 should be supported", e);
+		}
+	}
+
+	private String decode(String s) {
+		try {
+			return URLDecoder.decode(s, "UTF-8");
+		}
+		catch (UnsupportedEncodingException e) {
+			throw new JUnitException("UTF-8 should be supported", e);
+		}
+	}
 }

--- a/junit-platform-engine/src/test/java/org/junit/platform/engine/test/event/ExecutionEventConditions.java
+++ b/junit-platform-engine/src/test/java/org/junit/platform/engine/test/event/ExecutionEventConditions.java
@@ -29,6 +29,7 @@ import static org.junit.platform.engine.test.event.TestExecutionResultConditions
 import static org.junit.platform.engine.test.event.TestExecutionResultConditions.status;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
@@ -36,6 +37,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.engine.test.event.ExecutionEvent.Type;
 
@@ -96,9 +98,13 @@ public class ExecutionEventConditions {
 	}
 
 	public static Condition<ExecutionEvent> uniqueIdSubstring(String uniqueIdSubstring) {
+		Predicate<UniqueId.Segment> predicate = segment -> {
+			String text = segment.getType() + ":" + segment.getValue();
+			return text.contains(uniqueIdSubstring);
+		};
 		return new Condition<>(
-			byTestDescriptor(where(testDescriptor -> testDescriptor.getUniqueId().toString(),
-				uniqueId -> uniqueId.contains(uniqueIdSubstring))),
+			byTestDescriptor(
+				where(TestDescriptor::getUniqueId, uniqueId -> uniqueId.getSegments().stream().anyMatch(predicate))),
 			"descriptor with uniqueId substring \"%s\"", uniqueIdSubstring);
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
@@ -46,6 +46,7 @@ import org.junit.platform.console.options.Theme;
 /**
  * @since 1.0
  */
+@Disabled("#810 - unique id segment are encoded now")
 class ConsoleDetailsTests {
 
 	@DisplayName("Basic")

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
@@ -46,7 +46,6 @@ import org.junit.platform.console.options.Theme;
 /**
  * @since 1.0
  */
-@Disabled("#810 - unique id segment are encoded now")
 class ConsoleDetailsTests {
 
 	@DisplayName("Basic")

--- a/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-flat-ascii.out.txt
@@ -1,9 +1,9 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic])
-Started:     .oO fancy display name Oo. ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:changeDisplayName()])
-Finished:    .oO fancy display name Oo. ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:changeDisplayName()])
-Finished:    Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic])
+Started:     Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic])
+Started:     .oO fancy display name Oo. ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:changeDisplayName%28%29])
+Finished:    .oO fancy display name Oo. ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:changeDisplayName%28%29])
+Finished:    Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-flat-unicode.out.txt
@@ -1,9 +1,9 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic])
-Started:     .oO fancy display name Oo. ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:changeDisplayName()])
-Finished:    .oO fancy display name Oo. ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:changeDisplayName()])
-Finished:    Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic])
+Started:     Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic])
+Started:     .oO fancy display name Oo. ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:changeDisplayName%28%29])
+Finished:    .oO fancy display name Oo. ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:changeDisplayName%28%29])
+Finished:    Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Basic
 | | +-- .oO fancy display name Oo.
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:changeDisplayName()]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:changeDisplayName%28%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Basic', methodName = 'changeDisplayName', methodParameterTypes = '']
 \| \| \|  duration: [\d]+ ms
 | | |    status: [OK] SUCCESSFUL

--- a/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Basic
 │  │  ├─ .oO fancy display name Oo.
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:changeDisplayName()]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:changeDisplayName%28%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Basic', methodName = 'changeDisplayName', methodParameterTypes = '']
 │  │  │   duration: [\d]+ ms
 │  │  │     status: ✔ SUCCESSFUL

--- a/platform-tests/src/test/resources/console/details/basic/Basic-empty-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-empty-flat-ascii.out.txt
@@ -1,9 +1,9 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic])
-Started:     empty() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:empty()])
-Finished:    empty() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:empty()])
-Finished:    Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic])
+Started:     Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic])
+Started:     empty() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:empty%28%29])
+Finished:    empty() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:empty%28%29])
+Finished:    Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/basic/Basic-empty-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-empty-flat-unicode.out.txt
@@ -1,9 +1,9 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic])
-Started:     empty() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:empty()])
-Finished:    empty() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:empty()])
-Finished:    Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic])
+Started:     Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic])
+Started:     empty() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:empty%28%29])
+Finished:    empty() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:empty%28%29])
+Finished:    Basic ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/basic/Basic-empty-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-empty-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Basic
 | | +-- empty()
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:empty()]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:empty%28%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Basic', methodName = 'empty', methodParameterTypes = '']
 \| \| \|  duration: [\d]+ ms
 | | |    status: [OK] SUCCESSFUL

--- a/platform-tests/src/test/resources/console/details/basic/Basic-empty-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-empty-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Basic
 │  │  ├─ empty()
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]/[method:empty()]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Basic]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]/[method:empty%28%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Basic]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Basic', methodName = 'empty', methodParameterTypes = '']
 │  │  │   duration: [\d]+ ms
 │  │  │     status: ✔ SUCCESSFUL

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-flat-ascii.out.txt
@@ -1,14 +1,14 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
-Started:     failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithMultiLineMessage()])
-Finished:    failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithMultiLineMessage()])
+Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail])
+Started:     failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithMultiLineMessage%28%29])
+Finished:    failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithMultiLineMessage%28%29])
              => Exception: org.opentest4j.AssertionFailedError: multi
              line
              fail
              message
 >> S T A C K T R A C E >>
-Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
+Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-flat-unicode.out.txt
@@ -1,14 +1,14 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
-Started:     failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithMultiLineMessage()])
-Finished:    failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithMultiLineMessage()])
+Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail])
+Started:     failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithMultiLineMessage%28%29])
+Finished:    failWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithMultiLineMessage%28%29])
              => Exception: org.opentest4j.AssertionFailedError: multi
              line
              fail
              message
 >> S T A C K T R A C E >>
-Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
+Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Fail
 | | +-- failWithMultiLineMessage()
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithMultiLineMessage()]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithMultiLineMessage%28%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithMultiLineMessage', methodParameterTypes = '']
 | | |    caught: org.opentest4j.AssertionFailedError: multi
 | | |              line

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Fail
 │  │  ├─ failWithMultiLineMessage()
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithMultiLineMessage()]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithMultiLineMessage%28%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithMultiLineMessage', methodParameterTypes = '']
 │  │  │     caught: org.opentest4j.AssertionFailedError: multi
 │  │  │               line

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-flat-ascii.out.txt
@@ -1,11 +1,11 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
-Started:     failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()])
-Finished:    failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()])
+Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail])
+Started:     failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithSingleLineMessage%28%29])
+Finished:    failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithSingleLineMessage%28%29])
              => Exception: org.opentest4j.AssertionFailedError: single line fail message
 >> S T A C K T R A C E >>
-Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
+Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-flat-unicode.out.txt
@@ -1,11 +1,11 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
-Started:     failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()])
-Finished:    failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()])
+Started:     Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail])
+Started:     failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithSingleLineMessage%28%29])
+Finished:    failWithSingleLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithSingleLineMessage%28%29])
              => Exception: org.opentest4j.AssertionFailedError: single line fail message
 >> S T A C K T R A C E >>
-Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail])
+Finished:    Fail ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Fail
 | | +-- failWithSingleLineMessage()
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithSingleLineMessage%28%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
 | | |    caught: org.opentest4j.AssertionFailedError: single line fail message
 >> S T A C K T R A C E >>

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Fail
 │  │  ├─ failWithSingleLineMessage()
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]/[method:failWithSingleLineMessage()]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Fail]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]/[method:failWithSingleLineMessage%28%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Fail]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
 │  │  │     caught: org.opentest4j.AssertionFailedError: single line fail message
 >> S T A C K T R A C E >>

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-flat-ascii.out.txt
@@ -1,15 +1,15 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
-Started:     reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
-Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
+Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
+Started:     reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
+Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, user name = 'dk38', award year = '1974'\]
-Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
+Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, single = 'mapping'\]
-Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
+Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, user name = 'st77', award year = '1977', last seen = '2001'\]
-Finished:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
-Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
+Finished:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
+Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-flat-unicode.out.txt
@@ -1,15 +1,15 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
-Started:     reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
-Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
+Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
+Started:     reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
+Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, user name = 'dk38', award year = '1974'\]
-Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
+Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, single = 'mapping'\]
-Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
+Reported:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, user name = 'st77', award year = '1977', last seen = '2001'\]
-Finished:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)])
-Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
+Finished:    reportMultiEntriesWithMultiMappings(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29])
+Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Report
 | | +-- reportMultiEntriesWithMultiMappings(TestReporter)
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Report', methodName = 'reportMultiEntriesWithMultiMappings', methodParameterTypes = 'org.junit.jupiter.api.TestReporter']
 \| \| \|   reports: ReportEntry \[timestamp = ....-..-..T..:...*, user name = 'dk38', award year = '1974'\]
 \| \| \|   reports: ReportEntry \[timestamp = ....-..-..T..:...*, single = 'mapping'\]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Report
 │  │  ├─ reportMultiEntriesWithMultiMappings(TestReporter)
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithMultiMappings(org.junit.jupiter.api.TestReporter)]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithMultiMappings%28org.junit.jupiter.api.TestReporter%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Report', methodName = 'reportMultiEntriesWithMultiMappings', methodParameterTypes = 'org.junit.jupiter.api.TestReporter']
 │  │  │    reports: ReportEntry \[timestamp = ....-..-..T..:...*, user name = 'dk38', award year = '1974'\]
 │  │  │    reports: ReportEntry \[timestamp = ....-..-..T..:...*, single = 'mapping'\]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-flat-ascii.out.txt
@@ -1,13 +1,13 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
-Started:     reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)])
-Reported:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)])
+Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
+Started:     reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
+Reported:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, foo = 'bar'\]
-Reported:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)])
+Reported:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, far = 'boo'\]
-Finished:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)])
-Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
+Finished:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
+Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-flat-unicode.out.txt
@@ -1,13 +1,13 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
-Started:     reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)])
-Reported:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)])
+Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
+Started:     reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
+Reported:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, foo = 'bar'\]
-Reported:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)])
+Reported:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, far = 'boo'\]
-Finished:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)])
-Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
+Finished:    reportMultiEntriesWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
+Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Report
 | | +-- reportMultiEntriesWithSingleMapping(TestReporter)
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Report', methodName = 'reportMultiEntriesWithSingleMapping', methodParameterTypes = 'org.junit.jupiter.api.TestReporter']
 \| \| \|   reports: ReportEntry \[timestamp = ....-..-..T..:...*, foo = 'bar'\]
 \| \| \|   reports: ReportEntry \[timestamp = ....-..-..T..:...*, far = 'boo'\]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Report
 │  │  ├─ reportMultiEntriesWithSingleMapping(TestReporter)
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportMultiEntriesWithSingleMapping(org.junit.jupiter.api.TestReporter)]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportMultiEntriesWithSingleMapping%28org.junit.jupiter.api.TestReporter%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Report', methodName = 'reportMultiEntriesWithSingleMapping', methodParameterTypes = 'org.junit.jupiter.api.TestReporter']
 │  │  │    reports: ReportEntry \[timestamp = ....-..-..T..:...*, foo = 'bar'\]
 │  │  │    reports: ReportEntry \[timestamp = ....-..-..T..:...*, far = 'boo'\]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-flat-ascii.out.txt
@@ -1,11 +1,11 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
-Started:     reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportSingleEntryWithSingleMapping(org.junit.jupiter.api.TestReporter)])
-Reported:    reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportSingleEntryWithSingleMapping(org.junit.jupiter.api.TestReporter)])
+Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
+Started:     reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportSingleEntryWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
+Reported:    reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportSingleEntryWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, foo = 'bar'\]
-Finished:    reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportSingleEntryWithSingleMapping(org.junit.jupiter.api.TestReporter)])
-Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
+Finished:    reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportSingleEntryWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
+Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-flat-unicode.out.txt
@@ -1,11 +1,11 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
-Started:     reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportSingleEntryWithSingleMapping(org.junit.jupiter.api.TestReporter)])
-Reported:    reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportSingleEntryWithSingleMapping(org.junit.jupiter.api.TestReporter)])
+Started:     Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
+Started:     reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportSingleEntryWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
+Reported:    reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportSingleEntryWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
              => Reported values: ReportEntry \[timestamp = ....-..-..T..:...*, foo = 'bar'\]
-Finished:    reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportSingleEntryWithSingleMapping(org.junit.jupiter.api.TestReporter)])
-Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report])
+Finished:    reportSingleEntryWithSingleMapping(TestReporter) ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportSingleEntryWithSingleMapping%28org.junit.jupiter.api.TestReporter%29])
+Finished:    Report ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Report
 | | +-- reportSingleEntryWithSingleMapping(TestReporter)
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportSingleEntryWithSingleMapping(org.junit.jupiter.api.TestReporter)]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportSingleEntryWithSingleMapping%28org.junit.jupiter.api.TestReporter%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Report', methodName = 'reportSingleEntryWithSingleMapping', methodParameterTypes = 'org.junit.jupiter.api.TestReporter']
 \| \| \|   reports: ReportEntry \[timestamp = ....-..-..T..:...*, foo = 'bar'\]
 \| \| \|  duration: [\d]+ ms

--- a/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Report
 │  │  ├─ reportSingleEntryWithSingleMapping(TestReporter)
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]/[method:reportSingleEntryWithSingleMapping(org.junit.jupiter.api.TestReporter)]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Report]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]/[method:reportSingleEntryWithSingleMapping%28org.junit.jupiter.api.TestReporter%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Report]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Report', methodName = 'reportSingleEntryWithSingleMapping', methodParameterTypes = 'org.junit.jupiter.api.TestReporter']
 │  │  │    reports: ReportEntry \[timestamp = ....-..-..T..:...*, foo = 'bar'\]
 │  │  │   duration: [\d]+ ms

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-flat-ascii.out.txt
@@ -1,12 +1,12 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip])
-Skipped:     skipWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]/[method:skipWithMultiLineMessage()])
+Started:     Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip])
+Skipped:     skipWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]/[method:skipWithMultiLineMessage%28%29])
              => Reason: multi
              line
              fail
              message
-Finished:    Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip])
+Finished:    Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-flat-unicode.out.txt
@@ -1,12 +1,12 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip])
-Skipped:     skipWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]/[method:skipWithMultiLineMessage()])
+Started:     Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip])
+Skipped:     skipWithMultiLineMessage() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]/[method:skipWithMultiLineMessage%28%29])
              => Reason: multi
              line
              fail
              message
-Finished:    Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip])
+Finished:    Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Skip
 | | +-- skipWithMultiLineMessage()
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]/[method:skipWithMultiLineMessage()]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]/[method:skipWithMultiLineMessage%28%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Skip', methodName = 'skipWithMultiLineMessage', methodParameterTypes = '']
 | | |    reason: multi
 | | |              line

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Skip
 │  │  ├─ skipWithMultiLineMessage()
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]/[method:skipWithMultiLineMessage()]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]/[method:skipWithMultiLineMessage%28%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Skip', methodName = 'skipWithMultiLineMessage', methodParameterTypes = '']
 │  │  │     reason: multi
 │  │  │               line

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-flat-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-flat-ascii.out.txt
@@ -1,9 +1,9 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip])
-Skipped:     skipWithSingleLineReason() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]/[method:skipWithSingleLineReason()])
+Started:     Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip])
+Skipped:     skipWithSingleLineReason() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]/[method:skipWithSingleLineReason%28%29])
              => Reason: single line skip reason
-Finished:    Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip])
+Finished:    Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-flat-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-flat-unicode.out.txt
@@ -1,9 +1,9 @@
 Test execution started. Number of static tests: 1
 Started:     JUnit Jupiter ([engine:junit-jupiter])
-Started:     Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip])
-Skipped:     skipWithSingleLineReason() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]/[method:skipWithSingleLineReason()])
+Started:     Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip])
+Skipped:     skipWithSingleLineReason() ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]/[method:skipWithSingleLineReason%28%29])
              => Reason: single line skip reason
-Finished:    Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip])
+Finished:    Skip ([engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip])
 Finished:    JUnit Jupiter ([engine:junit-jupiter])
 Test execution finished.
 

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-verbose-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-verbose-ascii.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 | +-- Skip
 | | +-- skipWithSingleLineReason()
 | | |      tags: []
-| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]/[method:skipWithSingleLineReason()]
-| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]
+| | |  uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]/[method:skipWithSingleLineReason%28%29]
+| | |    parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]
 | | |    source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Skip', methodName = 'skipWithSingleLineReason', methodParameterTypes = '']
 | | |    reason: single line skip reason
 | | |    status: [S] SKIPPED

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-verbose-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-verbose-unicode.out.txt
@@ -4,8 +4,8 @@ Test plan execution started. Number of static tests: 1
 │  ├─ Skip
 │  │  ├─ skipWithSingleLineReason()
 │  │  │       tags: []
-│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]/[method:skipWithSingleLineReason()]
-│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests$Skip]
+│  │  │   uniqueId: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]/[method:skipWithSingleLineReason%28%29]
+│  │  │     parent: [engine:junit-jupiter]/[class:org.junit.platform.console.ConsoleDetailsTests%24Skip]
 │  │  │     source: MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Skip', methodName = 'skipWithSingleLineReason', methodParameterTypes = '']
 │  │  │     reason: single line skip reason
 │  │  │     status: ↷ SKIPPED


### PR DESCRIPTION
## Overview

URL-encode `UniqueID` segment string representation.

Solves #810 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
