### PR TITLE
Simplify `Map.entrySet().forEach()` usage to `Map.forEach()`

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/XmlReportWriter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/XmlReportWriter.java
@@ -220,8 +220,7 @@ class XmlReportWriter {
 		StringBuilder builder = new StringBuilder(format("Report Entry #{0} (timestamp: {1})\n", entryNumber,
 			ISO_LOCAL_DATE_TIME.format(reportEntry.getTimestamp())));
 
-		reportEntry.getKeyValuePairs().entrySet().forEach(
-			entry -> builder.append(format("\t- {0}: {1}\n", entry.getKey(), entry.getValue())));
+		reportEntry.getKeyValuePairs().forEach((key, value) -> builder.append(format("\t- {0}: {1}\n", key, value)));
 
 		return builder.toString();
 	}


### PR DESCRIPTION
## Overview

This PR simplifies a usage of `Map.entrySet().forEach()` in `XmlReportWriter` to the equivalent `Map.forEach()`, which removes a number of unneeded characters.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
