### PR TITLE
Issue843 gradle formatter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,16 +51,9 @@ ext {
 		'junit-platform-surefire-provider'
 	]
 
-	jupiterProjects = [
-		'junit-jupiter-api',
-		'junit-jupiter-engine',
-		'junit-jupiter-migrationsupport',
-		'junit-jupiter-params'
-	]
+	jupiterProjects = ['junit-jupiter-api', 'junit-jupiter-engine', 'junit-jupiter-migrationsupport', 'junit-jupiter-params']
 
-	vintageProjects = [
-		'junit-vintage-engine'
-	]
+	vintageProjects = ['junit-vintage-engine']
 
 	mavenizedProjects = platformProjects + jupiterProjects + vintageProjects
 
@@ -99,10 +92,8 @@ allprojects { subproj ->
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 	}
 	buildscript {
-		repositories {
-			// mavenLocal()
-			mavenCentral()
-		}
+		repositories { // mavenLocal()
+			mavenCentral() }
 	}
 
 	tasks.withType(Test) { task ->
@@ -165,9 +156,7 @@ allprojects { subproj ->
 		options.compilerArgs += '-parameters'
 	}
 
-	checkstyle {
-		toolVersion = '7.6'
-	}
+	checkstyle { toolVersion = '7.6' }
 	checkstyleMain {
 		configFile = rootProject.file('src/checkstyle/checkstyleMain.xml')
 	}
@@ -177,13 +166,9 @@ allprojects { subproj ->
 
 	if (project.hasProperty('enableClover') && subproj.name != "documentation") {
 
-		configurations {
-			clover
-		}
+		configurations { clover }
 
-		dependencies {
-			clover 'com.atlassian.clover:clover:4.1.1'
-		}
+		dependencies { clover 'com.atlassian.clover:clover:4.1.1' }
 
 		ext.cloverDir = file("$buildDir/clover")
 		ext.cloverInitstring = "$cloverDir/clover.db"
@@ -202,12 +187,12 @@ allprojects { subproj ->
 			onlyIf { sourceSets.main.allJava.any { it.exists() } }
 			doLast {
 				ant.'clover-instr'(
-					initstring: cloverInitstring,
-					recordTestResults: false,
-					destdir: instrumentedJavaSourcesDir,
-					source: compileJava.sourceCompatibility) {
-					sourceSets.main.allJava.addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
-				}
+						initstring: cloverInitstring,
+						recordTestResults: false,
+						destdir: instrumentedJavaSourcesDir,
+						source: compileJava.sourceCompatibility) {
+							sourceSets.main.allJava.addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
+						}
 			}
 		}
 
@@ -275,9 +260,7 @@ subprojects { subproj ->
 
 		afterEvaluate {
 			if (signArtifacts && uploadArchives.enabled) {
-				signing {
-					sign configurations.archives
-				}
+				signing { sign configurations.archives }
 			}
 		}
 
@@ -373,28 +356,24 @@ subprojects { subproj ->
 	}
 
 	// Enable JAR manifest generation
-	compileJava.doLast {
-		generateManifest = true
-	}
+	compileJava.doLast { generateManifest = true }
 
 	jar {
-		onlyIf {
-			project.generateManifest
-		}
+		onlyIf { project.generateManifest }
 		manifest {
 			attributes(
-				'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
-				'Built-By': builtByValue,
-				'Build-Date': buildDate,
-				'Build-Time': buildTime,
-				'Build-Revision': buildRevision,
-				'Specification-Title': project.name,
-				'Specification-Version': normalizeVersion(project.version),
-				'Specification-Vendor': 'junit.org',
-				'Implementation-Title': project.name,
-				'Implementation-Version': project.version,
-				'Implementation-Vendor': 'junit.org'
-			)
+					'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+					'Built-By': builtByValue,
+					'Build-Date': buildDate,
+					'Build-Time': buildTime,
+					'Build-Revision': buildRevision,
+					'Specification-Title': project.name,
+					'Specification-Version': normalizeVersion(project.version),
+					'Specification-Vendor': 'junit.org',
+					'Implementation-Title': project.name,
+					'Implementation-Version': project.version,
+					'Implementation-Vendor': 'junit.org'
+					)
 		}
 	}
 
@@ -463,9 +442,9 @@ configure(rootProject) {
 		options.links 'https://docs.oracle.com/javase/8/docs/api/', "http://ota4j-team.github.io/opentest4j/docs/${ota4jDocVersion}/api/"
 		options.stylesheetFile rootProject.file("src/javadoc/stylesheet.css")
 		options
-			.group("Jupiter", ["org.junit.jupiter.*"])
-			.group("Vintage", ["org.junit.vintage.*"])
-			.group("Platform", ["org.junit.platform.*"])
+				.group("Jupiter", ["org.junit.jupiter.*"])
+				.group("Vintage", ["org.junit.vintage.*"])
+				.group("Platform", ["org.junit.platform.*"])
 
 		source subprojects.collect { project ->
 			project.sourceSets.main.allJava
@@ -525,11 +504,11 @@ configure(rootProject) {
 			outputs.dir "$buildDir/reports/clover/html"
 			doLast {
 				ant."clover-report"(
-					initString: cloverAggregationFile) {
-					current(
-						outfile: "$buildDir/reports/clover/html", 
-						title: rootProject.description, homepage: 'overview') { format(type: 'html') }
-					}
+						initString: cloverAggregationFile) {
+							current(
+									outfile: "$buildDir/reports/clover/html",
+									title: rootProject.description, homepage: 'overview') { format(type: 'html') }
+						}
 			}
 		}
 
@@ -549,9 +528,7 @@ configure(rootProject) {
 	task prepareDocsForUploadToGhPages(dependsOn: [aggregateJavadocs, ":documentation:asciidoctor"], type: Copy) {
 		outputs.dir docsDir
 
-		from(project(':documentation').buildDir) {
-			include 'asciidoc/**'
-		}
+		from(project(':documentation').buildDir) { include 'asciidoc/**' }
 		from("$buildDir/docs") {
 			include 'javadoc/**'
 			filter { line ->

--- a/build.gradle
+++ b/build.gradle
@@ -64,12 +64,14 @@ ext {
 
 	mavenizedProjects = platformProjects + jupiterProjects + vintageProjects
 
-	licenseHeaderFileProvider = { project -> (
-		project.name == 'junit-platform-surefire-provider'
-			? 'apache-license-2.0.java'
-			: 'eclipse-public-license-1.0.java'
-		)
+	headerTextProvider = { project ->
+		def filename = (project.name == 'junit-platform-surefire-provider') ?
+				'apache-license-2.0.java' : 'eclipse-public-license-1.0.java'
+		return rootProject.file('src/spotless/' + filename)
 	}
+	importOrderConfig = rootProject.file('src/eclipse/junit-eclipse.importorder')
+	formatterJavaConfig = rootProject.file('src/eclipse/junit-eclipse-formatter-settings.xml')
+	formatterGroovyConfig = rootProject.file('src/eclipse/junit-greclipse-formatter-settings.prefs')
 
 	cloverTestProjects = [
 		'junit-jupiter-engine',
@@ -397,15 +399,11 @@ subprojects { subproj ->
 	}
 
 	spotless {
-		def headerText = rootProject.file('src/spotless/' + licenseHeaderFileProvider.call(project))
-		def importOrderConfig = rootProject.file('src/eclipse/junit-eclipse.importorder')
-		def formatterJavaConfig = rootProject.file('src/eclipse/junit-eclipse-formatter-settings.xml')
-		def formatterGroovyConfig = rootProject.file('src/eclipse/junit-greclipse-formatter-settings.prefs')
-
+		def headerText = project.headerTextProvider.call(subproj)
 		java {
 			licenseHeaderFile headerText, '(package|import) '
-			importOrderFile importOrderConfig
-			eclipse().configFile formatterJavaConfig
+			importOrderFile subproj.importOrderConfig
+			eclipse().configFile subproj.formatterJavaConfig
 			if (org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8) {
 				removeUnusedImports()
 			}
@@ -413,12 +411,11 @@ subprojects { subproj ->
 			trimTrailingWhitespace()
 			endWithNewline()
 		}
-
 		groovy {
 			target 'src/**/*.groovy'
 			licenseHeaderFile headerText, "package "
-			importOrderFile importOrderConfig
-			greclipse().configFile formatterJavaConfig, formatterGroovyConfig
+			importOrderFile subproj.importOrderConfig
+			greclipse().configFile subproj.formatterJavaConfig, subproj.formatterGroovyConfig
 
 			trimTrailingWhitespace()
 			endWithNewline()
@@ -483,8 +480,18 @@ configure(rootProject) {
 	}
 
 	spotless {
+		groovy {
+			target '**/*.gradle'
+			greclipse().configFile project.formatterJavaConfig, project.formatterGroovyConfig
+			trimTrailingWhitespace()
+			endWithNewline()
+			replaceRegex 'Remove line breaks between consecutive closing parentheses', /\)\n[\s]+\)\n/, '))\n'
+			replaceRegex 'Remove indentation at beginning of commented out code', /\/\*\n\s+([\w\s]+\{)\n/, '/*\n$1\n'
+			replaceRegex 'Remove indentation at end of commented out code', /\n\s\}\n\s\*\/\n/, '\n}\n*/\n'
+
+		}
 		format 'misc', {
-			target '**/*.gradle', '**/*.gitignore'
+			target '**/*.gitignore'
 			indentWithTabs()
 			trimTrailingWhitespace()
 			endWithNewline()

--- a/build.gradle
+++ b/build.gradle
@@ -372,8 +372,8 @@ subprojects { subproj ->
 		}
 	}
 
+	// Enable JAR manifest generation
 	compileJava.doLast {
-		// Enable JAR manifest generation
 		generateManifest = true
 	}
 
@@ -524,11 +524,12 @@ configure(rootProject) {
 		task cloverHtmlReport(dependsOn: cloverAggregateDatabases) {
 			outputs.dir "$buildDir/reports/clover/html"
 			doLast {
-				ant."clover-report"(initString: cloverAggregationFile) {
-					current(outfile: "$buildDir/reports/clover/html", title: rootProject.description, homepage: 'overview') {
-						format(type: 'html')
+				ant."clover-report"(
+					initString: cloverAggregationFile) {
+					current(
+						outfile: "$buildDir/reports/clover/html", 
+						title: rootProject.description, homepage: 'overview') { format(type: 'html') }
 					}
-				}
 			}
 		}
 
@@ -536,9 +537,7 @@ configure(rootProject) {
 			outputs.file "$buildDir/reports/clover/clover.xml"
 			doLast {
 				ant."clover-report"(initString: cloverAggregationFile) {
-					current(outfile: "$buildDir/reports/clover/clover.xml") {
-						format(type: 'xml')
-					}
+					current(outfile: "$buildDir/reports/clover/clover.xml") { format(type: 'xml') }
 				}
 			}
 		}

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -6,9 +6,7 @@ buildscript {
 	}
 }
 
-plugins {
-	id 'org.asciidoctor.convert' version '1.5.3'
-}
+plugins { id 'org.asciidoctor.convert' version '1.5.3' }
 
 apply plugin: 'org.junit.platform.gradle.plugin'
 
@@ -16,17 +14,15 @@ junitPlatform {
 	details 'tree'
 	filters {
 		includeClassNamePattern '.+(Tests|Demo)$'
-		tags {
-			exclude 'exclude'
-		}
+		tags { exclude 'exclude' }
 	}
 	logManager 'org.apache.logging.log4j.jul.LogManager'
 }
 
 /*
 test {
-	scanForTestClasses = false
-	include(['example/DocumentationTestSuite.class'])
+ scanForTestClasses = false
+ include(['example/DocumentationTestSuite.class'])
 }
 */
 
@@ -46,9 +42,7 @@ dependencies {
 	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 }
 
-asciidoctorj {
-	version = '1.5.5'
-}
+asciidoctorj { version = '1.5.5' }
 
 asciidoctor {
 	// enable the Asciidoctor Diagram extension
@@ -59,22 +53,22 @@ asciidoctor {
 
 	backends 'html5', 'pdf' // , 'epub3'
 
-	attributes(	
-				'jupiter-version': project.property('version'),
-				'platform-version': project.property('platformVersion'),
-				'vintage-version': project.property('vintageVersion'),
-				'junit4-version': project.property('junit4Version'),
-				'release-branch': project.property('releaseBranch'),
-				'revnumber' : project.version,
-				'mainDir': project.sourceSets.main.java.srcDirs[0],
-				'testDir': project.sourceSets.test.java.srcDirs[0],
-				'testResourcesDir': project.sourceSets.test.resources.srcDirs[0],
-				'outdir': outputDir.absolutePath,
-				'source-highlighter': 'coderay@', // TODO switch to 'rouge' once supported by the html5 backend and on MS Windows
-				'tabsize': '4',
-				'toc': 'left',
-				'icons': 'font',
-				'sectanchors': true,
-				'idprefix': '',
-				'idseparator': '-')
+	attributes(
+			'jupiter-version': project.property('version'),
+			'platform-version': project.property('platformVersion'),
+			'vintage-version': project.property('vintageVersion'),
+			'junit4-version': project.property('junit4Version'),
+			'release-branch': project.property('releaseBranch'),
+			'revnumber' : project.version,
+			'mainDir': project.sourceSets.main.java.srcDirs[0],
+			'testDir': project.sourceSets.test.java.srcDirs[0],
+			'testResourcesDir': project.sourceSets.test.resources.srcDirs[0],
+			'outdir': outputDir.absolutePath,
+			'source-highlighter': 'coderay@', // TODO switch to 'rouge' once supported by the html5 backend and on MS Windows
+			'tabsize': '4',
+			'toc': 'left',
+			'icons': 'font',
+			'sectanchors': true,
+			'idprefix': '',
+			'idseparator': '-')
 }

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -59,7 +59,8 @@ asciidoctor {
 
 	backends 'html5', 'pdf' // , 'epub3'
 
-	attributes	'jupiter-version': project.property('version'),
+	attributes(	
+				'jupiter-version': project.property('version'),
 				'platform-version': project.property('platformVersion'),
 				'vintage-version': project.property('vintageVersion'),
 				'junit4-version': project.property('junit4Version'),
@@ -75,5 +76,5 @@ asciidoctor {
 				'icons': 'font',
 				'sectanchors': true,
 				'idprefix': '',
-				'idseparator': '-'
+				'idseparator': '-')
 }

--- a/gradle/degraph.gradle
+++ b/gradle/degraph.gradle
@@ -6,12 +6,8 @@ import static org.hamcrest.Matchers.is
 import de.schauderhaft.degraph.configuration.NamedPattern
 
 buildscript {
-	repositories {
-		mavenCentral()
-		}
-		dependencies {
-			classpath "de.schauderhaft.degraph:degraph-check:${degraphVersion}"
-		}
+	repositories { mavenCentral() }
+	dependencies { classpath "de.schauderhaft.degraph:degraph-check:${degraphVersion}" }
 }
 
 task degraph(type: DegraphCheck) {
@@ -32,19 +28,18 @@ class DegraphCheck extends DefaultTask {
 	@TaskAction
 	void runDegraph() {
 		def graph = customClasspath(classpath.asPath)
-			.printTo(reportFile.getPath())
-			.noJars()
-			.including("org.junit.platform.**")
-			.including("org.junit.vintage.**")
-			.including("org.junit.jupiter.**")
-			.withSlicing(
+				.printTo(reportFile.getPath())
+				.noJars()
+				.including("org.junit.platform.**")
+				.including("org.junit.vintage.**")
+				.including("org.junit.jupiter.**")
+				.withSlicing(
 				"module",
 				new NamedPattern("org.junit.vintage.engine.**", "junit-vintage-engine"),
 				new NamedPattern("org.junit.jupiter.api.**", "junit-jupiter-api"),
 				new NamedPattern("org.junit.jupiter.engine.**", "junit-jupiter-engine"),
 				"org.junit.platform.(*).**"
-			)
+				)
 		assertThat(graph, is(violationFree()))
 	}
-
 }

--- a/gradle/degraph.gradle
+++ b/gradle/degraph.gradle
@@ -37,7 +37,8 @@ class DegraphCheck extends DefaultTask {
 			.including("org.junit.platform.**")
 			.including("org.junit.vintage.**")
 			.including("org.junit.jupiter.**")
-			.withSlicing("module",
+			.withSlicing(
+				"module",
 				new NamedPattern("org.junit.vintage.engine.**", "junit-vintage-engine"),
 				new NamedPattern("org.junit.jupiter.api.**", "junit-jupiter-api"),
 				new NamedPattern("org.junit.jupiter.engine.**", "junit-jupiter-engine"),

--- a/junit-jupiter-api/junit-jupiter-api.gradle
+++ b/junit-jupiter-api/junit-jupiter-api.gradle
@@ -6,7 +6,7 @@ dependencies {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.jupiter.api'
-		)
+				'Automatic-Module-Name': 'org.junit.jupiter.api'
+				)
 	}
 }

--- a/junit-jupiter-engine/junit-jupiter-engine.gradle
+++ b/junit-jupiter-engine/junit-jupiter-engine.gradle
@@ -2,9 +2,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 junitPlatform {
 	filters {
-		engines {
-			include 'junit-jupiter'
-		}
+		engines { include 'junit-jupiter' }
 		includeClassNamePattern '.*Tests?'
 	}
 	logManager 'org.apache.logging.log4j.jul.LogManager'
@@ -12,16 +10,16 @@ junitPlatform {
 
 /*
 test {
-	scanForTestClasses = false
-	include(['org/junit/jupiter/JupiterTestSuite.class'])
+ scanForTestClasses = false
+ include(['org/junit/jupiter/JupiterTestSuite.class'])
 }
 */
 
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.jupiter.engine'
-		)
+				'Automatic-Module-Name': 'org.junit.jupiter.engine'
+				)
 	}
 }
 

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle
@@ -2,9 +2,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 junitPlatform {
 	filters {
-		engines {
-			include 'junit-jupiter'
-		}
+		engines { include 'junit-jupiter' }
 		includeClassNamePattern '.*Tests?'
 	}
 	logManager 'org.apache.logging.log4j.jul.LogManager'
@@ -12,8 +10,8 @@ junitPlatform {
 
 /*
 test {
-	scanForTestClasses = false
-	include(['org/junit/jupiter/JupiterTestSuite.class'])
+ scanForTestClasses = false
+ include(['org/junit/jupiter/JupiterTestSuite.class'])
 }
 */
 
@@ -39,7 +37,7 @@ dependencies {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.jupiter.migrationsupport'
-		)
+				'Automatic-Module-Name': 'org.junit.jupiter.migrationsupport'
+				)
 	}
 }

--- a/junit-jupiter-params/junit-jupiter-params.gradle
+++ b/junit-jupiter-params/junit-jupiter-params.gradle
@@ -2,19 +2,13 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 buildscript {
-	repositories {
-		jcenter()
-	}
-	dependencies {
-		classpath "com.github.jengelman.gradle.plugins:shadow:${shadowVersion}"
-	}
+	repositories { jcenter() }
+	dependencies { classpath "com.github.jengelman.gradle.plugins:shadow:${shadowVersion}" }
 }
 
 junitPlatform {
 	filters {
-		engines {
-			include 'junit-jupiter'
-		}
+		engines { include 'junit-jupiter' }
 		includeClassNamePattern '.*Tests?'
 	}
 	logManager 'org.apache.logging.log4j.jul.LogManager'
@@ -44,13 +38,13 @@ sourceSets.test.runtimeClasspath += configurations.shadow
 
 eclipse {
 	classpath {
-		plusConfigurations += [ configurations.shadow ]
+		plusConfigurations += [configurations.shadow]
 	}
 }
 
 idea {
 	module {
-		scopes.PROVIDED.plus += [ configurations.shadow ]
+		scopes.PROVIDED.plus += [configurations.shadow]
 	}
 }
 
@@ -63,8 +57,8 @@ jar.enabled = false
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.jupiter.params'
-		)
+				'Automatic-Module-Name': 'org.junit.jupiter.params'
+				)
 	}
 }
 
@@ -84,6 +78,4 @@ shadowJar {
 	}
 }
 
-artifacts {
-	archives shadowJar
-}
+artifacts { archives shadowJar }

--- a/junit-platform-commons/junit-platform-commons.gradle
+++ b/junit-platform-commons/junit-platform-commons.gradle
@@ -1,7 +1,7 @@
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.platform.commons'
-		)
+				'Automatic-Module-Name': 'org.junit.platform.commons'
+				)
 	}
 }

--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle
@@ -2,12 +2,8 @@ apply plugin: 'java-library'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 buildscript {
-	repositories {
-		jcenter()
-	}
-	dependencies {
-		classpath "com.github.jengelman.gradle.plugins:shadow:${shadowVersion}"
-	}
+	repositories { jcenter() }
+	dependencies { classpath "com.github.jengelman.gradle.plugins:shadow:${shadowVersion}" }
 }
 
 dependencies {
@@ -29,8 +25,8 @@ jar {
 		// meant to be used on the Java 9 module path.
 		// See https://github.com/junit-team/junit5/issues/866#issuecomment-306017162
 		attributes(
-			'Main-Class': 'org.junit.platform.console.ConsoleLauncher'
-		)
+				'Main-Class': 'org.junit.platform.console.ConsoleLauncher'
+				)
 	}
 }
 
@@ -49,9 +45,9 @@ shadowJar {
 	}
 
 	dependsOn(
-		project(':junit-platform-console').shadowJar,
-		project(':junit-jupiter-params').shadowJar
-	)
+			project(':junit-platform-console').shadowJar,
+			project(':junit-jupiter-params').shadowJar
+			)
 
 	classifier = null
 	configurations = [project.configurations.shadow]
@@ -72,20 +68,18 @@ shadowJar {
 	manifest {
 		inheritFrom project.tasks.jar.manifest
 		attributes(
-			'Specification-Title': "$project.name",
-			'Implementation-Title': "$project.name",
-			// generate test engine version information in single shared manifest file
-			// pattern of key and value: `'Engine-Version-{YourTestEngine#getId()}': '47.11'`
-			'Engine-Version-junit-jupiter': "$rootProject.version",
-			'Engine-Version-junit-vintage': "$vintageVersion"
-		)
+				'Specification-Title': "$project.name",
+				'Implementation-Title': "$project.name",
+				// generate test engine version information in single shared manifest file
+				// pattern of key and value: `'Engine-Version-{YourTestEngine#getId()}': '47.11'`
+				'Engine-Version-junit-jupiter': "$rootProject.version",
+				'Engine-Version-junit-vintage': "$vintageVersion"
+				)
 	}
 }
 
 
-artifacts {
-	archives shadowJar
-}
+artifacts { archives shadowJar }
 
 task standaloneExec(type: JavaExec, dependsOn: [shadowJar, testClasses]) {
 	ignoreExitValue = true
@@ -95,9 +89,12 @@ task standaloneExec(type: JavaExec, dependsOn: [shadowJar, testClasses]) {
 	args = [
 		"$shadowJar.archiveName",
 		'--scan-classpath',
-		'--include-classname', 'standalone.*',
-		'--classpath', "$buildDir/classes/java/test",
-		'--details', 'tree'
+		'--include-classname',
+		'standalone.*',
+		'--classpath',
+		"$buildDir/classes/java/test",
+		'--details',
+		'tree'
 	]
 	standardOutput = new ByteArrayOutputStream()
 	errorOutput = new ByteArrayOutputStream()

--- a/junit-platform-console/junit-platform-console.gradle
+++ b/junit-platform-console/junit-platform-console.gradle
@@ -1,12 +1,8 @@
 apply plugin: 'com.github.johnrengelman.shadow'
 
 buildscript {
-	repositories {
-		jcenter()
-	}
-	dependencies {
-		classpath "com.github.jengelman.gradle.plugins:shadow:${shadowVersion}"
-	}
+	repositories { jcenter() }
+	dependencies { classpath "com.github.jengelman.gradle.plugins:shadow:${shadowVersion}" }
 }
 
 dependencies {
@@ -19,22 +15,22 @@ sourceSets.main.compileClasspath += configurations.shadow
 
 eclipse {
 	classpath {
-		plusConfigurations += [ configurations.shadow ]
+		plusConfigurations += [configurations.shadow]
 	}
 }
 
 idea {
 	module {
-		scopes.PROVIDED.plus += [ configurations.shadow ]
+		scopes.PROVIDED.plus += [configurations.shadow]
 	}
 }
 
 jar {
 	manifest {
 		attributes(
-			'Main-Class': 'org.junit.platform.console.ConsoleLauncher',
-			'Automatic-Module-Name': 'org.junit.platform.console'
-		)
+				'Main-Class': 'org.junit.platform.console.ConsoleLauncher',
+				'Automatic-Module-Name': 'org.junit.platform.console'
+				)
 	}
 }
 
@@ -55,10 +51,7 @@ shadowJar {
 	exclude 'META-INF/**'
 	relocate 'joptsimple', 'org.junit.platform.console.shadow.joptsimple'
 	transform(com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer) {
-		paths = [
-			'joptsimple/ExceptionMessages.properties',
-			'joptsimple/HelpFormatterMessages.properties'
-		]
+		paths = ['joptsimple/ExceptionMessages.properties', 'joptsimple/HelpFormatterMessages.properties']
 		keyTransformer = { key ->
 			key.replaceAll('^(joptsimple\\..*)$', 'org.junit.platform.console.shadow.$1')
 		}
@@ -69,6 +62,4 @@ shadowJar {
 	}
 }
 
-artifacts {
-	archives shadowJar
-}
+artifacts { archives shadowJar }

--- a/junit-platform-engine/junit-platform-engine.gradle
+++ b/junit-platform-engine/junit-platform-engine.gradle
@@ -1,15 +1,11 @@
-configurations {
-	testArtifacts.extendsFrom testRuntime
-}
+configurations { testArtifacts.extendsFrom testRuntime }
 
 task testJar(type: Jar) {
 	classifier 'test'
 	from sourceSets.test.output
 }
 
-artifacts {
-	testArtifacts testJar
-}
+artifacts { testArtifacts testJar }
 
 dependencies {
 	api(project(':junit-platform-commons'))
@@ -21,7 +17,7 @@ dependencies {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.platform.engine'
-		)
+				'Automatic-Module-Name': 'org.junit.platform.engine'
+				)
 	}
 }

--- a/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
+++ b/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
@@ -1,12 +1,8 @@
 apply plugin: 'groovy'
 
 configurations {
-	functionalTestRuntimeTestCompile {
-		description = 'Local dependencies used for compiling tests source code inside of Gradle functional tests'
-	}
-	functionalTestRuntimeTestRuntime {
-		description = 'Local dependencies used for tests runtime inside of Gradle functional tests'
-	}
+	functionalTestRuntimeTestCompile { description = 'Local dependencies used for compiling tests source code inside of Gradle functional tests' }
+	functionalTestRuntimeTestRuntime { description = 'Local dependencies used for tests runtime inside of Gradle functional tests' }
 }
 
 // Write the plugin's classpath to a file to share with the tests.
@@ -34,9 +30,7 @@ dependencies {
 	api(project(path: ':junit-platform-console', configuration: 'shadow'))
 	api(project(':junit-platform-launcher'))
 	testRuntimeOnly("junit:junit:${junit4Version}")
-	testImplementation('org.spockframework:spock-core:1.0-groovy-2.4') {
-		exclude module: 'groovy-all'
-	}
+	testImplementation('org.spockframework:spock-core:1.0-groovy-2.4') { exclude module: 'groovy-all' }
 	testImplementation(gradleTestKit())
 	functionalTestRuntimeTestCompile(project(':junit-jupiter-api'))
 	functionalTestRuntimeTestRuntime(project(':junit-platform-console'))
@@ -55,7 +49,7 @@ processResources {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.platform.gradle.plugin'
-		)
+				'Automatic-Module-Name': 'org.junit.platform.gradle.plugin'
+				)
 	}
 }

--- a/junit-platform-launcher/junit-platform-launcher.gradle
+++ b/junit-platform-launcher/junit-platform-launcher.gradle
@@ -5,7 +5,7 @@ dependencies {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.platform.launcher'
-		)
+				'Automatic-Module-Name': 'org.junit.platform.launcher'
+				)
 	}
 }

