### PR TITLE
Issues/835 forbid return values from test and lifecycle methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -42,7 +42,7 @@ on GitHub.
 
 ===== Deprecations and Breaking Changes
 
-* ❓
+* A `void` return type is now enforced for `@Test` and lifecycle methods.
 
 ===== New Features and Improvements
 

--- a/documentation/src/docs/asciidoc/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/writing-tests.adoc
@@ -35,6 +35,9 @@ module.
 | `@ExtendWith`      | Used to register custom <<extensions,extensions>>
 |===
 
+Methods annotated with `@Test`, `@TestTemplate`, `@RepeatedTest`, `@BeforeAll`, `@AfterAll`,
+`@BeforeEach`, or `@AfterEach` annotations must not return a value.
+
 [[writing-tests-meta-annotations]]
 ==== Meta-Annotations and Composed Annotations
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterAll.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterAll.java
@@ -36,6 +36,7 @@ import org.junit.platform.commons.meta.API;
  * {@link TestInstance @TestInstance(Lifecycle.PER_CLASS)}. {@code @AfterAll}
  * methods may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
+ * {@code @AfterAll} methods must not return a value.
  *
  * <h3>Inheritance</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterAll.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterAll.java
@@ -29,14 +29,14 @@ import org.junit.platform.commons.meta.API;
  *
  * <h3>Method Signatures</h3>
  *
- * <p>{@code @AfterAll} methods must not be {@code private} and must be
- * {@code static} by default. Consequently, {@code @AfterAll} methods are not
+ * {@code @AfterAll} methods must have a {@code void} return type,
+ * must not be {@code private}, and must be {@code static} by default.
+ * Consequently, {@code @AfterAll} methods are not
  * supported in {@link Nested @Nested} test classes or as <em>interface default
  * methods</em> unless the test class is annotated with
  * {@link TestInstance @TestInstance(Lifecycle.PER_CLASS)}. {@code @AfterAll}
  * methods may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
- * {@code @AfterAll} methods must not return a value.
  *
  * <h3>Inheritance</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterEach.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterEach.java
@@ -27,10 +27,10 @@ import org.junit.platform.commons.meta.API;
  *
  * <h3>Method Signatures</h3>
  *
- * <p>{@code @AfterEach} methods must not be {@code private}, must not be
- * {@code static}, and may optionally declare parameters to be resolved by
+ * {@code @AfterEach} methods must have a {@code void} return type,
+ * must not be {@code private}, and must not be {@code static}.
+ * They may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
- * {@code @AfterEach} methods must not return a value.
  *
  * <h3>Inheritance</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterEach.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterEach.java
@@ -30,6 +30,7 @@ import org.junit.platform.commons.meta.API;
  * <p>{@code @AfterEach} methods must not be {@code private}, must not be
  * {@code static}, and may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
+ * {@code @AfterEach} methods must not return a value.
  *
  * <h3>Inheritance</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeAll.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeAll.java
@@ -36,6 +36,7 @@ import org.junit.platform.commons.meta.API;
  * {@link TestInstance @TestInstance(Lifecycle.PER_CLASS)}. {@code @BeforeAll}
  * methods may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
+ * {@code @BeforeAll} methods must not return a value.
  *
  * <h3>Inheritance</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeAll.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeAll.java
@@ -29,14 +29,14 @@ import org.junit.platform.commons.meta.API;
  *
  * <h3>Method Signatures</h3>
  *
- * <p>{@code @BeforeAll} methods must not be {@code private} and must be
- * {@code static} by default. Consequently, {@code @BeforeAll} methods are not
+ * {@code @BeforeAll} methods must have a {@code void} return type,
+ * must not be {@code private}, and must be {@code static} by default.
+ * Consequently, {@code @BeforeAll} methods are not
  * supported in {@link Nested @Nested} test classes or as <em>interface default
  * methods</em> unless the test class is annotated with
  * {@link TestInstance @TestInstance(Lifecycle.PER_CLASS)}. {@code @BeforeAll}
  * methods may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
- * {@code @BeforeAll} methods must not return a value.
  *
  * <h3>Inheritance</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeEach.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeEach.java
