### PR TITLE
Use `Optional.map` and `ArrayDeque` more consistently

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdFilter.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdFilter.java
@@ -10,11 +10,11 @@
 
 package org.junit.vintage.engine.discovery;
 
-import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
 
+import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.Optional;
 import java.util.Set;
 
@@ -34,7 +34,7 @@ class UniqueIdFilter extends RunnerTestDescriptorAwareFilter {
 	private Deque<Description> path;
 	private Set<Description> descendants;
 
-	public UniqueIdFilter(UniqueId uniqueId) {
+	UniqueIdFilter(UniqueId uniqueId) {
 		this.uniqueId = uniqueId;
 	}
 
@@ -47,7 +47,7 @@ class UniqueIdFilter extends RunnerTestDescriptorAwareFilter {
 
 	private Deque<Description> determinePath(RunnerTestDescriptor runnerTestDescriptor,
 			Optional<? extends TestDescriptor> identifiedTestDescriptor) {
-		Deque<Description> path = new LinkedList<>();
+		Deque<Description> path = new ArrayDeque<>();
 		Optional<? extends TestDescriptor> current = identifiedTestDescriptor;
 		while (current.isPresent() && !current.get().equals(runnerTestDescriptor)) {
 			path.addFirst(((VintageTestDescriptor) current.get()).getDescription());
@@ -57,17 +57,16 @@ class UniqueIdFilter extends RunnerTestDescriptorAwareFilter {
 	}
 
 	private Set<Description> determineDescendants(Optional<? extends TestDescriptor> identifiedTestDescriptor) {
-		if (identifiedTestDescriptor.isPresent()) {
-			// @formatter:off
-			return identifiedTestDescriptor.get()
-					.getDescendants()
-					.stream()
-					.map(VintageTestDescriptor.class::cast)
-					.map(VintageTestDescriptor::getDescription)
-					.collect(toSet());
-			// @formatter:on
-		}
-		return emptySet();
+		// @formatter:off
+		return identifiedTestDescriptor.map(
+				testDescriptor -> testDescriptor
+						.getDescendants()
+						.stream()
+						.map(VintageTestDescriptor.class::cast)
+						.map(VintageTestDescriptor::getDescription)
+						.collect(toSet()))
+				.orElseGet(Collections::emptySet);
+		// @formatter:on
 	}
 
 	@Override


### PR DESCRIPTION
## Overview

As described in the commit message:

```txt
- Use of `Optional.map` was reported by IntelliJ IDEA inspections.
- `ArrayDeque` javadoc states that it is likely to be "faster than
  `LinkedList` when used as a queue".
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
