### PR TITLE
Read the project modules from settings.gradle

### DIFF
--- a/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
+++ b/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
@@ -61,10 +61,10 @@ class AutomaticModuleNameTests {
 
 	static Stream<String> moduleDirectoryNames() throws IOException {
 		// @formatter:off
-		return Files.walk(Paths.get(".."), 1)
-				.filter(Files::isDirectory)
-				.map(Path::getFileName)
-				.map(Object::toString)
+		String startOfModuleLine = "include '";
+		return Files.lines(Paths.get("../settings.gradle"))
+				.filter(line -> line.startsWith(startOfModuleLine))
+				.map(line -> line.substring(startOfModuleLine.length(), line.length() - 1))
 				.filter(name -> !name.equals("junit-platform-console-standalone"))
 				.filter(name -> name.startsWith("junit-"));
 		// @formatter:on


### PR DESCRIPTION
## Overview
Read the gradle modules from where they are actually defined.

The test `org.junit.AutomaticModuleNameTests#automaticModuleName` was failing on my local junit copy because I still had the directory `junit-jupiter-migration-support` that was later renamed to `junit-jupiter-migrationsupport`. The `Automatic-Module-Name` field was missing in the old build artifacts. It took me some time to figure out what the problem was and deleting the old directory fixed the failing test.

Reading the module information form settings.gradle will prevent this problem for good.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
