### PR TITLE
Provide UniqueId instead of parent descriptor

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -13,7 +13,7 @@ package org.junit.vintage.engine.descriptor;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
 import org.junit.platform.commons.meta.API;
-import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.runner.Request;
 import org.junit.runner.Runner;
@@ -27,9 +27,8 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 	private final Runner runner;
 	private final Class<?> testClass;
 
-	public RunnerTestDescriptor(TestDescriptor parent, Class<?> testClass, Runner runner) {
-		super(parent, SEGMENT_TYPE_RUNNER, testClass.getName(), runner.getDescription(), testClass.getName(),
-			new ClassSource(testClass));
+	public RunnerTestDescriptor(UniqueId uniqueId, Class<?> testClass, Runner runner) {
+		super(uniqueId, runner.getDescription(), testClass.getName(), new ClassSource(testClass));
 		this.testClass = testClass;
 		this.runner = runner;
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -29,6 +29,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
@@ -46,17 +47,12 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 
 	private final Description description;
 
-	public VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue,
-			Description description) {
-		this(parent, segmentType, segmentValue, description, generateDisplayName(description),
-			toTestSource(description));
+	public VintageTestDescriptor(UniqueId uniqueId, Description description) {
+		this(uniqueId, description, generateDisplayName(description), toTestSource(description));
 	}
 
-	VintageTestDescriptor(TestDescriptor parent, String segmentType, String segmentValue, Description description,
-			String displayName, TestSource source) {
-
-		super(parent.getUniqueId().append(segmentType, segmentValue), displayName, source);
-
+	VintageTestDescriptor(UniqueId uniqueId, Description description, String displayName, TestSource source) {
+		super(uniqueId, displayName, source);
 		this.description = description;
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/execution/RunListenerAdapterTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/execution/RunListenerAdapterTests.java
@@ -22,7 +22,6 @@ import java.util.logging.LogRecord;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.runner.Description;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.vintage.engine.RecordCollectingLogger;
@@ -38,8 +37,7 @@ class RunListenerAdapterTests {
 	void logsUnknownDescriptions() throws Exception {
 		Class<?> testClass = PlainJUnit4TestCaseWithSingleTestWhichFails.class;
 		RecordCollectingLogger logger = new RecordCollectingLogger();
-		EngineDescriptor engineDescriptor = new EngineDescriptor(engineId(), "JUnit 4");
-		RunnerTestDescriptor runnerTestDescriptor = new RunnerTestDescriptor(engineDescriptor, testClass,
+		RunnerTestDescriptor runnerTestDescriptor = new RunnerTestDescriptor(engineId(), testClass,
 			new BlockJUnit4ClassRunner(testClass));
 
 		TestRun testRun = new TestRun(runnerTestDescriptor, logger);


### PR DESCRIPTION
Make the creation of `VintageTestDescriptor` independent from the `EngineDescriptor`. This enables us to simplify the `TestClassRequestResolver` by letting it only create `TestClassRequest`s.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
