### PR TITLE
Resolvers apply class filter themselves

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ClassSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ClassSelectorResolver.java
@@ -10,6 +10,8 @@
 
 package org.junit.vintage.engine.discovery;
 
+import java.util.function.Predicate;
+
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.discovery.ClassSelector;
 
@@ -19,11 +21,12 @@ import org.junit.platform.engine.discovery.ClassSelector;
 class ClassSelectorResolver implements DiscoverySelectorResolver {
 
 	@Override
-	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
+	public void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector) {
 		// @formatter:off
 		request.getSelectorsByType(ClassSelector.class)
 			.stream()
 			.map(ClassSelector::getJavaClass)
+			.filter(classFilter)
 			.forEach(collector::addCompletely);
 		// @formatter:on
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ClasspathRootSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ClasspathRootSelectorResolver.java
@@ -30,12 +30,12 @@ class ClasspathRootSelectorResolver implements DiscoverySelectorResolver {
 	}
 
 	@Override
-	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
+	public void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector) {
 		// @formatter:off
 		request.getSelectorsByType(ClasspathRootSelector.class)
 			.stream()
 			.map(ClasspathRootSelector::getClasspathRoot)
-			.map(root -> findAllClassesInClasspathRoot(root, classTester, classNamePredicate))
+			.map(root -> findAllClassesInClasspathRoot(root, classFilter, classNamePredicate))
 			.flatMap(Collection::stream)
 			.forEach(collector::addCompletely);
 		// @formatter:on

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/DiscoverySelectorResolver.java
@@ -10,6 +10,8 @@
 
 package org.junit.vintage.engine.discovery;
 
+import java.util.function.Predicate;
+
 import org.junit.platform.engine.EngineDiscoveryRequest;
 
 /**
@@ -17,7 +19,5 @@ import org.junit.platform.engine.EngineDiscoveryRequest;
  */
 interface DiscoverySelectorResolver {
 
-	IsPotentialJUnit4TestClass classTester = new IsPotentialJUnit4TestClass();
-
-	void resolve(EngineDiscoveryRequest request, TestClassCollector collector);
+	void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector);
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
@@ -14,6 +14,7 @@ import static org.junit.runner.manipulation.Filter.matchMethodDescription;
 import static org.junit.vintage.engine.discovery.RunnerTestDescriptorAwareFilter.adapter;
 
 import java.lang.reflect.Method;
+import java.util.function.Predicate;
 
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.discovery.MethodSelector;
@@ -25,15 +26,17 @@ import org.junit.runner.Description;
 class MethodSelectorResolver implements DiscoverySelectorResolver {
 
 	@Override
-	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
-		request.getSelectorsByType(MethodSelector.class).forEach(selector -> resolve(selector, collector));
+	public void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector) {
+		request.getSelectorsByType(MethodSelector.class).forEach(selector -> resolve(selector, classFilter, collector));
 	}
 
-	private void resolve(MethodSelector selector, TestClassCollector collector) {
+	private void resolve(MethodSelector selector, Predicate<Class<?>> classFilter, TestClassCollector collector) {
 		Class<?> testClass = selector.getJavaClass();
-		Method testMethod = selector.getJavaMethod();
-		Description methodDescription = Description.createTestDescription(testClass, testMethod.getName());
-		collector.addFiltered(testClass, adapter(matchMethodDescription(methodDescription)));
+		if (classFilter.test(testClass)) {
+			Method testMethod = selector.getJavaMethod();
+			Description methodDescription = Description.createTestDescription(testClass, testMethod.getName());
+			collector.addFiltered(testClass, adapter(matchMethodDescription(methodDescription)));
+		}
 	}
 
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/PackageNameSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/PackageNameSelectorResolver.java
@@ -30,12 +30,12 @@ class PackageNameSelectorResolver implements DiscoverySelectorResolver {
 	}
 
 	@Override
-	public void resolve(EngineDiscoveryRequest request, TestClassCollector collector) {
+	public void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector) {
 		// @formatter:off
 		request.getSelectorsByType(PackageSelector.class)
 			.stream()
 			.map(PackageSelector::getPackageName)
-			.map(packageName -> findAllClassesInPackage(packageName, classTester, classNamePredicate))
+			.map(packageName -> findAllClassesInPackage(packageName, classFilter, classNamePredicate))
 			.flatMap(Collection::stream)
 			.forEach(collector::addCompletely);
 		// @formatter:on

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/TestClassCollector.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/TestClassCollector.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -39,20 +38,19 @@ class TestClassCollector {
 		filteredTestClasses.computeIfAbsent(testClass, key -> new LinkedList<>()).add(filter);
 	}
 
-	Stream<TestClassRequest> toRequests(Predicate<? super Class<?>> predicate) {
-		return concat(completeRequests(predicate), filteredRequests(predicate)).distinct();
+	Stream<TestClassRequest> toRequests() {
+		return concat(completeRequests(), filteredRequests()).distinct();
 	}
 
-	private Stream<TestClassRequest> completeRequests(Predicate<? super Class<?>> predicate) {
-		return completeTestClasses.stream().filter(predicate).map(TestClassRequest::new);
+	private Stream<TestClassRequest> completeRequests() {
+		return completeTestClasses.stream().map(TestClassRequest::new);
 	}
 
-	private Stream<TestClassRequest> filteredRequests(Predicate<? super Class<?>> predicate) {
+	private Stream<TestClassRequest> filteredRequests() {
 		// @formatter:off
 		return filteredTestClasses.entrySet()
 				.stream()
 				.filter(where(Entry::getKey, testClass -> !completeTestClasses.contains(testClass)))
-				.filter(where(Entry::getKey, predicate))
 				.map(entry -> new TestClassRequest(entry.getKey(), entry.getValue()));
 		// @formatter:on
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
@@ -49,7 +49,7 @@ public class VintageDiscoverer {
 		EngineDescriptor engineDescriptor = new EngineDescriptor(uniqueId, "JUnit Vintage");
 		// @formatter:off
 		collectTestClasses(discoveryRequest)
-				.toRequests(createTestClassPredicate(discoveryRequest))
+				.toRequests()
 				.map(request -> resolver.createRunnerTestDescriptor(request, uniqueId))
 				.filter(Objects::nonNull)
 				.forEach(engineDescriptor::addChild);
@@ -58,9 +58,10 @@ public class VintageDiscoverer {
 	}
 
 	private TestClassCollector collectTestClasses(EngineDiscoveryRequest discoveryRequest) {
+		Predicate<Class<?>> classFilter = createTestClassPredicate(discoveryRequest);
 		TestClassCollector collector = new TestClassCollector();
 		for (DiscoverySelectorResolver selectorResolver : getAllDiscoverySelectorResolvers(discoveryRequest)) {
-			selectorResolver.resolve(discoveryRequest, collector);
+			selectorResolver.resolve(discoveryRequest, classFilter, collector);
 		}
 		return collector;
 	}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/UniqueIdSelectorResolverTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/UniqueIdSelectorResolverTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.Stream;
@@ -36,6 +37,7 @@ import org.junit.vintage.engine.VintageUniqueIdBuilder;
  */
 class UniqueIdSelectorResolverTests {
 
+	private static final Predicate<Class<?>> allClassesPredicate = clazz -> true;
 	private RecordCollectingLogger logger = new RecordCollectingLogger();
 	private TestClassCollector collector = new TestClassCollector();
 
@@ -44,7 +46,7 @@ class UniqueIdSelectorResolverTests {
 		UniqueId uniqueId = VintageUniqueIdBuilder.uniqueIdForClass("foo.bar.UnknownClass");
 		EngineDiscoveryRequest request = requestWithSelector(selectUniqueId(uniqueId));
 
-		new UniqueIdSelectorResolver(logger).resolve(request, collector);
+		new UniqueIdSelectorResolver(logger).resolve(request, allClassesPredicate, collector);
 
 		assertNoRequests();
 		assertLoggedWarning("Unresolvable Unique ID (" + uniqueId + "): Unknown class foo.bar.UnknownClass");
@@ -55,7 +57,7 @@ class UniqueIdSelectorResolverTests {
 		String uniqueId = engineId().toString();
 		EngineDiscoveryRequest request = requestWithSelector(selectUniqueId(uniqueId));
 
-		new UniqueIdSelectorResolver(logger).resolve(request, collector);
+		new UniqueIdSelectorResolver(logger).resolve(request, allClassesPredicate, collector);
 
 		assertNoRequests();
 		assertLoggedWarning("Unresolvable Unique ID (" + engineId() + "): Cannot resolve the engine's unique ID");
@@ -66,7 +68,7 @@ class UniqueIdSelectorResolverTests {
 		UniqueId uniqueId = UniqueId.forEngine("someEngine");
 		EngineDiscoveryRequest request = requestWithSelector(selectUniqueId(uniqueId));
 
-		new UniqueIdSelectorResolver(logger).resolve(request, collector);
+		new UniqueIdSelectorResolver(logger).resolve(request, allClassesPredicate, collector);
 
 		assertNoRequests();
 		assertThat(logger.getLogRecords()).isEmpty();
@@ -77,7 +79,7 @@ class UniqueIdSelectorResolverTests {
 		UniqueId uniqueId = UniqueId.forEngine(ENGINE_ID).append("wrong-type", "foo:bar");
 		EngineDiscoveryRequest request = requestWithSelector(selectUniqueId(uniqueId));
 
-		new UniqueIdSelectorResolver(logger).resolve(request, collector);
+		new UniqueIdSelectorResolver(logger).resolve(request, allClassesPredicate, collector);
 
 		assertNoRequests();
 		assertLoggedWarning("Unresolvable Unique ID (" + uniqueId
@@ -92,7 +94,7 @@ class UniqueIdSelectorResolverTests {
 	}
 
 	private void assertNoRequests() {
-		Stream<TestClassRequest> requests = collector.toRequests(c -> true);
+		Stream<TestClassRequest> requests = collector.toRequests();
 		assertThat(requests).isEmpty();
 	}
 


### PR DESCRIPTION
## Overview

This avoids that some class filters are applied twice. Now there is a dedicated place for applying the class filters.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
