### PR TITLE
Delete dead code

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
@@ -133,16 +133,18 @@ class ClasspathScanner {
 
 	private void processClassFileSafely(Path baseDir, String basePackageName, Predicate<Class<?>> classFilter,
 			Predicate<String> classNameFilter, Path classFile, Consumer<Class<?>> classConsumer) {
-		Optional<Class<?>> clazz = Optional.empty();
 		try {
 			String fullyQualifiedClassName = determineFullyQualifiedClassName(baseDir, basePackageName, classFile);
 			if (classNameFilter.test(fullyQualifiedClassName)) {
-				clazz = this.loadClass.apply(fullyQualifiedClassName, getClassLoader());
-				clazz.filter(classFilter).ifPresent(classConsumer);
+				Optional<Class<?>> clazz = Optional.empty();
+				try {
+					clazz = this.loadClass.apply(fullyQualifiedClassName, getClassLoader());
+					clazz.filter(classFilter).ifPresent(classConsumer);
+				}
+				catch (InternalError internalError) {
+					handleInternalError(classFile, clazz, internalError);
+				}
 			}
-		}
-		catch (InternalError internalError) {
-			handleInternalError(classFile, clazz, internalError);
 		}
 		catch (Throwable throwable) {
 			handleThrowable(classFile, throwable);


### PR DESCRIPTION
## Overview

`handleInternalError` should only be called when the class cannot be loaded because of a malformed class name. This means that the error is thrown by the `loadClass.apply` call. Therefore the `Class` object is never available when `handleInternalError` is called.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
