### PR TITLE
Support primitive array types as argument providers

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-M6.adoc
@@ -47,6 +47,8 @@ on GitHub.
 
 * All tags declared via `@Tag` are now trimmed in order to remove leading and trailing
   whitespace. Furthermore, blank tags are now ignored.
+* All primitive array types (from `boolean[]` to `short[]`) are now supported as a
+  return type of static argument providing methods for parameterized tests.
 
 ===== Deprecations and Breaking Changes
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.JUnitException;
@@ -98,12 +99,105 @@ class MethodArgumentsProviderTests {
 		assertThat(exception).hasMessageContaining("required test class is not present");
 	}
 
+	@Nested
+	class PrimitiveArrays {
+
+		@Test
+		void providesArgumentsUsingBooleanArray() {
+			Stream<Object[]> arguments = provideArguments("booleanArrayProvider");
+
+			assertThat(arguments).containsExactly(array(Boolean.TRUE), array(Boolean.FALSE));
+		}
+
+		@Test
+		void providesArgumentsUsingByteArray() {
+			Stream<Object[]> arguments = provideArguments("byteArrayProvider");
+
+			assertThat(arguments).containsExactly(array((byte) 1), array(Byte.MIN_VALUE));
+		}
+
+		@Test
+		void providesArgumentsUsingCharArray() {
+			Stream<Object[]> arguments = provideArguments("charArrayProvider");
+
+			assertThat(arguments).containsExactly(array((char) 1), array(Character.MIN_VALUE));
+		}
+
+		@Test
+		void providesArgumentsUsingDoubleArray() {
+			Stream<Object[]> arguments = provideArguments("doubleArrayProvider");
+
+			assertThat(arguments).containsExactly(array(1d), array(Double.MIN_VALUE));
+		}
+
+		@Test
+		void providesArgumentsUsingFloatArray() {
+			Stream<Object[]> arguments = provideArguments("floatArrayProvider");
+
+			assertThat(arguments).containsExactly(array(1f), array(Float.MIN_VALUE));
+		}
+
+		@Test
+		void providesArgumentsUsingIntArray() {
+			Stream<Object[]> arguments = provideArguments("intArrayProvider");
+
+			assertThat(arguments).containsExactly(array(47), array(Integer.MIN_VALUE));
+		}
+
+		@Test
+		void providesArgumentsUsingLongArray() {
+			Stream<Object[]> arguments = provideArguments("longArrayProvider");
+
+			assertThat(arguments).containsExactly(array(47L), array(Long.MIN_VALUE));
+		}
+
+		@Test
+		void providesArgumentsUsingShortArray() {
+			Stream<Object[]> arguments = provideArguments("shortArrayProvider");
+
+			assertThat(arguments).containsExactly(array((short) 47), array(Short.MIN_VALUE));
+		}
+	}
+
+	@SuppressWarnings("unused")
 	static class TestCase {
 
 		static AtomicBoolean collectionStreamClosed = new AtomicBoolean(false);
 
 		static Stream<String> stringStreamProvider() {
 			return Stream.of("foo", "bar");
+		}
+
+		static boolean[] booleanArrayProvider() {
+			return new boolean[] { true, false };
+		}
+
+		static byte[] byteArrayProvider() {
+			return new byte[] { (byte) 1, Byte.MIN_VALUE };
+		}
+
+		static char[] charArrayProvider() {
+			return new char[] { (char) 1, Character.MIN_VALUE };
+		}
+
+		static double[] doubleArrayProvider() {
+			return new double[] { 1d, Double.MIN_VALUE };
+		}
+
+		static float[] floatArrayProvider() {
+			return new float[] { 1f, Float.MIN_VALUE };
+		}
+
+		static int[] intArrayProvider() {
+			return new int[] { 47, Integer.MIN_VALUE };
+		}
+
+		static long[] longArrayProvider() {
+			return new long[] { 47L, Long.MIN_VALUE };
+		}
+
+		static short[] shortArrayProvider() {
+			return new short[] { (short) 47, Short.MIN_VALUE };
 		}
 
 		static Iterable<String> stringIterableProvider() {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
@@ -17,6 +17,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.junit.platform.commons.meta.API.Usage.Internal;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -131,6 +132,18 @@ public final class CollectionUtils {
 		}
 		if (object instanceof Object[]) {
 			return Arrays.stream((Object[]) object);
+		}
+		if (object instanceof double[]) {
+			return DoubleStream.of((double[]) object).boxed();
+		}
+		if (object instanceof int[]) {
+			return IntStream.of((int[]) object).boxed();
+		}
+		if (object instanceof long[]) {
+			return LongStream.of((long[]) object).boxed();
+		}
+		if (object.getClass().isArray() && object.getClass().getComponentType().isPrimitive()) {
+			return IntStream.range(0, Array.getLength(object)).mapToObj(i -> Array.get(object, i));
 		}
 		throw new PreconditionViolationException(
 			"Cannot convert instance of " + object.getClass().getName() + " into a Stream: " + object);

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
@@ -18,8 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -30,7 +33,9 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
 /**
  * Unit tests for {@link CollectionUtils}.
@@ -190,4 +195,36 @@ class CollectionUtilsTests {
 		assertThat(result).containsExactly("foo", "bar");
 	}
 
+	@TestFactory
+	Stream<DynamicTest> toStreamWithPrimitiveArrays() {
+		//@formatter:off
+		return Stream.of(
+				dynamicTest("boolean[]",
+						() -> toStreamWithPrimitiveArray(new boolean[] { true, false })),
+				dynamicTest("byte[]",
+						() -> toStreamWithPrimitiveArray(new byte[] { 0, Byte.MIN_VALUE, Byte.MAX_VALUE })),
+				dynamicTest("char[]",
+						() -> toStreamWithPrimitiveArray(new char[] { 0, Character.MIN_VALUE, Character.MAX_VALUE })),
+				dynamicTest("double[]",
+						() -> toStreamWithPrimitiveArray(new double[] { 0, Double.MIN_VALUE, Double.MAX_VALUE })),
+				dynamicTest("float[]",
+						() -> toStreamWithPrimitiveArray(new float[] { 0, Float.MIN_VALUE, Float.MAX_VALUE })),
+				dynamicTest("int[]",
+						() -> toStreamWithPrimitiveArray(new int[] { 0, Integer.MIN_VALUE, Integer.MAX_VALUE })),
+				dynamicTest("long[]",
+						() -> toStreamWithPrimitiveArray(new long[] { 0, Long.MIN_VALUE, Long.MAX_VALUE })),
+				dynamicTest("short[]",
+						() -> toStreamWithPrimitiveArray(new short[] { 0, Short.MIN_VALUE, Short.MAX_VALUE }))
+		);
+		//@formatter:on
+	}
+
+	private void toStreamWithPrimitiveArray(Object primitiveArray) {
+		assertTrue(primitiveArray.getClass().isArray());
+		assertTrue(primitiveArray.getClass().getComponentType().isPrimitive());
+		Object[] result = CollectionUtils.toStream(primitiveArray).toArray();
+		for (int i = 0; i < result.length; i++) {
+			assertEquals(Array.get(primitiveArray, i), result[i]);
+		}
+	}
 }


### PR DESCRIPTION
## Overview

Prior to this commit simple 1-dimensional arrays with primitive component types were not supported. The user could circumvent the issue by using an IntStream like:

```
  static IntStream data() {
    return IntStream.of(3, 24, 12);
  }
```

Now all primitive array types (from `boolean[]` to `short[]`) are supported as a return type of static argument providing methods for parameterized tests. For example:

```
  static int[] data() {
    return new int[] { 3, 24, 12 };
  }
```

Fixes #953

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
