### PR TITLE
Rename method to getFilterByType.

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -24,7 +24,8 @@ on GitHub.
 
 ===== Deprecations and Breaking Changes
 
-* ❓
+* The method `getDiscoveryFiltersByType` of `EngineDiscoveryRequest` has been renamed to
+  `getFiltersByType`.
 
 ===== New Features and Improvements
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/DiscoveryFilterApplier.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/DiscoveryFilterApplier.java
@@ -32,8 +32,8 @@ class DiscoveryFilterApplier {
 	 * Apply all filters. Currently only {@link ClassNameFilter} is considered.
 	 */
 	void applyAllFilters(EngineDiscoveryRequest discoveryRequest, TestDescriptor engineDescriptor) {
-		applyClassNameFilters(discoveryRequest.getDiscoveryFiltersByType(ClassNameFilter.class), engineDescriptor);
-		applyPackageNameFilters(discoveryRequest.getDiscoveryFiltersByType(PackageNameFilter.class), engineDescriptor);
+		applyClassNameFilters(discoveryRequest.getFiltersByType(ClassNameFilter.class), engineDescriptor);
+		applyPackageNameFilters(discoveryRequest.getFiltersByType(PackageNameFilter.class), engineDescriptor);
 	}
 
 	private void applyPackageNameFilters(List<PackageNameFilter> packageNameFilters, TestDescriptor engineDescriptor) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
@@ -58,7 +58,7 @@ public interface EngineDiscoveryRequest {
 	 * @param filterType the type of {@link DiscoveryFilter} to filter by
 	 * @return all filters of this request that are instances of {@code filterType}
 	 */
-	<T extends DiscoveryFilter<?>> List<T> getDiscoveryFiltersByType(Class<T> filterType);
+	<T extends DiscoveryFilter<?>> List<T> getFiltersByType(Class<T> filterType);
 
 	/**
 	 * Get the {@link ConfigurationParameters} for this request.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/filter/ClasspathScanningSupport.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/filter/ClasspathScanningSupport.java
@@ -39,8 +39,8 @@ public class ClasspathScanningSupport {
 	 */
 	public static Predicate<String> buildClassNamePredicate(EngineDiscoveryRequest request) {
 		List<DiscoveryFilter<String>> filters = new ArrayList<>();
-		filters.addAll(request.getDiscoveryFiltersByType(ClassNameFilter.class));
-		filters.addAll(request.getDiscoveryFiltersByType(PackageNameFilter.class));
+		filters.addAll(request.getFiltersByType(ClassNameFilter.class));
+		filters.addAll(request.getFiltersByType(PackageNameFilter.class));
 		return composeFilters(filters).toPredicate();
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultDiscoveryRequest.java
@@ -69,7 +69,7 @@ final class DefaultDiscoveryRequest implements LauncherDiscoveryRequest {
 	}
 
 	@Override
-	public <T extends DiscoveryFilter<?>> List<T> getDiscoveryFiltersByType(Class<T> filterType) {
+	public <T extends DiscoveryFilter<?>> List<T> getFiltersByType(Class<T> filterType) {
 		Preconditions.notNull(filterType, "filterType must not be null");
 		return this.discoveryFilters.stream().filter(filterType::isInstance).map(filterType::cast).collect(toList());
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/JUnit4DiscoveryRequestResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/JUnit4DiscoveryRequestResolver.java
@@ -77,7 +77,7 @@ public class JUnit4DiscoveryRequestResolver {
 
 	private Set<TestClassRequest> filterAndConvertToTestClassRequests(EngineDiscoveryRequest discoveryRequest,
 			TestClassCollector collector) {
-		List<ClassNameFilter> allClassNameFilters = discoveryRequest.getDiscoveryFiltersByType(ClassNameFilter.class);
+		List<ClassNameFilter> allClassNameFilters = discoveryRequest.getFiltersByType(ClassNameFilter.class);
 		Filter<Class<?>> adaptedFilter = adaptFilter(composeFilters(allClassNameFilters), Class::getName);
 		Filter<Class<?>> classFilter = new ExclusionReasonConsumingFilter<>(adaptedFilter,
 			(testClass, reason) -> logger.fine(() -> String.format("Class %s was excluded by a class filter: %s",

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
@@ -103,7 +103,7 @@ class DiscoveryRequestCreatorTests {
 
 		LauncherDiscoveryRequest request = convert();
 
-		List<ClassNameFilter> filter = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+		List<ClassNameFilter> filter = request.getFiltersByType(ClassNameFilter.class);
 		assertThat(filter).hasSize(1);
 		assertThat(filter.get(0).toString()).contains(STANDARD_INCLUDE_PATTERN);
 	}
@@ -115,7 +115,7 @@ class DiscoveryRequestCreatorTests {
 
 		LauncherDiscoveryRequest request = convert();
 
-		List<ClassNameFilter> filter = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+		List<ClassNameFilter> filter = request.getFiltersByType(ClassNameFilter.class);
 		assertThat(filter).hasSize(1);
 		assertThat(filter.get(0).toString()).contains("Foo.*Bar");
 		assertThat(filter.get(0).toString()).contains("Bar.*Foo");
@@ -128,7 +128,7 @@ class DiscoveryRequestCreatorTests {
 
 		LauncherDiscoveryRequest request = convert();
 
-		List<ClassNameFilter> filter = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+		List<ClassNameFilter> filter = request.getFiltersByType(ClassNameFilter.class);
 		assertThat(filter).hasSize(2);
 		assertThat(filter.get(1).toString()).contains("Foo.*Bar");
 		assertThat(filter.get(1).toString()).contains("Bar.*Foo");
@@ -141,7 +141,7 @@ class DiscoveryRequestCreatorTests {
 		options.setExcludedPackages(asList("org.junit.excluded1"));
 
 		LauncherDiscoveryRequest request = convert();
-		List<PackageNameFilter> packageNameFilters = request.getDiscoveryFiltersByType(PackageNameFilter.class);
+		List<PackageNameFilter> packageNameFilters = request.getFiltersByType(PackageNameFilter.class);
 
 		assertThat(packageNameFilters).hasSize(2);
 		assertThat(packageNameFilters.get(0).toString()).contains("org.junit.included1");

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilderTests.java
@@ -193,7 +193,7 @@ class LauncherDiscoveryRequestBuilderTests {
 					).build();
 			// @formatter:on
 
-			List<String> filterStrings = discoveryRequest.getDiscoveryFiltersByType(DiscoveryFilter.class).stream().map(
+			List<String> filterStrings = discoveryRequest.getFiltersByType(DiscoveryFilter.class).stream().map(
 				DiscoveryFilter::toString).collect(toList());
 			assertThat(filterStrings).hasSize(2);
 			assertThat(filterStrings).contains("filter1", "filter2");

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -151,7 +151,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<PackageNameFilter> filters = request.getDiscoveryFiltersByType(PackageNameFilter.class);
+			List<PackageNameFilter> filters = request.getFiltersByType(PackageNameFilter.class);
 			assertThat(filters).hasSize(1);
 
 			PackageNameFilter filter = filters.get(0);
@@ -169,7 +169,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<PackageNameFilter> filters = request.getDiscoveryFiltersByType(PackageNameFilter.class);
+			List<PackageNameFilter> filters = request.getFiltersByType(PackageNameFilter.class);
 			assertThat(filters).hasSize(1);
 
 			PackageNameFilter filter = filters.get(0);
@@ -255,7 +255,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(getOnlyElement(filters).toString()).contains(STANDARD_INCLUDE_PATTERN);
 		}
 
@@ -268,7 +268,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(filters).isEmpty();
 		}
 
@@ -282,7 +282,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(getOnlyElement(filters).toString()).contains(".*Foo");
 		}
 
@@ -295,7 +295,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(getOnlyElement(filters).toString()).contains(".*Foo");
 		}
 
@@ -309,7 +309,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(getOnlyElement(filters).toString()).contains(".*Foo", "Bar.*");
 		}
 
@@ -322,7 +322,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(getOnlyElement(filters).toString()).contains(".*Foo", "Bar.*");
 		}
 
@@ -336,7 +336,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(getOnlyElement(filters).toString()).contains(STANDARD_INCLUDE_PATTERN);
 		}
 
@@ -350,7 +350,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(filters).isEmpty();
 		}
 
@@ -364,7 +364,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(filters).isEmpty();
 		}
 
@@ -377,7 +377,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(getOnlyElement(filters).toString()).contains("'foo'", "'bar'");
 		}
 
@@ -390,7 +390,7 @@ class JUnitPlatformRunnerTests {
 
 			LauncherDiscoveryRequest request = instantiateRunnerAndCaptureGeneratedRequest(TestCase.class);
 
-			List<ClassNameFilter> filters = request.getDiscoveryFiltersByType(ClassNameFilter.class);
+			List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 			assertThat(getOnlyElement(filters).toString()).contains("'foo'", "'bar'");
 		}
 


### PR DESCRIPTION
## Overview

Provide a consistent API. The method for retrieving selectors already has the name `getSelectorsByType` instead of `getDiscoverySelectorsByType`. I think it is helpful to omit the word discovery in the method name because it reduces its length but the reader still can deduce from the context (it's an `EngineDiscoveryRequest`) that the methods return `DiscoveryFilter`s and `DiscoverySelector`s.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
