### PR TITLE
Don't call distinct on stream of requests

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/TestClassCollector.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/TestClassCollector.java
@@ -39,7 +39,7 @@ class TestClassCollector {
 	}
 
 	Stream<TestClassRequest> toRequests() {
-		return concat(completeRequests(), filteredRequests()).distinct();
+		return concat(completeRequests(), filteredRequests());
 	}
 
 	private Stream<TestClassRequest> completeRequests() {


### PR DESCRIPTION
The requests are already distinct, because

1. TestClassRequest does not override equals.
2. CompleteRequests never have filters but filteredRequests always have. Therefore completeRequests and filteredRequests are disjunct.
3. CompleteRequests are created from a set of classes. Hence they are all different.
4. FilteredRequests are created from map entries. Hence they are all different.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
