### PR TITLE
Issues/790 add more methods to reflectionsupport

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -37,9 +37,14 @@ on GitHub.
 * The `findAnnotation()` method in `AnnotationSupport` now searches on interfaces
   implemented by a class if the supplied element is a class.
 
-* More methods of `org.junit.platform.commons.util.ReflectionUtils` are now exposed
-  via `org.junit.platform.commons.support.ReflectionSupport`.
-
+* The following methods of `org.junit.platform.commons.util.ReflectionUtils` are now
+  exposed via `org.junit.platform.commons.support.ReflectionSupport`:
+** `public static Optional<Class<?>> loadClass(String name)`
+** `public static Optional<Method> findMethod(Class<?> clazz, String methodName, String parameterTypeNames)`
+** `public static Optional<Method> findMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes)`
+** `public static <T> T newInstance(Class<T> clazz, Object... args)`
+** `public static Object invokeMethod(Method method, Object target, Object... args)`
+** `public static List<Class<?>> findNestedClasses(Class<?> clazz, Predicate<Class<?>> predicate)`
 
 [[release-notes-5.0.0-m6-junit-jupiter]]
 ==== JUnit Jupiter

--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -37,6 +37,9 @@ on GitHub.
 * The `findAnnotation()` method in `AnnotationSupport` now searches on interfaces
   implemented by a class if the supplied element is a class.
 
