### PR TITLE
Add missing private constructors to utilities classes

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertAll.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertAll.java
@@ -28,6 +28,12 @@ import org.opentest4j.MultipleFailuresError;
  */
 class AssertAll {
 
+	///CLOVER:OFF
+	private AssertAll() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertAll(Executable... executables) {
 		assertAll(null, executables);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
@@ -30,6 +30,12 @@ import java.util.function.Supplier;
  */
 class AssertArrayEquals {
 
+	///CLOVER:OFF
+	private AssertArrayEquals() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertArrayEquals(boolean[] expected, boolean[] actual) {
 		assertArrayEquals(expected, actual, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertEquals.java
@@ -27,6 +27,12 @@ import java.util.function.Supplier;
  */
 class AssertEquals {
 
+	///CLOVER:OFF
+	private AssertEquals() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertEquals(byte expected, byte actual) {
 		assertEquals(expected, actual, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertFalse.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertFalse.java
@@ -23,6 +23,12 @@ import java.util.function.Supplier;
  */
 class AssertFalse {
 
+	///CLOVER:OFF
+	private AssertFalse() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertFalse(boolean condition) {
 		assertFalse(() -> condition, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -31,6 +31,12 @@ import java.util.function.Supplier;
  */
 class AssertIterableEquals {
 
+	///CLOVER:OFF
+	private AssertIterableEquals() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertIterableEquals(Iterable<?> expected, Iterable<?> actual) {
 		assertIterableEquals(expected, actual, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -28,6 +28,12 @@ import java.util.regex.PatternSyntaxException;
  */
 class AssertLinesMatch {
 
+	///CLOVER:OFF
+	private AssertLinesMatch() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	private final static int MAX_SNIPPET_LENGTH = 21;
 
 	static void assertLinesMatch(List<String> expectedLines, List<String> actualLines) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotEquals.java
@@ -25,6 +25,12 @@ import java.util.function.Supplier;
  */
 class AssertNotEquals {
 
+	///CLOVER:OFF
+	private AssertNotEquals() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertNotEquals(Object unexpected, Object actual) {
 		assertNotEquals(unexpected, actual, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotNull.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotNull.java
@@ -23,6 +23,12 @@ import java.util.function.Supplier;
  */
 class AssertNotNull {
 
+	///CLOVER:OFF
+	private AssertNotNull() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertNotNull(Object actual) {
 		assertNotNull(actual, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotSame.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotSame.java
@@ -24,6 +24,12 @@ import java.util.function.Supplier;
  */
 class AssertNotSame {
 
+	///CLOVER:OFF
+	private AssertNotSame() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertNotSame(Object unexpected, Object actual) {
 		assertNotSame(unexpected, actual, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNull.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNull.java
@@ -24,6 +24,12 @@ import java.util.function.Supplier;
  */
 class AssertNull {
 
+	///CLOVER:OFF
+	private AssertNull() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertNull(Object actual) {
 		assertNull(actual, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertSame.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertSame.java
@@ -24,6 +24,12 @@ import java.util.function.Supplier;
  */
 class AssertSame {
 
+	///CLOVER:OFF
+	private AssertSame() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertSame(Object expected, Object actual) {
 		assertSame(expected, actual, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
@@ -28,6 +28,12 @@ import org.opentest4j.AssertionFailedError;
  */
 class AssertThrows {
 
+	///CLOVER:OFF
+	private AssertThrows() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
 		return assertThrows(expectedType, executable, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -36,6 +36,12 @@ import org.opentest4j.AssertionFailedError;
  */
 class AssertTimeout {
 
+	///CLOVER:OFF
+	private AssertTimeout() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertTimeout(Duration timeout, Executable executable) {
 		assertTimeout(timeout, executable, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTrue.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTrue.java
@@ -23,6 +23,12 @@ import java.util.function.Supplier;
  */
 class AssertTrue {
 
+	///CLOVER:OFF
+	private AssertTrue() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	static void assertTrue(boolean condition) {
 		assertTrue(() -> condition, () -> null);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -42,9 +42,11 @@ import org.opentest4j.TestAbortedException;
 @API(Maintained)
 public final class Assumptions {
 
+	///CLOVER:OFF
 	private Assumptions() {
 		/* no-op */
 	}
+	///CLOVER:ON
 
 	// --- assumeTrue ----------------------------------------------------
 

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/member/TestRuleAnnotatedMemberFactory.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/member/TestRuleAnnotatedMemberFactory.java
@@ -25,6 +25,12 @@ import org.junit.platform.commons.util.PreconditionViolationException;
 @API(Internal)
 public final class TestRuleAnnotatedMemberFactory {
 
+	///CLOVER:OFF
+	private TestRuleAnnotatedMemberFactory() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	public static TestRuleAnnotatedMember from(Object testInstance, Member member) {
 		if (member instanceof Method) {
 			return new TestRuleAnnotatedMethod(testInstance, (Method) member);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumerInitializer.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumerInitializer.java
@@ -32,6 +32,12 @@ import org.junit.platform.commons.util.AnnotationUtils;
 @API(Internal)
 public final class AnnotationConsumerInitializer {
 
+	///CLOVER:OFF
+	private AnnotationConsumerInitializer() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	// @formatter:off
 	private static final Predicate<Method> isAnnotationConsumerAcceptMethod = method ->
 			method.getName().equals("accept")

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
@@ -40,6 +40,12 @@ import org.junit.platform.launcher.TestExecutionListener;
 @API(Experimental)
 public class LauncherFactory {
 
+	///CLOVER:OFF
+	private LauncherFactory() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
 	/**
 	 * Factory method for creating a new {@link Launcher} using dynamically
 	 * detected test engines.


### PR DESCRIPTION
## Overview

As requested by @sbrannen in https://github.com/junit-team/junit5/pull/961/files#r134089533, this PR takes a subset of the changes proposed for https://github.com/junit-team/junit5/pull/961/files and makes them a separate PR.

This is just a cleanup PR designed to add missing private constructors to various utilities classes.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
