### PR TITLE
Fix selection of method from JUnit 4 parameterized test

### DIFF
--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTestCase.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.vintage.engine;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class JUnit4ParameterizedTestCase {
+
+	private final boolean b;
+	private final long l;
+	private final int i;
+
+	@Parameterized.Parameters(name = "{0} ---> : Test")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] { { 1L, false, 21 }, { 2L, true, 11 }, { 3L, false, 21 }, });
+	}
+
+	public JUnit4ParameterizedTestCase(long l, boolean b, int i) {
+		this.b = b;
+		this.l = l;
+		this.i = i;
+	}
+
+	@Test
+	public void test1() {
+		fail("this test should fail");
+	}
+
+	@Test
+	public void endingIn_test1() {
+		fail("this test should fail");
+	}
+
+	@Test
+	public void test1_atTheBeginning() {
+		fail("this test should fail");
+	}
+
+	@Test
+	public void test2() {
+		/* always succeed */
+	}
+}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.vintage.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+class JUnit4ParameterizedTests {
+	private final Launcher launcher = LauncherFactory.create();
+	private final Map<TestExecutionResult.Status, Integer> callCounts = new HashMap<>();
+	private final LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request();
+
+	@BeforeEach
+	void setUpLauncher() {
+		launcher.registerTestExecutionListeners(new TestListenerMock());
+	}
+
+	@Test
+	void selectingWholeParameterizedClassRunsTestsWithAllValues() {
+		requestBuilder.selectors(selectClass(JUnit4ParameterizedTestCase.class));
+		LauncherDiscoveryRequest discoveryRequest = requestBuilder.build();
+
+		launcher.execute(discoveryRequest);
+
+		HashMap<TestExecutionResult.Status, Integer> expectedCallCounts = new HashMap<>();
+		expectedCallCounts.put(TestExecutionResult.Status.SUCCESSFUL, 3);
+		expectedCallCounts.put(TestExecutionResult.Status.FAILED, 9);
+		assertEquals(expectedCallCounts, callCounts);
+	}
+
+	@Test
+	void selectingOneTestFromParameterizedClassRunsWithAllValues() {
+		requestBuilder.selectors(selectMethod(JUnit4ParameterizedTestCase.class, "test1"));
+		LauncherDiscoveryRequest discoveryRequest = requestBuilder.build();
+
+		launcher.execute(discoveryRequest);
+
+		HashMap<TestExecutionResult.Status, Integer> expectedCallCounts = new HashMap<>();
+		expectedCallCounts.put(TestExecutionResult.Status.FAILED, 3);
+		assertEquals(expectedCallCounts, callCounts);
+	}
+
+	private class TestListenerMock implements TestExecutionListener {
+		@Override
+		public void executionFinished(TestIdentifier identifier, TestExecutionResult result) {
+			if (identifier.isTest()) {
+				final TestExecutionResult.Status status = result.getStatus();
+				callCounts.merge(status, 1, Integer::sum);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Overview

When selecting a test method from a JUnit 4 parameterized test it, the method would run only once, without considering the parameters it should receive.

Resolves #549 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---