### PR TITLE
Remove deprecated execute method from Launcher

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-RC1.adoc
@@ -1,0 +1,52 @@
+[[release-notes-5.0.0-rc1]]
+=== 5.0.0-RC1
+
+*Date of Release:* ❓
+
+*Scope:* Final bug fixes and documentation improvements before 5.0 GA
+
+WARNING: This is a pre-release and should only contain bug fixes. Please refer to the
+<<running-tests-ide-intellij-idea,instructions>> above to use this version in a version of
+IntelliJ IDEA that bundles an older milestone release.
+
+For a complete list of all _closed_ issues and pull requests for this release, consult the
+link:{junit5-repo}+/milestone/9?closed=1+[5.0 RC1] milestone page in the JUnit repository
+on GitHub.
+
+
+[[release-notes-5.0.0-rc1-junit-platform]]
+==== JUnit Platform
+
+===== Bug Fixes
+
+* ❓
+
+===== Deprecations and Breaking Changes
+
+* Removed deprecated method `execute(LauncherDiscoveryRequest)` from `Launcher` class.
+  The removed method was replaced in milestone 4 by method
+  `execute(LauncherDiscoveryRequest, TestExecutionListener...)`.
+
+
+[[release-notes-5.0.0-rc1-junit-jupiter]]
+==== JUnit Jupiter
+
+===== Bug Fixes
+
+* ❓
+
+===== Deprecations and Breaking Changes
+
+* ❓
+
+
+[[release-notes-5.0.0-rc1-junit-vintage]]
+==== JUnit Vintage
+
+===== Bug Fixes
+
+* ❓
+
+===== Deprecations and Breaking Changes
+
+* ❓

--- a/documentation/src/docs/asciidoc/release-notes.adoc
+++ b/documentation/src/docs/asciidoc/release-notes.adoc
@@ -17,4 +17,6 @@ include::release-notes-5.0.0-M5.adoc[]
 
 include::release-notes-5.0.0-M6.adoc[]
 
+include::release-notes-5.0.0-RC1.adoc[]
+
 :numbered:

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
@@ -89,10 +89,4 @@ public interface Launcher {
 	 */
 	void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners);
 
-	// This method is temporarily available to restore binary compatibility.
-	// It is *not* tagged as "deprecated" to avoid compiler warnings.
-	// See https://github.com/junit-team/junit5/issues/740 for details.
-	default void execute(LauncherDiscoveryRequest launcherDiscoveryRequest) {
-		execute(launcherDiscoveryRequest, new TestExecutionListener[0]);
-	}
 }


### PR DESCRIPTION
## Overview

Prior to this commit the `execute(LauncherDiscoveryRequest)` method was temporarily available to restore binary compatibility with external tools using it.

Now the method is removed. External tools are now forced to recompile against the new SNAPSHOT version of the JUnit Platform.

Closes #740

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
