### PR TITLE
Add info the parameters must not be null.

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestEngine.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestEngine.java
@@ -64,9 +64,9 @@ public interface TestEngine {
 	 * must be used to create unique IDs for children of the root's descriptor
 	 * by calling {@link UniqueId#append}.
 	 *
-	 * @param discoveryRequest the discovery request
+	 * @param discoveryRequest the discovery request; never {@code null}
 	 * @param uniqueId the unique ID to be used for this test engine's
-	 * {@code TestDescriptor}
+	 * {@code TestDescriptor}; never {@code null}
 	 * @return the root {@code TestDescriptor} of this engine, typically an
 	 * instance of {@code EngineDescriptor}
 	 * @see org.junit.platform.engine.support.descriptor.EngineDescriptor
@@ -81,7 +81,7 @@ public interface TestEngine {
 	 * the {@link EngineExecutionListener} to be notified of test execution
 	 * events, and {@link ConfigurationParameters} that may influence test execution.
 	 *
-	 * @param request the request to execute tests for
+	 * @param request the request to execute tests for; never {@code null}
 	 */
 	void execute(ExecutionRequest request);
 


### PR DESCRIPTION
## Overview

Add info the parameters must not be null.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
