### PR TITLE
Support test sharding

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -97,12 +97,16 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	@Override
 	public final void setParent(TestDescriptor parent) {
+		if (this.parent != null && parent != null) {
+			throw new IllegalStateException("TestDescriptor already has a parent");
+		}
 		this.parent = parent;
 	}
 
 	@Override
 	public void removeChild(TestDescriptor child) {
 		Preconditions.notNull(child, "child must not be null");
+		Preconditions.condition(child.getParent().orElse(null) == this, "child is not a child of this TestDescriptor");
 		this.children.remove(child);
 		child.setParent(null);
 	}
@@ -134,7 +138,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	@Override
 	public void addChild(TestDescriptor child) {
 		Preconditions.notNull(child, "child must not be null");
-		child.setParent(this);
+		child.setParent(this); // throws if child has a parent already
 		this.children.add(child);
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UnmodifiableTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UnmodifiableTestDescriptor.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.support.descriptor;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.meta.API.Usage;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * Decorator for an {@link TestDescriptor} that throws {@link UnsupportedOperationException}
+ * for any mutable operations.
+ *
+ * <p>Methods that are not supported are annotated with {@code @Deprecated}.
+ *
+ * @since 1.0
+ */
+@API(Usage.Experimental)
+public final class UnmodifiableTestDescriptor implements TestDescriptor {
+	private final TestDescriptor delegate;
+
+	public UnmodifiableTestDescriptor(TestDescriptor testDescriptor) {
+		this.delegate = Preconditions.notNull(testDescriptor, "testDescriptor must not be null");
+	}
+
+	@Override
+	public UniqueId getUniqueId() {
+		return delegate.getUniqueId();
+	}
+
+	@Override
+	public String getDisplayName() {
+		return delegate.getDisplayName();
+	}
+
+	@Override
+	public Set<TestTag> getTags() {
+		return Collections.unmodifiableSet(delegate.getTags());
+	}
+
+	@Override
+	public Optional<TestSource> getSource() {
+		return delegate.getSource();
+	}
+
+	@Override
+	public Optional<TestDescriptor> getParent() {
+		return delegate.getParent().map(UnmodifiableTestDescriptor::new);
+	}
+
+	@Override
+	@Deprecated
+	public void setParent(TestDescriptor parent) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Set<? extends TestDescriptor> getChildren() {
+		// @formatter:off
+		Set<? extends TestDescriptor> wrapped = delegate.getChildren().stream()
+				.map(UnmodifiableTestDescriptor::new)
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+		// @formatter:on
+		return Collections.unmodifiableSet(wrapped);
+	}
+
+	@Override
+	@Deprecated
+	public void addChild(TestDescriptor descriptor) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	@Deprecated
+	public void removeChild(TestDescriptor descriptor) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	@Deprecated
+	public void removeFromHierarchy() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	@Deprecated
+	public void prune() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isRoot() {
+		return delegate.isRoot();
+	}
+
+	@Override
+	public Type getType() {
+		return delegate.getType();
+	}
+
+	@Override
+	public Optional<? extends TestDescriptor> findByUniqueId(UniqueId uniqueId) {
+		return delegate.findByUniqueId(uniqueId).map(UnmodifiableTestDescriptor::new);
+	}
+
+	@Override
+	public void accept(Visitor visitor) {
+		delegate.accept(d -> visitor.visit(new UnmodifiableTestDescriptor(d)));
+	}
+
+	@Override
+	public int hashCode() {
+		return delegate.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other == this) {
+			return true;
+		}
+		if (!(other instanceof UnmodifiableTestDescriptor)) {
+			return false;
+		}
+		UnmodifiableTestDescriptor that = (UnmodifiableTestDescriptor) other;
+		return this.delegate.equals(that.delegate);
+	}
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
@@ -19,6 +19,7 @@ import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.TestDescriptor;
 
 /**
  * {@code LauncherDiscoveryRequest} extends the {@link EngineDiscoveryRequest} API
@@ -66,6 +67,15 @@ public interface LauncherDiscoveryRequest extends EngineDiscoveryRequest {
 	 * {@code null} but potentially empty
 	 */
 	List<EngineFilter> getEngineFilters();
+
+	/**
+	 * Get the visitors to visit each {@link TestDescriptor} after the
+	 * discovery phase has completed, but before the filtering has occurred.
+	 *
+	 * @return the list of visitors for this request; never {@code null} but
+	 * potentially empty
+	 */
+	List<TestDescriptor.Visitor> getTestVisitors();
 
 	/**
 	 * Get the {@code PostDiscoveryFilters} for this request.

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -117,6 +117,7 @@ class DefaultLauncher implements Launcher {
 			Optional<TestDescriptor> engineRoot = discoverEngineRoot(testEngine, discoveryRequest);
 			engineRoot.ifPresent(rootDescriptor -> root.add(testEngine, rootDescriptor));
 		}
+		root.applyVisitors(discoveryRequest);
 		root.applyPostDiscoveryFilters(discoveryRequest);
 		root.prune();
 		return root;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -24,6 +24,7 @@ import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
@@ -79,11 +80,12 @@ import org.junit.platform.launcher.PostDiscoveryFilter;
 @API(Stable)
 public final class LauncherDiscoveryRequestBuilder {
 
-	private List<DiscoverySelector> selectors = new ArrayList<>();
-	private List<EngineFilter> engineFilters = new ArrayList<>();
-	private List<DiscoveryFilter<?>> discoveryFilters = new ArrayList<>();
-	private List<PostDiscoveryFilter> postDiscoveryFilters = new ArrayList<>();
-	private Map<String, String> configurationParameters = new HashMap<>();
+	List<DiscoverySelector> selectors = new ArrayList<>();
+	List<EngineFilter> engineFilters = new ArrayList<>();
+	List<DiscoveryFilter<?>> discoveryFilters = new ArrayList<>();
+	List<TestDescriptor.Visitor> testVisitors = new ArrayList<>();
+	List<PostDiscoveryFilter> postDiscoveryFilters = new ArrayList<>();
+	Map<String, String> configurationParameters = new HashMap<>();
 
 	/**
 	 * Create a new {@code LauncherDiscoveryRequestBuilder}.
@@ -116,6 +118,22 @@ public final class LauncherDiscoveryRequestBuilder {
 		Preconditions.notNull(selectors, "selectors list must not be null");
 		Preconditions.containsNoNullElements(selectors, "individual selectors must not be null");
 		this.selectors.addAll(selectors);
+		return this;
+	}
+
+	/**
+	 * Add all of the supplied {@code visitors} to the request.
+	 *
+	 * <p>The {@code visitors} are called after the tests are discovered, but before
+	 * the filters are applied.
+	 *
+	 * @param visitors the {@code Visitor} instances to add; never {@code null}
+	 * @return this builder for method chaining
+	 */
+	public LauncherDiscoveryRequestBuilder visitors(TestDescriptor.Visitor... visitors) {
+		Preconditions.notNull(visitors, "visitors array must not be null");
+		Preconditions.containsNoNullElements(visitors, "individual visitors must not be null");
+		testVisitors.addAll(Arrays.asList(visitors));
 		return this;
 	}
 
@@ -191,10 +209,7 @@ public final class LauncherDiscoveryRequestBuilder {
 	 * this builder.
 	 */
 	public LauncherDiscoveryRequest build() {
-		LauncherConfigurationParameters launcherConfigurationParameters = new LauncherConfigurationParameters(
-			this.configurationParameters);
-		return new DefaultDiscoveryRequest(this.selectors, this.engineFilters, this.discoveryFilters,
-			this.postDiscoveryFilters, launcherConfigurationParameters);
+		return new DefaultDiscoveryRequest(this);
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.support.descriptor.UnmodifiableTestDescriptor;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 
 /**
@@ -72,7 +73,8 @@ class Root {
 	}
 
 	private boolean isExcluded(TestDescriptor descriptor, Filter<TestDescriptor> postDiscoveryFilter) {
-		return descriptor.getChildren().isEmpty() && postDiscoveryFilter.apply(descriptor).excluded();
+		return descriptor.getChildren().isEmpty()
+				&& postDiscoveryFilter.apply(new UnmodifiableTestDescriptor(descriptor)).excluded();
 	}
 
 	private void acceptInAllTestEngines(TestDescriptor.Visitor visitor) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
@@ -51,6 +51,12 @@ class Root {
 		return this.testEngineDescriptors.get(testEngine);
 	}
 
+	void applyVisitors(LauncherDiscoveryRequest discoveryRequest) {
+		for (TestDescriptor.Visitor visitor : discoveryRequest.getTestVisitors()) {
+			acceptInAllTestEngines(d -> visitor.visit(new UnmodifiableTestDescriptor(d)));
+		}
+	}
+
 	void applyPostDiscoveryFilters(LauncherDiscoveryRequest discoveryRequest) {
 		Filter<TestDescriptor> postDiscoveryFilter = composeFilters(discoveryRequest.getPostDiscoveryFilters());
 		TestDescriptor.Visitor removeExcludedTestDescriptors = descriptor -> {
@@ -77,7 +83,7 @@ class Root {
 				&& postDiscoveryFilter.apply(new UnmodifiableTestDescriptor(descriptor)).excluded();
 	}
 
-	private void acceptInAllTestEngines(TestDescriptor.Visitor visitor) {
+	void acceptInAllTestEngines(TestDescriptor.Visitor visitor) {
 		this.testEngineDescriptors.values().forEach(descriptor -> descriptor.accept(visitor));
 	}
 


### PR DESCRIPTION
## Overview

Add LauncherDiscoveryRequestBuilder.visitors()

This allows users of the launcher to learn about the discovered tests
before filters are applied. This is essential for build systems
like Bazel that want to "shard" (aka partition) a test run into
multiple processes while ensuring that the tests included in
each "shard" are consistent, even if test discovery does not
result in a deterministic ordering of tests (see https://goo.gl/Yj4fXL
for what Bazel does to Shard JUnit4 tests today).

This change also creates a wrapper to make a TestDescription
unmodifiable. This ensures that tests cannot be removed during
the visit phase, and cannot be added during the filtering stage.

Finally, FilterResult is made final, so that no one can override
the methods to make them inconsistent with one another.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
