### PR TITLE
Pass engine descriptor to resolve method

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
@@ -63,7 +63,7 @@ public class VintageTestEngine implements TestEngine {
 	@Override
 	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
 		EngineDescriptor engineDescriptor = new EngineDescriptor(uniqueId, "JUnit Vintage");
-		new JUnit4DiscoveryRequestResolver(engineDescriptor, LOG).resolve(discoveryRequest);
+		new JUnit4DiscoveryRequestResolver(LOG).resolveSelectors(discoveryRequest, engineDescriptor);
 		return engineDescriptor;
 	}
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/JUnit4DiscoveryRequestResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/JUnit4DiscoveryRequestResolver.java
@@ -25,8 +25,8 @@ import org.junit.platform.commons.meta.API;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.Filter;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.discovery.ClassNameFilter;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.engine.support.filter.ExclusionReasonConsumingFilter;
 
 /**
@@ -36,18 +36,16 @@ import org.junit.platform.engine.support.filter.ExclusionReasonConsumingFilter;
 public class JUnit4DiscoveryRequestResolver {
 
 	private static final IsPotentialJUnit4TestClass isPotentialJUnit4TestClass = new IsPotentialJUnit4TestClass();
-	private final EngineDescriptor engineDescriptor;
 	private final Logger logger;
 
-	public JUnit4DiscoveryRequestResolver(EngineDescriptor engineDescriptor, Logger logger) {
-		this.engineDescriptor = engineDescriptor;
+	public JUnit4DiscoveryRequestResolver(Logger logger) {
 		this.logger = logger;
 	}
 
-	public void resolve(EngineDiscoveryRequest discoveryRequest) {
+	public void resolveSelectors(EngineDiscoveryRequest discoveryRequest, TestDescriptor engineDescriptor) {
 		TestClassCollector collector = collectTestClasses(discoveryRequest);
 		Set<TestClassRequest> requests = filterAndConvertToTestClassRequests(discoveryRequest, collector);
-		populateEngineDescriptor(requests);
+		populateEngineDescriptor(requests, engineDescriptor);
 	}
 
 	private TestClassCollector collectTestClasses(EngineDiscoveryRequest discoveryRequest) {
@@ -97,7 +95,7 @@ public class JUnit4DiscoveryRequestResolver {
 		};
 	}
 
-	private void populateEngineDescriptor(Set<TestClassRequest> requests) {
+	private void populateEngineDescriptor(Set<TestClassRequest> requests, TestDescriptor engineDescriptor) {
 		new TestClassRequestResolver(engineDescriptor, logger).populateEngineDescriptorFrom(requests);
 	}
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscoveryRequestResolverTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscoveryRequestResolverTests.java
@@ -49,8 +49,8 @@ class VintageDiscoveryRequestResolverTests {
 				.build();
 		// @formatter:on
 
-		JUnit4DiscoveryRequestResolver resolver = new JUnit4DiscoveryRequestResolver(engineDescriptor, logger);
-		resolver.resolve(request);
+		JUnit4DiscoveryRequestResolver resolver = new JUnit4DiscoveryRequestResolver(logger);
+		resolver.resolveSelectors(request, engineDescriptor);
 
 		assertThat(engineDescriptor.getChildren()).hasSize(1);
 
@@ -92,8 +92,8 @@ class VintageDiscoveryRequestResolverTests {
 
 		RecordCollectingLogger logger = new RecordCollectingLogger();
 
-		JUnit4DiscoveryRequestResolver resolver = new JUnit4DiscoveryRequestResolver(engineDescriptor, logger);
-		resolver.resolve(request);
+		JUnit4DiscoveryRequestResolver resolver = new JUnit4DiscoveryRequestResolver(logger);
+		resolver.resolveSelectors(request, engineDescriptor);
 
 		assertThat(engineDescriptor.getChildren()).isEmpty();
 


### PR DESCRIPTION

## Overview

In addition I renamed the method resolve to resolveSelectors. I did this change for two reasons:

1. JUnit4DiscoveryRequestResolver has now the same interface like Jupiter's DiscoverySelectorResolver.
2. The change makes the resolver stateless and I think nowadays people are more used to stateless objects. At least for me it was surprising that the resolve method writes its output to an object that was passed to the resolver by its constructor.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
