### PR TITLE
Cleanup ExtensionContext Namespace API

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0-RC3.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0-RC3.adoc
@@ -41,6 +41,10 @@ on GitHub.
   `junit.jupiter.conditions.deactivate`.
 * The `junit.extensions.autodetection.enabled` configuration parameter has been renamed
   to `junit.jupiter.extensions.autodetection.enabled`.
+* The default, global extension namespace constant in `ExtensionContext` is now named
+  `Namespace.GLOBAL` instead of `Namespace.DEFAULT`.
+* The default `getStore()` method was removed from the `ExtensionContext` interface.
+  Use the explicit call `getStore(Namespace.GLOBAL)` instead.
 
 ===== New Features and Improvements
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -242,22 +242,14 @@ public interface ExtensionContext {
 	}
 
 	/**
-	 * Get the {@link Store} for the default, global {@link Namespace}.
-	 *
-	 * @return the default, global {@code Store}; never {@code null}
-	 * @see #getStore(Namespace)
-	 * @see Namespace#DEFAULT
-	 */
-	default Store getStore() {
-		return getStore(Namespace.DEFAULT);
-	}
-
-	/**
 	 * Get the {@link Store} for the supplied {@link Namespace}.
+	 *
+	 * <p>Use {@code getStore(Namespace.GLOBAL)} to get the default, global {@link Namespace}.
 	 *
 	 * @param namespace the {@code Namespace} to get the store for; never {@code null}
 	 * @return the store in which to put and get objects for other invocations
 	 * working in the same namespace; never {@code null}
+	 * @see Namespace#GLOBAL
 	 */
 	Store getStore(Namespace namespace);
 
@@ -406,7 +398,7 @@ public interface ExtensionContext {
 		 * The default, global namespace which allows access to stored data from
 		 * all extensions.
 		 */
-		public static final Namespace DEFAULT = Namespace.create(new Object());
+		public static final Namespace GLOBAL = Namespace.create(new Object());
 
 		/**
 		 * Create a namespace which restricts access to data to all extensions

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.engine.descriptor.ClassExtensionContext;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
@@ -160,16 +161,19 @@ class ExtensionContextTests {
 
 		extensionContext.publishReportEntry(map1);
 		extensionContext.publishReportEntry(map2);
+		extensionContext.publishReportEntry("3rd key", "third value");
 
 		ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
-		Mockito.verify(engineExecutionListener, Mockito.times(2)).reportingEntryPublished(
+		Mockito.verify(engineExecutionListener, Mockito.times(3)).reportingEntryPublished(
 			Mockito.eq(classTestDescriptor), entryCaptor.capture());
 
 		ReportEntry reportEntry1 = entryCaptor.getAllValues().get(0);
 		ReportEntry reportEntry2 = entryCaptor.getAllValues().get(1);
+		ReportEntry reportEntry3 = entryCaptor.getAllValues().get(2);
 
 		assertEquals(map1, reportEntry1.getKeyValuePairs());
 		assertEquals(map2, reportEntry2.getKeyValuePairs());
+		assertEquals("third value", reportEntry3.getKeyValuePairs().get("3rd key"));
 	}
 
 	@Test
@@ -180,8 +184,8 @@ class ExtensionContextTests {
 		MethodExtensionContext childContext = new MethodExtensionContext(parentContext, null, methodTestDescriptor,
 			new OuterClass(), new ThrowableCollector());
 
-		ExtensionContext.Store childStore = childContext.getStore();
-		ExtensionContext.Store parentStore = parentContext.getStore();
+		ExtensionContext.Store childStore = childContext.getStore(Namespace.GLOBAL);
+		ExtensionContext.Store parentStore = parentContext.getStore(Namespace.GLOBAL);
 
 		final Object key1 = "key 1";
 		final String value1 = "a value";

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionStoreConcurrencyTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionStoreConcurrencyTests.java
@@ -46,7 +46,7 @@ class ExtensionStoreConcurrencyTests {
 
 	private Store reset() {
 		count.set(0);
-		return new NamespaceAwareStore(new ExtensionValuesStore(null), Namespace.DEFAULT);
+		return new NamespaceAwareStore(new ExtensionValuesStore(null), Namespace.GLOBAL);
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionContextExecutionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionContextExecutionTests.java
@@ -90,7 +90,8 @@ class ExtensionContextExecutionTests extends AbstractJupiterTestEngineTests {
 	static class OnlyIncrementCounterOnce implements BeforeAllCallback {
 		@Override
 		public void beforeAll(ExtensionContext context) throws Exception {
-			getRoot(context).getStore().getOrComputeIfAbsent("counter", key -> Parent.counter.incrementAndGet());
+			ExtensionContext.Store store = getRoot(context).getStore(ExtensionContext.Namespace.GLOBAL);
+			store.getOrComputeIfAbsent("counter", key -> Parent.counter.incrementAndGet());
 		}
 
 		private ExtensionContext getRoot(ExtensionContext context) {


### PR DESCRIPTION
## Overview

This PR removes the method `getStore()` from the `ExtensionContext` interface and renames `Namespace.DEFAULT` to `Namespace.GLOBAL`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
