### PR TITLE
Clean up TestDescriptor API to enable reasoning about a TestPlan before executing it

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
@@ -66,7 +66,8 @@ is placed on the Java 9 module path.
   2.20 or higher.
 * The `isLeaf()` method of the `org.junit.platform.engine.support.hierarchical.Node`
   interface has been removed.
-* The default methods `prune()` and `pruneTree()` have been removed from `TestDescriptor`.
+* The default methods `prune()`, `pruneTree()`, and `hasTests()` have been removed from
+  `TestDescriptor`.
 * The `DefaultLauncher` no longer prunes trees of `TestDescriptors` it receives from test
   engines. It's the responsibility of test engines to only return `TestDescriptors` they
   wish to execute.
@@ -86,6 +87,8 @@ is placed on the Java 9 module path.
 * When a `TestEngine` is discovered via Java's `ServiceLoader` mechanism, an attempt
   will now be made to determine the location from which the engine class was loaded,
   and if the location URL is available, it will be logged at configuration-level.
+* The `mayRegisterTests()` method may be used to signal that a `TestDescriptor` will
+  register dynamic tests during execution.
 
 
 [[release-notes-5.0.0-m5-junit-jupiter]]

--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
@@ -66,6 +66,10 @@ is placed on the Java 9 module path.
   2.20 or higher.
 * The `isLeaf()` method of the `org.junit.platform.engine.support.hierarchical.Node`
   interface has been removed.
+* The default methods `prune()` and `pruneTree()` have been removed from `TestDescriptor`.
+* The `DefaultLauncher` no longer prunes trees of `TestDescriptors` it receives from test
+  engines. It's the responsibility of test engines to only return `TestDescriptors` they
+  wish to execute.
 
 ===== New Features and Improvements
 

--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M5.adoc
@@ -89,6 +89,8 @@ is placed on the Java 9 module path.
   and if the location URL is available, it will be logged at configuration-level.
 * The `mayRegisterTests()` method may be used to signal that a `TestDescriptor` will
   register dynamic tests during execution.
