### PR TITLE
Allow setSource to be called with null

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -126,7 +126,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	}
 
 	protected final void setSource(TestSource source) {
-		this.source = Preconditions.notNull(source, "TestSource must not be null");
+		this.source = source;
 	}
 
 	@Override

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -12,8 +12,6 @@ package org.junit.vintage.engine.descriptor;
 
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
-import java.util.Optional;
-
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
@@ -31,7 +29,7 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 
 	public RunnerTestDescriptor(TestDescriptor parent, Class<?> testClass, Runner runner) {
 		super(parent, SEGMENT_TYPE_RUNNER, testClass.getName(), runner.getDescription(), testClass.getName(),
-			Optional.of(new ClassSource(testClass)));
+			new ClassSource(testClass));
 		this.testClass = testClass;
 		this.runner = runner;
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -54,18 +54,18 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 	}
 
 	VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue, Description description,
-			Optional<? extends TestSource> source) {
+			TestSource source) {
 
 		this(parent, segmentType, segmentValue, description, generateDisplayName(description), source);
 	}
 
 	VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue, Description description,
-			String displayName, Optional<? extends TestSource> source) {
+			String displayName, TestSource source) {
 
 		super(parent.getUniqueId().append(segmentType, segmentValue), displayName);
 
 		this.description = description;
-		source.ifPresent(this::setSource);
+		setSource(source);
 	}
 
 	private static String generateDisplayName(Description description) {
@@ -104,19 +104,19 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 		return Optional.ofNullable(annotation).map(Category::value);
 	}
 
-	private static Optional<TestSource> toTestSource(Description description) {
+	private static TestSource toTestSource(Description description) {
 		Class<?> testClass = description.getTestClass();
 		if (testClass != null) {
 			String methodName = description.getMethodName();
 			if (methodName != null) {
 				MethodSource methodSource = toMethodSource(testClass, methodName);
 				if (methodSource != null) {
-					return Optional.of(methodSource);
+					return methodSource;
 				}
 			}
-			return Optional.of(new ClassSource(testClass));
+			return new ClassSource(testClass);
 		}
-		return Optional.empty();
+		return null;
 	}
 
 	private static MethodSource toMethodSource(Class<?> testClass, String methodName) {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
@@ -34,10 +34,7 @@ public class DemoHierarchicalContainerDescriptor extends AbstractTestDescriptor
 	public DemoHierarchicalContainerDescriptor(UniqueId uniqueId, String displayName, TestSource source,
 			Runnable beforeBlock) {
 		super(uniqueId, displayName);
-
-		if (source != null) {
-			setSource(source);
-		}
+		setSource(source);
 		this.beforeBlock = beforeBlock;
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
@@ -33,9 +33,7 @@ public class DemoHierarchicalTestDescriptor extends AbstractTestDescriptor imple
 	public DemoHierarchicalTestDescriptor(UniqueId uniqueId, String displayName, TestSource source,
 			Runnable executeBlock) {
 		super(uniqueId, displayName);
-		if (source != null) {
-			setSource(source);
-		}
+		setSource(source);
 		this.executeBlock = executeBlock;
 	}
 


### PR DESCRIPTION
## Overview

The field source already can be `null`. This is the case as long as `setSource` is not called. Existing code always checked the provided source and didn't call `setSource` if it was `null`. This check is not needed anymore.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
