### PR TITLE
Provide TestSource in constructors

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -31,6 +31,8 @@ on GitHub.
 * The method `getDiscoveryFiltersByType` of `EngineDiscoveryRequest` has been renamed to
   `getFiltersByType`.
 * The method `getSegments()` of `UniqueId` now returns an immutable list.
+* The method `setSource` of `AbstractTestDescriptor` has been removed. There is an additional
+  constructor with a `source` argument that can be used instead.
 
 ===== New Features and Improvements
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -80,7 +80,7 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 			Class<?> testClass) {
 
 		super(uniqueId, determineDisplayName(Preconditions.notNull(testClass, "Class must not be null"),
-			defaultDisplayNameGenerator));
+			defaultDisplayNameGenerator), new ClassSource(testClass));
 
 		this.testClass = testClass;
 		this.lifecycle = getTestInstanceLifecycle(testClass);
@@ -89,8 +89,6 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 		this.afterAllMethods = findAfterAllMethods(testClass, this.lifecycle == Lifecycle.PER_METHOD);
 		this.beforeEachMethods = findBeforeEachMethods(testClass);
 		this.afterEachMethods = findAfterEachMethods(testClass);
-
-		setSource(new ClassSource(testClass));
 	}
 
 	// --- TestDescriptor ------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -34,10 +34,9 @@ class DynamicContainerTestDescriptor extends JupiterTestDescriptor {
 	private final TestSource testSource;
 
 	DynamicContainerTestDescriptor(UniqueId uniqueId, DynamicContainer dynamicContainer, TestSource testSource) {
-		super(uniqueId, dynamicContainer.getDisplayName());
+		super(uniqueId, dynamicContainer.getDisplayName(), testSource);
 		this.dynamicContainer = dynamicContainer;
 		this.testSource = testSource;
-		setSource(testSource);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
@@ -26,9 +26,8 @@ class DynamicTestTestDescriptor extends JupiterTestDescriptor {
 	private final DynamicTest dynamicTest;
 
 	DynamicTestTestDescriptor(UniqueId uniqueId, DynamicTest dynamicTest, TestSource source) {
-		super(uniqueId, dynamicTest.getDisplayName());
+		super(uniqueId, dynamicTest.getDisplayName(), source);
 		this.dynamicTest = dynamicTest;
-		setSource(source);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
@@ -53,8 +54,8 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 
 	private static final ConditionEvaluator conditionEvaluator = new ConditionEvaluator();
 
-	JupiterTestDescriptor(UniqueId uniqueId, String displayName) {
-		super(uniqueId, displayName);
+	JupiterTestDescriptor(UniqueId uniqueId, String displayName, TestSource source) {
+		super(uniqueId, displayName, source);
 	}
 
 	// --- TestDescriptor ------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -34,12 +34,10 @@ abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod) {
-		super(uniqueId, displayName);
+		super(uniqueId, displayName, new MethodSource(Preconditions.notNull(testMethod, "Method must not be null")));
 
 		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
-		this.testMethod = Preconditions.notNull(testMethod, "Method must not be null");
-
-		setSource(new MethodSource(testMethod));
+		this.testMethod = testMethod;
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -30,7 +30,7 @@ import org.junit.platform.engine.UniqueId;
  * Abstract base implementation of {@link TestDescriptor} that may be used by
  * custom {@link org.junit.platform.engine.TestEngine TestEngines}.
  *
- * <p>Subclasses should call {@link #setSource} in their constructor, if
+ * <p>Subclasses should provide a {@code source} in their constructor, if
  * possible, and override {@link #getTags}, if appropriate.
  *
  * @since 1.0
@@ -44,7 +44,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	private TestDescriptor parent;
 
-	private TestSource source;
+	private final TestSource source;
 
 	private final Set<TestDescriptor> children = Collections.synchronizedSet(new LinkedHashSet<>(16));
 
@@ -56,10 +56,28 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	 * {@code null}
 	 * @param displayName the display name for this {@code TestDescriptor};
 	 * never {@code null} or blank
+	 * @see #AbstractTestDescriptor(UniqueId, String, TestSource)
 	 */
 	protected AbstractTestDescriptor(UniqueId uniqueId, String displayName) {
+		this(uniqueId, displayName, null);
+	}
+
+	/**
+	 * Create a new {@code AbstractTestDescriptor} with the supplied
+	 * {@link UniqueId}, display name and source.
+	 *
+	 * @param uniqueId the unique ID of this {@code TestDescriptor}; never
+	 * {@code null}
+	 * @param displayName the display name for this {@code TestDescriptor};
+	 * never {@code null} or blank
+	 * @param source the source of the test or container described by this
+	 * {@code TestDescriptor}; can be {@code null}
+	 * @see #AbstractTestDescriptor(UniqueId, String)
+	 */
+	protected AbstractTestDescriptor(UniqueId uniqueId, String displayName, TestSource source) {
 		this.uniqueId = Preconditions.notNull(uniqueId, "UniqueId must not be null");
 		this.displayName = Preconditions.notBlank(displayName, "displayName must not be null or blank");
+		this.source = source;
 	}
 
 	@Override
@@ -123,10 +141,6 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	@Override
 	public final Set<? extends TestDescriptor> getChildren() {
 		return Collections.unmodifiableSet(this.children);
-	}
-
-	protected final void setSource(TestSource source) {
-		this.source = Preconditions.notNull(source, "TestSource must not be null");
 	}
 
 	@Override

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -12,8 +12,6 @@ package org.junit.vintage.engine.descriptor;
 
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
-import java.util.Optional;
-
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
@@ -31,7 +29,7 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 
 	public RunnerTestDescriptor(TestDescriptor parent, Class<?> testClass, Runner runner) {
 		super(parent, SEGMENT_TYPE_RUNNER, testClass.getName(), runner.getDescription(), testClass.getName(),
-			Optional.of(new ClassSource(testClass)));
+			new ClassSource(testClass));
 		this.testClass = testClass;
 		this.runner = runner;
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import org.junit.experimental.categories.Category;
@@ -54,18 +53,17 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 	}
 
 	VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue, Description description,
-			Optional<? extends TestSource> source) {
+			TestSource source) {
 
 		this(parent, segmentType, segmentValue, description, generateDisplayName(description), source);
 	}
 
 	VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue, Description description,
-			String displayName, Optional<? extends TestSource> source) {
+			String displayName, TestSource source) {
 
-		super(parent.getUniqueId().append(segmentType, segmentValue), displayName);
+		super(parent.getUniqueId().append(segmentType, segmentValue), displayName, source);
 
 		this.description = description;
-		source.ifPresent(this::setSource);
 	}
 
 	private static String generateDisplayName(Description description) {
@@ -108,19 +106,19 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 		}
 	}
 
-	private static Optional<TestSource> toTestSource(Description description) {
+	private static TestSource toTestSource(Description description) {
 		Class<?> testClass = description.getTestClass();
 		if (testClass != null) {
 			String methodName = description.getMethodName();
 			if (methodName != null) {
 				MethodSource methodSource = toMethodSource(testClass, methodName);
 				if (methodSource != null) {
-					return Optional.of(methodSource);
+					return methodSource;
 				}
 			}
-			return Optional.of(new ClassSource(testClass));
+			return new ClassSource(testClass);
 		}
-		return Optional.empty();
+		return null;
 	}
 
 	private static MethodSource toMethodSource(Class<?> testClass, String methodName) {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoClassTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoClassTestDescriptor.java
@@ -30,8 +30,8 @@ public class DemoClassTestDescriptor extends AbstractTestDescriptor {
 	private final Class<?> testClass;
 
 	public DemoClassTestDescriptor(UniqueId uniqueId, Class<?> testClass) {
-		super(uniqueId, Preconditions.notNull(testClass, "Class must not be null").getSimpleName());
-		setSource(new ClassSource(testClass));
+		super(uniqueId, Preconditions.notNull(testClass, "Class must not be null").getSimpleName(),
+			new ClassSource(testClass));
 		this.testClass = testClass;
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoMethodTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoMethodTestDescriptor.java
@@ -33,13 +33,13 @@ public class DemoMethodTestDescriptor extends AbstractTestDescriptor {
 	private final Method testMethod;
 
 	public DemoMethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod) {
-		super(uniqueId, String.format("%s(%s)", Preconditions.notNull(testMethod, "Method must not be null").getName(),
-			ClassUtils.nullSafeToString(Class::getSimpleName, testMethod.getParameterTypes())));
+		super(uniqueId,
+			String.format("%s(%s)", Preconditions.notNull(testMethod, "Method must not be null").getName(),
+				ClassUtils.nullSafeToString(Class::getSimpleName, testMethod.getParameterTypes())),
+			new MethodSource(testMethod));
 
 		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
 		this.testMethod = testMethod;
-
-		setSource(new MethodSource(testMethod));
 	}
 
 	@Override

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalContainerDescriptor.java
@@ -33,11 +33,7 @@ public class DemoHierarchicalContainerDescriptor extends AbstractTestDescriptor
 
 	public DemoHierarchicalContainerDescriptor(UniqueId uniqueId, String displayName, TestSource source,
 			Runnable beforeBlock) {
-		super(uniqueId, displayName);
-
-		if (source != null) {
-			setSource(source);
-		}
+		super(uniqueId, displayName, source);
 		this.beforeBlock = beforeBlock;
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestDescriptor.java
@@ -32,10 +32,7 @@ public class DemoHierarchicalTestDescriptor extends AbstractTestDescriptor imple
 
 	public DemoHierarchicalTestDescriptor(UniqueId uniqueId, String displayName, TestSource source,
 			Runnable executeBlock) {
-		super(uniqueId, displayName);
-		if (source != null) {
-			setSource(source);
-		}
+		super(uniqueId, displayName, source);
 		this.executeBlock = executeBlock;
 	}
 


### PR DESCRIPTION
## Overview

Source has been set by the method `setSource` that was always called in the constructor. By adding a constructor with an additional `source` parameter we can make the field `source` final and remove the setter. This means we don't have to care about proper changes of the field anymore.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
