### PR TITLE
Remove the workaround for Kotlin on JDK9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,7 @@ buildscript {
 		classpath 'org.ajoberstar:gradle-git-publish:0.3.0'
 		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-SNAPSHOT'
 
-		classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}") {
-			// temporary workaround for incompatibility of commons-lang:2.4 with
-			// versioning scheme of Java 9
-			// see: https://youtrack.jetbrains.com/issue/KT-18832
-			exclude module: 'commons-lang'
-		}
-		classpath 'commons-lang:commons-lang:2.6'
+		classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
 	}
 }
 


### PR DESCRIPTION
As the bug was fixed in Kotlin 1.1.4 acording to youtrack this
workarround can be removed.
https://youtrack.jetbrains.com/issue/KT-18832

## Overview

Please describe your changes here and list any open questions you might have.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
