### PR TITLE
Add getting help section with links to SO and Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ to file feature requests and bug reports using the project's
 <a href="https://github.com/junit-team/junit5/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs">`up-for-grabs`</a>
 label are specifically targeted for community contributions.
 
+## Getting Help
+Ask JUnit 5 related questions on [StackOverflow] or chat with us on [Gitter].
+
 ## Continuous Integration Builds
 
 | CI Server | OS      | Status | Description |
@@ -123,8 +126,10 @@ See also <http://repo1.maven.org/maven2/org/junit/> for releases and <https://os
 [Atlassian]: https://www.atlassian.com/
 [Clover]: https://www.atlassian.com/software/clover/
 [CONTRIBUTING.md]: https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md
+[Gitter]: https://gitter.im/junit-team/junit5
 [Jenkins CI server]: https://junit.ci.cloudbees.com/job/JUnit5/lastSuccessfulBuild/clover-report/
 [JUnit 5 Javadoc]: http://junit.org/junit5/docs/current/api/
 [JUnit 5 User Guide]: http://junit.org/junit5/docs/current/user-guide/
 [Prototype]: https://github.com/junit-team/junit5/wiki/Prototype
+[StackOverflow]: https://stackoverflow.com/questions/tagged/junit5
 [Twitter]: https://twitter.com/junitlambda

--- a/documentation/src/docs/asciidoc/index.adoc
+++ b/documentation/src/docs/asciidoc/index.adoc
@@ -72,9 +72,11 @@ ifdef::backend-pdf[:imagesdir: {outdir}/{imagesdir}]
 :MockitoExtension:                  {junit5-samples-repo}/tree/{release-branch}/junit5-mockito-extension/src/main/java/com/example/mockito/MockitoExtension.java[MockitoExtension]
 //
 :AssertJ:                           http://joel-costigliola.github.io/assertj/[AssertJ]
+:Gitter:                            https://gitter.im/junit-team/junit5[Gitter]
 :Hamcrest:                          http://hamcrest.org/JavaHamcrest/[Hamcrest]
 :Specsy:                            http://specsy.org/[Specsy]
 :SpringExtension:                   https://github.com/spring-projects/spring-framework/tree/master/spring-test/src/main/java/org/springframework/test/context/junit/jupiter/SpringExtension.java[SpringExtension]
+:StackOverflow:                     https://stackoverflow.com/questions/tagged/junit5[Stack Overflow]
 :Truth:                             http://google.github.io/truth/[Truth]
 
 

--- a/documentation/src/docs/asciidoc/overview.adoc
+++ b/documentation/src/docs/asciidoc/overview.adoc
@@ -32,8 +32,14 @@ the platform.
 [[overview-java-versions]]
 === Supported Java Versions
 
-JUnit 5 requires Java 8 at runtime. However, you can still test code that has been
-compiled with previous versions of the JDK.
+JUnit 5 requires Java 8 (or higher) at runtime. However, you can still test code that
+has been compiled with previous versions of the JDK.
+
+
+[[overview-getting-help]]
+=== Getting Help
+
+Ask JUnit 5 related questions on {StackOverflow} or chat with us on {Gitter}.
 
 [[installation]]
 == Installation


### PR DESCRIPTION
## Overview

Add getting help section to README.md file and the User Guide with links to SO and Gitter.

Closes #707

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

