### PR TITLE
Make UniqueId segment list immutable

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -26,6 +26,7 @@ on GitHub.
 
 * The method `getDiscoveryFiltersByType` of `EngineDiscoveryRequest` has been renamed to
   `getFiltersByType`.
+* The method `getSegments()` of `UniqueId` now returns an immutable list.
 
 ===== New Features and Improvements
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/JavaElementsResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/JavaElementsResolver.java
@@ -18,6 +18,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.findNestedClasses;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -81,7 +82,7 @@ class JavaElementsResolver {
 	}
 
 	void resolveUniqueId(UniqueId uniqueId) {
-		List<UniqueId.Segment> segments = uniqueId.getSegments();
+		List<UniqueId.Segment> segments = new ArrayList<>(uniqueId.getSegments());
 		segments.remove(0); // Ignore engine unique ID
 
 		if (!resolveUniqueId(this.engineDescriptor, segments)) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -10,6 +10,8 @@
 
 package org.junit.platform.engine;
 
+import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
 import static org.junit.platform.commons.meta.API.Usage.Experimental;
 
 import java.io.Serializable;
@@ -81,16 +83,16 @@ public class UniqueId implements Cloneable, Serializable {
 	}
 
 	private final UniqueIdFormat uniqueIdFormat;
-	private final List<Segment> segments = new ArrayList<>();
+	private final List<Segment> segments;
 
 	private UniqueId(UniqueIdFormat uniqueIdFormat, Segment segment) {
 		this.uniqueIdFormat = uniqueIdFormat;
-		this.segments.add(segment);
+		this.segments = singletonList(segment);
 	}
 
 	UniqueId(UniqueIdFormat uniqueIdFormat, List<Segment> segments) {
 		this.uniqueIdFormat = uniqueIdFormat;
-		this.segments.addAll(segments);
+		this.segments = unmodifiableList(new ArrayList<>(segments));
 	}
 
 	final Optional<Segment> getRoot() {
@@ -133,22 +135,9 @@ public class UniqueId implements Cloneable, Serializable {
 	public final UniqueId append(String segmentType, String value) {
 		Preconditions.notBlank(segmentType, "segmentType must not be null or blank");
 		Preconditions.notBlank(value, "value must not be null or blank");
-		Segment segment = new Segment(segmentType, value);
-		return append(segment);
-	}
-
-	/**
-	 * Construct a new {@code UniqueId} by appending the supplied {@link Segment}
-	 * to the end of this {@code UniqueId}.
-	 *
-	 * <p>This {@code UniqueId} will not be modified.
-	 *
-	 * @see #append(String, String)
-	 */
-	private UniqueId append(Segment segment) {
-		UniqueId clone = new UniqueId(this.uniqueIdFormat, this.segments);
-		clone.segments.add(segment);
-		return clone;
+		List<Segment> baseSegments = new ArrayList<>(this.segments);
+		baseSegments.add(new Segment(segmentType, value));
+		return new UniqueId(this.uniqueIdFormat, baseSegments);
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -90,9 +90,16 @@ public class UniqueId implements Cloneable, Serializable {
 		this.segments = singletonList(segment);
 	}
 
+	/**
+	 * Initialize a {@code UniqueId} instance.
+	 *
+	 * @implNote A defensive copy of the segment list is <b>not</b> created by
+	 * this implementation. All callers should immediately drop the reference
+	 * to the list instance that they pass into this constructor.
+	 */
 	UniqueId(UniqueIdFormat uniqueIdFormat, List<Segment> segments) {
 		this.uniqueIdFormat = uniqueIdFormat;
-		this.segments = unmodifiableList(new ArrayList<>(segments));
+		this.segments = unmodifiableList(segments);
 	}
 
 	final Optional<Segment> getRoot() {
@@ -109,13 +116,11 @@ public class UniqueId implements Cloneable, Serializable {
 	}
 
 	/**
-	 * Get a copy of the list of {@linkplain Segment segments} that make up this
+	 * Get the immutable list of {@linkplain Segment segments} that make up this
 	 * {@code UniqueId}.
-	 *
-	 * <p>Clients are free to modify the returned list.
 	 */
 	public final List<Segment> getSegments() {
-		return new ArrayList<>(this.segments);
+		return this.segments;
 	}
 
 	/**


### PR DESCRIPTION
## Overview

Make UniqueId segment list immutable and turn `getSegments()` into a simple getter, i.e. it does no longer create a copy of the internal list on each invocation. The single place where a modifiable list was expected was in `JavaElementsResolver`. There a copy is created explicitly.

This commit also removes the defensive copy creation of the segment list from the package-private constructor. All two internal callers do not modify the underlying list, they actually drop their list reference.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

