### PR TITLE
Use jdk-9 provided by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,8 @@ env:
 
 matrix:
   include:
-    - jdk: oraclejdk8 # JDK 1.8.0_131-b11
-    - jdk: oraclejdk9 # JDK 9-ea+174 provided by Travis will be replaced by 9+178 in "before_install"
-      before_install:
-        - cd ~
-        - wget http://download.java.net/java/jdk9/archive/178/binaries/jdk-9+178_linux-x64_bin.tar.gz
-        - tar -xzf jdk-9+178_linux-x64_bin.tar.gz
-        - export JAVA_HOME=~/jdk-9
-        - PATH=$JAVA_HOME/bin:$PATH
-        - cd -
+    - jdk: oraclejdk8 # JDK 1.8.0_131-b11 or newer
+    - jdk: oraclejdk9 # JDK 9+175 or newer
 
 # Don't let Travis CI execute './gradlew assemble' by default
 install:


### PR DESCRIPTION
## Overview

Travis CI upgraded their jdk-9 version to 175. This version supports all features JUnit 5 needs for its build process. Newer jkd-9 versions like the recent build 178 only contain fixes for bugs that don't prevent JUnit 5 to build.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
