### PR TITLE
Exclude release tag from Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: java
 sudo: false
 dist: trusty
 
+# Specify which branches/tags that we do not want to be built: r5.0.0-M5
+branches:
+  except:
+    - /^r\d.*$/
+
 env:
   - _JAVA_OPTIONS='-Xmx500m'
 


### PR DESCRIPTION
## Overview

Specify which branches/tags that we do not want to be built, like: r5.0.0-M5
```
branches:
  except:
    - /^r\d.*$/
```

See https://docs.travis-ci.com/user/customizing-the-build/#Safelisting-or-blocklisting-branches

---

I hereby agree to the terms of the JUnit Contributor License Agreement.
