### PR TITLE
Gradle Plugin: Static accessors for sub-extensions on JunitPlatformExtension

### DIFF
--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/FiltersExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/FiltersExtension.groovy
@@ -9,6 +9,7 @@
  */
 package org.junit.platform.gradle.plugin
 
+import org.gradle.api.Action
 import org.junit.platform.engine.discovery.ClassNameFilter
 
 /**
@@ -80,6 +81,27 @@ class FiltersExtension {
 			excludeClassNamePatterns = []
 		}
 		excludeClassNamePatterns.addAll(patterns)
+	}
+
+	/**
+	 * Configure the {@link PackagesExtension} for this plugin.
+	 */
+	void packages(Action<PackagesExtension> closure) {
+		closure.execute(getProperty(JUnitPlatformPlugin.FILTERS_PACKAGES_EXTENSION_NAME) as PackagesExtension)
+	}
+
+	/**
+	 * Configure the {@link TagsExtension} for this plugin.
+	 */
+	void tags(Action<TagsExtension> closure) {
+		closure.execute(getProperty(JUnitPlatformPlugin.FILTERS_TAGS_EXTENSION_NAME) as TagsExtension)
+	}
+
+	/**
+	 * Configure the {@link EnginesExtension} for this plugin.
+	 */
+	void engines(Action<EnginesExtension> closure) {
+		closure.execute(getProperty(JUnitPlatformPlugin.FILTERS_ENGINES_EXTENSION_NAME) as EnginesExtension)
 	}
 
 }

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformExtension.groovy
@@ -9,6 +9,7 @@
  */
 package org.junit.platform.gradle.plugin
 
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.junit.platform.console.options.Details
 
@@ -78,5 +79,20 @@ class JUnitPlatformExtension {
 	 * <p>Defaults to {@link Details#NONE}.
 	 */
 	Details details = Details.NONE
+
+
+	/**
+	 * Configure the {@link SelectorsExtension} for this plugin.
+	 */
+	void selectors(Action<SelectorsExtension> closure) {
+		closure.execute(getProperty(JUnitPlatformPlugin.SELECTORS_EXTENSION_NAME) as SelectorsExtension)
+	}
+
+	/**
+	 * Configure the {@link FiltersExtension} for this plugin.
+	 */
+	void filters(Action<FiltersExtension> closure) {
+		closure.execute(getProperty(JUnitPlatformPlugin.FILTERS_EXTENSION_NAME) as FiltersExtension)
+	}
 
 }

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -25,14 +25,25 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 	private static final String EXTENSION_NAME = 'junitPlatform'
 	private static final String TASK_NAME      = 'junitPlatformTest'
 
+	protected static final String SELECTORS_EXTENSION_NAME = 'selectors'
+	protected static final String FILTERS_EXTENSION_NAME = 'filters'
+	protected static final String FILTERS_PACKAGES_EXTENSION_NAME = 'packages'
+	protected static final String FILTERS_TAGS_EXTENSION_NAME = 'tags'
+	protected static final String FILTERS_ENGINES_EXTENSION_NAME = 'engines'
+
 	void apply(Project project) {
 		project.pluginManager.apply('java')
 		def junitExtension = project.extensions.create(EXTENSION_NAME, JUnitPlatformExtension, project)
-		junitExtension.extensions.create('selectors', SelectorsExtension)
-		junitExtension.extensions.create('filters', FiltersExtension)
-		junitExtension.filters.extensions.create('packages', PackagesExtension)
-		junitExtension.filters.extensions.create('tags', TagsExtension)
-		junitExtension.filters.extensions.create('engines', EnginesExtension)
+		junitExtension.extensions.create(SELECTORS_EXTENSION_NAME, SelectorsExtension)
+		junitExtension.extensions.create(FILTERS_EXTENSION_NAME, FiltersExtension)
+		junitExtension.filters.extensions.create(FILTERS_PACKAGES_EXTENSION_NAME, PackagesExtension)
+		junitExtension.filters.extensions.create(FILTERS_TAGS_EXTENSION_NAME, TagsExtension)
+		junitExtension.filters.extensions.create(FILTERS_ENGINES_EXTENSION_NAME, EnginesExtension)
+		/* NOTE TO FUTURE DEVELOPERS!
+		 * If you are adding another extension make sure you also provide a statically typed configuration method
+		 * on the extension class you are dynamically adding to here.
+		 * https://github.com/junit-team/junit5/issues/902
+		 */
 
 		// configuration.defaultDependencies used below was introduced in Gradle 2.5
 		if (GradleVersion.current().compareTo(GradleVersion.version('2.5')) < 0) {

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -9,10 +9,13 @@
  */
 package org.junit.platform.gradle.plugin
 
+import groovy.transform.CompileStatic
+
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testfixtures.ProjectBuilder
@@ -78,6 +81,59 @@ class JUnitPlatformPluginSpec extends Specification {
 			reportsDir new File("any")
 
 			details 'NONE'
+		}
+		then:
+		noExceptionThrown()
+	}
+
+	@CompileStatic
+	def "setting junitPlatform properties statically"() {
+		/*
+		 * This test ensures that the extensions can be accessed as expected in statically typed languages like Kotlin.
+		 * The `Action` syntax is much nice in kotlin and doesn't require `it` everywhere.
+		 * https://github.com/junit-team/junit5/issues/902
+		 */
+		given:
+		// Goofy syntax required because of closure overload
+		project.apply ({ObjectConfigurationAction it ->
+			it.plugin('org.junit.platform.gradle.plugin')
+		})
+		when:
+		JUnitPlatformExtension junitPlatform = project.extensions.getByType(JUnitPlatformExtension)
+		junitPlatform.platformVersion = '5.0.0-M1'
+		junitPlatform.enableStandardTestTask = true
+		junitPlatform.logManager = 'org.apache.logging.log4j.jul.LogManager'
+		junitPlatform.selectors {
+			it.uris'u:foo', 'u:bar'
+			it.uri 'u:qux'
+			it.files 'foo.txt', 'bar.csv'
+			it.file 'qux.json'
+			it.directories 'foo/bar', 'bar/qux'
+			it.directory 'qux/bar'
+			it.packages 'com.acme.foo', 'com.acme.bar'
+			it.aPackage 'com.example.app'
+			it.classes 'com.acme.Foo', 'com.acme.Bar'
+			it.aClass 'com.example.app.Application'
+			it.methods 'com.acme.Foo#a', 'com.acme.Foo#b'
+			it.method 'com.example.app.Application#run(java.lang.String[])'
+			it.resources '/bar.csv', '/foo/input.json'
+			it.resource '/com/acme/my.properties'
+		}
+		junitPlatform.filters {
+			it.includeClassNamePattern '.*Tests?'
+			it.excludeClassNamePattern '.*TestCase'
+			it.packages {
+				it.include 'testpackage.included.p1', 'testpackage.included.p2'
+				it.exclude 'testpackage.excluded.p1', 'testpackage.excluded.p2'
+			}
+			it.engines {
+				it.include 'foo'
+				it.exclude 'bar'
+			}
+			it.tags {
+				it.include 'fast'
+				it.exclude 'slow'
+			}
 		}
 		then:
 		noExceptionThrown()


### PR DESCRIPTION
## Overview

This allows statically typed build systems (eg. written in Kotlin) to configure the
JUnitPlatformExtension sub-extensions without jumping through confusing syntax hoops.

Closes #902 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
