### PR TITLE
Fix thread-safety issue in ExtensionValuesStore

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-RC1.adoc
@@ -53,6 +53,7 @@ on GitHub.
   `@BeforeEach`, etc.
 * Fixed `ExecutionContext.Store.getOrComputeIfAbsent()` to look for values in the
   (great) grandparent context before computing a value.
+* Fixed thread-safety issue in `ExecutionContext.Store.getOrComputeIfAbsent()`.
 
 ===== New Features and Improvements
 

--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-RC1.adoc
@@ -51,6 +51,8 @@ on GitHub.
 * Overridden interface default methods are no longer included in the test plan. This
   applies to default methods annotated with Jupiter annotations such as `@Test`,
   `@BeforeEach`, etc.
+* Fixed `ExecutionContext.Store.getOrComputeIfAbsent()` to look for values in the
+  (great) grandparent context before computing a value.
 
 ===== New Features and Improvements
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionValuesStore.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionValuesStore.java
@@ -49,15 +49,7 @@ public class ExtensionValuesStore {
 	Object get(Namespace namespace, Object key) {
 		synchronized (this.monitor) {
 			StoredValue storedValue = getStoredValue(namespace, key);
-			if (storedValue != null) {
-				return storedValue.value;
-			}
-			else if (this.parentStore != null) {
-				return this.parentStore.get(namespace, key);
-			}
-			else {
-				return null;
-			}
+			return storedValue == null ? null : storedValue.value;
 		}
 	}
 
@@ -70,13 +62,8 @@ public class ExtensionValuesStore {
 		synchronized (this.monitor) {
 			StoredValue storedValue = getStoredValue(namespace, key);
 			if (storedValue == null) {
-				if (this.parentStore != null) {
-					storedValue = this.parentStore.getStoredValue(namespace, key);
-				}
-				if (storedValue == null) {
-					storedValue = new StoredValue(defaultCreator.apply(key));
-					putStoredValue(namespace, key, storedValue);
-				}
+				storedValue = new StoredValue(defaultCreator.apply(key));
+				putStoredValue(namespace, key, storedValue);
 			}
 			return storedValue.value;
 		}
@@ -109,8 +96,16 @@ public class ExtensionValuesStore {
 	}
 
 	private StoredValue getStoredValue(Namespace namespace, Object key) {
-		CompositeKey compositeKey = new CompositeKey(namespace, key);
-		return this.storedValues.get(compositeKey);
+		StoredValue storedValue = this.storedValues.get(new CompositeKey(namespace, key));
+		if (storedValue != null) {
+			return storedValue;
+		}
+		else if (this.parentStore != null) {
+			return this.parentStore.getStoredValue(namespace, key);
+		}
+		else {
+			return null;
+		}
 	}
 
 	private void putStoredValue(Namespace namespace, Object key, StoredValue storedValue) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionValuesStoreTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionValuesStoreTests.java
@@ -38,10 +38,12 @@ class ExtensionValuesStoreTests {
 
 	private ExtensionValuesStore store;
 	private ExtensionValuesStore parentStore;
+	private ExtensionValuesStore grandParentStore;
 
 	@BeforeEach
 	void initializeStore() {
-		parentStore = new ExtensionValuesStore();
+		grandParentStore = new ExtensionValuesStore();
+		parentStore = new ExtensionValuesStore(grandParentStore);
 		store = new ExtensionValuesStore(parentStore);
 	}
 
@@ -87,6 +89,14 @@ class ExtensionValuesStoreTests {
 		@Test
 		void valueIsNotComputedIfPresentInParent() {
 			parentStore.put(namespace, key, value);
+
+			assertEquals(value, store.getOrComputeIfAbsent(namespace, key, k -> "a different value"));
+			assertEquals(value, store.get(namespace, key));
+		}
+
+		@Test
+		void valueIsNotComputedIfPresentInGrandParent() {
+			grandParentStore.put(namespace, key, value);
 
 			assertEquals(value, store.getOrComputeIfAbsent(namespace, key, k -> "a different value"));
 			assertEquals(value, store.get(namespace, key));


### PR DESCRIPTION
## Overview

getOrComputeIfAbsent() was accessing the parent store's map without
acquiring the parent's lock.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
