### PR TITLE
Use the modern java.time API to get build times

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
-import java.text.SimpleDateFormat
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 
 buildscript {
 	repositories {
@@ -26,7 +27,7 @@ buildScan {
 }
 
 
-Date buildTimeAndDate = new Date()
+def buildTimeAndDate = OffsetDateTime.now()
 ext {
 	// Generate JAR manifest only if code was compiled or recompiled;
 	// otherwise the junitPlatformTest task will always be executed even if
@@ -34,8 +35,8 @@ ext {
 	// the buildDate and buildTime causes JAR manifests to be modified
 	// which triggers unnecessary rebuilding of the dependent JARs.
 	generateManifest = false
-	buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
-	buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
+	buildDate = DateTimeFormatter.ISO_LOCAL_DATE.format(buildTimeAndDate)
+	buildTime = DateTimeFormatter.ofPattern('HH:mm:ss.SSSZ').format(buildTimeAndDate)
 	buildRevision = versioning.info.commit
 	builtByValue = project.hasProperty('builtBy') ? project.builtBy : project.defaultBuiltBy
 


### PR DESCRIPTION
## Overview

In the interest of keeping up-to-date with the most modern, safest APIs, I have migrated the use of `Date` and `SimpleDateFormatter` in `build.gradle` to `java.time.OffsetDateTime` and `java.time.DateTimeFormatter` for calculating build dates and times.

I've manually confirmed that the artifact produced by `gradlew clean shadowJar` for subproject _junit-platform-console-standalone_ has the same format for both the `Build-Date` and `Build-Time` in its MANIFEST.MF.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