@@ -30,6 +30,7 @@ import org.junit.platform.commons.meta.API;
  * <p>{@code @BeforeEach} methods must not be {@code private}, must not be
  * {@code static}, and may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
+ * {@code @BeforeEach} methods must not return a value.
  *
  * <h3>Inheritance</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeEach.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeEach.java
@@ -27,10 +27,10 @@ import org.junit.platform.commons.meta.API;
  *
  * <h3>Method Signatures</h3>
  *
- * <p>{@code @BeforeEach} methods must not be {@code private}, must not be
- * {@code static}, and may optionally declare parameters to be resolved by
+ * {@code @BeforeEach} methods must have a {@code void} return type,
+ * must not be {@code private}, and must not be {@code static}.
+ * They may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
- * {@code @BeforeEach} methods must not return a value.
  *
  * <h3>Inheritance</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Test.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Test.java
@@ -25,7 +25,8 @@ import org.junit.platform.commons.meta.API;
  * {@code @Test} is used to signal that the annotated method is a
  * <em>test</em> method.
  *
- * <p>{@code @Test} methods must not be {@code private} or {@code static}.
+ * <p>{@code @Test} methods must not be {@code private} or {@code static}
+ * and must not return a value.
  *
  * <p>{@code @Test} methods may optionally declare parameters to be
  * resolved by {@link org.junit.jupiter.api.extension.ParameterResolver

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtils.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.descriptor;
 
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedMethods;
+import static org.junit.platform.commons.util.ReflectionUtils.returnsVoid;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -96,10 +97,6 @@ final class LifecycleMethodUtils {
 		List<Method> methods = findAnnotatedMethods(testClass, annotationType, traversalMode);
 		methods.forEach(method -> assertVoid(annotationType, method));
 		return methods;
-	}
-
-	private static boolean returnsVoid(Method method) {
-		return method.getReturnType().toString().equals("void");
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -24,7 +24,7 @@ import org.junit.platform.commons.meta.API;
 public class IsTestFactoryMethod extends IsTestableMethod {
 
 	public IsTestFactoryMethod() {
-		super(TestFactory.class);
+		super(TestFactory.class, false);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethod.java
@@ -24,7 +24,7 @@ import org.junit.platform.commons.meta.API;
 public class IsTestMethod extends IsTestableMethod {
 
 	public IsTestMethod() {
-		super(Test.class);
+		super(Test.class, true);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethod.java
@@ -24,7 +24,7 @@ import org.junit.platform.commons.meta.API;
 public class IsTestTemplateMethod extends IsTestableMethod {
 
 	public IsTestTemplateMethod() {
-		super(TestTemplate.class);
+		super(TestTemplate.class, true);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -26,12 +26,14 @@ import org.junit.platform.commons.meta.API;
  * @since 5.0
  */
 @API(Internal)
-class IsTestableMethod implements Predicate<Method> {
+abstract class IsTestableMethod implements Predicate<Method> {
 
 	private final Class<? extends Annotation> annotationType;
+	private final boolean mustReturnVoid;
 
-	IsTestableMethod(Class<? extends Annotation> annotationType) {
+	IsTestableMethod(Class<? extends Annotation> annotationType, boolean mustReturnVoid) {
 		this.annotationType = annotationType;
+		this.mustReturnVoid = mustReturnVoid;
 	}
 
 	@Override
@@ -46,7 +48,16 @@ class IsTestableMethod implements Predicate<Method> {
 		if (isAbstract(candidate)) {
 			return false;
 		}
+		if ((this.returnsVoid(candidate) != mustReturnVoid)) {
+			return false;
+		}
+
 		return isAnnotated(candidate, this.annotationType);
+	}
+
+	private boolean returnsVoid(Method method) {
+		//checking the class itself yields problems with bridge methods
+		return method.getReturnType().toString().equals("void");
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
 import static org.junit.platform.commons.util.ReflectionUtils.isAbstract;
 import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
 import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
+import static org.junit.platform.commons.util.ReflectionUtils.returnsVoid;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -48,16 +49,11 @@ abstract class IsTestableMethod implements Predicate<Method> {
 		if (isAbstract(candidate)) {
 			return false;
 		}
-		if ((this.returnsVoid(candidate) != mustReturnVoid)) {
+		if (returnsVoid(candidate) != mustReturnVoid) {
 			return false;
 		}
 
 		return isAnnotated(candidate, this.annotationType);
-	}
-
-	private boolean returnsVoid(Method method) {
-		//checking the class itself yields problems with bridge methods
-		return method.getReturnType().toString().equals("void");
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/NonVoidTestableMethodIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/NonVoidTestableMethodIntegrationTests.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.engine;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -21,24 +21,21 @@ class NonVoidTestableMethodIntegrationTests {
 	void valid() {
 	}
 
-	//this method must never be called
 	@Test
 	int invalidMethodReturningPrimitive() {
-		assertTrue(false);
+		fail("This method should never have been called.");
 		return 1;
 	}
 
-	//this method must never be called
 	@Test
 	String invalidMethodReturningObject() {
-		assertTrue(false);
+		fail("This method should never have been called.");
 		return "";
 	}
 
-	//this method must never be called
 	@RepeatedTest(3)
 	int invalidMethodVerifyingTestTemplateMethod() {
-		assertTrue(false);
+		fail("This method should never have been called.");
 		return 1;
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/NonVoidTestableMethodIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/NonVoidTestableMethodIntegrationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+class NonVoidTestableMethodIntegrationTests {
+
+	@Test
+	void valid() {
+	}
+
+	//this method must never be called
+	@Test
+	int invalidMethodReturningPrimitive() {
+		assertTrue(false);
+		return 1;
+	}
+
+	//this method must never be called
+	@Test
+	String invalidMethodReturningObject() {
+		assertTrue(false);
+		return "";
+	}
+
+	//this method must never be called
+	@RepeatedTest(3)
+	int invalidMethodVerifyingTestTemplateMethod() {
+		assertTrue(false);
+		return 1;
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtilsTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtilsTest.java
@@ -1,134 +1,228 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package org.junit.jupiter.engine.descriptor;
 
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.platform.commons.JUnitException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findAfterAllMethods;
+import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findAfterEachMethods;
+import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findBeforeAllMethods;
+import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findBeforeEachMethods;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.platform.commons.JUnitException;
 
 class LifecycleMethodUtilsTest {
 
-    @Test
-    void findBeforeEachMethodsWithStandardLifecycle() {
-        List<Method> methods = findBeforeEachMethods(TestCaseWithStandardLifecycle.class);
+	@Test
+	void findNonVoidBeforeAllMethodsWithStandardLifecycle() {
+		JUnitException exception = assertThrows(JUnitException.class,
+			() -> findBeforeAllMethods(TestCaseWithNonVoidLifecyleMethods.class, true));
+		assertEquals(
+			"@BeforeAll method 'java.lang.Double org.junit.jupiter.engine.descriptor.TestCaseWithNonVoidLifecyleMethods.cc()' must not return a value.",
+			exception.getMessage());
+	}
 
-        assertEquals(2, methods.size());
-        assertTrue(contains(methods, "nine"));
-        assertTrue(contains(methods, "ten"));
-    }
+	@Test
+	void findNonVoidAfterAllMethodsWithStandardLifecycle() {
+		JUnitException exception = assertThrows(JUnitException.class,
+			() -> findAfterAllMethods(TestCaseWithNonVoidLifecyleMethods.class, true));
+		assertEquals(
+			"@AfterAll method 'java.lang.String org.junit.jupiter.engine.descriptor.TestCaseWithNonVoidLifecyleMethods.dd()' must not return a value.",
+			exception.getMessage());
+	}
 
-    @Test
-    void findAfterEachMethodsWithStandardLifecycle() {
-        List<Method> methods = findAfterEachMethods(TestCaseWithStandardLifecycle.class);
+	@Test
+	void findNonVoidBeforeEachMethodsWithStandardLifecycle() {
+		JUnitException exception = assertThrows(JUnitException.class,
+			() -> findBeforeEachMethods(TestCaseWithNonVoidLifecyleMethods.class));
+		assertEquals(
+			"@BeforeEach method 'java.lang.String org.junit.jupiter.engine.descriptor.TestCaseWithNonVoidLifecyleMethods.aa()' must not return a value.",
+			exception.getMessage());
+	}
 
-        assertEquals(2, methods.size());
-        assertTrue(contains(methods, "eleven"));
-        assertTrue(contains(methods, "twelve"));
-    }
+	@Test
+	void findNonVoidAfterEachMethodsWithStandardLifecycle() {
+		JUnitException exception = assertThrows(JUnitException.class,
+			() -> findAfterEachMethods(TestCaseWithNonVoidLifecyleMethods.class));
+		assertEquals(
+			"@AfterEach method 'int org.junit.jupiter.engine.descriptor.TestCaseWithNonVoidLifecyleMethods.bb()' must not return a value.",
+			exception.getMessage());
+	}
 
-    @Test
-    void findBeforeAllMethodsWithStandardLifecycleAndWithoutRequiringStatic() {
-        List<Method> methods = findBeforeAllMethods(TestCaseWithStandardLifecycle.class, false);
+	@Test
+	void findBeforeEachMethodsWithStandardLifecycle() {
+		List<Method> methods = findBeforeEachMethods(TestCaseWithStandardLifecycle.class);
 
-        assertEquals(2, methods.size());
-        assertTrue(contains(methods, "one"));
-        assertTrue(contains(methods, "two"));
-    }
+		assertEquals(2, methods.size());
+		assertTrue(contains(methods, "nine"));
+		assertTrue(contains(methods, "ten"));
+	}
 
+	@Test
+	void findAfterEachMethodsWithStandardLifecycle() {
+		List<Method> methods = findAfterEachMethods(TestCaseWithStandardLifecycle.class);
 
-    @Test
-    void findBeforeAllMethodsWithStandardLifecycleAndRequiringStatic() {
-        assertThrows(JUnitException.class, () -> findBeforeAllMethods(TestCaseWithStandardLifecycle.class, true));
-    }
+		assertEquals(2, methods.size());
+		assertTrue(contains(methods, "eleven"));
+		assertTrue(contains(methods, "twelve"));
+	}
 
-    @Test
-    void findBeforeAllMethodsWithLifeCyclePerClassAndRequiringStatic() {
-        List<Method> methods = findBeforeAllMethods(TestCaseWithLifecyclePerClass.class, false);
+	@Test
+	void findBeforeAllMethodsWithStandardLifecycleAndWithoutRequiringStatic() {
+		List<Method> methods = findBeforeAllMethods(TestCaseWithStandardLifecycle.class, false);
 
-        assertEquals(2, methods.size());
-        assertTrue(contains(methods, "three"));
-        assertTrue(contains(methods, "four"));
-    }
+		assertEquals(2, methods.size());
+		assertTrue(contains(methods, "one"));
+		assertTrue(contains(methods, "two"));
+	}
 
-    @Test
-    void findAfterAllMethodsWithStandardLifecycleAndWithoutRequiringStatic() {
-        List<Method> methods = findAfterAllMethods(TestCaseWithStandardLifecycle.class, false);
+	@Test
+	void findBeforeAllMethodsWithStandardLifecycleAndRequiringStatic() {
+		JUnitException exception = assertThrows(JUnitException.class,
+			() -> findBeforeAllMethods(TestCaseWithStandardLifecycle.class, true));
+		assertEquals(
+			"@BeforeAll method 'void org.junit.jupiter.engine.descriptor.TestCaseWithStandardLifecycle.one()' must be static unless the test class is annotated with @TestInstance(Lifecycle.PER_CLASS).",
+			exception.getMessage());
+	}
 
-        assertEquals(2, methods.size());
-        assertTrue(contains(methods, "five"));
-        assertTrue(contains(methods, "six"));
-    }
+	@Test
+	void findBeforeAllMethodsWithLifeCyclePerClassAndRequiringStatic() {
+		List<Method> methods = findBeforeAllMethods(TestCaseWithLifecyclePerClass.class, false);
 
+		assertEquals(2, methods.size());
+		assertTrue(contains(methods, "three"));
+		assertTrue(contains(methods, "four"));
+	}
 
-    @Test
-    void findAfterAllMethodsWithStandardLifecycleAndRequiringStatic() {
-        assertThrows(JUnitException.class, () -> findAfterAllMethods(TestCaseWithStandardLifecycle.class, true));
-    }
+	@Test
+	void findAfterAllMethodsWithStandardLifecycleAndWithoutRequiringStatic() {
+		List<Method> methods = findAfterAllMethods(TestCaseWithStandardLifecycle.class, false);
 
-    @Test
-    void findAfterAllMethodsWithLifeCyclePerClassAndRequiringStatic() {
-        List<Method> methods = findAfterAllMethods(TestCaseWithLifecyclePerClass.class, false);
+		assertEquals(2, methods.size());
+		assertTrue(contains(methods, "five"));
+		assertTrue(contains(methods, "six"));
+	}
 
-        assertEquals(2, methods.size());
-        assertTrue(contains(methods, "seven"));
-        assertTrue(contains(methods, "eight"));
-    }
+	@Test
+	void findAfterAllMethodsWithStandardLifecycleAndRequiringStatic() {
+		assertThrows(JUnitException.class, () -> findAfterAllMethods(TestCaseWithStandardLifecycle.class, true));
+	}
 
-    private boolean contains(List<Method> methods, String methodName) {
-        // @formatter:off
+	@Test
+	void findAfterAllMethodsWithLifeCyclePerClassAndRequiringStatic() {
+		List<Method> methods = findAfterAllMethods(TestCaseWithLifecyclePerClass.class, false);
+
+		assertEquals(2, methods.size());
+		assertTrue(contains(methods, "seven"));
+		assertTrue(contains(methods, "eight"));
+	}
+
+	private boolean contains(List<Method> methods, String methodName) {
+		// @formatter:off
         return methods.stream()
                 .map(Method::getName)
                 .anyMatch(name -> name.equals(methodName));
         // @formatter:on
-    }
+	}
 
 }
 
 class TestCaseWithStandardLifecycle {
 
-    @BeforeAll
-    void one(){}
+	@BeforeAll
+	void one() {
+	}
 
-    @BeforeAll
-    void two(){}
+	@BeforeAll
+	void two() {
+	}
 
-    @BeforeEach
-    void nine(){}
+	@BeforeEach
+	void nine() {
+	}
 
-    @BeforeEach
-    void ten(){}
+	@BeforeEach
+	void ten() {
+	}
 
-    @AfterEach
-    void eleven(){}
+	@AfterEach
+	void eleven() {
+	}
 
-    @AfterEach
-    void twelve(){}
+	@AfterEach
+	void twelve() {
+	}
 
-    @AfterAll
-    void five(){}
+	@AfterAll
+	void five() {
+	}
 
-    @AfterAll
-    void six(){}
+	@AfterAll
+	void six() {
+	}
 
 }
 
 @TestInstance(Lifecycle.PER_CLASS)
 class TestCaseWithLifecyclePerClass {
 
-    @BeforeAll
-    void three(){}
+	@BeforeAll
+	void three() {
+	}
 
-    @BeforeAll
-    void four(){}
+	@BeforeAll
+	void four() {
+	}
 
-    @AfterAll
-    void seven(){}
+	@AfterAll
+	void seven() {
+	}
 
-    @AfterAll
-    void eight(){}
+	@AfterAll
+	void eight() {
+	}
+
+}
+
+class TestCaseWithNonVoidLifecyleMethods {
+
+	@BeforeEach
+	String aa() {
+		return null;
+	}
+
+	@AfterEach
+	int bb() {
+		return 1;
+	}
+
+	@BeforeAll
+	Double cc() {
+		return null;
+	}
+
+	@AfterAll
+	String dd() {
+		return "";
+	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtilsTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtilsTest.java
@@ -90,9 +90,8 @@ class LifecycleMethodUtilsTest {
 	void findBeforeAllMethodsWithStandardLifecycleAndWithoutRequiringStatic() {
 		List<Method> methods = findBeforeAllMethods(TestCaseWithStandardLifecycle.class, false);
 
-		assertEquals(2, methods.size());
+		assertEquals(1, methods.size());
 		assertTrue(contains(methods, "one"));
-		assertTrue(contains(methods, "two"));
 	}
 
 	@Test
@@ -150,10 +149,6 @@ class TestCaseWithStandardLifecycle {
 
 	@BeforeAll
 	void one() {
-	}
-
-	@BeforeAll
-	void two() {
 	}
 
 	@BeforeEach

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtilsTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtilsTest.java
@@ -137,10 +137,10 @@ class LifecycleMethodUtilsTest {
 
 	private boolean contains(List<Method> methods, String methodName) {
 		// @formatter:off
-        return methods.stream()
-                .map(Method::getName)
-                .anyMatch(name -> name.equals(methodName));
-        // @formatter:on
+		return methods.stream()
+				.map(Method::getName)
+				.anyMatch(methodName::equals);
+		// @formatter:on
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtilsTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtilsTest.java
@@ -1,0 +1,134 @@
+package org.junit.jupiter.engine.descriptor;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.platform.commons.JUnitException;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.*;
+
+class LifecycleMethodUtilsTest {
+
+    @Test
+    void findBeforeEachMethodsWithStandardLifecycle() {
+        List<Method> methods = findBeforeEachMethods(TestCaseWithStandardLifecycle.class);
+
+        assertEquals(2, methods.size());
+        assertTrue(contains(methods, "nine"));
+        assertTrue(contains(methods, "ten"));
+    }
+
+    @Test
+    void findAfterEachMethodsWithStandardLifecycle() {
+        List<Method> methods = findAfterEachMethods(TestCaseWithStandardLifecycle.class);
+
+        assertEquals(2, methods.size());
+        assertTrue(contains(methods, "eleven"));
+        assertTrue(contains(methods, "twelve"));
+    }
+
+    @Test
+    void findBeforeAllMethodsWithStandardLifecycleAndWithoutRequiringStatic() {
+        List<Method> methods = findBeforeAllMethods(TestCaseWithStandardLifecycle.class, false);
+
+        assertEquals(2, methods.size());
+        assertTrue(contains(methods, "one"));
+        assertTrue(contains(methods, "two"));
+    }
+
+
+    @Test
+    void findBeforeAllMethodsWithStandardLifecycleAndRequiringStatic() {
+        assertThrows(JUnitException.class, () -> findBeforeAllMethods(TestCaseWithStandardLifecycle.class, true));
+    }
+
+    @Test
+    void findBeforeAllMethodsWithLifeCyclePerClassAndRequiringStatic() {
+        List<Method> methods = findBeforeAllMethods(TestCaseWithLifecyclePerClass.class, false);
+
+        assertEquals(2, methods.size());
+        assertTrue(contains(methods, "three"));
+        assertTrue(contains(methods, "four"));
+    }
+
+    @Test
+    void findAfterAllMethodsWithStandardLifecycleAndWithoutRequiringStatic() {
+        List<Method> methods = findAfterAllMethods(TestCaseWithStandardLifecycle.class, false);
+
+        assertEquals(2, methods.size());
+        assertTrue(contains(methods, "five"));
+        assertTrue(contains(methods, "six"));
+    }
+
+
+    @Test
+    void findAfterAllMethodsWithStandardLifecycleAndRequiringStatic() {
+        assertThrows(JUnitException.class, () -> findAfterAllMethods(TestCaseWithStandardLifecycle.class, true));
+    }
+
+    @Test
+    void findAfterAllMethodsWithLifeCyclePerClassAndRequiringStatic() {
+        List<Method> methods = findAfterAllMethods(TestCaseWithLifecyclePerClass.class, false);
+
+        assertEquals(2, methods.size());
+        assertTrue(contains(methods, "seven"));
+        assertTrue(contains(methods, "eight"));
+    }
+
+    private boolean contains(List<Method> methods, String methodName) {
+        // @formatter:off
+        return methods.stream()
+                .map(Method::getName)
+                .anyMatch(name -> name.equals(methodName));
+        // @formatter:on
+    }
+
+}
+
+class TestCaseWithStandardLifecycle {
+
+    @BeforeAll
+    void one(){}
+
+    @BeforeAll
+    void two(){}
+
+    @BeforeEach
+    void nine(){}
+
+    @BeforeEach
+    void ten(){}
+
+    @AfterEach
+    void eleven(){}
+
+    @AfterEach
+    void twelve(){}
+
+    @AfterAll
+    void five(){}
+
+    @AfterAll
+    void six(){}
+
+}
+
+@TestInstance(Lifecycle.PER_CLASS)
+class TestCaseWithLifecyclePerClass {
+
+    @BeforeAll
+    void three(){}
+
+    @BeforeAll
+    void four(){}
+
+    @AfterAll
+    void seven(){}
+
+    @AfterAll
+    void eight(){}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethodTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine.discovery.predicates;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
@@ -27,9 +28,15 @@ class IsTestFactoryMethodTests {
 	private final Predicate<Method> isTestMethod = new IsTestFactoryMethod();
 
 	@Test
-	void publicTestMethodsEvaluatesToTrue() throws NoSuchMethodException {
+	void factoryMethodReturningCollectionEvaluatesToTrue() throws NoSuchMethodException {
 		Method publicTestMethod = this.findMethod("factory");
 		assertTrue(isTestMethod.test(publicTestMethod));
+	}
+
+	@Test
+	void factoryMethodReturningVoidEvaluatesToFalse() throws NoSuchMethodException {
+		Method publicTestMethod = this.findMethod("badFactory");
+		assertFalse(isTestMethod.test(publicTestMethod));
 	}
 
 	private Method findMethod(String name) {
@@ -44,6 +51,10 @@ class AnotherClassWithTestFactory {
 	@TestFactory
 	Collection<DynamicTest> factory() {
 		return new ArrayList<>();
+	}
+
+	@TestFactory
+	void badFactory() {
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethodTests.java
@@ -83,11 +83,11 @@ class IsTestMethodTests {
 class ClassWithTestMethods {
 
 	@Test
-	void publicTestMethod() {
+	public void publicTestMethod() {
 	}
 
 	@Test
-	void publicTestMethodWithArgument(TestInfo info) {
+	public void publicTestMethodWithArgument(TestInfo info) {
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethodTests.java
@@ -28,25 +28,25 @@ class IsTestMethodTests {
 	private final Predicate<Method> isTestMethod = new IsTestMethod();
 
 	@Test
-	void publicTestMethodsEvaluatesToTrue() throws NoSuchMethodException {
+	void publicTestMethodEvaluatesToTrue() throws NoSuchMethodException {
 		Method publicTestMethod = this.findMethod("publicTestMethod");
 		assertTrue(isTestMethod.test(publicTestMethod));
 	}
 
 	@Test
-	void publicTestMethodsWithArgumentEvaluatesToTrue() throws NoSuchMethodException {
+	void publicTestMethodWithArgumentEvaluatesToTrue() throws NoSuchMethodException {
 		Method publicTestMethodWithArgument = findMethod("publicTestMethodWithArgument", TestInfo.class);
 		assertTrue(isTestMethod.test(publicTestMethodWithArgument));
 	}
 
 	@Test
-	void protectedTestMethodsEvaluatesToTrue() throws NoSuchMethodException {
+	void protectedTestMethodEvaluatesToTrue() throws NoSuchMethodException {
 		Method protectedTestMethod = this.findMethod("protectedTestMethod");
 		assertTrue(isTestMethod.test(protectedTestMethod));
 	}
 
 	@Test
-	void packageVisibleTestMethodTestMethodsEvaluatesToTrue() throws NoSuchMethodException {
+	void packageVisibleTestMethodEvaluatesToTrue() throws NoSuchMethodException {
 		Method packageVisibleTestMethod = this.findMethod("packageVisibleTestMethod");
 		assertTrue(isTestMethod.test(packageVisibleTestMethod));
 	}
@@ -69,6 +69,18 @@ class IsTestMethodTests {
 		assertFalse(isTestMethod.test(abstractTestMethod));
 	}
 
+	@Test
+	void testMethodReturningObjectEvaluatesToFalse() {
+		Method nonVoidMethod = this.findMethod("supposedTestMethodReturningObject");
+		assertFalse(isTestMethod.test(nonVoidMethod));
+	}
+
+	@Test
+	void testMethodReturningPrimitiveTypeEvaluatesToFalse() throws NoSuchMethodException {
+		Method nonVoidMethod = this.findMethod("supposedTestMethodReturningPrimitiveType");
+		assertFalse(isTestMethod.test(nonVoidMethod));
+	}
+
 	private Method findMethod(String name, Class<?>... aClass) {
 		return ReflectionUtils.findMethod(ClassWithTestMethods.class, name, aClass).get();
 	}
@@ -81,6 +93,16 @@ class IsTestMethodTests {
 
 //class name must not end with 'Tests', otherwise it would be picked up by the suite
 class ClassWithTestMethods {
+
+	@Test
+	String supposedTestMethodReturningObject() {
+		return "";
+	}
+
+	@Test
+	int supposedTestMethodReturningPrimitiveType() {
+		return 0;
+	}
 
 	@Test
 	public void publicTestMethod() {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestTemplateMethodTests.java
@@ -21,14 +21,29 @@ import org.junit.platform.commons.util.ReflectionUtils;
 class IsTestTemplateMethodTests {
 
 	@Test
-	void publicTestMethodsEvaluatesToTrue() throws NoSuchMethodException {
-		Method templateMethod = ReflectionUtils.findMethod(AClassWithTestTemplate.class, "template").get();
+	void testTemplateMethodReturningVoidEvaluatesToTrue() throws NoSuchMethodException {
+		Method templateMethod = ReflectionUtils.findMethod(AClassWithTestTemplate.class, "templateReturningVoid").get();
 		assertThat(templateMethod).matches(new IsTestTemplateMethod());
 	}
 
+	@Test
+	void testTemplateMethodReturningObjectEvaluatesToFalse() throws NoSuchMethodException {
+		Method templateMethod = ReflectionUtils.findMethod(AClassWithTestTemplate.class,
+			"templateReturningObject").get();
+		assertThat(templateMethod).matches(new IsTestTemplateMethod().negate(),
+			"negated test template method predicate");
+	}
+
 	private static class AClassWithTestTemplate {
+
 		@TestTemplate
-		void template() {
+		void templateReturningVoid() {
 		}
+
+		@TestTemplate
+		String templateReturningObject() {
+			return "";
+		}
+
 	}
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -244,6 +244,11 @@ public final class ReflectionUtils {
 		return Modifier.isStatic(member.getModifiers());
 	}
 
+	public static boolean returnsVoid(Method method) {
+		//checking the class itself yields problems with bridge methods
+		return method.getReturnType().toString().equals("void");
+	}
+
 	/**
 	 * Determine if the supplied object is an array.
 	 *

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -245,8 +245,7 @@ public final class ReflectionUtils {
 	}
 
 	public static boolean returnsVoid(Method method) {
-		//checking the class itself yields problems with bridge methods
-		return method.getReturnType().toString().equals("void");
+		return method.getReturnType().equals(Void.TYPE);
 	}
 
 	/**

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -107,6 +107,16 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
+	void returnsVoid() throws Exception {
+		assertTrue(ReflectionUtils.returnsVoid(ClassWithVoidAndNonVoidMethods.class.getDeclaredMethod("voidMethod")));
+
+		assertFalse(ReflectionUtils.returnsVoid(
+			ClassWithVoidAndNonVoidMethods.class.getDeclaredMethod("methodReturningObject")));
+		assertFalse(ReflectionUtils.returnsVoid(
+			ClassWithVoidAndNonVoidMethods.class.getDeclaredMethod("methodReturningPrimitive")));
+	}
+
+	@Test
 	void getAllAssignmentCompatibleClassesWithNullClass() {
 		assertThrows(PreconditionViolationException.class,
 			() -> ReflectionUtils.getAllAssignmentCompatibleClasses(null));
@@ -990,6 +1000,21 @@ class ReflectionUtilsTests {
 
 		static void staticMethod() {
 		}
+	}
+
+	static class ClassWithVoidAndNonVoidMethods {
+
+		void voidMethod() {
+		}
+
+		String methodReturningObject() {
+			return "";
+		}
+
+		int methodReturningPrimitive() {
+			return 0;
+		}
+
 	}
 
 	static class InvocationTracker {


### PR DESCRIPTION
## Overview

This PR implements #835.

Following the existing styles in the respective parts of the codebase this is realised via predicates for `@Test` methods, but via `JUnitException`s for lifecycle methods. This might be subject to change in the context of the somewhat related issue #242.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