--- a/junit-platform-runner/junit-platform-runner.gradle
+++ b/junit-platform-runner/junit-platform-runner.gradle
@@ -7,7 +7,7 @@ dependencies {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.platform.runner'
-		)
+				'Automatic-Module-Name': 'org.junit.platform.runner'
+				)
 	}
 }

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle
@@ -5,7 +5,7 @@ dependencies {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.platform.suite.api'
-		)
+				'Automatic-Module-Name': 'org.junit.platform.suite.api'
+				)
 	}
 }

--- a/junit-platform-surefire-provider/junit-platform-surefire-provider.gradle
+++ b/junit-platform-surefire-provider/junit-platform-surefire-provider.gradle
@@ -2,9 +2,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 junitPlatform {
 	filters {
-		engines {
-			include 'junit-jupiter'
-		}
+		engines { include 'junit-jupiter' }
 		includeClassNamePattern '.*Tests?'
 	}
 	logManager 'org.apache.logging.log4j.jul.LogManager'
@@ -31,7 +29,7 @@ dependencies {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.platform.surefire.provider'
-		)
+				'Automatic-Module-Name': 'org.junit.platform.surefire.provider'
+				)
 	}
 }

--- a/junit-vintage-engine/junit-vintage-engine.gradle
+++ b/junit-vintage-engine/junit-vintage-engine.gradle
@@ -2,9 +2,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 junitPlatform {
 	filters {
-		engines {
-			include 'junit-jupiter'
-		}
+		engines { include 'junit-jupiter' }
 		includeClassNamePattern '.*Tests?'
 	}
 	logManager 'org.apache.logging.log4j.jul.LogManager'
@@ -12,8 +10,8 @@ junitPlatform {
 
 /*
 test {
-	scanForTestClasses = false
-	include(['org/junit/vintage/engine/VintageTestEngineTestSuite.class'])
+ scanForTestClasses = false
+ include(['org/junit/vintage/engine/VintageTestEngineTestSuite.class'])
 }
 */
 
@@ -40,7 +38,7 @@ dependencies {
 jar {
 	manifest {
 		attributes(
-			'Automatic-Module-Name': 'org.junit.vintage.engine'
-		)
+				'Automatic-Module-Name': 'org.junit.vintage.engine'
+				)
 	}
 }

--- a/platform-tests/platform-tests.gradle
+++ b/platform-tests/platform-tests.gradle
@@ -2,9 +2,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 junitPlatform {
 	filters {
-		engines {
-			include 'junit-jupiter'
-		}
+		engines { include 'junit-jupiter' }
 		includeClassNamePattern '.*Tests?'
 	}
 	logManager 'org.apache.logging.log4j.jul.LogManager'
@@ -12,10 +10,10 @@ junitPlatform {
 
 // Tests in `AutomaticModuleNameTests` depend on all and the three jars. #894
 junitPlatformTest.dependsOn(
-	project(':junit-jupiter-migrationsupport').jar,
-	project(':junit-platform-gradle-plugin').jar,
-	project(':junit-platform-surefire-provider').jar
-)
+		project(':junit-jupiter-migrationsupport').jar,
+		project(':junit-platform-gradle-plugin').jar,
+		project(':junit-platform-surefire-provider').jar
+		)
 
 dependencies {
 	// --- Things we are testing --------------------------------------------------


### PR DESCRIPTION
## Overview

Provided Gradel formatting using spotless groovy formatter, as proposed for #843.
Change is split in 3 parts:

1. Modification to gradle build
2. Manual adaptations required due to groovy formatter constraints
3. Applied groovy formatter on the gradle files

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass

## Remaining problems
I am afraid that there is a test failure also occurring for the master branch, hence not all tests passed.

> AssertionFailedError: `Automatic-Module-Name` not found in manifest of JAR: ../junit-jupiter-migration-support/

Anyhow, maybe you can already let me know whether you consider the modifications useful.