### PR TITLE
Use ArrayList instead of LinkedList

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
@@ -13,15 +13,15 @@ package org.junit.jupiter.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class DynamicTestTests {
 
-	private final List<String> assertedValues = new LinkedList<>();
+	private final List<String> assertedValues = new ArrayList<>();
 
 	@Test
 	void streamFromIterator() throws Throwable {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
@@ -22,8 +22,8 @@ import static org.junit.platform.launcher.TagFilter.includeTags;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -73,7 +73,7 @@ class DiscoveryRequestCreator {
 	}
 
 	private List<DiscoverySelector> createExplicitDiscoverySelectors(CommandLineOptions options) {
-		List<DiscoverySelector> selectors = new LinkedList<>();
+		List<DiscoverySelector> selectors = new ArrayList<>();
 		options.getSelectedUris().stream().map(DiscoverySelectors::selectUri).forEach(selectors::add);
 		options.getSelectedFiles().stream().map(DiscoverySelectors::selectFile).forEach(selectors::add);
 		options.getSelectedDirectories().stream().map(DiscoverySelectors::selectDirectory).forEach(selectors::add);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -12,9 +12,9 @@ package org.junit.platform.launcher.core;
 
 import static org.junit.platform.commons.meta.API.Usage.Stable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -79,10 +79,10 @@ import org.junit.platform.launcher.PostDiscoveryFilter;
 @API(Stable)
 public final class LauncherDiscoveryRequestBuilder {
 
-	private List<DiscoverySelector> selectors = new LinkedList<>();
-	private List<EngineFilter> engineFilters = new LinkedList<>();
-	private List<DiscoveryFilter<?>> discoveryFilters = new LinkedList<>();
-	private List<PostDiscoveryFilter> postDiscoveryFilters = new LinkedList<>();
+	private List<DiscoverySelector> selectors = new ArrayList<>();
+	private List<EngineFilter> engineFilters = new ArrayList<>();
+	private List<DiscoveryFilter<?>> discoveryFilters = new ArrayList<>();
+	private List<PostDiscoveryFilter> postDiscoveryFilters = new ArrayList<>();
 	private Map<String, String> configurationParameters = new HashMap<>();
 
 	/**

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/TestClassCollector.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/TestClassCollector.java
@@ -13,9 +13,9 @@ package org.junit.vintage.engine.discovery;
 import static java.util.stream.Stream.concat;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -35,7 +35,7 @@ class TestClassCollector {
 	}
 
 	void addFiltered(Class<?> testClass, RunnerTestDescriptorAwareFilter filter) {
-		filteredTestClasses.computeIfAbsent(testClass, key -> new LinkedList<>()).add(filter);
+		filteredTestClasses.computeIfAbsent(testClass, key -> new ArrayList<>()).add(filter);
 	}
 
 	Stream<TestClassRequest> toRequests() {

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/RecordCollectingLogger.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/RecordCollectingLogger.java
@@ -10,7 +10,7 @@
 
 package org.junit.vintage.engine;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
  */
 public class RecordCollectingLogger extends Logger {
 
-	private final List<LogRecord> logRecords = new LinkedList<>();
+	private final List<LogRecord> logRecords = new ArrayList<>();
 
 	public RecordCollectingLogger() {
 		super("RecordCollectingLogger", null);


### PR DESCRIPTION
## Overview

Motivated by the discussion here https://github.com/junit-team/junit5/pull/1039#discussion_r136281377 this PR replaces `LinkedList` usages with `ArrayList` where appropriate.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