+* More methods of `org.junit.platform.commons.util.ReflectionUtils` are now exposed
+  via `org.junit.platform.commons.support.ReflectionSupport`.
+
 
 [[release-notes-5.0.0-m6-junit-jupiter]]
 ==== JUnit Jupiter

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -89,7 +89,11 @@ public final class ReflectionSupport {
 	 * Load a class by its <em>primitive name</em> or <em>fully qualified name</em>,
 	 * using the default {@link ClassLoader}.
 	 *
+	 * <p>See {@link ReflectionUtils#loadClass(String, ClassLoader)} for details on
+	 * support for class names for arrays.
+	 *
 	 * @param name the name of the class to load; never {@code null} or blank
+	 * @see ReflectionUtils#loadClass(String, ClassLoader)
 	 */
 	public static Optional<Class<?>> loadClass(String name) {
 		return ReflectionUtils.loadClass(name);
@@ -151,6 +155,7 @@ public final class ReflectionSupport {
 	 * @param clazz the class to instantiate; never {@code null}
 	 * @param args the arguments to pass to the constructor none of which may be {@code null}
 	 * @return the new instance
+	 * @see ReflectionUtils#newInstance(java.lang.reflect.Constructor, Object...)
 	 * @see ExceptionUtils#throwAsUncheckedException(Throwable)
 	 */
 	public static <T> T newInstance(Class<T> clazz, Object... args) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.meta.API.Usage.Maintained;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.platform.commons.meta.API;
@@ -81,6 +82,30 @@ public final class ReflectionSupport {
 
 		return ReflectionUtils.findMethods(clazz, predicate,
 			ReflectionUtils.HierarchyTraversalMode.valueOf(traversalMode.name()));
+	}
+
+	public static Optional<Class<?>> loadClass(String name) {
+		return ReflectionUtils.loadClass(name);
+	}
+
+	public static Optional<Method> findMethod(Class<?> clazz, String methodName, String parameterTypeNames) {
+		return ReflectionUtils.findMethod(clazz, methodName, parameterTypeNames);
+	}
+
+	public static Optional<Method> findMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
+		return ReflectionUtils.findMethod(clazz, methodName, parameterTypes);
+	}
+
+	public static <T> T newInstance(Class<T> clazz, Object... args) {
+		return ReflectionUtils.newInstance(clazz, args);
+	}
+
+	public static Object invokeMethod(Method method, Object target, Object... args) {
+		return ReflectionUtils.invokeMethod(method, target, args);
+	}
+
+	public static List<Class<?>> findNestedClasses(Class<?> clazz, Predicate<Class<?>> predicate) {
+		return ReflectionUtils.findNestedClasses(clazz, predicate);
 	}
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
@@ -84,26 +85,103 @@ public final class ReflectionSupport {
 			ReflectionUtils.HierarchyTraversalMode.valueOf(traversalMode.name()));
 	}
 
+	/**
+	 * Load a class by its <em>primitive name</em> or <em>fully qualified name</em>,
+	 * using the default {@link ClassLoader}.
+	 *
+	 * @param name the name of the class to load; never {@code null} or blank
+	 */
 	public static Optional<Class<?>> loadClass(String name) {
 		return ReflectionUtils.loadClass(name);
 	}
 
+	/**
+	 * Find the first {@link Method} of the supplied class or interface that
+	 * meets the specified criteria, beginning with the specified class or
+	 * interface and traversing up the type hierarchy until such a method is
+	 * found or the type hierarchy is exhausted.
+	 *
+	 * <p>Note, however, that the current algorithm traverses the entire
+	 * type hierarchy even after having found a match.
+	 *
+	 * @param clazz the class or interface in which to find the method; never {@code null}
+	 * @param methodName the name of the method to find; never {@code null} or empty
+	 * @param parameterTypeNames the fully qualified names of the types of parameters
+	 * accepted by the method, if any, provided as a comma-separated list
+	 * @return an {@code Optional} containing the method found; never {@code null}
+	 * but potentially empty if no such method could be found
+	 * @see #findMethod(Class, String, Class...)
+	 * @see ReflectionUtils.HierarchyTraversalMode#BOTTOM_UP
+	 */
 	public static Optional<Method> findMethod(Class<?> clazz, String methodName, String parameterTypeNames) {
 		return ReflectionUtils.findMethod(clazz, methodName, parameterTypeNames);
 	}
 
+	/**
+	 * Find the first {@link Method} of the supplied class or interface that
+	 * meets the specified criteria, beginning with the specified class or
+	 * interface and traversing up the type hierarchy until such a method is
+	 * found or the type hierarchy is exhausted.
+	 *
+	 * <p>Note, however, that the current algorithm traverses the entire
+	 * type hierarchy even after having found a match.
+	 *
+	 * @param clazz the class or interface in which to find the method; never {@code null}
+	 * @param methodName the name of the method to find; never {@code null} or empty
+	 * @param parameterTypes the types of parameters accepted by the method, if any;
+	 * never {@code null}
+	 * @return an {@code Optional} containing the method found; never {@code null}
+	 * but potentially empty if no such method could be found
+	 * @see #findMethod(Class, String, String)
+	 * @see ReflectionUtils.HierarchyTraversalMode#BOTTOM_UP
+	 */
 	public static Optional<Method> findMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
 		return ReflectionUtils.findMethod(clazz, methodName, parameterTypes);
 	}
 
+	/**
+	 * Create a new instance of the specified {@link Class} by invoking
+	 * the constructor whose argument list matches the types of the supplied
+	 * arguments.
+	 *
+	 * <p>The constructor will be made accessible if necessary, and any checked
+	 * exception will be {@linkplain ExceptionUtils#throwAsUncheckedException masked}
+	 * as an unchecked exception.
+	 *
+	 * @param clazz the class to instantiate; never {@code null}
+	 * @param args the arguments to pass to the constructor none of which may be {@code null}
+	 * @return the new instance
+	 * @see ExceptionUtils#throwAsUncheckedException(Throwable)
+	 */
 	public static <T> T newInstance(Class<T> clazz, Object... args) {
 		return ReflectionUtils.newInstance(clazz, args);
 	}
 
+	/**
+	 * Invoke the supplied method, making it accessible if necessary and
+	 * {@linkplain ExceptionUtils#throwAsUncheckedException masking} any
+	 * checked exception as an unchecked exception.
+	 *
+	 * @param method the method to invoke; never {@code null}
+	 * @param target the object on which to invoke the method; may be
+	 * {@code null} if the method is {@code static}
+	 * @param args the arguments to pass to the method
+	 * @return the value returned by the method invocation or {@code null}
+	 * if the return type is {@code void}
+	 * @see ExceptionUtils#throwAsUncheckedException(Throwable)
+	 */
 	public static Object invokeMethod(Method method, Object target, Object... args) {
 		return ReflectionUtils.invokeMethod(method, target, args);
 	}
 
+	/**
+	 * Find all nested classes of the given class conforming to the given predicate.
+	 *
+	 * @param clazz the class to be searched; never {@code null}
+	 * @param predicate the predicate against which the list of nested classes is
+	 * checked; never {@code null}
+	 * @return the list of all such classes found; never {@code null}
+	 */
 	public static List<Class<?>> findNestedClasses(Class<?> clazz, Predicate<Class<?>> predicate) {
 		return ReflectionUtils.findNestedClasses(clazz, predicate);
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -305,19 +305,7 @@ public final class ReflectionUtils {
 	}
 
 	/**
-	 * Create a new instance of the specified {@link Class} by invoking
-	 * the constructor whose argument list matches the types of the supplied
-	 * arguments.
-	 *
-	 * <p>The constructor will be made accessible if necessary, and any checked
-	 * exception will be {@linkplain ExceptionUtils#throwAsUncheckedException masked}
-	 * as an unchecked exception.
-	 *
-	 * @param clazz the class to instantiate; never {@code null}
-	 * @param args the arguments to pass to the constructor none of which may be {@code null}
-	 * @return the new instance
-	 * @see #newInstance(Constructor, Object...)
-	 * @see ExceptionUtils#throwAsUncheckedException(Throwable)
+	 * @see org.junit.platform.commons.support.ReflectionSupport#newInstance(Class, Object...)
 	 */
 	public static <T> T newInstance(Class<T> clazz, Object... args) {
 		Preconditions.notNull(clazz, "class must not be null");
@@ -359,17 +347,7 @@ public final class ReflectionUtils {
 	}
 
 	/**
-	 * Invoke the supplied method, making it accessible if necessary and
-	 * {@linkplain ExceptionUtils#throwAsUncheckedException masking} any
-	 * checked exception as an unchecked exception.
-	 *
-	 * @param method the method to invoke; never {@code null}
-	 * @param target the object on which to invoke the method; may be
-	 * {@code null} if the method is {@code static}
-	 * @param args the arguments to pass to the method
-	 * @return the value returned by the method invocation or {@code null}
-	 * if the return type is {@code void}
-	 * @see ExceptionUtils#throwAsUncheckedException(Throwable)
+	 * @see org.junit.platform.commons.support.ReflectionSupport#invokeMethod(Method, Object, Object...)
 	 */
 	public static Object invokeMethod(Method method, Object target, Object... args) {
 		Preconditions.notNull(method, "method must not be null");
@@ -385,14 +363,7 @@ public final class ReflectionUtils {
 	}
 
 	/**
-	 * Load a class by its <em>primitive name</em> or <em>fully qualified name</em>,
-	 * using the default {@link ClassLoader}.
-	 *
-	 * <p>See {@link #loadClass(String, ClassLoader)} for details on support for
-	 * class names for arrays.
-	 *
-	 * @param name the name of the class to load; never {@code null} or blank
-	 * @see #loadClass(String, ClassLoader)
+	 * @see org.junit.platform.commons.support.ReflectionSupport#loadClass(String)
 	 */
 	public static Optional<Class<?>> loadClass(String name) {
 		return loadClass(name, ClassLoaderUtils.getDefaultClassLoader());
@@ -724,44 +695,14 @@ public final class ReflectionUtils {
 	}
 
 	/**
-	 * Find the first {@link Method} of the supplied class or interface that
-	 * meets the specified criteria, beginning with the specified class or
-	 * interface and traversing up the type hierarchy until such a method is
-	 * found or the type hierarchy is exhausted.
-	 *
-	 * <p>Note, however, that the current algorithm traverses the entire
-	 * type hierarchy even after having found a match.
-	 *
-	 * @param clazz the class or interface in which to find the method; never {@code null}
-	 * @param methodName the name of the method to find; never {@code null} or empty
-	 * @param parameterTypeNames the fully qualified names of the types of parameters
-	 * accepted by the method, if any, provided as a comma-separated list
-	 * @return an {@code Optional} containing the method found; never {@code null}
-	 * but potentially empty if no such method could be found
-	 * @see #findMethod(Class, String, Class...)
-	 * @see HierarchyTraversalMode#BOTTOM_UP
+	 * @see org.junit.platform.commons.support.ReflectionSupport#findMethod(Class, String, String)
 	 */
 	public static Optional<Method> findMethod(Class<?> clazz, String methodName, String parameterTypeNames) {
 		return findMethod(clazz, methodName, resolveParameterTypes(parameterTypeNames));
 	}
 
 	/**
-	 * Find the first {@link Method} of the supplied class or interface that
-	 * meets the specified criteria, beginning with the specified class or
-	 * interface and traversing up the type hierarchy until such a method is
-	 * found or the type hierarchy is exhausted.
-	 *
-	 * <p>Note, however, that the current algorithm traverses the entire
-	 * type hierarchy even after having found a match.
-	 *
-	 * @param clazz the class or interface in which to find the method; never {@code null}
-	 * @param methodName the name of the method to find; never {@code null} or empty
-	 * @param parameterTypes the types of parameters accepted by the method, if any;
-	 * never {@code null}
-	 * @return an {@code Optional} containing the method found; never {@code null}
-	 * but potentially empty if no such method could be found
-	 * @see #findMethod(Class, String, String)
-	 * @see HierarchyTraversalMode#BOTTOM_UP
+	 * @see org.junit.platform.commons.support.ReflectionSupport#findMethod(Class, String, Class...)
 	 */
 	public static Optional<Method> findMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
 		Preconditions.notNull(clazz, "Class must not be null");

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -642,6 +642,9 @@ public final class ReflectionUtils {
 			classpathScanner.scanForClassesInPackage(basePackageName, classTester, classNameFilter));
 	}
 
+	/**
+	 * @see org.junit.platform.commons.support.ReflectionSupport#findNestedClasses(Class, Predicate)
+	 */
 	public static List<Class<?>> findNestedClasses(Class<?> clazz, Predicate<Class<?>> predicate) {
 		Preconditions.notNull(clazz, "Class must not be null");
 		Preconditions.notNull(predicate, "Predicate must not be null");


### PR DESCRIPTION
## Overview

This PR adds the requested methods to `org.junit.platform.commons.support.ReflectionSupport`
by delegating to respective `org.junit.platform.commons.util.ReflectionUtils` methods.

No new tests are introduced as the implementation is delegated to existing code.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
