### PR TITLE
Polishing

### DIFF
--- a/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
+++ b/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
@@ -10,6 +10,7 @@
 
 package org.junit;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.jar.JarFile;
@@ -83,14 +83,13 @@ class AutomaticModuleNameTests {
 			assertNotNull(automaticModuleName, "`Automatic-Module-Name` not found in manifest of JAR: " + jarPath);
 			assertEquals(expected, automaticModuleName);
 			// second, check entries are located in matching packages
-			List<String> unexpectedNames = new ArrayList<>();
 			String expectedStartOfPackageName = expected.replace('.', '/');
 			// @formatter:off
-			jarFile.stream()
+			List<String> unexpectedNames = jarFile.stream()
 					.map(ZipEntry::getName)
 					.filter(n -> n.endsWith(".class"))
 					.filter(n -> !n.startsWith(expectedStartOfPackageName))
-					.forEach(unexpectedNames::add);
+					.collect(toList());
 			// @formatter:on
 			assertTrue(unexpectedNames.isEmpty(), unexpectedNames.size()
 					+ " entries are not located in (a sub-) package of " + expectedStartOfPackageName);

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
@@ -78,7 +78,7 @@ class CollectionUtilsTests {
 	@Test
 	void toUnmodifiableListThrowsOnMutation() {
 		List<Integer> numbers = Stream.of(1).collect(toUnmodifiableList());
-		assertThrows(UnsupportedOperationException.class, () -> numbers.clear());
+		assertThrows(UnsupportedOperationException.class, numbers::clear);
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -10,8 +10,6 @@
 
 package org.junit.platform.commons.util;
 
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -467,7 +465,7 @@ class ReflectionUtilsTests {
 		Preconditions.notNull(methodName, "methodName must not be null");
 		Preconditions.notNull(params, "params must not be null");
 
-		return String.format("%s#%s(%s)", clazz.getName(), methodName, stream(params).collect(joining(", ")));
+		return String.format("%s#%s(%s)", clazz.getName(), methodName, String.join(", ", params));
 	}
 
 	private static void assertFqmn(String fqmn) {

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
@@ -208,8 +208,8 @@ class ConsoleDetailsTests {
 
 			URL url = optionalUrl.orElseThrow(AssertionError::new);
 			Path path = Paths.get(url.toURI());
-			assumeTrue(path.toFile().exists(), "path does not exist: " + path);
-			assumeTrue(path.toFile().canRead(), "can not read: " + path);
+			assumeTrue(Files.exists(path), "path does not exist: " + path);
+			assumeTrue(Files.isReadable(path), "can not read: " + path);
 
 			List<String> expectedLines = Files.readAllLines(path, UTF_8);
 			List<String> actualLines = asList(result.out.split("\\R"));


### PR DESCRIPTION
## Overview

This PR introduces minor polishing improvements to JUnit 5 tests.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
