### PR TITLE
Fixed "NoSuchMethodError" when running tests from IntelliJ

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
@@ -89,4 +89,10 @@ public interface Launcher {
 	 */
 	void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners);
 
+	// This method is temporarily available to restore binary compatibility.
+	// It is *not* tagged as "deprecated" to avoid compiler warnings.
+	// See https://github.com/junit-team/junit5/issues/740 for details.
+	default void execute(LauncherDiscoveryRequest launcherDiscoveryRequest) {
+		execute(launcherDiscoveryRequest, new TestExecutionListener[0]);
+	}
 }


### PR DESCRIPTION
## Overview

Upon running any test from the `documentation` project or from `org.junit.vintage.engine` IntelliJ throws `NoSuchMethodError`. It seems that the problem is the missing `execute(LauncherDiscoveryRequest)` from `org.junit.platform.launcher`. Upon adding it, the tests run as expected.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.