### PR TITLE
Provide request to DiscoverySelectorResolver.

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ClassSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ClassSelectorResolver.java
@@ -10,20 +10,22 @@
 
 package org.junit.vintage.engine.discovery;
 
+import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.discovery.ClassSelector;
 
 /**
  * @since 4.12
  */
-class ClassSelectorResolver extends DiscoverySelectorResolver<ClassSelector> {
-
-	ClassSelectorResolver() {
-		super(ClassSelector.class);
-	}
+class ClassSelectorResolver implements DiscoverySelectorResolver {
 
 	@Override
-	void resolve(ClassSelector selector, TestClassCollector collector) {
-		collector.addCompletely(selector.getJavaClass());
+	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
+		// @formatter:off
+		request.getSelectorsByType(ClassSelector.class)
+			.stream()
+			.map(ClassSelector::getJavaClass)
+			.forEach(collector::addCompletely);
+		// @formatter:on
 	}
 
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ClasspathRootSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ClasspathRootSelectorResolver.java
@@ -12,26 +12,33 @@ package org.junit.vintage.engine.discovery;
 
 import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInClasspathRoot;
 
+import java.util.Collection;
 import java.util.function.Predicate;
 
+import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.discovery.ClasspathRootSelector;
 
 /**
  * @since 4.12
  */
-class ClasspathRootSelectorResolver extends DiscoverySelectorResolver<ClasspathRootSelector> {
+class ClasspathRootSelectorResolver implements DiscoverySelectorResolver {
 
 	private final Predicate<String> classNamePredicate;
 
 	ClasspathRootSelectorResolver(Predicate<String> classNamePredicate) {
-		super(ClasspathRootSelector.class);
 		this.classNamePredicate = classNamePredicate;
 	}
 
 	@Override
-	void resolve(ClasspathRootSelector selector, TestClassCollector collector) {
-		findAllClassesInClasspathRoot(selector.getClasspathRoot(), classTester, classNamePredicate).forEach(
-			collector::addCompletely);
+	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
+		// @formatter:off
+		request.getSelectorsByType(ClasspathRootSelector.class)
+			.stream()
+			.map(ClasspathRootSelector::getClasspathRoot)
+			.map(root -> findAllClassesInClasspathRoot(root, classTester, classNamePredicate))
+			.flatMap(Collection::stream)
+			.forEach(collector::addCompletely);
+		// @formatter:on
 	}
 
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/DiscoverySelectorResolver.java
@@ -10,25 +10,14 @@
 
 package org.junit.vintage.engine.discovery;
 
-import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.EngineDiscoveryRequest;
 
 /**
  * @since 4.12
  */
-abstract class DiscoverySelectorResolver<T extends DiscoverySelector> {
+interface DiscoverySelectorResolver {
 
-	protected static final IsPotentialJUnit4TestClass classTester = new IsPotentialJUnit4TestClass();
+	IsPotentialJUnit4TestClass classTester = new IsPotentialJUnit4TestClass();
 
-	private final Class<T> selectorClass;
-
-	DiscoverySelectorResolver(Class<T> selectorClass) {
-		this.selectorClass = selectorClass;
-	}
-
-	Class<T> getSelectorClass() {
-		return selectorClass;
-	}
-
-	abstract void resolve(T selector, TestClassCollector collector);
-
+	void resolve(EngineDiscoveryRequest request, TestClassCollector collector);
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/JUnit4DiscoveryRequestResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/JUnit4DiscoveryRequestResolver.java
@@ -22,7 +22,6 @@ import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import org.junit.platform.commons.meta.API;
-import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.discovery.ClassNameFilter;
@@ -52,13 +51,13 @@ public class JUnit4DiscoveryRequestResolver {
 
 	private TestClassCollector collectTestClasses(EngineDiscoveryRequest discoveryRequest) {
 		TestClassCollector collector = new TestClassCollector();
-		for (DiscoverySelectorResolver<?> selectorResolver : getAllDiscoverySelectorResolvers(discoveryRequest)) {
-			resolveSelectorsOfSingleType(discoveryRequest, selectorResolver, collector);
+		for (DiscoverySelectorResolver selectorResolver : getAllDiscoverySelectorResolvers(discoveryRequest)) {
+			selectorResolver.resolve(discoveryRequest, collector);
 		}
 		return collector;
 	}
 
-	private List<DiscoverySelectorResolver<?>> getAllDiscoverySelectorResolvers(EngineDiscoveryRequest request) {
+	private List<DiscoverySelectorResolver> getAllDiscoverySelectorResolvers(EngineDiscoveryRequest request) {
 		Predicate<String> classNamePredicate = buildClassNamePredicate(request);
 		return asList( //
 			new ClasspathRootSelectorResolver(classNamePredicate), //
@@ -67,12 +66,6 @@ public class JUnit4DiscoveryRequestResolver {
 			new MethodSelectorResolver(), //
 			new UniqueIdSelectorResolver(logger)//
 		);
-	}
-
-	private <T extends DiscoverySelector> void resolveSelectorsOfSingleType(EngineDiscoveryRequest discoveryRequest,
-			DiscoverySelectorResolver<T> selectorResolver, TestClassCollector collector) {
-		discoveryRequest.getSelectorsByType(selectorResolver.getSelectorClass()).forEach(
-			selector -> selectorResolver.resolve(selector, collector));
 	}
 
 	private Set<TestClassRequest> filterAndConvertToTestClassRequests(EngineDiscoveryRequest discoveryRequest,

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
@@ -15,20 +15,21 @@ import static org.junit.vintage.engine.discovery.RunnerTestDescriptorAwareFilter
 
 import java.lang.reflect.Method;
 
+import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.discovery.MethodSelector;
 import org.junit.runner.Description;
 
 /**
  * @since 4.12
  */
-class MethodSelectorResolver extends DiscoverySelectorResolver<MethodSelector> {
-
-	MethodSelectorResolver() {
-		super(MethodSelector.class);
-	}
+class MethodSelectorResolver implements DiscoverySelectorResolver {
 
 	@Override
-	void resolve(MethodSelector selector, TestClassCollector collector) {
+	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
+		request.getSelectorsByType(MethodSelector.class).forEach(selector -> resolve(selector, collector));
+	}
+
+	private void resolve(MethodSelector selector, TestClassCollector collector) {
 		Class<?> testClass = selector.getJavaClass();
 		Method testMethod = selector.getJavaMethod();
 		Description methodDescription = Description.createTestDescription(testClass, testMethod.getName());

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/PackageNameSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/PackageNameSelectorResolver.java
@@ -12,26 +12,33 @@ package org.junit.vintage.engine.discovery;
 
 import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInPackage;
 
+import java.util.Collection;
 import java.util.function.Predicate;
 
+import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.discovery.PackageSelector;
 
 /**
  * @since 4.12
  */
-class PackageNameSelectorResolver extends DiscoverySelectorResolver<PackageSelector> {
+class PackageNameSelectorResolver implements DiscoverySelectorResolver {
 
 	private final Predicate<String> classNamePredicate;
 
 	PackageNameSelectorResolver(Predicate<String> classNamePredicate) {
-		super(PackageSelector.class);
 		this.classNamePredicate = classNamePredicate;
 	}
 
 	@Override
-	void resolve(PackageSelector selector, TestClassCollector collector) {
-		findAllClassesInPackage(selector.getPackageName(), classTester, classNamePredicate).forEach(
-			collector::addCompletely);
+	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
+		// @formatter:off
+		request.getSelectorsByType(PackageSelector.class)
+			.stream()
+			.map(PackageSelector::getPackageName)
+			.map(packageName -> findAllClassesInPackage(packageName, classTester, classNamePredicate))
+			.flatMap(Collection::stream)
+			.forEach(collector::addCompletely);
+		// @formatter:on
 	}
 
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdSelectorResolver.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.UniqueId.Segment;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
@@ -25,21 +26,24 @@ import org.junit.platform.engine.discovery.UniqueIdSelector;
 /**
  * @since 4.12
  */
-class UniqueIdSelectorResolver extends DiscoverySelectorResolver<UniqueIdSelector> {
+class UniqueIdSelectorResolver implements DiscoverySelectorResolver {
 
 	private final Logger logger;
 
 	UniqueIdSelectorResolver(Logger logger) {
-		super(UniqueIdSelector.class);
 		this.logger = logger;
 	}
 
 	@Override
-	void resolve(UniqueIdSelector selector, TestClassCollector collector) {
-		UniqueId uniqueId = selector.getUniqueId();
-		if (isNotEngineId(uniqueId) && isForVintageEngine(uniqueId)) {
-			resolveIntoFilteredTestClass(uniqueId, collector);
-		}
+	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
+		// @formatter:off
+		request.getSelectorsByType(UniqueIdSelector.class)
+			.stream()
+			.map(UniqueIdSelector::getUniqueId)
+			.filter(this::isNotEngineId)
+			.filter(this::isForVintageEngine)
+			.forEach(uniqueId -> resolveIntoFilteredTestClass(uniqueId, collector));
+		// @formatter:on
 	}
 
 	private boolean isNotEngineId(UniqueId uniqueId) {


### PR DESCRIPTION
## Overview

Each DiscoverySelectorResolver is now responsible for discovering test classes based on the provided EngineDiscoveryRequest. This minimizes the interface of DiscoverySelectorResolvers and makes it easier to use them.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
