### PR TITLE
Prevent subclassing of a utilities class

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/filter/ClasspathScanningSupport.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/filter/ClasspathScanningSupport.java
@@ -29,7 +29,13 @@ import org.junit.platform.engine.discovery.PackageNameFilter;
  * @since 1.0
  */
 @API(Experimental)
-public class ClasspathScanningSupport {
+public final class ClasspathScanningSupport {
+
+	///CLOVER:OFF
+	private ClasspathScanningSupport() {
+		/* no-op */
+	}
+	///CLOVER:ON
 
 	/**
 	 * Build a {@link Predicate} for fully qualified class names to be used for


### PR DESCRIPTION
## Overview

Although `ClasspathScanningSupport` is an `@API(Experimental)` utilities class, it can be subclassed, which doesn't seem to make sense to allow. This PR ensures that it cannot be subclassed.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