+* The `TestPlan` may now be queried for whether it `containsTests()`. This is used by the
+  Surefire provider to decide if a class is a test class that should be executed.
 
 
 [[release-notes-5.0.0-m5-junit-jupiter]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -55,7 +55,7 @@ public class TestFactoryTestDescriptor extends MethodTestDescriptor {
 	}
 
 	@Override
-	public boolean hasTests() {
+	public boolean mayRegisterTests() {
 		return true;
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -47,7 +47,7 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor {
 	}
 
 	@Override
-	public boolean hasTests() {
+	public boolean mayRegisterTests() {
 		return true;
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.discovery;
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInClasspathRoot;
 import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInPackage;
+import static org.junit.platform.engine.TestDescriptor.containsTests;
 import static org.junit.platform.engine.support.filter.ClasspathScanningSupport.buildClassNamePredicate;
 
 import java.util.HashSet;
@@ -67,12 +68,11 @@ public class DiscoverySelectorResolver {
 		pruneTree(engineDescriptor);
 	}
 
-	private void pruneTree(TestDescriptor engineDescriptor) {
-		engineDescriptor.accept(testDescriptor -> {
-			if (testDescriptor.isRoot() || testDescriptor.hasTests()) {
-				return;
+	private void pruneTree(TestDescriptor rootDescriptor) {
+		rootDescriptor.accept(testDescriptor -> {
+			if (!testDescriptor.isRoot() && !containsTests(testDescriptor)) {
+				testDescriptor.removeFromHierarchy();
 			}
-			testDescriptor.removeFromHierarchy();
 		});
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -64,7 +64,16 @@ public class DiscoverySelectorResolver {
 		request.getSelectorsByType(UniqueIdSelector.class).forEach(selector -> {
 			javaElementsResolver.resolveUniqueId(selector.getUniqueId());
 		});
-		engineDescriptor.pruneTree();
+		pruneTree(engineDescriptor);
+	}
+
+	private void pruneTree(TestDescriptor engineDescriptor) {
+		engineDescriptor.accept(testDescriptor -> {
+			if (testDescriptor.isRoot() || testDescriptor.hasTests()) {
+				return;
+			}
+			testDescriptor.removeFromHierarchy();
+		});
 	}
 
 	private JavaElementsResolver createJavaElementsResolver(TestDescriptor engineDescriptor) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -196,37 +196,6 @@ public interface TestDescriptor {
 	}
 
 	/**
-	 * Remove this descriptor from the hierarchy unless it is a root or has tests.
-	 *
-	 * <p>A concrete {@link TestEngine} may override this method in order to implement
-	 * a different algorithm or to skip pruning altogether.
-	 *
-	 * @see #isRoot()
-	 * @see #hasTests()
-	 * @see #removeFromHierarchy()
-	 */
-	default void prune() {
-		if (isRoot() || hasTests()) {
-			return;
-		}
-		removeFromHierarchy();
-	}
-
-	/**
-	 * Remove this descriptor and its descendants from the hierarchy.
-	 *
-	 * <p>The default implementation supplies the {@link #prune()} method as a
-	 * {@link Visitor} to this descriptor, thereby effectively removing this
-	 * descriptor and all of its descendants.
-	 *
-	 * @see #accept(Visitor)
-	 * @see #prune()
-	 */
-	default void pruneTree() {
-		accept(TestDescriptor::prune);
-	}
-
-	/**
 	 * Find the descriptor with the supplied unique ID.
 	 *
 	 * <p>The search algorithm begins with this descriptor and then searches

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -185,14 +185,22 @@ public interface TestDescriptor {
 	}
 
 	/**
-	 * Determine if this descriptor or any of its descendants describes a test.
+	 * Determine if this descriptor may register dynamic tests during execution.
 	 *
-	 * <p>The default implementation returns {@code true} if {@link #isTest()}
-	 * returns {@code true} and otherwise recurses through this descriptor's
-	 * {@linkplain #getChildren() children} to determine if they have tests.
+	 * <p>The default implementation assumes tests are usually known during
+	 * discovery and thus returns {@code false}.
 	 */
-	default boolean hasTests() {
-		return isTest() || getChildren().stream().anyMatch(TestDescriptor::hasTests);
+	default boolean mayRegisterTests() {
+		return false;
+	}
+
+	/**
+	 * Determine if the supplied descriptor or any of its descendants contains
+	 * any tests.
+	 */
+	static boolean containsTests(TestDescriptor testDescriptor) {
+		return testDescriptor.isTest() || testDescriptor.mayRegisterTests()
+				|| testDescriptor.getChildren().stream().anyMatch(TestDescriptor::containsTests);
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -60,6 +60,8 @@ public final class TestPlan {
 
 	private final Map<String, TestIdentifier> allIdentifiers = new ConcurrentHashMap<>(32);
 
+	private final boolean containsTests;
+
 	/**
 	 * Construct a new {@code TestPlan} from the supplied collection of
 	 * {@link TestDescriptor TestDescriptors}.
@@ -74,14 +76,14 @@ public final class TestPlan {
 	@API(Internal)
 	public static TestPlan from(Collection<TestDescriptor> engineDescriptors) {
 		Preconditions.notNull(engineDescriptors, "Cannot create TestPlan from a null collection of TestDescriptors");
-		TestPlan testPlan = new TestPlan();
+		TestPlan testPlan = new TestPlan(engineDescriptors.stream().anyMatch(TestDescriptor::containsTests));
 		Visitor visitor = descriptor -> testPlan.add(TestIdentifier.from(descriptor));
 		engineDescriptors.forEach(engineDescriptor -> engineDescriptor.accept(visitor));
 		return testPlan;
 	}
 
-	private TestPlan() {
-		/* no-op */
+	private TestPlan(boolean containsTests) {
+		this.containsTests = containsTests;
 	}
 
 	/**
@@ -199,4 +201,7 @@ public final class TestPlan {
 		return unmodifiableSet(result);
 	}
 
+	public boolean containsTests() {
+		return containsTests;
+	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -118,7 +118,6 @@ class DefaultLauncher implements Launcher {
 			engineRoot.ifPresent(rootDescriptor -> root.add(testEngine, rootDescriptor));
 		}
 		root.applyPostDiscoveryFilters(discoveryRequest);
-		root.prune();
 		return root;
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
@@ -60,17 +60,6 @@ class Root {
 		acceptInAllTestEngines(removeExcludedTestDescriptors);
 	}
 
-	/**
-	 * Prune all branches in the tree of {@link TestDescriptor TestDescriptors}
-	 * that do not have executable tests.
-	 *
-	 * <p>If a {@link TestEngine} ends up with no {@code TestDescriptors} after
-	 * pruning, it will <strong>not</strong> be removed.
-	 */
-	void prune() {
-		acceptInAllTestEngines(TestDescriptor::prune);
-	}
-
 	private boolean isExcluded(TestDescriptor descriptor, Filter<TestDescriptor> postDiscoveryFilter) {
 		return descriptor.getChildren().isEmpty() && postDiscoveryFilter.apply(descriptor).excluded();
 	}

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/TestPlanScannerFilter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/TestPlanScannerFilter.java
@@ -19,13 +19,10 @@ package org.junit.platform.surefire.provider;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
-import java.util.function.Predicate;
-
 import org.apache.maven.surefire.util.ScannerFilter;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
-import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
@@ -33,13 +30,10 @@ import org.junit.platform.launcher.TestPlan;
  */
 final class TestPlanScannerFilter implements ScannerFilter {
 
-	private static final Predicate<TestIdentifier> hasTests = testIdentifier -> testIdentifier.isTest()
-			|| testIdentifier.isContainer();
-
 	private final Launcher launcher;
 	private final Filter<?>[] includeAndExcludeFilters;
 
-	public TestPlanScannerFilter(Launcher launcher, Filter<?>[] includeAndExcludeFilters) {
+	TestPlanScannerFilter(Launcher launcher, Filter<?>[] includeAndExcludeFilters) {
 		this.launcher = launcher;
 		this.includeAndExcludeFilters = includeAndExcludeFilters;
 	}
@@ -47,10 +41,14 @@ final class TestPlanScannerFilter implements ScannerFilter {
 	@Override
 	@SuppressWarnings("rawtypes")
 	public boolean accept(Class testClass) {
-		LauncherDiscoveryRequest discoveryRequest = request().selectors(selectClass(testClass)).filters(
-			includeAndExcludeFilters).build();
+		// @formatter:off
+		LauncherDiscoveryRequest discoveryRequest = request()
+				.selectors(selectClass(testClass))
+				.filters(includeAndExcludeFilters)
+				.build();
+		// @formatter:on
 		TestPlan testPlan = launcher.discover(discoveryRequest);
-		return testPlan.countTestIdentifiers(hasTests) > 0;
+		return testPlan.containsTests();
 	}
 
 }

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/TestPlanScannerFilterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/TestPlanScannerFilterTests.java
@@ -17,6 +17,7 @@
 package org.junit.platform.surefire.provider;
 
 import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -37,14 +38,13 @@ import org.junit.platform.launcher.core.LauncherFactory;
 class TestPlanScannerFilterTests {
 
 	@Test
-	void emptyClassAccepted() {
-		assertTrue(newFilter().accept(EmptyClass.class), "accepts empty class because it is a container");
+	void emptyClassIsNotAccepted() {
+		assertFalse(newFilter().accept(EmptyClass.class), "does not accept empty class");
 	}
 
 	@Test
-	void classWithNoTestMethodsIsAccepted() {
-		assertTrue(newFilter().accept(ClassWithMethods.class),
-			"accepts class with no @Test methods because it is a container");
+	void classWithNoTestMethodsIsNotAccepted() {
+		assertFalse(newFilter().accept(ClassWithMethods.class), "does not accept class with no @Test methods");
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
@@ -47,7 +47,7 @@ public class DemoHierarchicalContainerDescriptor extends AbstractTestDescriptor
 	}
 
 	@Override
-	public boolean hasTests() {
+	public boolean mayRegisterTests() {
 		return true;
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.launcher;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+
+class TestPlanTests {
+
+	private EngineDescriptor engineDescriptor = new EngineDescriptor(UniqueId.forEngine("foo"), "Foo");
+
+	@Test
+	void doesNotContainTestsForEmptyContainers() {
+		engineDescriptor.addChild(
+			new AbstractTestDescriptor(engineDescriptor.getUniqueId().append("test", "bar"), "Bar") {
+				@Override
+				public Type getType() {
+					return Type.CONTAINER;
+				}
+			});
+
+		TestPlan testPlan = TestPlan.from(singleton(engineDescriptor));
+
+		assertThat(testPlan.containsTests()).as("contains tests").isFalse();
+	}
+
+	@Test
+	void containsTestsForTests() {
+		engineDescriptor.addChild(
+			new AbstractTestDescriptor(engineDescriptor.getUniqueId().append("test", "bar"), "Bar") {
+				@Override
+				public Type getType() {
+					return Type.TEST;
+				}
+			});
+
+		TestPlan testPlan = TestPlan.from(singleton(engineDescriptor));
+
+		assertThat(testPlan.containsTests()).as("contains tests").isTrue();
+	}
+
+	@Test
+	void containsTestsForContainersThatMayRegisterTests() {
+		engineDescriptor.addChild(
+			new AbstractTestDescriptor(engineDescriptor.getUniqueId().append("test", "bar"), "Bar") {
+				@Override
+				public Type getType() {
+					return Type.CONTAINER;
+				}
+
+				@Override
+				public boolean mayRegisterTests() {
+					return true;
+				}
+			});
+
+		TestPlan testPlan = TestPlan.from(singleton(engineDescriptor));
+
+		assertThat(testPlan.containsTests()).as("contains tests").isTrue();
+	}
+}


### PR DESCRIPTION
This pull request is an attempt to solve #732, #508, and #879 in three independent but related commits.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [X] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [X] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass