### PR TITLE
Overloaded assertThrows() that accept a message or message supplier

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
@@ -10,8 +10,12 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
 import static org.junit.jupiter.api.AssertionUtils.format;
 import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
+import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.function.Executable;
 import org.opentest4j.AssertionFailedError;
@@ -38,8 +42,37 @@ class AssertThrows {
 				throw new AssertionFailedError(message, actualException);
 			}
 		}
-		throw new AssertionFailedError(
-			String.format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType)));
+		throw new AssertionFailedError(getFailureMessage(expectedType));
 	}
 
+	static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable, String message) {
+		return assertThrows(expectedType, executable, () -> message);
+	}
+
+	@SuppressWarnings("unchecked")
+	static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable,
+			Supplier<String> messageSupplier) {
+		try {
+			executable.execute();
+		}
+		catch (Throwable actualException) {
+			if (expectedType.isInstance(actualException)) {
+				return (T) actualException;
+			}
+			else {
+				throw new AssertionFailedError(getFailureWithSuppliedMessage(expectedType, messageSupplier),
+					actualException);
+			}
+		}
+		throw new AssertionFailedError(getFailureWithSuppliedMessage(expectedType, messageSupplier));
+	}
+
+	private static <T extends Throwable> String getFailureWithSuppliedMessage(Class<T> expectedType,
+			Supplier<String> messageSupplier) {
+		return buildPrefix(nullSafeGet(messageSupplier)) + getFailureMessage(expectedType);
+	}
+
+	private static <T extends Throwable> String getFailureMessage(Class<T> expectedType) {
+		return String.format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType));
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -1113,6 +1113,36 @@ public final class Assertions {
 		return AssertThrows.assertThrows(expectedType, executable);
 	}
 
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable} throws
+	 * an exception of the {@code expectedType} and returns the exception.
+	 *
+	 * <p>If no exception is thrown, or if an exception of a different type is thrown,
+	 * this method will fail with the supplied {@code message}.
+	 *
+	 * <p>If you do not want to perform additional checks on the exception instance,
+	 * simply ignore the return value.
+	 */
+	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable, String message) {
+		return AssertThrows.assertThrows(expectedType, executable, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable} throws
+	 * an exception of the {@code expectedType} and returns the exception.
+	 *
+	 * <p>If no exception is thrown, or if an exception of a different type is thrown,
+	 * this method will fail.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 *
+	 * <p>If you do not want to perform additional checks on the exception instance,
+	 * simply ignore the return value.
+	 */
+	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable,
+			Supplier<String> messageSupplier) {
+		return AssertThrows.assertThrows(expectedType, executable, messageSupplier);
+	}
+
 	// --- assertTimeout -------------------------------------------------------
 
 	// --- executable ---

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertThrowsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertThrowsTests.java
@@ -29,6 +29,32 @@ import org.opentest4j.AssertionFailedError;
 class AssertionsAssertThrowsTests {
 
 	@Test
+	void assertThrowsExceptionWithMessageString() {
+		try {
+			assertThrows(IOException.class, () -> {
+			}, "IOException not thrown");
+			expectAssertionFailedError();
+		}
+		catch (AssertionError ex) {
+			assertMessageContains(ex, "IOException not thrown");
+			assertMessageContains(ex, "Expected java.io.IOException to be thrown, but nothing was thrown.");
+		}
+	}
+
+	@Test
+	void assertThrowsExceptionWithMessageSupplier() {
+		try {
+			assertThrows(IOException.class, () -> {
+			}, () -> "IOException not thrown");
+			expectAssertionFailedError();
+		}
+		catch (AssertionError ex) {
+			assertMessageContains(ex, "IOException not thrown");
+			assertMessageContains(ex, "Expected java.io.IOException to be thrown, but nothing was thrown.");
+		}
+	}
+
+	@Test
 	void assertThrowsThrowable() {
 		EnigmaThrowable enigmaThrowable = assertThrows(EnigmaThrowable.class, () -> {
 			throw new EnigmaThrowable();


### PR DESCRIPTION
## Overview

This PR adds overloads for `assertThrows` that accept either a `String` or a `Supplier<String>` as requested by issue #977 .

- [x] Introduce a version of assertThrows() that accepts a String message.
- [x] Introduce a version of assertThrows() that accepts a Supplier<String> message supplier.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.