### PR TITLE
Add ExtensionContext.getRoot() accessor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
     - jdk: oraclejdk9
       before_install:
         - cd ~
-        - wget http://download.java.net/java/jdk9/archive/176/binaries/jdk-9+176_linux-x64_bin.tar.gz
-        - tar -xzf jdk-9+176_linux-x64_bin.tar.gz
+        - wget http://download.java.net/java/jdk9/archive/177/binaries/jdk-9+177_linux-x64_bin.tar.gz
+        - tar -xzf jdk-9+177_linux-x64_bin.tar.gz
         - export JAVA_HOME=~/jdk-9
         - PATH=$JAVA_HOME/bin:$PATH
         - cd -

--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -48,7 +48,8 @@ on GitHub.
 * All `fail(...)` methods in `Assertions` can now be used to implement single-statement
   lambda expressions, thereby avoiding the need to implement a code block with an explicit
   return value.
-
+* New method `getRoot()` in `ExtensionContext` lets extension authors easily access the
+  top-most extension context.
 
 [[release-notes-5.0.0-m6-junit-vintage]]
 ==== JUnit Vintage

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -45,8 +45,17 @@ public interface ExtensionContext {
 	 *
 	 * @return an {@code Optional} containing the parent; never {@code null} but
 	 * potentially empty
+	* @see #getRoot()
 	 */
 	Optional<ExtensionContext> getParent();
+
+	/**
+	 * Get the extension context root.
+	 *
+	 * @return root extension context; never {@code null} but potentially {@code this}
+	 * @see #getParent()
+	 */
+	ExtensionContext getRoot();
 
 	/**
 	 * Get the unique ID of the current test or container.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -72,6 +72,15 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 		return Optional.ofNullable(parent);
 	}
 
+	@Override
+	public ExtensionContext getRoot() {
+		ExtensionContext root = this;
+		while (parent != null && parent != root) {
+			root = parent;
+		}
+		return root;
+	}
+
 	protected T getTestDescriptor() {
 		return testDescriptor;
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
@@ -58,7 +58,8 @@ class ExtensionContextTests {
 			() -> assertThat(engineContext.getTestMethod()).isEmpty(), //
 			() -> assertThat(engineContext.getElement()).isEmpty(), //
 			() -> assertThat(engineContext.getDisplayName()).isEqualTo(engineTestDescriptor.getDisplayName()), //
-			() -> assertThat(engineContext.getParent()).isEmpty() //
+			() -> assertThat(engineContext.getParent()).isEmpty(), //
+			() -> assertThat(engineContext.getRoot()).isSameAs(engineContext) //
 		);
 	}
 
@@ -89,14 +90,17 @@ class ExtensionContextTests {
 		ClassExtensionContext outerExtensionContext = new ClassExtensionContext(null, null, outerClassDescriptor, null);
 
 		assertThat(outerExtensionContext.getTags()).containsExactly("outer-tag");
+		assertThat(outerExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 
 		ClassExtensionContext nestedExtensionContext = new ClassExtensionContext(outerExtensionContext, null,
 			nestedClassDescriptor, null);
 		assertThat(nestedExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "nested-tag");
+		assertThat(nestedExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 
 		MethodExtensionContext methodExtensionContext = new MethodExtensionContext(outerExtensionContext, null,
 			methodTestDescriptor, new OuterClass(), new ThrowableCollector());
 		assertThat(methodExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "method-tag");
+		assertThat(methodExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 	}
 
 	@Test
@@ -111,6 +115,7 @@ class ExtensionContextTests {
 			() -> assertThat(methodExtensionContext.getTestClass()).contains(OuterClass.class), //
 			() -> assertThat(methodExtensionContext.getDisplayName()).isEqualTo(methodTestDescriptor.getDisplayName()), //
 			() -> assertThat(methodExtensionContext.getParent()).contains(classExtensionContext), //
+			() -> assertThat(methodExtensionContext.getRoot()).isSameAs(classExtensionContext), //
 			() -> assertThat(methodExtensionContext.getTestInstance().get()).isExactlyInstanceOf(OuterClass.class) //
 		);
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -104,6 +104,11 @@ class ParameterizedTestExtensionTests {
 			}
 
 			@Override
+			public ExtensionContext getRoot() {
+				return this;
+			}
+
+			@Override
 			public String getUniqueId() {
 				return null;
 			}


### PR DESCRIPTION
## Overview

This commit adds a convenient accessor that retrieves the root context of the current one. It eases the work of extension authors that want to store a value in the top-most, the root context.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
