### PR TITLE
Rename Spotless variables in build.gradle for clarity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -392,15 +392,15 @@ subprojects { subproj ->
 	}
 
 	spotless {
-		def headerText = rootProject.file('src/spotless/' + licenseHeaderFileProvider.call(project))
-		def importOrderConfig = rootProject.file('src/eclipse/junit-eclipse.importorder')
-		def formatterJavaConfig = rootProject.file('src/eclipse/junit-eclipse-formatter-settings.xml')
-		def formatterGroovyConfig = rootProject.file('src/eclipse/junit-greclipse-formatter-settings.prefs')
+		def headerFile = rootProject.file('src/spotless/' + licenseHeaderFileProvider.call(project))
+		def importOrderConfigFile = rootProject.file('src/eclipse/junit-eclipse.importorder')
+		def javaFormatterConfigFile = rootProject.file('src/eclipse/junit-eclipse-formatter-settings.xml')
+		def groovyFormatterConfigFile = rootProject.file('src/eclipse/junit-greclipse-formatter-settings.prefs')
 
 		java {
-			licenseHeaderFile headerText, '(package|import) '
-			importOrderFile importOrderConfig
-			eclipse().configFile formatterJavaConfig
+			licenseHeaderFile headerFile, '(package|import) '
+			importOrderFile importOrderConfigFile
+			eclipse().configFile javaFormatterConfigFile
 			if (org.gradle.api.JavaVersion.current() == org.gradle.api.JavaVersion.VERSION_1_8) {
 				removeUnusedImports()
 			}
@@ -411,9 +411,9 @@ subprojects { subproj ->
 
 		groovy {
 			target 'src/**/*.groovy'
-			licenseHeaderFile headerText, "package "
-			importOrderFile importOrderConfig
-			greclipse().configFile formatterJavaConfig, formatterGroovyConfig
+			licenseHeaderFile headerFile, "package "
+			importOrderFile importOrderConfigFile
+			greclipse().configFile javaFormatterConfigFile, groovyFormatterConfigFile
 
 			trimTrailingWhitespace()
 			endWithNewline()


### PR DESCRIPTION
## Overview

Arguably, the variables affected by this PR weren't as informatively- and intuitively-named as they could have been. This PR attempts to fix that.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
