### PR TITLE
Add support for TestNG-style assertions.

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.api;
 import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
 import static org.junit.jupiter.api.AssertionUtils.fail;
 import static org.junit.jupiter.api.AssertionUtils.formatIndexes;
+import static org.junit.jupiter.api.AssertionUtils.formatLengths;
 import static org.junit.jupiter.api.AssertionUtils.formatValues;
 import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 import static org.junit.platform.commons.util.ReflectionUtils.isArray;
@@ -414,8 +415,7 @@ class AssertArrayEquals {
 
 		if (expected != actual) {
 			String prefix = buildPrefix(nullSafeGet(messageSupplier));
-			String message = "array lengths differ" + formatIndexes(indexes) + ", expected: <" + expected
-					+ "> but was: <" + actual + ">";
+			String message = "array lengths differ" + formatIndexes(indexes) + ", " + formatLengths(expected, actual);
 			fail(prefix + message);
 		}
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -113,6 +113,10 @@ class AssertionUtils {
 		return " at index " + indexesString;
 	}
 
+	static String formatLengths(int expected, int actual) {
+		return "expected: <" + expected + "> but was: <" + actual + ">";
+	}
+
 	static boolean floatsAreEqual(float value1, float value2, float delta) {
 		assertValidDelta(delta);
 		return floatsAreEqual(value1, value2) || Math.abs(value1 - value2) <= delta;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionsTestNG.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionsTestNG.java
@@ -1,0 +1,1407 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.platform.commons.meta.API.Usage.Experimental;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.junit.platform.commons.meta.API;
+import org.opentest4j.MultipleFailuresError;
+
+@API(Experimental)
+public class AssertionsTestNG {
+	///CLOVER:OFF
+	private AssertionsTestNG() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
+	// --- fail ----------------------------------------------------------------
+
+	/**
+	 * <em>Fails</em> a test with the given failure {@code message}.
+	 *
+	 * <p>See Javadoc for {@link #fail(String, Throwable)} for an explanation of
+	 * this method's generic return type {@code V}.
+	 */
+	public static <V> V fail(String message) {
+		AssertionUtils.fail(message);
+		return null; // appeasing the compiler: this line will never be executed.
+	}
+
+	/**
+	 * <em>Fails</em> a test with the given failure {@code message} as well
+	 * as the underlying {@code cause}.
+	 *
+	 * <p>The generic return type {@code V} allows this method to be used
+	 * directly as a single-statement lambda expression, thereby avoiding the
+	 * need to implement a code block with an explicit return value. Since this
+	 * method throws an {@link org.opentest4j.AssertionFailedError} before its
+	 * return statement, this method never actually returns a value to its caller.
+	 * The following example demonstrates how this may be used in practice.
+	 *
+	 * <pre>{@code
+	 * Stream.of().map(entry -> fail("should not be called"));
+	 * }</pre>
+	 */
+	public static <V> V fail(String message, Throwable cause) {
+		AssertionUtils.fail(message, cause);
+		return null; // appeasing the compiler: this line will never be executed.
+	}
+
+	/**
+	 * <em>Fails</em> a test with the given underlying {@code cause}.
+	 *
+	 * <p>See Javadoc for {@link #fail(String, Throwable)} for an explanation of
+	 * this method's generic return type {@code V}.
+	 */
+	public static <V> V fail(Throwable cause) {
+		AssertionUtils.fail(cause);
+		return null; // appeasing the compiler: this line will never be executed.
+	}
+
+	/**
+	 * <em>Fails</em> a test with the failure message retrieved from the
+	 * given {@code messageSupplier}.
+	 *
+	 * <p>See Javadoc for {@link #fail(String, Throwable)} for an explanation of
+	 * this method's generic return type {@code V}.
+	 */
+	public static <V> V fail(Supplier<String> messageSupplier) {
+		AssertionUtils.fail(messageSupplier);
+		return null; // appeasing the compiler: this line will never be executed.
+	}
+
+	// --- assertTrue ----------------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that the supplied {@code condition} is {@code true}.
+	 */
+	public static void assertTrue(boolean condition) {
+		AssertTrue.assertTrue(condition);
+	}
+
+	/**
+	 * <em>Asserts</em> that the supplied {@code condition} is {@code true}.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertTrue(boolean condition, Supplier<String> messageSupplier) {
+		AssertTrue.assertTrue(condition, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that the boolean condition supplied by {@code booleanSupplier} is {@code true}.
+	 */
+	public static void assertTrue(BooleanSupplier booleanSupplier) {
+		AssertTrue.assertTrue(booleanSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that the boolean condition supplied by {@code booleanSupplier} is {@code true}.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertTrue(BooleanSupplier booleanSupplier, String message) {
+		AssertTrue.assertTrue(booleanSupplier, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that the supplied {@code condition} is {@code true}.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertTrue(boolean condition, String message) {
+		AssertTrue.assertTrue(condition, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that the boolean condition supplied by {@code booleanSupplier} is {@code true}.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertTrue(BooleanSupplier booleanSupplier, Supplier<String> messageSupplier) {
+		AssertTrue.assertTrue(booleanSupplier, messageSupplier);
+	}
+
+	// --- assertFalse ---------------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that the supplied {@code condition} is not {@code true}.
+	 */
+	public static void assertFalse(boolean condition) {
+		AssertFalse.assertFalse(condition);
+	}
+
+	/**
+	 * <em>Asserts</em> that the supplied {@code condition} is not {@code true}.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertFalse(boolean condition, String message) {
+		AssertFalse.assertFalse(condition, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that the supplied {@code condition} is not {@code true}.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertFalse(boolean condition, Supplier<String> messageSupplier) {
+		AssertFalse.assertFalse(condition, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that the boolean condition supplied by {@code booleanSupplier} is not {@code true}.
+	 */
+	public static void assertFalse(BooleanSupplier booleanSupplier) {
+		AssertFalse.assertFalse(booleanSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that the boolean condition supplied by {@code booleanSupplier} is not {@code true}.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertFalse(BooleanSupplier booleanSupplier, String message) {
+		AssertFalse.assertFalse(booleanSupplier, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that the boolean condition supplied by {@code booleanSupplier} is not {@code true}.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertFalse(BooleanSupplier booleanSupplier, Supplier<String> messageSupplier) {
+		AssertFalse.assertFalse(booleanSupplier, messageSupplier);
+	}
+
+	// --- assertNull ----------------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code actual} is {@code null}.
+	 */
+	public static void assertNull(Object actual) {
+		AssertNull.assertNull(actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code actual} is {@code null}.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertNull(Object actual, String message) {
+		AssertNull.assertNull(actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code actual} is {@code null}.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertNull(Object actual, Supplier<String> messageSupplier) {
+		AssertNull.assertNull(actual, messageSupplier);
+	}
+
+	// --- assertNotNull -------------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code actual} is not {@code null}.
+	 */
+	public static void assertNotNull(Object actual) {
+		AssertNotNull.assertNotNull(actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code actual} is not {@code null}.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertNotNull(Object actual, String message) {
+		AssertNotNull.assertNotNull(actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code actual} is not {@code null}.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertNotNull(Object actual, Supplier<String> messageSupplier) {
+		AssertNotNull.assertNotNull(actual, messageSupplier);
+	}
+
+	// --- assertEquals --------------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(short actual, short expected) {
+		AssertEquals.assertEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(short actual, short expected, String message) {
+		AssertEquals.assertEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(short actual, short expected, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(byte actual, byte expected) {
+		AssertEquals.assertEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(byte actual, byte expected, String message) {
+		AssertEquals.assertEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(byte actual, byte expected, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(int actual, int expected) {
+		AssertEquals.assertEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(int actual, int expected, String message) {
+		AssertEquals.assertEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(int actual, int expected, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(long actual, long expected) {
+		AssertEquals.assertEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(long actual, long expected, String message) {
+		AssertEquals.assertEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(long actual, long expected, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(char actual, char expected) {
+		AssertEquals.assertEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 */
+	public static void assertEquals(char actual, char expected, String message) {
+		AssertEquals.assertEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(char actual, char expected, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 */
+	public static void assertEquals(float actual, float expected) {
+		AssertEquals.assertEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 */
+	public static void assertEquals(float actual, float expected, String message) {
+		AssertEquals.assertEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(float actual, float expected, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 */
+	public static void assertEquals(float actual, float expected, float delta) {
+		AssertEquals.assertEquals(expected, actual, delta);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 */
+	public static void assertEquals(float actual, float expected, float delta, String message) {
+		AssertEquals.assertEquals(expected, actual, delta, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(float actual, float expected, float delta, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, delta, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 */
+	public static void assertEquals(double actual, double expected) {
+		AssertEquals.assertEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 */
+	public static void assertEquals(double actual, double expected, String message) {
+		AssertEquals.assertEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(double actual, double expected, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 */
+	public static void assertEquals(double actual, double expected, double delta) {
+		AssertEquals.assertEquals(expected, actual, delta);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 */
+	public static void assertEquals(double actual, double expected, double delta, String message) {
+		AssertEquals.assertEquals(expected, actual, delta, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertEquals(double actual, double expected, double delta, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, delta, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 *
+	 * @see Object#equals(Object)
+	 */
+	public static void assertEquals(Object actual, Object expected) {
+		AssertEquals.assertEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see Object#equals(Object)
+	 */
+	public static void assertEquals(Object actual, Object expected, String message) {
+		AssertEquals.assertEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 *
+	 * @see Object#equals(Object)
+	 */
+	public static void assertEquals(Object actual, Object expected, Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, messageSupplier);
+	}
+
+	// --- assertArrayEquals ---------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} boolean arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 */
+	public static void assertArrayEquals(boolean[] actual, boolean[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} boolean arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(boolean[] actual, boolean[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} boolean arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(boolean[] actual, boolean[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} char arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 */
+	public static void assertArrayEquals(char[] actual, char[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} char arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(char[] actual, char[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} char arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(char[] actual, char[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} byte arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 */
+	public static void assertArrayEquals(byte[] actual, byte[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} byte arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(byte[] actual, byte[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} byte arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(byte[] actual, byte[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} short arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 */
+	public static void assertArrayEquals(short[] actual, short[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} short arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(short[] actual, short[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} short arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(short[] actual, short[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} int arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 */
+	public static void assertArrayEquals(int[] actual, int[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} int arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(int[] actual, int[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} int arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(int[] actual, int[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} long arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 */
+	public static void assertArrayEquals(long[] actual, long[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} long arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(long[] actual, long[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} long arrays are equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(long[] actual, long[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 */
+	public static void assertArrayEquals(float[] actual, float[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(float[] actual, float[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(float[] actual, float[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 */
+	public static void assertArrayEquals(float[] actual, float[] expected, float delta) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, delta);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(float[] actual, float[] expected, float delta, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, delta, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
+	 * {@link Float#compare(float, float)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(float[] actual, float[] expected, float delta,
+			Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, delta, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 */
+	public static void assertArrayEquals(double[] actual, double[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(double[] actual, double[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(double[] actual, double[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 */
+	public static void assertArrayEquals(double[] actual, double[] expected, double delta) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, delta);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertArrayEquals(double[] actual, double[] expected, double delta, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, delta, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
+	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
+	 * {@link Double#compare(double, double)}.</p>
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertArrayEquals(double[] actual, double[] expected, double delta,
+			Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, delta, messageSupplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} object arrays are deeply equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Nested float arrays are checked as in {@link #assertEquals(float, float)}.
+	 * <p>Nested double arrays are checked as in {@link #assertEquals(double, double)}.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 */
+	public static void assertArrayEquals(Object[] actual, Object[] expected) {
+		AssertArrayEquals.assertArrayEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} object arrays are deeply equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Nested float arrays are checked as in {@link #assertEquals(float, float)}.
+	 * <p>Nested double arrays are checked as in {@link #assertEquals(double, double)}.
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 */
+	public static void assertArrayEquals(Object[] actual, Object[] expected, String message) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} object arrays are deeply equal.
+	 * <p>If both are {@code null}, they are considered equal.
+	 * <p>Nested float arrays are checked as in {@link #assertEquals(float, float)}.
+	 * <p>Nested double arrays are checked as in {@link #assertEquals(double, double)}.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 */
+	public static void assertArrayEquals(Object[] actual, Object[] expected, Supplier<String> messageSupplier) {
+		AssertArrayEquals.assertArrayEquals(expected, actual, messageSupplier);
+	}
+
+	// --- assertIterableEquals --------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} iterables are deeply equal.
+	 * <p>Similarly to the check for deep equality in {@link #assertArrayEquals(Object[], Object[])},
+	 * if two iterables are encountered (including {@code expected} and {@code actual}) then their
+	 * iterators must return equal elements in the same order as each other. <strong>Note:</strong>
+	 * this means that the iterables <em>do not</em> need to be of the same type. Example: <pre>{@code
+	 * import static java.util.Arrays.asList;
+	 *  . . .
+	 * Iterable<Integer> i0 = new ArrayList<>(asList(1, 2, 3));
+	 * Iterable<Integer> i1 = new LinkedList<>(asList(1, 2, 3));
+	 * assertIterableEquals(i0, i1); // Passes
+	 * }</pre>
+	 * <p>If both {@code expected} and {@code actual} are {@code null}, they are considered equal.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 * @see #assertArrayEquals(Object[], Object[])
+	 */
+	public static void assertIterableEquals(Iterable<?> actual, Iterable<?> expected) {
+		AssertIterableEquals.assertIterableEquals(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} iterables are deeply equal.
+	 * <p>Similarly to the check for deep equality in
+	 * {@link #assertArrayEquals(Object[], Object[], String)}, if two iterables are encountered
+	 * (including {@code expected} and {@code actual}) then their iterators must return equal
+	 * elements in the same order as each other. <strong>Note:</strong> this means that the iterables
+	 * <em>do not</em> need to be of the same type. Example: <pre>{@code
+	 * import static java.util.Arrays.asList;
+	 *  . . .
+	 * Iterable<Integer> i0 = new ArrayList<>(asList(1, 2, 3));
+	 * Iterable<Integer> i1 = new LinkedList<>(asList(1, 2, 3));
+	 * assertIterableEquals(i0, i1); // Passes
+	 * }</pre>
+	 * <p>If both {@code expected} and {@code actual} are {@code null}, they are considered equal.
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 * @see #assertArrayEquals(Object[], Object[], String)
+	 */
+	public static void assertIterableEquals(Iterable<?> actual, Iterable<?> expected, String message) {
+		AssertIterableEquals.assertIterableEquals(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} iterables are deeply equal.
+	 * <p>Similarly to the check for deep equality in
+	 * {@link #assertArrayEquals(Object[], Object[], Supplier)}, if two iterables are encountered
+	 * (including {@code expected} and {@code actual}) then their iterators must return equal
+	 * elements in the same order as each other. <strong>Note:</strong> this means that the iterables
+	 * <em>do not</em> need to be of the same type. Example: <pre>{@code
+	 * import static java.util.Arrays.asList;
+	 *  . . .
+	 * Iterable<Integer> i0 = new ArrayList<>(asList(1, 2, 3));
+	 * Iterable<Integer> i1 = new LinkedList<>(asList(1, 2, 3));
+	 * assertIterableEquals(i0, i1); // Passes
+	 * }</pre>
+	 * <p>If both {@code expected} and {@code actual} are {@code null}, they are considered equal.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 *
+	 * @see Objects#equals(Object, Object)
+	 * @see Arrays#deepEquals(Object[], Object[])
+	 * @see #assertArrayEquals(Object[], Object[], Supplier)
+	 */
+	public static void assertIterableEquals(Iterable<?> actual, Iterable<?> expected,
+			Supplier<String> messageSupplier) {
+		AssertIterableEquals.assertIterableEquals(expected, actual, messageSupplier);
+	}
+
+	// --- assertLinesMatch ----------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code expected} list of {@linkplain String}s matches {@code actual}
+	 * list.
+	 *
+	 * <p>This method differs from other assertions that effectively only check {@link String#equals(Object)},
+	 * in that it uses the following staged matching algorithm:
+	 *
+	 * <p>For each pair of expected and actual lines do
+	 * <ol>
+	 *   <li>check if {@code expected.equals(actual)} - if yes, continue with next pair</li>
+	 *   <li>otherwise treat {@code expected} as a regular expression and check via
+	 *   {@link String#matches(String)} - if yes, continue with next pair</li>
+	 *   <li>otherwise check if {@code expected} line is a fast-forward marker, if yes apply
+	 *   fast-forward actual lines accordingly (see below) and goto 1.</li>
+	 * </ol>
+	 *
+	 * <p>A valid fast-forward marker is an expected line that starts and ends with the literal
+	 * {@code >>} and contains at least 4 characters. Examples:
+	 * <ul>
+	 *   <li>{@code >>>>}<br>{@code >> stacktrace >>}<br>{@code >> single line, non Integer.parse()-able comment >>}
+	 *   <br>Skip arbitrary number of actual lines, until first matching subsequent expected line is found. Any
+	 *   character between the fast-forward literals are discarded.</li>
+	 *   <li>{@code ">> 21 >>"}
+	 *   <br>Skip strictly 21 lines. If they can't be skipped for any reason, an assertion error is raised.</li>
+	 * </ul>
+	 *
+	 * <p>Example showing all three kinds of expected line formats:
+	 * <pre>{@code
+	 * │  │  │     caught: AssertionFailedError: single line fail message
+	 * >> S T A C K T R A C E >>
+	 * │  │  │   duration: [\d]+ ms
+	 * │  │  │     status: ✘ FAILED
+	 * │  └─ test() finished after [\d]+ ms\.
+	 * └─ JUnit Jupiter finished after [\d]+ ms\.
+	 * Test plan execution finished. Number of all tests: 1
+	 *
+	 * Test run finished after [\d]+ ms
+	 * }</pre>
+	 */
+	public static void assertLinesMatch(List<String> actualLines, List<String> expectedLines) {
+		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines);
+	}
+
+	// --- assertNotEquals -----------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are not equal.
+	 * <p>Fails if both are {@code null}.
+	 *
+	 * @see Object#equals(Object)
+	 */
+	public static void assertNotEquals(Object unexpected, Object actual) {
+		AssertNotEquals.assertNotEquals(unexpected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are not equal.
+	 * <p>Fails if both are {@code null}.
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see Object#equals(Object)
+	 */
+	public static void assertNotEquals(Object unexpected, Object actual, String message) {
+		AssertNotEquals.assertNotEquals(unexpected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are not equal.
+	 * <p>Fails if both are {@code null}.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 *
+	 * @see Object#equals(Object)
+	 */
+	public static void assertNotEquals(Object unexpected, Object actual, Supplier<String> messageSupplier) {
+		AssertNotEquals.assertNotEquals(unexpected, actual, messageSupplier);
+	}
+
+	// --- assertSame ----------------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} refer to the same object.
+	 */
+	public static void assertSame(Object actual, Object expected) {
+		AssertSame.assertSame(expected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} refer to the same object.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertSame(Object actual, Object expected, String message) {
+		AssertSame.assertSame(expected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} refer to the same object.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertSame(Object actual, Object expected, Supplier<String> messageSupplier) {
+		AssertSame.assertSame(expected, actual, messageSupplier);
+	}
+
+	// --- assertNotSame -------------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} do not refer to the same object.
+	 */
+	public static void assertNotSame(Object unexpected, Object actual) {
+		AssertNotSame.assertNotSame(unexpected, actual);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} do not refer to the same object.
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static void assertNotSame(Object unexpected, Object actual, String message) {
+		AssertNotSame.assertNotSame(unexpected, actual, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that {@code expected} and {@code actual} do not refer to the same object.
+	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
+	 */
+	public static void assertNotSame(Object unexpected, Object actual, Supplier<String> messageSupplier) {
+		AssertNotSame.assertNotSame(unexpected, actual, messageSupplier);
+	}
+
+	// --- assertAll -----------------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that <em>all</em> supplied {@code executables} do not throw
+	 * exceptions.
+	 *
+	 * <p>See Javadoc for {@link #assertAll(String, Stream)} for an explanation of this
+	 * method's exception handling semantics.
+	 *
+	 * @see #assertAll(String, Executable...)
+	 * @see #assertAll(Stream)
+	 * @see #assertAll(String, Stream)
+	 */
+	@API(Experimental)
+	public static void assertAll(Executable... executables) throws MultipleFailuresError {
+		AssertAll.assertAll(executables);
+	}
+
+	/**
+	 * <em>Asserts</em> that <em>all</em> supplied {@code executables} do not throw
+	 * exceptions.
+	 *
+	 * <p>See Javadoc for {@link #assertAll(String, Stream)} for an explanation of this
+	 * method's exception handling semantics.
+	 *
+	 * @see #assertAll(Executable...)
+	 * @see #assertAll(String, Executable...)
+	 * @see #assertAll(String, Stream)
+	 */
+	@API(Experimental)
+	public static void assertAll(Stream<Executable> executables) throws MultipleFailuresError {
+		AssertAll.assertAll(executables);
+	}
+
+	/**
+	 * <em>Asserts</em> that <em>all</em> supplied {@code executables} do not throw
+	 * exceptions.
+	 *
+	 * <p>See Javadoc for {@link #assertAll(String, Stream)} for an explanation of this
+	 * method's exception handling semantics.
+	 *
+	 * @see #assertAll(Executable...)
+	 * @see #assertAll(Stream)
+	 * @see #assertAll(String, Stream)
+	 */
+	@API(Experimental)
+	public static void assertAll(String heading, Executable... executables) throws MultipleFailuresError {
+		AssertAll.assertAll(heading, executables);
+	}
+
+	/**
+	 * <em>Asserts</em> that <em>all</em> supplied {@code executables} do not throw
+	 * exceptions.
+	 *
+	 * <p>If any supplied {@link Executable} throws an exception (i.e., a {@link Throwable}
+	 * or any subclass thereof), all remaining {@code executables} will still be executed,
+	 * and all exceptions will be aggregated and reported in a {@link MultipleFailuresError}.
+	 * However, if an {@code executable} throws a <em>blacklisted</em> exception &mdash; for
+	 * example, an {@link OutOfMemoryError} &mdash; execution will halt immediately, and the
+	 * blacklisted exception will be rethrown <em>as is</em> but <em>masked</em> as an
+	 * unchecked exception.
+	 *
+	 * <p>The supplied {@code heading} will be included in the message string for the
+	 * {@link MultipleFailuresError}.
+	 *
+	 * @see #assertAll(Executable...)
+	 * @see #assertAll(String, Executable...)
+	 * @see #assertAll(Stream)
+	 */
+	@API(Experimental)
+	public static void assertAll(String heading, Stream<Executable> executables) throws MultipleFailuresError {
+		AssertAll.assertAll(heading, executables);
+	}
+
+	// --- assert exceptions ---------------------------------------------------
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable} throws
+	 * an exception of the {@code expectedType} and returns the exception.
+	 *
+	 * <p>If no exception is thrown, or if an exception of a different type is
+	 * thrown, this method will fail.
+	 *
+	 * <p>If you do not want to perform additional checks on the exception instance,
+	 * simply ignore the return value.
+	 */
+	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
+		return AssertThrows.assertThrows(expectedType, executable);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable} throws
+	 * an exception of the {@code expectedType} and returns the exception.
+	 *
+	 * <p>If no exception is thrown, or if an exception of a different type is
+	 * thrown, this method will fail.
+	 *
+	 * <p>If you do not want to perform additional checks on the exception instance,
+	 * simply ignore the return value.
+	 */
+	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable, String message) {
+		return AssertThrows.assertThrows(expectedType, executable, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable} throws
+	 * an exception of the {@code expectedType} and returns the exception.
+	 *
+	 * <p>If no exception is thrown, or if an exception of a different type is
+	 * thrown, this method will fail.
+	 *
+	 * <p>If necessary, the failure message will be retrieved lazily from the
+	 * supplied {@code messageSupplier}.
+	 *
+	 * <p>If you do not want to perform additional checks on the exception instance,
+	 * simply ignore the return value.
+	 */
+	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable,
+			Supplier<String> messageSupplier) {
+		return AssertThrows.assertThrows(expectedType, executable, messageSupplier);
+	}
+
+	// --- assertTimeout -------------------------------------------------------
+
+	// --- executable ---
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>Note: the {@code executable} will be executed in the same thread as that
+	 * of the calling code. Consequently, execution of the {@code executable} will
+	 * not be preemptively aborted if the timeout is exceeded.
+	 *
+	 * @see #assertTimeout(Duration, Executable, String)
+	 * @see #assertTimeout(Duration, Executable, Supplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, Executable)
+	 */
+	public static void assertTimeout(Duration timeout, Executable executable) {
+		AssertTimeout.assertTimeout(timeout, executable);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>Note: the {@code executable} will be executed in the same thread as that
+	 * of the calling code. Consequently, execution of the {@code executable} will
+	 * not be preemptively aborted if the timeout is exceeded.
+	 *
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see #assertTimeout(Duration, Executable)
+	 * @see #assertTimeout(Duration, Executable, Supplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, String)
+	 */
+	public static void assertTimeout(Duration timeout, Executable executable, String message) {
+		AssertTimeout.assertTimeout(timeout, executable, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>Note: the {@code executable} will be executed in the same thread as that
+	 * of the calling code. Consequently, execution of the {@code executable} will
+	 * not be preemptively aborted if the timeout is exceeded.
+	 *
+	 * <p>If necessary, the failure message will be retrieved lazily from the
+	 * supplied {@code messageSupplier}.
+	 *
+	 * @see #assertTimeout(Duration, Executable)
+	 * @see #assertTimeout(Duration, Executable, String)
+	 * @see #assertTimeout(Duration, ThrowingSupplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, Supplier)
+	 */
+	public static void assertTimeout(Duration timeout, Executable executable, Supplier<String> messageSupplier) {
+		AssertTimeout.assertTimeout(timeout, executable, messageSupplier);
+	}
+
+	// --- supplier ---
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code supplier}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>If the assertion passes then the {@code supplier}'s result is returned.
+	 *
+	 * <p>Note: the {@code supplier} will be executed in the same thread as that
+	 * of the calling code. Consequently, execution of the {@code supplier} will
+	 * not be preemptively aborted if the timeout is exceeded.
+	 *
+	 * @see #assertTimeout(Duration, Executable)
+	 * @see #assertTimeout(Duration, Executable, String)
+	 * @see #assertTimeout(Duration, Executable, Supplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, Executable)
+	 */
+	public static <T> T assertTimeout(Duration timeout, ThrowingSupplier<T> supplier) {
+		return AssertTimeout.assertTimeout(timeout, supplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code supplier}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>If the assertion passes then the {@code supplier}'s result is returned.
+	 *
+	 * <p>Note: the {@code supplier} will be executed in the same thread as that
+	 * of the calling code. Consequently, execution of the {@code supplier} will
+	 * not be preemptively aborted if the timeout is exceeded.
+	 *
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see #assertTimeout(Duration, Executable)
+	 * @see #assertTimeout(Duration, Executable, String)
+	 * @see #assertTimeout(Duration, Executable, Supplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, String)
+	 */
+	public static <T> T assertTimeout(Duration timeout, ThrowingSupplier<T> supplier, String message) {
+		return AssertTimeout.assertTimeout(timeout, supplier, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code supplier}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>If the assertion passes then the {@code supplier}'s result is returned.
+	 *
+	 * <p>Note: the {@code supplier} will be executed in the same thread as that
+	 * of the calling code. Consequently, execution of the {@code supplier} will
+	 * not be preemptively aborted if the timeout is exceeded.
+	 *
+	 * <p>If necessary, the failure message will be retrieved lazily from the
+	 * supplied {@code messageSupplier}.
+	 *
+	 * @see #assertTimeout(Duration, Executable)
+	 * @see #assertTimeout(Duration, Executable, String)
+	 * @see #assertTimeout(Duration, Executable, Supplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier)
+	 * @see #assertTimeout(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, Supplier)
+	 */
+	public static <T> T assertTimeout(Duration timeout, ThrowingSupplier<T> supplier,
+			Supplier<String> messageSupplier) {
+		return AssertTimeout.assertTimeout(timeout, supplier, messageSupplier);
+	}
+
+	// --- executable - preemptively ---
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>Note: the {@code executable} will be executed in a different thread than
+	 * that of the calling code. Furthermore, execution of the {@code executable} will
+	 * be preemptively aborted if the timeout is exceeded.
+	 *
+	 * @see #assertTimeoutPreemptively(Duration, Executable, String)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeout(Duration, Executable)
+	 */
+	public static void assertTimeoutPreemptively(Duration timeout, Executable executable) {
+		AssertTimeout.assertTimeoutPreemptively(timeout, executable);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>Note: the {@code executable} will be executed in a different thread than
+	 * that of the calling code. Furthermore, execution of the {@code executable} will
+	 * be preemptively aborted if the timeout is exceeded.
+	 *
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see #assertTimeoutPreemptively(Duration, Executable)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeout(Duration, Executable, String)
+	 */
+	public static void assertTimeoutPreemptively(Duration timeout, Executable executable, String message) {
+		AssertTimeout.assertTimeoutPreemptively(timeout, executable, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code executable}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>Note: the {@code executable} will be executed in a different thread than
+	 * that of the calling code. Furthermore, execution of the {@code executable} will
+	 * be preemptively aborted if the timeout is exceeded.
+	 *
+	 * <p>If necessary, the failure message will be retrieved lazily from the
+	 * supplied {@code messageSupplier}.
+	 *
+	 * @see #assertTimeoutPreemptively(Duration, Executable)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, String)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeout(Duration, Executable, Supplier)
+	 */
+	public static void assertTimeoutPreemptively(Duration timeout, Executable executable,
+			Supplier<String> messageSupplier) {
+		AssertTimeout.assertTimeoutPreemptively(timeout, executable, messageSupplier);
+	}
+
+	// --- supplier - preemptively ---
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code supplier}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>If the assertion passes then the {@code supplier}'s result is returned.
+	 *
+	 * <p>Note: the {@code supplier} will be executed in a different thread than
+	 * that of the calling code. Furthermore, execution of the {@code supplier} will
+	 * be preemptively aborted if the timeout is exceeded.
+	 *
+	 * @see #assertTimeoutPreemptively(Duration, Executable)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, String)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeout(Duration, Executable)
+	 */
+	public static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier) {
+		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code supplier}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>If the assertion passes then the {@code supplier}'s result is returned.
+	 *
+	 * <p>Note: the {@code supplier} will be executed in a different thread than
+	 * that of the calling code. Furthermore, execution of the {@code supplier} will
+	 * be preemptively aborted if the timeout is exceeded.
+	 *
+	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see #assertTimeoutPreemptively(Duration, Executable)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, String)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, Supplier)
+	 * @see #assertTimeout(Duration, Executable, String)
+	 */
+	public static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier, String message) {
+		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier, message);
+	}
+
+	/**
+	 * <em>Asserts</em> that execution of the supplied {@code supplier}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>If the assertion passes then the {@code supplier}'s result is returned.
+	 *
+	 * <p>Note: the {@code supplier} will be executed in a different thread than
+	 * that of the calling code. Furthermore, execution of the {@code supplier} will
+	 * be preemptively aborted if the timeout is exceeded.
+	 *
+	 * <p>If necessary, the failure message will be retrieved lazily from the
+	 * supplied {@code messageSupplier}.
+	 *
+	 * @see #assertTimeoutPreemptively(Duration, Executable)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, String)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeout(Duration, Executable, Supplier)
+	 */
+	public static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
+			Supplier<String> messageSupplier) {
+		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier, messageSupplier);
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsTestNGTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsTestNGTests.java
@@ -1,0 +1,803 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.jupiter.api.AssertionTestUtils.assertExpectedAndActualValues;
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
+import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
+import static org.junit.jupiter.api.AssertionUtils.formatLengths;
+import static org.junit.jupiter.api.AssertionUtils.formatValues;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.AssertionsTestNG.assertArrayEquals;
+import static org.junit.jupiter.api.AssertionsTestNG.assertEquals;
+import static org.junit.jupiter.api.AssertionsTestNG.assertIterableEquals;
+import static org.junit.jupiter.api.AssertionsTestNG.assertLinesMatch;
+import static org.junit.jupiter.api.AssertionsTestNG.assertSame;
+import static org.junit.jupiter.api.IterableFactory.listOf;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.opentest4j.AssertionFailedError;
+
+class AssertionsTestNGTests {
+	private final static String MESSAGE = "ignored";
+	private final static Supplier<String> MESSAGE_SUPPLIER = () -> "ignored";
+
+	@Test
+	void assertSameAssertMethods() {
+		Class<Assertions> assertions = Assertions.class;
+		Class<AssertionsTestNG> assertionsTestNG = AssertionsTestNG.class;
+
+		List<Method> unsupportedAssertions = Arrays.stream(assertions.getMethods()).filter(
+			junitAssert -> !methodInClass(junitAssert, assertionsTestNG)).collect(Collectors.toList());
+
+		assertTrue(unsupportedAssertions.isEmpty(),
+			"Found unsupported assertions:\n" + formatMethods(unsupportedAssertions));
+	}
+
+	@Test
+	void assertNoExtraMethods() {
+		Class<Assertions> assertions = Assertions.class;
+		Class<AssertionsTestNG> assertionsTestNG = AssertionsTestNG.class;
+
+		List<Method> extraAssertions = Arrays.stream(assertionsTestNG.getMethods()).filter(
+			testngAssert -> !methodInClass(testngAssert, assertions)).collect(Collectors.toList());
+
+		assertTrue(extraAssertions.isEmpty(), "Found extra assertions:\n" + formatMethods(extraAssertions));
+	}
+
+	private static boolean methodInClass(Method method, Class<?> clazz) {
+		try {
+			clazz.getMethod(method.getName(), method.getParameterTypes());
+			return true;
+		}
+		catch (NoSuchMethodException e) {
+			return false;
+		}
+	}
+
+	@Test
+	void testAssertEqualsShort() {
+		short actual = 2179;
+		short expected = 2181;
+
+		try {
+			assertEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsByte() {
+		byte actual = 83;
+		byte expected = 79;
+
+		try {
+			assertEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsInt() {
+		int actual = 2128675309;
+		int expected = 2127365000;
+
+		try {
+			assertEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsLong() {
+		long actual = 6178675309L;
+		long expected = 6175365400L;
+
+		try {
+			assertEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsChar() {
+		char actual = 'A';
+		char expected = 'T';
+
+		try {
+			assertEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsFloat() {
+		float actual = 2179.0F;
+		float expected = 2181.0F;
+
+		try {
+			assertEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsFloatDelta() {
+		float actual = 2179.0F;
+		float expected = 2181.0F;
+		float delta = 0.1F;
+
+		try {
+			assertEquals(actual, expected, delta);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, delta, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, delta, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsDouble() {
+		double actual = 2179.0;
+		double expected = 2181.0;
+
+		try {
+			assertEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsDoubleDelta() {
+		double actual = 2179.0;
+		double expected = 2181.0;
+		double delta = 0.1;
+
+		try {
+			assertEquals(actual, expected, delta);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, delta, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, delta, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertEqualsObject() {
+		String actual = "A man, a plan, a canal, Panama!";
+		String expected = "!amanaP ,lanac a ,nalp a ,nam A";
+
+		try {
+			assertEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsBoolean() {
+		boolean[] actual = { true, false };
+		boolean[] expected = { true, true };
+		int index = 1;
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsChar() {
+		char[] actual = { 'A', 'T' };
+		char[] expected = { 'L', 'T' };
+		int index = 0;
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsByte() {
+		byte[] actual = { 21, 79 };
+		byte[] expected = { 21, 81 };
+		int index = 1;
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsShort() {
+		short[] actual = { 2179, 2650 };
+		short[] expected = { 2181, 2650 };
+		int index = 0;
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsInt() {
+		int[] actual = { 2128675309, 2127365000 };
+		int[] expected = { 2128675309, 2125357710 };
+		int index = 1;
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsLong() {
+		long[] actual = { 6175365400L, 6178675309L };
+		long[] expected = { 6172679300L, 6178675309L };
+		int index = 0;
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsFloat() {
+		float[] actual = { 2179.0F, 2650.0F };
+		float[] expected = { 2181.0F, 2650.0F };
+		int index = 0;
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsFloatDelta() {
+		float[] actual = { 2179.0F, 2650.0F };
+		float[] expected = { 2181.0F, 2650.0F };
+		int index = 0;
+
+		try {
+			assertArrayEquals(actual, expected, 0.1F);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, 0.1F, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, 0.1F, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsDouble() {
+		double[] actual = { 2179.0, 2650.0 };
+		double[] expected = { 2181.0, 2650.0 };
+		int index = 0;
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsDoubleDelta() {
+		double[] actual = { 2179.0, 2650.0 };
+		double[] expected = { 2181.0, 2650.0 };
+		int index = 0;
+
+		try {
+			assertArrayEquals(actual, expected, 0.1F);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, 0.1F, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, 0.1F, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, expected[index], actual[index]);
+		}
+	}
+
+	@Test
+	void testAssertArrayEqualsObject() {
+		Object[] actual = { 'A', 'T' };
+		Object[] expected = { 'P', 'C', 'T' };
+
+		try {
+			assertArrayEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertArraySizeMessage(ex, expected, actual);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertArraySizeMessage(ex, expected, actual);
+		}
+
+		try {
+			assertArrayEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertArraySizeMessage(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void testAssertIterableEquals() {
+		Iterable<Object> actual = listOf("foo", 'b', 1, 0.0);
+		Iterable<Object> expected = listOf("foo", 'b', 2, 0.3);
+
+		try {
+			assertIterableEquals(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, 2, 1);
+		}
+
+		try {
+			assertIterableEquals(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, 2, 1);
+		}
+
+		try {
+			assertIterableEquals(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertElementMessage(ex, 2, 1);
+		}
+	}
+
+	@Test
+	void testAssertLinesMatch() {
+		List<String> actual = Arrays.asList("A", "man", "a", "plan", "a", "canal", "Van Halen");
+		List<String> expected = Arrays.asList("A", "man", "a", "plan", "a", "canal", "Panama");
+
+		try {
+			assertLinesMatch(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected.stream().collect(Collectors.joining("\n")),
+				actual.stream().collect(Collectors.joining("\n")));
+		}
+	}
+
+	@Test
+	void testAssertSame() {
+		String actual = "A man, a plan, a canal, Panama!";
+		String expected = "!amanaP ,lanac a ,nalp a ,nam A";
+
+		try {
+			assertSame(actual, expected);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertSame(actual, expected, MESSAGE);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+
+		try {
+			assertSame(actual, expected, MESSAGE_SUPPLIER);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	/*
+	 * This is nowhere near general enough to go in AssertionTestUtils, but we need the sanity check
+	 * here to make sure we really have our actual and expected values in the right places.
+	 */
+	private static void assertElementMessage(AssertionFailedError ex, Object expected, Object actual) {
+		assertMessageContains(ex, formatValues(expected, actual));
+	}
+
+	private static void assertArraySizeMessage(AssertionFailedError ex, Object[] expected, Object[] actual) {
+		assertMessageContains(ex, formatLengths(expected.length, actual.length));
+	}
+
+	private static String formatMethods(List<Method> methods) {
+		return methods.stream().map(Method::toString).collect(Collectors.joining("\n"));
+	}
+}


### PR DESCRIPTION
## Overview

This change provides a migration path for projects to migrate from
TestNG-style assertions to JUnit-5-style assertions. Specifically, it
implements an AssertionsTestNG class that duplicates the functionality
of Assertions, but with the order of expected and actual arguments
reversed to fit with the TestNG convention.

Issue: #1009

Javadoc in AssertionsTestNG.java hasn't been updated pending agreement that this change is fundamentally acceptable. I propose that the documentation for every method be limited to a link to the equivalent method in Assertions.java and a class-level introduction explaining the difference.

The tests are purposely shallow, and is solely to be sure that the correct expected and actual value information ends up in the AssertionFailedErrors that are raised.

---

~~I hereby agree to the terms of the JUnit Contributor License Agreement.~~
(Pending corporate agreement)

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
