### PR TITLE
Delete unnecessary constructor

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -48,14 +48,8 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 
 	public VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue,
 			Description description) {
-
-		this(parent, segmentType, segmentValue, description, toTestSource(description));
-	}
-
-	VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue, Description description,
-			TestSource source) {
-
-		this(parent, segmentType, segmentValue, description, generateDisplayName(description), source);
+		this(parent, segmentType, segmentValue, description, generateDisplayName(description),
+			toTestSource(description));
 	}
 
 	VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue, Description description,


### PR DESCRIPTION
## Overview

The deleted constructor was only used internally by one of the other constructors.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
