### PR TITLE
Change PostDiscoveryFilter to filter on TestIdentifier

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/PostDiscoveryFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/PostDiscoveryFilter.java
@@ -14,11 +14,10 @@ import static org.junit.platform.commons.meta.API.Usage.Stable;
 
 import org.junit.platform.commons.meta.API;
 import org.junit.platform.engine.Filter;
-import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 
 /**
- * A {@code PostDiscoveryFilter} is applied to {@link TestDescriptor TestDescriptors}
+ * A {@code PostDiscoveryFilter} is applied to {@link TestIdentifier TestIdentifiers}
  * after test discovery.
  *
  * <p>{@link TestEngine TestEngines} must <strong>not</strong> apply
@@ -29,5 +28,5 @@ import org.junit.platform.engine.TestEngine;
  * @see TestEngine
  */
 @API(Stable)
-public interface PostDiscoveryFilter extends Filter<TestDescriptor> {
+public interface PostDiscoveryFilter extends Filter<TestIdentifier> {
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
@@ -20,6 +20,7 @@ import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestIdentifier;
 
 /**
  * Represents the root of all discovered {@link TestEngine TestEngines} and
@@ -51,7 +52,7 @@ class Root {
 	}
 
 	void applyPostDiscoveryFilters(LauncherDiscoveryRequest discoveryRequest) {
-		Filter<TestDescriptor> postDiscoveryFilter = composeFilters(discoveryRequest.getPostDiscoveryFilters());
+		Filter<TestIdentifier> postDiscoveryFilter = composeFilters(discoveryRequest.getPostDiscoveryFilters());
 		TestDescriptor.Visitor removeExcludedTestDescriptors = descriptor -> {
 			if (!descriptor.isRoot() && isExcluded(descriptor, postDiscoveryFilter)) {
 				descriptor.removeFromHierarchy();
@@ -71,8 +72,9 @@ class Root {
 		acceptInAllTestEngines(TestDescriptor::prune);
 	}
 
-	private boolean isExcluded(TestDescriptor descriptor, Filter<TestDescriptor> postDiscoveryFilter) {
-		return descriptor.getChildren().isEmpty() && postDiscoveryFilter.apply(descriptor).excluded();
+	private boolean isExcluded(TestDescriptor descriptor, Filter<TestIdentifier> postDiscoveryFilter) {
+		return descriptor.getChildren().isEmpty()
+				&& postDiscoveryFilter.apply(TestIdentifier.from(descriptor)).excluded();
 	}
 
 	private void acceptInAllTestEngines(TestDescriptor.Visitor visitor) {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/PostDiscoveryFilterStub.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/PostDiscoveryFilterStub.java
@@ -14,18 +14,17 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.platform.engine.FilterResult;
-import org.junit.platform.engine.TestDescriptor;
 
 /**
  * @since 1.0
  */
-public class PostDiscoveryFilterStub extends FilterStub<TestDescriptor> implements PostDiscoveryFilter {
+public class PostDiscoveryFilterStub extends FilterStub<TestIdentifier> implements PostDiscoveryFilter {
 
 	public PostDiscoveryFilterStub(String toString) {
 		super(toString);
 	}
 
-	public PostDiscoveryFilterStub(Function<TestDescriptor, FilterResult> function, Supplier<String> toString) {
+	public PostDiscoveryFilterStub(Function<TestIdentifier, FilterResult> function, Supplier<String> toString) {
 		super(function, toString);
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
@@ -23,7 +23,6 @@ import java.lang.annotation.RetentionPolicy;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.PreconditionViolationException;
-import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.DemoClassTestDescriptor;
 
@@ -38,14 +37,14 @@ import org.junit.platform.engine.support.descriptor.DemoClassTestDescriptor;
  */
 class TagFilterTests {
 
-	private static final TestDescriptor classWithTag1 = classTestDescriptor("class1", ClassWithTag1.class);
-	private static final TestDescriptor classWithTag1AndSurroundingWhitespace = classTestDescriptor(
+	private static final TestIdentifier classWithTag1 = classTestIdentifier("class1", ClassWithTag1.class);
+	private static final TestIdentifier classWithTag1AndSurroundingWhitespace = classTestIdentifier(
 		"class1-surrounding-whitespace", ClassWithTag1AndSurroundingWhitespace.class);
-	private static final TestDescriptor classWithTag2 = classTestDescriptor("class2", ClassWithTag2.class);
-	private static final TestDescriptor classWithBothTags = classTestDescriptor("class12", ClassWithBothTags.class);
-	private static final TestDescriptor classWithDifferentTags = classTestDescriptor("classX",
+	private static final TestIdentifier classWithTag2 = classTestIdentifier("class2", ClassWithTag2.class);
+	private static final TestIdentifier classWithBothTags = classTestIdentifier("class12", ClassWithBothTags.class);
+	private static final TestIdentifier classWithDifferentTags = classTestIdentifier("classX",
 		ClassWithDifferentTags.class);
-	private static final TestDescriptor classWithNoTags = classTestDescriptor("class", ClassWithNoTags.class);
+	private static final TestIdentifier classWithNoTags = classTestIdentifier("class", ClassWithNoTags.class);
 
 	@Test
 	void includeTagsWithInvalidSyntax() {
@@ -187,9 +186,9 @@ class TagFilterTests {
 	private static class ClassWithNoTags {
 	}
 
-	private static TestDescriptor classTestDescriptor(String uniqueId, Class<?> testClass) {
+	private static TestIdentifier classTestIdentifier(String uniqueId, Class<?> testClass) {
 		UniqueId rootUniqueId = UniqueId.root("class", uniqueId);
-		return new DemoClassTestDescriptor(rootUniqueId, testClass);
+		return TestIdentifier.from(new DemoClassTestDescriptor(rootUniqueId, testClass));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,7 @@ import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.suite.api.ExcludeClassNamePatterns;
 import org.junit.platform.suite.api.ExcludeEngines;
@@ -191,9 +193,9 @@ class JUnitPlatformRunnerTests {
 			assertThat(filters).hasSize(1);
 
 			PostDiscoveryFilter filter = filters.get(0);
-			assertTrue(filter.apply(testDescriptorWithTag("foo")).included());
-			assertTrue(filter.apply(testDescriptorWithTag("bar")).included());
-			assertTrue(filter.apply(testDescriptorWithTag("baz")).excluded());
+			assertTrue(filter.apply(testIdentifierWithTag("foo")).included());
+			assertTrue(filter.apply(testIdentifierWithTag("bar")).included());
+			assertTrue(filter.apply(testIdentifierWithTag("baz")).excluded());
 		}
 
 		@Test
@@ -209,9 +211,9 @@ class JUnitPlatformRunnerTests {
 			assertThat(filters).hasSize(1);
 
 			PostDiscoveryFilter filter = filters.get(0);
-			assertTrue(filter.apply(testDescriptorWithTag("foo")).excluded());
-			assertTrue(filter.apply(testDescriptorWithTag("bar")).excluded());
-			assertTrue(filter.apply(testDescriptorWithTag("baz")).included());
+			assertTrue(filter.apply(testIdentifierWithTag("foo")).excluded());
+			assertTrue(filter.apply(testIdentifierWithTag("bar")).excluded());
+			assertTrue(filter.apply(testIdentifierWithTag("baz")).included());
 		}
 
 		@Test
@@ -664,10 +666,28 @@ class JUnitPlatformRunnerTests {
 		return createTestDescription(uniqueId, uniqueId, uniqueId);
 	}
 
-	private TestDescriptor testDescriptorWithTag(String tag) {
-		TestDescriptor testDescriptor = mock(TestDescriptor.class);
-		when(testDescriptor.getTags()).thenReturn(singleton(TestTag.create(tag)));
-		return testDescriptor;
+	private TestIdentifier testIdentifierWithTag(String tag) {
+		TestDescriptor testDescriptor = new FakeTestDescriptor(TestTag.create(tag));
+		return TestIdentifier.from(testDescriptor);
+	}
+
+	private static class FakeTestDescriptor extends AbstractTestDescriptor {
+		private final TestTag tag;
+
+		FakeTestDescriptor(TestTag tag) {
+			super(UniqueId.forEngine("fake"), "displayName");
+			this.tag = tag;
+		}
+
+		@Override
+		public Type getType() {
+			return Type.TEST;
+		}
+
+		@Override
+		public Set<TestTag> getTags() {
+			return singleton(tag);
+		}
 	}
 
 	private LauncherDiscoveryRequest instantiateRunnerAndCaptureGeneratedRequest(Class<?> testClass)


### PR DESCRIPTION
## Overview

`TestDescriptor` is mutable, so a `PostDiscoveryFilter` could add tests
or directly remove tests, which is problematic. Since `TestIdentifier` is
immutable, changing `PostDiscoveryFilter` to use it solves this problem.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
