### PR TITLE
Apply `final` modifiers to Color static instances

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/Color.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/Color.java
@@ -57,21 +57,21 @@ enum Color {
 		return testIdentifier.isContainer() ? CONTAINER : TEST;
 	}
 
-	static Color SUCCESSFUL = GREEN;
+	static final Color SUCCESSFUL = GREEN;
 
-	static Color ABORTED = YELLOW;
+	static final Color ABORTED = YELLOW;
 
-	static Color FAILED = RED;
+	static final Color FAILED = RED;
 
-	static Color SKIPPED = PURPLE;
+	static final Color SKIPPED = PURPLE;
 
-	static Color CONTAINER = CYAN;
+	static final Color CONTAINER = CYAN;
 
-	static Color TEST = BLUE;
+	static final Color TEST = BLUE;
 
-	static Color DYNAMIC = PURPLE;
+	static final Color DYNAMIC = PURPLE;
 
-	static Color REPORTED = WHITE;
+	static final Color REPORTED = WHITE;
 
 	private final String ansiString;
 


### PR DESCRIPTION
## Overview

Although the `static` instances in the `Color` class are effectively constants, they aren't declared as idiomatic constants, so they're technically mutable. This PR ensures that they are proper constants.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
