### PR TITLE
VintageDiscoverer

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
@@ -24,9 +24,8 @@ import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
-import org.junit.vintage.engine.discovery.JUnit4DiscoveryRequestResolver;
+import org.junit.vintage.engine.discovery.VintageDiscoverer;
 import org.junit.vintage.engine.execution.RunnerExecutor;
 
 /**
@@ -62,9 +61,7 @@ public class VintageTestEngine implements TestEngine {
 
 	@Override
 	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
-		EngineDescriptor engineDescriptor = new EngineDescriptor(uniqueId, "JUnit Vintage");
-		new JUnit4DiscoveryRequestResolver(engineDescriptor, LOG).resolve(discoveryRequest);
-		return engineDescriptor;
+		return new VintageDiscoverer(LOG).discover(discoveryRequest, uniqueId);
 	}
 
 	@Override

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/TestClassCollector.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/TestClassCollector.java
@@ -10,7 +10,6 @@
 
 package org.junit.vintage.engine.discovery;
 
-import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Stream.concat;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 
@@ -40,11 +39,8 @@ class TestClassCollector {
 		filteredTestClasses.computeIfAbsent(testClass, key -> new LinkedList<>()).add(filter);
 	}
 
-	Set<TestClassRequest> toRequests(Predicate<? super Class<?>> predicate) {
-		// @formatter:off
-		return concat(completeRequests(predicate), filteredRequests(predicate))
-				.collect(toCollection(LinkedHashSet::new));
-		// @formatter:on
+	Stream<TestClassRequest> toRequests(Predicate<? super Class<?>> predicate) {
+		return concat(completeRequests(predicate), filteredRequests(predicate)).distinct();
 	}
 
 	private Stream<TestClassRequest> completeRequests(Predicate<? super Class<?>> predicate) {

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/TestClassRequestResolverTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/TestClassRequestResolverTests.java
@@ -12,7 +12,6 @@ package org.junit.vintage.engine.discovery;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.runner.Description.createTestDescription;
@@ -25,8 +24,6 @@ import java.util.logging.LogRecord;
 
 import org.junit.internal.builders.IgnoredClassRunner;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.vintage.engine.RecordCollectingLogger;
 import org.junit.vintage.engine.VintageUniqueIdBuilder;
 import org.junit.vintage.engine.samples.junit4.IgnoredJUnit4TestCase;
@@ -77,11 +74,10 @@ class TestClassRequestResolverTests {
 	}
 
 	private List<LogRecord> resolve(TestClassRequest request) {
-		TestDescriptor engineDescriptor = new EngineDescriptor(VintageUniqueIdBuilder.engineId(), "JUnit 4");
 		RecordCollectingLogger logger = new RecordCollectingLogger();
 
-		TestClassRequestResolver resolver = new TestClassRequestResolver(engineDescriptor, logger);
-		resolver.populateEngineDescriptorFrom(singleton(request));
+		TestClassRequestResolver resolver = new TestClassRequestResolver(logger);
+		resolver.createRunnerTestDescriptor(request, VintageUniqueIdBuilder.engineId());
 
 		return logger.getLogRecords();
 	}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/UniqueIdSelectorResolverTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/UniqueIdSelectorResolverTests.java
@@ -20,9 +20,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -92,7 +92,7 @@ class UniqueIdSelectorResolverTests {
 	}
 
 	private void assertNoRequests() {
-		Set<TestClassRequest> requests = collector.toRequests(c -> true);
+		Stream<TestClassRequest> requests = collector.toRequests(c -> true);
 		assertThat(requests).isEmpty();
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
@@ -23,8 +23,8 @@ import java.util.logging.LogRecord;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.discovery.ClassNameFilter;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.vintage.engine.RecordCollectingLogger;
 import org.junit.vintage.engine.samples.junit3.AbstractJUnit3TestCase;
@@ -33,11 +33,10 @@ import org.junit.vintage.engine.samples.junit4.AbstractJunit4TestCaseWithConstru
 /**
  * @since 4.12
  */
-class VintageDiscoveryRequestResolverTests {
+class VintageDiscovererTests {
 
 	@Test
 	void logsWarningWhenFilterExcludesClass() {
-		EngineDescriptor engineDescriptor = new EngineDescriptor(engineId(), "JUnit Vintage");
 		RecordCollectingLogger logger = new RecordCollectingLogger();
 
 		ClassNameFilter filter = className -> includedIf(Foo.class.getName().equals(className), () -> "match",
@@ -49,10 +48,10 @@ class VintageDiscoveryRequestResolverTests {
 				.build();
 		// @formatter:on
 
-		JUnit4DiscoveryRequestResolver resolver = new JUnit4DiscoveryRequestResolver(engineDescriptor, logger);
-		resolver.resolve(request);
+		VintageDiscoverer discoverer = new VintageDiscoverer(logger);
+		TestDescriptor testDescriptor = discoverer.discover(request, engineId());
 
-		assertThat(engineDescriptor.getChildren()).hasSize(1);
+		assertThat(testDescriptor.getChildren()).hasSize(1);
 
 		assertThat(logger.getLogRecords()).hasSize(1);
 		LogRecord logRecord = getOnlyElement(logger.getLogRecords());
@@ -87,15 +86,14 @@ class VintageDiscoveryRequestResolverTests {
 	}
 
 	private void doesNotResolve(Class<?> testClass) {
-		EngineDescriptor engineDescriptor = new EngineDescriptor(engineId(), "JUnit Vintage");
 		LauncherDiscoveryRequest request = request().selectors(selectClass(testClass)).build();
 
 		RecordCollectingLogger logger = new RecordCollectingLogger();
 
-		JUnit4DiscoveryRequestResolver resolver = new JUnit4DiscoveryRequestResolver(engineDescriptor, logger);
-		resolver.resolve(request);
+		VintageDiscoverer discoverer = new VintageDiscoverer(logger);
+		TestDescriptor testDescriptor = discoverer.discover(request, engineId());
 
-		assertThat(engineDescriptor.getChildren()).isEmpty();
+		assertThat(testDescriptor.getChildren()).isEmpty();
 		assertThat(logger.getLogRecords()).isEmpty();
 	}
 


### PR DESCRIPTION
## Overview

Let the `VintageDiscoverer` handle the discovery.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
