### PR TITLE
Fix bug in AssertionUtils.toString(Object)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bin/
 *.iws
 *.uml
 .idea/
+*/out/*
 
 # Misc
 *.log

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.api;
 
 import static java.util.stream.Collectors.joining;
 
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.function.Supplier;
 
@@ -93,7 +94,15 @@ class AssertionUtils {
 	}
 
 	private static String toString(Object obj) {
-		return (obj instanceof Class ? getCanonicalName((Class<?>) obj) : String.valueOf(obj));
+		if (obj instanceof Class) {
+			return getCanonicalName((Class<?>) obj);
+		}
+		else if (obj instanceof Object[]) {
+			return Arrays.toString((Object[]) obj);
+		}
+		else {
+			return String.valueOf(obj);
+		}
 	}
 
 	private static String toHash(Object obj) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -100,7 +100,7 @@ class AssertionUtils {
 		if (obj instanceof Object[]) {
 			return Arrays.toString((Object[]) obj);
 		}
-		return String.valueOf(obj);
+		return StringUtils.nullSafeToString(obj);
 	}
 
 	private static String toHash(Object obj) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -97,12 +97,10 @@ class AssertionUtils {
 		if (obj instanceof Class) {
 			return getCanonicalName((Class<?>) obj);
 		}
-		else if (obj instanceof Object[]) {
+		if (obj instanceof Object[]) {
 			return Arrays.toString((Object[]) obj);
 		}
-		else {
-			return String.valueOf(obj);
-		}
+		return String.valueOf(obj);
 	}
 
 	private static String toHash(Object obj) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertArrayEqualsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertArrayEqualsTests.java
@@ -16,8 +16,6 @@ import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import java.util.Arrays;
-
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -1869,15 +1867,13 @@ class AssertionsAssertArrayEqualsTests {
 			assertMessageEquals(ex, "array contents differ at index [2][1][1][0], expected: <false> but was: <true>");
 		}
 
-		Object[] differentElement = new Object[] {};
 		try {
 			assertArrayEquals(new Object[] { 1, 2, 3, new Object[] { new Object[] { 4, new Object[] { 5 } } } },
-				new Object[] { 1, 2, 3, new Object[] { new Object[] { 4, new Object[] { differentElement } } } });
+				new Object[] { 1, 2, 3, new Object[] { new Object[] { 4, new Object[] { new Object[] {} } } } });
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageEquals(ex, "array contents differ at index [3][0][1][0], expected: <5> but was: <"
-					+ Arrays.toString(differentElement) + ">");
+			assertMessageEquals(ex, "array contents differ at index [3][0][1][0], expected: <5> but was: <[]>");
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertArrayEqualsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionsAssertArrayEqualsTests.java
@@ -16,6 +16,8 @@ import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
+import java.util.Arrays;
+
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -1874,8 +1876,8 @@ class AssertionsAssertArrayEqualsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageEquals(ex,
-				"array contents differ at index [3][0][1][0], expected: <5> but was: <" + differentElement + ">");
+			assertMessageEquals(ex, "array contents differ at index [3][0][1][0], expected: <5> but was: <"
+					+ Arrays.toString(differentElement) + ">");
 		}
 	}
 


### PR DESCRIPTION
As described in the commit message,

```
Beforehand it would print arrays via the arrays' toString() methods.
Now it prints them using `Arrays.toString()`, which produces the
expected result.

This is a prerequisite for #961.
```

This PR was requested by @sbrannen at https://github.com/junit-team/junit5/pull/961#discussion_r134114088.

## Overview

Please describe your changes here and list any open questions you might have.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
