### PR TITLE
Replace constructors with static factory methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.0.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0.adoc
@@ -19,9 +19,22 @@ on GitHub.
 
 ===== Deprecations and Breaking Changes
 
+* The constructor for `FilePosition` has been replaced with a static factory method named
+  `from(int, int)`.
+* A `FilePosition` can now be constructed solely from a line number via the new
+  `from(int)` static factory method.
+* `FilePosition.getColumn()` now returns `Optional<Integer>` instead of `int`.
+* The constructors in the following concrete `TestSource` implementations have been
+  replaced with static factory methods named `from(...)`.
+  - `ClasspathResourceSource`
+  - `ClassSource`
+  - `CompositeTestSource`
+  - `DirectorySource`
+  - `FileSource`
+  - `MethodSource`
+  - `PackageSource`
 * The constructor for `LoggingListener` has been replaced with a static factory method
   named `forBiConsumer(...)`.
-
 
 ===== New Features and Improvements
 

--- a/documentation/src/docs/asciidoc/release-notes-5.0.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.0.0.adoc
@@ -19,7 +19,9 @@ on GitHub.
 
 ===== Deprecations and Breaking Changes
 
-* ❓
+* The constructor for `LoggingListener` has been replaced with a static factory method
+  named `forBiConsumer(...)`.
+
 
 ===== New Features and Improvements
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -78,7 +78,7 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 			Class<?> testClass) {
 
 		super(uniqueId, determineDisplayName(Preconditions.notNull(testClass, "Class must not be null"),
-			defaultDisplayNameGenerator), new ClassSource(testClass));
+			defaultDisplayNameGenerator), ClassSource.from(testClass));
 
 		this.testClass = testClass;
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -34,7 +34,7 @@ abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod) {
-		super(uniqueId, displayName, new MethodSource(Preconditions.notNull(testMethod, "Method must not be null")));
+		super(uniqueId, displayName, MethodSource.from(Preconditions.notNull(testMethod, "Method must not be null")));
 
 		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
 		this.testMethod = testMethod;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -35,20 +35,14 @@ public class ClassSource implements TestSource {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String className;
-
-	private Class<?> javaClass;
-
-	private final FilePosition filePosition;
-
 	/**
 	 * Create a new {@code ClassSource} using the supplied
 	 * className.
 	 *
 	 * @param className the Java class name; must not be {@code null}
 	 */
-	public ClassSource(String className) {
-		this(className, null);
+	public static ClassSource from(String className) {
+		return new ClassSource(className);
 	}
 
 	/**
@@ -58,9 +52,8 @@ public class ClassSource implements TestSource {
 	 * @param className the Java class name; must not be {@code null}
 	 * @param filePosition the position in the Java source file; may be {@code null}
 	 */
-	public ClassSource(String className, FilePosition filePosition) {
-		this.className = className;
-		this.filePosition = filePosition;
+	public static ClassSource from(String className, FilePosition filePosition) {
+		return new ClassSource(className, filePosition);
 	}
 
 	/**
@@ -69,8 +62,8 @@ public class ClassSource implements TestSource {
 	 *
 	 * @param javaClass the Java class; must not be {@code null}
 	 */
-	public ClassSource(Class<?> javaClass) {
-		this(javaClass, null);
+	public static ClassSource from(Class<?> javaClass) {
+		return new ClassSource(javaClass);
 	}
 
 	/**
@@ -80,7 +73,28 @@ public class ClassSource implements TestSource {
 	 * @param javaClass the Java class; must not be {@code null}
 	 * @param filePosition the position in the Java source file; may be {@code null}
 	 */
-	public ClassSource(Class<?> javaClass, FilePosition filePosition) {
+	public static ClassSource from(Class<?> javaClass, FilePosition filePosition) {
+		return new ClassSource(javaClass, filePosition);
+	}
+
+	private final String className;
+	private final FilePosition filePosition;
+	private Class<?> javaClass;
+
+	private ClassSource(String className) {
+		this(className, null);
+	}
+
+	private ClassSource(String className, FilePosition filePosition) {
+		this.className = className;
+		this.filePosition = filePosition;
+	}
+
+	private ClassSource(Class<?> javaClass) {
+		this(javaClass, null);
+	}
+
+	private ClassSource(Class<?> javaClass, FilePosition filePosition) {
 		this.javaClass = Preconditions.notNull(javaClass, "class must not be null");
 		this.className = this.javaClass.getName();
 		this.filePosition = filePosition;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
@@ -32,9 +32,6 @@ public class ClasspathResourceSource implements TestSource {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String classpathResourceName;
-	private final FilePosition filePosition;
-
 	/**
 	 * Create a new {@code ClasspathResourceSource} using the supplied classpath
 	 * resource name.
@@ -51,8 +48,8 @@ public class ClasspathResourceSource implements TestSource {
 	 * @see ClassLoader#getResourceAsStream(String)
 	 * @see ClassLoader#getResources(String)
 	 */
-	public ClasspathResourceSource(String classpathResourceName) {
-		this(classpathResourceName, null);
+	public static ClasspathResourceSource from(String classpathResourceName) {
+		return new ClasspathResourceSource(classpathResourceName, null);
 	}
 
 	/**
@@ -69,7 +66,18 @@ public class ClasspathResourceSource implements TestSource {
 	 * {@code null} or blank
 	 * @param filePosition the position in the classpath resource; may be {@code null}
 	 */
-	public ClasspathResourceSource(String classpathResourceName, FilePosition filePosition) {
+	public static ClasspathResourceSource from(String classpathResourceName, FilePosition filePosition) {
+		return new ClasspathResourceSource(classpathResourceName, filePosition);
+	}
+
+	private final String classpathResourceName;
+	private final FilePosition filePosition;
+
+	private ClasspathResourceSource(String classpathResourceName) {
+		this(classpathResourceName, null);
+	}
+
+	private ClasspathResourceSource(String classpathResourceName, FilePosition filePosition) {
 		Preconditions.notBlank(classpathResourceName, "Classpath resource name must not be null or blank");
 		boolean startsWithSlash = classpathResourceName.startsWith("/");
 		this.classpathResourceName = (startsWithSlash ? classpathResourceName.substring(1) : classpathResourceName);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/CompositeTestSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/CompositeTestSource.java
@@ -34,8 +34,6 @@ public class CompositeTestSource implements TestSource {
 
 	private static final long serialVersionUID = 1L;
 
-	private final List<TestSource> sources;
-
 	/**
 	 * Create a new {@code CompositeTestSource} based on the supplied
 	 * collection of {@link TestSource sources}.
@@ -47,7 +45,13 @@ public class CompositeTestSource implements TestSource {
 	 * @param sources the collection of sources to store in this
 	 * {@code CompositeTestSource}; never {@code null} or empty
 	 */
-	public CompositeTestSource(Collection<? extends TestSource> sources) {
+	public static CompositeTestSource from(Collection<? extends TestSource> sources) {
+		return new CompositeTestSource(sources);
+	}
+
+	private final List<TestSource> sources;
+
+	private CompositeTestSource(Collection<? extends TestSource> sources) {
 		Preconditions.notEmpty(sources, "TestSource collection must not be null or empty");
 		Preconditions.containsNoNullElements(sources, "individual TestSources must not be null");
 		this.sources = Collections.unmodifiableList(new ArrayList<>(sources));

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DirectorySource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DirectorySource.java
@@ -32,15 +32,19 @@ public class DirectorySource implements FileSystemSource {
 
 	private static final long serialVersionUID = 1L;
 
-	private final File directory;
-
 	/**
 	 * Create a new {@code DirectorySource} using the supplied
 	 * {@linkplain File directory}.
 	 *
 	 * @param directory the source directory; must not be {@code null}
 	 */
-	public DirectorySource(File directory) {
+	public static DirectorySource from(File directory) {
+		return new DirectorySource(directory);
+	}
+
+	private final File directory;
+
+	private DirectorySource(File directory) {
 		Preconditions.notNull(directory, "directory must not be null");
 		try {
 			this.directory = directory.getCanonicalFile();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FilePosition.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FilePosition.java
@@ -14,13 +14,15 @@ import static org.junit.platform.commons.meta.API.Usage.Stable;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.junit.platform.commons.meta.API;
+import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
  * Position inside a file represented by {@linkplain #getLine line} and
- * {@linkplain #getColumn column}.
+ * {@linkplain #getColumn column} numbers.
  *
  * @since 1.0
  */
@@ -29,33 +31,60 @@ public class FilePosition implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final int line;
-	private final int column;
-
 	/**
-	 * Create a new {@code FilePosition} using the supplied {@code line} and
-	 * {@code column}.
+	 * Create a new {@code FilePosition} using the supplied {@code line} number
+	 * and an undefined column number.
 	 *
-	 * @param line the line (1-based)
-	 * @param column the column (1-based)
+	 * @param line the line number; must be greater than zero
 	 */
-	public FilePosition(int line, int column) {
-		this.line = line;
-		this.column = column;
+	public static FilePosition from(int line) {
+		return new FilePosition(line);
 	}
 
 	/**
-	 * Get the line (1-based) of this position.
+	 * Create a new {@code FilePosition} using the supplied {@code line} and
+	 * {@code column} numbers.
+	 *
+	 * @param line the line number; must be greater than zero
+	 * @param column the column number; must be greater than zero
+	 */
+	public static FilePosition from(int line, int column) {
+		return new FilePosition(line, column);
+	}
+
+	private final int line;
+	private final Integer column;
+
+	private FilePosition(int line) {
+		Preconditions.condition(line > 0, "line number must be greater than zero");
+		this.line = line;
+		this.column = null;
+	}
+
+	private FilePosition(int line, int column) {
+		Preconditions.condition(line > 0, "line number must be greater than zero");
+		Preconditions.condition(column > 0, "column number must be greater than zero");
+		this.line = line;
+		this.column = Integer.valueOf(column);
+	}
+
+	/**
+	 * Get the line number of this {@code FilePosition}.
+	 *
+	 * @return the line number
 	 */
 	public int getLine() {
 		return this.line;
 	}
 
 	/**
-	 * Get the column (1-based) of this position.
+	 * Get the column number of this {@code FilePosition}, if available.
+	 *
+	 * @return an {@code Optional} containing the column number; never
+	 * {@code null} but potentially empty
 	 */
-	public int getColumn() {
-		return this.column;
+	public Optional<Integer> getColumn() {
+		return Optional.ofNullable(this.column);
 	}
 
 	@Override
@@ -80,7 +109,7 @@ public class FilePosition implements Serializable {
 		// @formatter:off
 		return new ToStringBuilder(this)
 				.append("line", this.line)
-				.append("column", this.column)
+				.append("column", getColumn().orElse(-1))
 				.toString();
 		// @formatter:on
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FileSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FileSource.java
@@ -35,16 +35,13 @@ public class FileSource implements FileSystemSource {
 
 	private static final long serialVersionUID = 1L;
 
-	private final File file;
-	private final FilePosition filePosition;
-
 	/**
 	 * Create a new {@code FileSource} using the supplied {@link File file}.
 	 *
 	 * @param file the source file; must not be {@code null}
 	 */
-	public FileSource(File file) {
-		this(file, null);
+	public static FileSource from(File file) {
+		return new FileSource(file);
 	}
 
 	/**
@@ -54,7 +51,18 @@ public class FileSource implements FileSystemSource {
 	 * @param file the source file; must not be {@code null}
 	 * @param filePosition the position in the source file; may be {@code null}
 	 */
-	public FileSource(File file, FilePosition filePosition) {
+	public static FileSource from(File file, FilePosition filePosition) {
+		return new FileSource(file, filePosition);
+	}
+
+	private final File file;
+	private final FilePosition filePosition;
+
+	private FileSource(File file) {
+		this(file, null);
+	}
+
+	private FileSource(File file, FilePosition filePosition) {
 		Preconditions.notNull(file, "file must not be null");
 		try {
 			this.file = file.getCanonicalFile();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
@@ -36,10 +36,6 @@ public class MethodSource implements TestSource {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String className;
-	private final String methodName;
-	private final String methodParameterTypes;
-
 	/**
 	 * Create a new {@code MethodSource} using the supplied
 	 * class and method name.
@@ -47,8 +43,8 @@ public class MethodSource implements TestSource {
 	 * @param className the {@link Class} name; must not be {@code null} or blank
 	 * @param methodName the {@link Method} name; must not be {@code null} or blank
 	 */
-	public MethodSource(String className, String methodName) {
-		this(className, methodName, null);
+	public static MethodSource from(String className, String methodName) {
+		return new MethodSource(className, methodName);
 	}
 
 	/**
@@ -59,12 +55,8 @@ public class MethodSource implements TestSource {
 	 * @param methodName the {@link Method} name; must not be {@code null} or blank
 	 * @param methodParameterTypes the {@link Method} parameter types as string
 	 */
-	public MethodSource(String className, String methodName, String methodParameterTypes) {
-		Preconditions.notBlank(className, "Class name must not be null or blank");
-		Preconditions.notBlank(methodName, "Method name must not be null or blank");
-		this.className = className;
-		this.methodName = methodName;
-		this.methodParameterTypes = methodParameterTypes;
+	public static MethodSource from(String className, String methodName, String methodParameterTypes) {
+		return new MethodSource(className, methodName, methodParameterTypes);
 	}
 
 	/**
@@ -73,7 +65,27 @@ public class MethodSource implements TestSource {
 	 *
 	 * @param method the Java method; must not be {@code null}
 	 */
-	public MethodSource(Method method) {
+	public static MethodSource from(Method method) {
+		return new MethodSource(method);
+	}
+
+	private final String className;
+	private final String methodName;
+	private final String methodParameterTypes;
+
+	private MethodSource(String className, String methodName) {
+		this(className, methodName, null);
+	}
+
+	private MethodSource(String className, String methodName, String methodParameterTypes) {
+		Preconditions.notBlank(className, "Class name must not be null or blank");
+		Preconditions.notBlank(methodName, "Method name must not be null or blank");
+		this.className = className;
+		this.methodName = methodName;
+		this.methodParameterTypes = methodParameterTypes;
+	}
+
+	private MethodSource(Method method) {
 		Preconditions.notNull(method, "method must not be null");
 		this.className = method.getDeclaringClass().getName();
 		this.methodName = method.getName();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
@@ -34,15 +34,13 @@ public class PackageSource implements TestSource {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String packageName;
-
 	/**
 	 * Create a new {@code PackageSource} using the supplied Java {@link Package}.
 	 *
 	 * @param javaPackage the Java package; must not be {@code null}
 	 */
-	public PackageSource(Package javaPackage) {
-		this(Preconditions.notNull(javaPackage, "package must not be null").getName());
+	public static PackageSource from(Package javaPackage) {
+		return new PackageSource(javaPackage);
 	}
 
 	/**
@@ -50,7 +48,17 @@ public class PackageSource implements TestSource {
 	 *
 	 * @param packageName the package name; must not be {@code null} or blank
 	 */
-	public PackageSource(String packageName) {
+	public static PackageSource from(String packageName) {
+		return new PackageSource(packageName);
+	}
+
+	private final String packageName;
+
+	private PackageSource(Package javaPackage) {
+		this(Preconditions.notNull(javaPackage, "package must not be null").getName());
+	}
+
+	private PackageSource(String packageName) {
 		this.packageName = Preconditions.notBlank(packageName, "package name must not be null or blank");
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LoggingListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LoggingListener.java
@@ -41,7 +41,9 @@ public class LoggingListener implements TestExecutionListener {
 	 * Create a {@code LoggingListener} which delegates to a
 	 * {@link java.util.logging.Logger} using a log level of
 	 * {@link Level#FINE FINE}.
+	 *
 	 * @see #forJavaUtilLogging(Level)
+	 * @see #forBiConsumer(BiConsumer)
 	 */
 	public static LoggingListener forJavaUtilLogging() {
 		return forJavaUtilLogging(Level.FINE);
@@ -54,14 +56,13 @@ public class LoggingListener implements TestExecutionListener {
 	 *
 	 * @param logLevel the log level to use; never {@code null}
 	 * @see #forJavaUtilLogging()
+	 * @see #forBiConsumer(BiConsumer)
 	 */
 	public static LoggingListener forJavaUtilLogging(Level logLevel) {
 		Preconditions.notNull(logLevel, "logLevel must not be null");
 		Logger logger = Logger.getLogger(LoggingListener.class.getName());
 		return new LoggingListener((t, messageSupplier) -> logger.log(logLevel, t, messageSupplier));
 	}
-
-	private final BiConsumer<Throwable, Supplier<String>> logger;
 
 	/**
 	 * Create a {@code LoggingListener} which delegates to the supplied
@@ -73,7 +74,13 @@ public class LoggingListener implements TestExecutionListener {
 	 * @see #forJavaUtilLogging()
 	 * @see #forJavaUtilLogging(Level)
 	 */
-	public LoggingListener(BiConsumer<Throwable, Supplier<String>> logger) {
+	public static LoggingListener forBiConsumer(BiConsumer<Throwable, Supplier<String>> logger) {
+		return new LoggingListener(logger);
+	}
+
+	private final BiConsumer<Throwable, Supplier<String>> logger;
+
+	private LoggingListener(BiConsumer<Throwable, Supplier<String>> logger) {
 		this.logger = Preconditions.notNull(logger, "logger must not be null");
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LoggingListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LoggingListener.java
@@ -68,6 +68,10 @@ public class LoggingListener implements TestExecutionListener {
 	 * Create a {@code LoggingListener} which delegates to the supplied
 	 * {@link BiConsumer} for consumption of logging messages.
 	 *
+	 * <p>The {@code BiConsumer's} arguments are a {@link Throwable} (potentially
+	 * {@code null}) and a {@link Supplier} (never {@code null}) for the log
+	 * message.
+	 *
 	 * @param logger a logger implemented as a {@code BiConsumer};
 	 * never {@code null}
 	 *

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -27,7 +27,7 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 	private final Runner runner;
 
 	public RunnerTestDescriptor(UniqueId uniqueId, Class<?> testClass, Runner runner) {
-		super(uniqueId, runner.getDescription(), testClass.getName(), new ClassSource(testClass));
+		super(uniqueId, runner.getDescription(), testClass.getName(), ClassSource.from(testClass));
 		this.runner = runner;
 	}
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -107,7 +107,7 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 					return methodSource;
 				}
 			}
-			return new ClassSource(testClass);
+			return ClassSource.from(testClass);
 		}
 		return null;
 	}
@@ -119,7 +119,7 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 		}
 		else {
 			List<Method> methods = findMethods(testClass, where(Method::getName, isEqual(methodName)));
-			return (methods.size() == 1) ? new MethodSource(getOnlyElement(methods)) : null;
+			return (methods.size() == 1) ? MethodSource.from(getOnlyElement(methods)) : null;
 		}
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestSourceTests.java
@@ -20,13 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.platform.engine.TestSource;
 
 /**
- * Abstract base class for unit tests involving {@link TestSource TestSources}.
+ * Abstract base class for unit tests involving {@link TestSource TestSources}
+ * and {@link FilePosition FilePositions}.
  *
  * @since 1.0
  */
 abstract class AbstractTestSourceTests {
 
-	protected void assertEqualsAndHashCode(TestSource equal1, TestSource equal2, TestSource different) {
+	protected <T> void assertEqualsAndHashCode(T equal1, T equal2, T different) {
 		assertNotNull(equal1);
 		assertNotNull(equal2);
 		assertNotNull(different);

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSourceTests.java
@@ -28,14 +28,14 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void preconditions() {
-		assertThrows(PreconditionViolationException.class, () -> new ClasspathResourceSource(null));
-		assertThrows(PreconditionViolationException.class, () -> new ClasspathResourceSource(""));
-		assertThrows(PreconditionViolationException.class, () -> new ClasspathResourceSource("   "));
+		assertThrows(PreconditionViolationException.class, () -> ClasspathResourceSource.from(null));
+		assertThrows(PreconditionViolationException.class, () -> ClasspathResourceSource.from(""));
+		assertThrows(PreconditionViolationException.class, () -> ClasspathResourceSource.from("   "));
 	}
 
 	@Test
 	void resourceWithoutPosition() throws Exception {
-		ClasspathResourceSource source = new ClasspathResourceSource(FOO_RESOURCE);
+		ClasspathResourceSource source = ClasspathResourceSource.from(FOO_RESOURCE);
 
 		assertThat(source.getClasspathResourceName()).isEqualTo(FOO_RESOURCE);
 		assertThat(source.getPosition()).isEmpty();
@@ -43,7 +43,7 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void resourceWithLeadingSlashWithoutPosition() throws Exception {
-		ClasspathResourceSource source = new ClasspathResourceSource("/" + FOO_RESOURCE);
+		ClasspathResourceSource source = ClasspathResourceSource.from("/" + FOO_RESOURCE);
 
 		assertThat(source.getClasspathResourceName()).isEqualTo(FOO_RESOURCE);
 		assertThat(source.getPosition()).isEmpty();
@@ -51,8 +51,8 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void resourceWithPosition() throws Exception {
-		FilePosition position = new FilePosition(42, 23);
-		ClasspathResourceSource source = new ClasspathResourceSource(FOO_RESOURCE, position);
+		FilePosition position = FilePosition.from(42, 23);
+		ClasspathResourceSource source = ClasspathResourceSource.from(FOO_RESOURCE, position);
 
 		assertThat(source.getClasspathResourceName()).isEqualTo(FOO_RESOURCE);
 		assertThat(source.getPosition()).hasValue(position);
@@ -60,12 +60,12 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void equalsAndHashCode() {
-		assertEqualsAndHashCode(new ClasspathResourceSource(FOO_RESOURCE), new ClasspathResourceSource(FOO_RESOURCE),
-			new ClasspathResourceSource(BAR_RESOURCE));
+		assertEqualsAndHashCode(ClasspathResourceSource.from(FOO_RESOURCE), ClasspathResourceSource.from(FOO_RESOURCE),
+			ClasspathResourceSource.from(BAR_RESOURCE));
 
-		FilePosition position = new FilePosition(42, 23);
-		assertEqualsAndHashCode(new ClasspathResourceSource(FOO_RESOURCE, position),
-			new ClasspathResourceSource(FOO_RESOURCE, position), new ClasspathResourceSource(BAR_RESOURCE, position));
+		FilePosition position = FilePosition.from(42, 23);
+		assertEqualsAndHashCode(ClasspathResourceSource.from(FOO_RESOURCE, position),
+			ClasspathResourceSource.from(FOO_RESOURCE, position), ClasspathResourceSource.from(BAR_RESOURCE, position));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/CompositeTestSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/CompositeTestSourceTests.java
@@ -32,20 +32,20 @@ class CompositeTestSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void createCompositeTestSourceFromNullList() {
-		assertThrows(PreconditionViolationException.class, () -> new CompositeTestSource(null));
+		assertThrows(PreconditionViolationException.class, () -> CompositeTestSource.from(null));
 	}
 
 	@Test
 	void createCompositeTestSourceFromEmptyList() {
-		assertThrows(PreconditionViolationException.class, () -> new CompositeTestSource(Collections.emptyList()));
+		assertThrows(PreconditionViolationException.class, () -> CompositeTestSource.from(Collections.emptyList()));
 	}
 
 	@Test
 	void createCompositeTestSourceFromClassAndFileSources() {
-		FileSource fileSource = new FileSource(new File("example.test"));
-		ClassSource classSource = new ClassSource(getClass());
+		FileSource fileSource = FileSource.from(new File("example.test"));
+		ClassSource classSource = ClassSource.from(getClass());
 		List<TestSource> sources = new ArrayList<>(Arrays.asList(fileSource, classSource));
-		CompositeTestSource compositeTestSource = new CompositeTestSource(sources);
+		CompositeTestSource compositeTestSource = CompositeTestSource.from(sources);
 
 		assertThat(compositeTestSource.getSources().size()).isEqualTo(2);
 		assertThat(compositeTestSource.getSources()).contains(fileSource, classSource);
@@ -60,10 +60,10 @@ class CompositeTestSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void equalsAndHashCode() {
-		List<TestSource> sources1 = Arrays.asList(new ClassSource(Number.class));
-		List<TestSource> sources2 = Arrays.asList(new ClassSource(String.class));
-		assertEqualsAndHashCode(new CompositeTestSource(sources1), new CompositeTestSource(sources1),
-			new CompositeTestSource(sources2));
+		List<TestSource> sources1 = Arrays.asList(ClassSource.from(Number.class));
+		List<TestSource> sources2 = Arrays.asList(ClassSource.from(String.class));
+		assertEqualsAndHashCode(CompositeTestSource.from(sources1), CompositeTestSource.from(sources1),
+			CompositeTestSource.from(sources2));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoClassTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoClassTestDescriptor.java
@@ -33,7 +33,7 @@ public class DemoClassTestDescriptor extends AbstractTestDescriptor {
 
 	public DemoClassTestDescriptor(UniqueId uniqueId, Class<?> testClass) {
 		super(uniqueId, Preconditions.notNull(testClass, "Class must not be null").getSimpleName(),
-			new ClassSource(testClass));
+			ClassSource.from(testClass));
 		this.testClass = testClass;
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoMethodTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoMethodTestDescriptor.java
@@ -38,7 +38,7 @@ public class DemoMethodTestDescriptor extends AbstractTestDescriptor {
 		super(uniqueId,
 			String.format("%s(%s)", Preconditions.notNull(testMethod, "Method must not be null").getName(),
 				ClassUtils.nullSafeToString(Class::getSimpleName, testMethod.getParameterTypes())),
-			new MethodSource(testMethod));
+			MethodSource.from(testMethod));
 
 		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
 		this.testMethod = testMethod;

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FilePositionTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FilePositionTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.support.descriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.PreconditionViolationException;
+
+/**
+ * Unit tests for {@link FilePosition}.
+ *
+ * @since 1.0
+ */
+class FilePositionTests extends AbstractTestSourceTests {
+
+	@Test
+	void preconditions() {
+		assertThrows(PreconditionViolationException.class, () -> FilePosition.from(-1));
+		assertThrows(PreconditionViolationException.class, () -> FilePosition.from(0, -1));
+	}
+
+	@Test
+	void filePositionFromLine() throws Exception {
+		FilePosition filePosition = FilePosition.from(42);
+
+		assertThat(filePosition.getLine()).isEqualTo(42);
+		assertThat(filePosition.getColumn()).isEmpty();
+	}
+
+	@Test
+	void filePositionFromLineAndColumn() throws Exception {
+		FilePosition filePosition = FilePosition.from(42, 99);
+
+		assertThat(filePosition.getLine()).isEqualTo(42);
+		assertThat(filePosition.getColumn()).contains(99);
+	}
+
+	@Test
+	void equalsAndHashCode() {
+		FilePosition same = FilePosition.from(42, 99);
+		FilePosition sameSame = FilePosition.from(42, 99);
+		FilePosition different = FilePosition.from(1, 2);
+
+		assertEqualsAndHashCode(same, sameSame, different);
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FileSystemSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FileSystemSourceTests.java
@@ -27,7 +27,7 @@ class FileSystemSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void nullSourceFileOrDirectoryYieldsException() {
-		assertThrows(PreconditionViolationException.class, () -> new FileSource(null));
+		assertThrows(PreconditionViolationException.class, () -> FileSource.from(null));
 	}
 
 	@Test
@@ -35,7 +35,7 @@ class FileSystemSourceTests extends AbstractTestSourceTests {
 		File canonicalDir = new File(".").getCanonicalFile();
 		File relativeDir = new File("..", canonicalDir.getName());
 
-		DirectorySource source = new DirectorySource(relativeDir);
+		DirectorySource source = DirectorySource.from(relativeDir);
 
 		assertThat(source.getUri()).isEqualTo(canonicalDir.toURI());
 		assertThat(source.getFile()).isEqualTo(canonicalDir);
@@ -48,7 +48,7 @@ class FileSystemSourceTests extends AbstractTestSourceTests {
 		File relativeFile = new File(relativeDir, "test.txt");
 		File canonicalFile = relativeFile.getCanonicalFile();
 
-		FileSource source = new FileSource(relativeFile);
+		FileSource source = FileSource.from(relativeFile);
 
 		assertThat(source.getUri()).isEqualTo(canonicalFile.toURI());
 		assertThat(source.getFile()).isEqualTo(canonicalFile);
@@ -58,8 +58,8 @@ class FileSystemSourceTests extends AbstractTestSourceTests {
 	@Test
 	void fileWithPosition() throws Exception {
 		File file = new File("test.txt");
-		FilePosition position = new FilePosition(42, 23);
-		FileSource source = new FileSource(file, position);
+		FilePosition position = FilePosition.from(42, 23);
+		FileSource source = FileSource.from(file, position);
 
 		assertThat(source.getUri()).isEqualTo(file.getAbsoluteFile().toURI());
 		assertThat(source.getFile()).isEqualTo(file.getAbsoluteFile());
@@ -70,18 +70,18 @@ class FileSystemSourceTests extends AbstractTestSourceTests {
 	void equalsAndHashCodeForFileSource() {
 		File file1 = new File("foo.txt");
 		File file2 = new File("bar.txt");
-		assertEqualsAndHashCode(new FileSource(file1), new FileSource(file1), new FileSource(file2));
+		assertEqualsAndHashCode(FileSource.from(file1), FileSource.from(file1), FileSource.from(file2));
 
-		FilePosition position = new FilePosition(42, 23);
-		assertEqualsAndHashCode(new FileSource(file1, position), new FileSource(file1, position),
-			new FileSource(file2, position));
+		FilePosition position = FilePosition.from(42, 23);
+		assertEqualsAndHashCode(FileSource.from(file1, position), FileSource.from(file1, position),
+			FileSource.from(file2, position));
 	}
 
 	@Test
 	void equalsAndHashCodeForDirectorySource() {
 		File dir1 = new File(".");
 		File dir2 = new File("..");
-		assertEqualsAndHashCode(new DirectorySource(dir1), new DirectorySource(dir1), new DirectorySource(dir2));
+		assertEqualsAndHashCode(DirectorySource.from(dir1), DirectorySource.from(dir1), DirectorySource.from(dir2));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/GenericSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/GenericSourceTests.java
@@ -29,31 +29,31 @@ class GenericSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void packageSourceFromNullPackageName() {
-		assertThrows(PreconditionViolationException.class, () -> new PackageSource((String) null));
+		assertThrows(PreconditionViolationException.class, () -> PackageSource.from((String) null));
 	}
 
 	@Test
 	void packageSourceFromEmptyPackageName() {
-		assertThrows(PreconditionViolationException.class, () -> new PackageSource("  "));
+		assertThrows(PreconditionViolationException.class, () -> PackageSource.from("  "));
 	}
 
 	@Test
 	void packageSourceFromPackageName() {
 		String testPackage = getClass().getPackage().getName();
-		PackageSource source = new PackageSource(testPackage);
+		PackageSource source = PackageSource.from(testPackage);
 
 		assertThat(source.getPackageName()).isEqualTo(testPackage);
 	}
 
 	@Test
 	void packageSourceFromNullPackageReference() {
-		assertThrows(PreconditionViolationException.class, () -> new PackageSource((Package) null));
+		assertThrows(PreconditionViolationException.class, () -> PackageSource.from((Package) null));
 	}
 
 	@Test
 	void packageSourceFromPackageReference() {
 		Package testPackage = getClass().getPackage();
-		PackageSource source = new PackageSource(testPackage);
+		PackageSource source = PackageSource.from(testPackage);
 
 		assertThat(source.getPackageName()).isEqualTo(testPackage.getName());
 	}
@@ -61,7 +61,7 @@ class GenericSourceTests extends AbstractTestSourceTests {
 	@Test
 	void classNameSource() {
 		String testClassName = "com.unknown.mypackage.ClassByName";
-		ClassSource source = new ClassSource(testClassName);
+		ClassSource source = ClassSource.from(testClassName);
 
 		assertThat(source.getClassName()).isEqualTo(testClassName);
 		assertThat(source.getPosition()).isEmpty();
@@ -70,8 +70,8 @@ class GenericSourceTests extends AbstractTestSourceTests {
 	@Test
 	void classNameSourceWithFilePosition() {
 		String testClassName = "com.unknown.mypackage.ClassByName";
-		FilePosition position = new FilePosition(42, 23);
-		ClassSource source = new ClassSource(testClassName, position);
+		FilePosition position = FilePosition.from(42, 23);
+		ClassSource source = ClassSource.from(testClassName, position);
 
 		assertThat(source.getClassName()).isEqualTo(testClassName);
 		assertThat(source.getPosition()).isNotEmpty();
@@ -81,7 +81,7 @@ class GenericSourceTests extends AbstractTestSourceTests {
 	@Test
 	void classSource() {
 		Class<?> testClass = getClass();
-		ClassSource source = new ClassSource(testClass);
+		ClassSource source = ClassSource.from(testClass);
 
 		assertThat(source.getJavaClass()).isEqualTo(testClass);
 		assertThat(source.getPosition()).isEmpty();
@@ -90,8 +90,8 @@ class GenericSourceTests extends AbstractTestSourceTests {
 	@Test
 	void classSourceWithFilePosition() {
 		Class<?> testClass = getClass();
-		FilePosition position = new FilePosition(42, 23);
-		ClassSource source = new ClassSource(testClass, position);
+		FilePosition position = FilePosition.from(42, 23);
+		ClassSource source = ClassSource.from(testClass, position);
 
 		assertThat(source.getJavaClass()).isEqualTo(testClass);
 		assertThat(source.getPosition()).isNotEmpty();
@@ -101,7 +101,7 @@ class GenericSourceTests extends AbstractTestSourceTests {
 	@Test
 	void methodSource() throws Exception {
 		Method testMethod = getMethod("method1");
-		MethodSource source = new MethodSource(testMethod);
+		MethodSource source = MethodSource.from(testMethod);
 
 		assertThat(source.getClassName()).isEqualTo(getClass().getName());
 		assertThat(source.getMethodName()).isEqualTo(testMethod.getName());
@@ -112,21 +112,21 @@ class GenericSourceTests extends AbstractTestSourceTests {
 	void equalsAndHashCodeForPackageSource() {
 		Package pkg1 = getClass().getPackage();
 		Package pkg2 = String.class.getPackage();
-		assertEqualsAndHashCode(new PackageSource(pkg1), new PackageSource(pkg1), new PackageSource(pkg2));
+		assertEqualsAndHashCode(PackageSource.from(pkg1), PackageSource.from(pkg1), PackageSource.from(pkg2));
 	}
 
 	@Test
 	void equalsAndHashCodeForClassSource() {
 		Class<?> class1 = String.class;
 		Class<?> class2 = Number.class;
-		assertEqualsAndHashCode(new ClassSource(class1), new ClassSource(class1), new ClassSource(class2));
+		assertEqualsAndHashCode(ClassSource.from(class1), ClassSource.from(class1), ClassSource.from(class2));
 	}
 
 	@Test
 	void equalsAndHashCodeForMethodSource(TestInfo testInfo) throws Exception {
 		Method method1 = getMethod("method1");
 		Method method2 = getMethod("method2");
-		assertEqualsAndHashCode(new MethodSource(method1), new MethodSource(method1), new MethodSource(method2));
+		assertEqualsAndHashCode(MethodSource.from(method1), MethodSource.from(method1), MethodSource.from(method2));
 	}
 
 	private Method getMethod(String name) throws Exception {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
@@ -28,97 +28,97 @@ class MethodSourceTests {
 
 	@Test
 	void instantiatingWithNullNamesShouldThrowPreconditionViolationException() {
-		assertThrows(PreconditionViolationException.class, () -> new MethodSource("foo", null));
-		assertThrows(PreconditionViolationException.class, () -> new MethodSource(null, "foo"));
+		assertThrows(PreconditionViolationException.class, () -> MethodSource.from("foo", null));
+		assertThrows(PreconditionViolationException.class, () -> MethodSource.from(null, "foo"));
 	}
 
 	@Test
 	void instantiatingWithEmptyNamesShouldThrowPreconditionViolationException() {
-		assertThrows(PreconditionViolationException.class, () -> new MethodSource("foo", ""));
-		assertThrows(PreconditionViolationException.class, () -> new MethodSource("", "foo"));
+		assertThrows(PreconditionViolationException.class, () -> MethodSource.from("foo", ""));
+		assertThrows(PreconditionViolationException.class, () -> MethodSource.from("", "foo"));
 	}
 
 	@Test
 	void instantiatingWithBlankNamesShouldThrowPreconditionViolationException() {
-		assertThrows(PreconditionViolationException.class, () -> new MethodSource("foo", "  "));
-		assertThrows(PreconditionViolationException.class, () -> new MethodSource("  ", "foo"));
+		assertThrows(PreconditionViolationException.class, () -> MethodSource.from("foo", "  "));
+		assertThrows(PreconditionViolationException.class, () -> MethodSource.from("  ", "foo"));
 	}
 
 	@Test
 	void instantiationWithNullMethodShouldThrowPreconditionViolationException() {
-		assertThrows(PreconditionViolationException.class, () -> new MethodSource(null));
+		assertThrows(PreconditionViolationException.class, () -> MethodSource.from(null));
 	}
 
 	@Test
 	void twoEqualMethodsShouldHaveEqualMethodSourceObjects() {
-		assertEquals(new MethodSource("TestClass1", "testMethod1"), new MethodSource("TestClass1", "testMethod1"));
+		assertEquals(MethodSource.from("TestClass1", "testMethod1"), MethodSource.from("TestClass1", "testMethod1"));
 	}
 
 	@Test
 	void twoUnequalMethodsShouldHaveUnequalMethodSourceObjects() {
-		assertNotEquals(new MethodSource("TestClass1", "testMethod1"), new MethodSource("TestClass2", "testMethod1"));
+		assertNotEquals(MethodSource.from("TestClass1", "testMethod1"), MethodSource.from("TestClass2", "testMethod1"));
 	}
 
 	@Test
 	void twoUnequalMethodsInTheSameClassShouldHaveUnequalMethodSourceObjects() {
-		assertNotEquals(new MethodSource("TestClass1", "testMethod1"), new MethodSource("TestClass1", "testMethod2"));
+		assertNotEquals(MethodSource.from("TestClass1", "testMethod1"), MethodSource.from("TestClass1", "testMethod2"));
 	}
 
 	@Test
 	void twoEqualMethodSourceObjectsShouldHaveEqualHashCodes() {
-		assertEquals(new MethodSource("TestClass1", "testMethod1").hashCode(),
-			new MethodSource("TestClass1", "testMethod1").hashCode());
+		assertEquals(MethodSource.from("TestClass1", "testMethod1").hashCode(),
+			MethodSource.from("TestClass1", "testMethod1").hashCode());
 	}
 
 	@Test
 	void twoEqualMethodsWithEqualParametersShouldHaveEqualMethodSourceObjects() {
-		assertEquals(new MethodSource("TestClass1", "testMethod1", "int, String"),
-			new MethodSource("TestClass1", "testMethod1", "int, String"));
+		assertEquals(MethodSource.from("TestClass1", "testMethod1", "int, String"),
+			MethodSource.from("TestClass1", "testMethod1", "int, String"));
 	}
 
 	@Test
 	void twoUnequalMethodsWithEqualParametersShouldHaveUnequalMethodSourceObjects() {
-		assertNotEquals(new MethodSource("TestClass1", "testMethod1", "int, String"),
-			new MethodSource("TestClass1", "testMethod2", "int, String"));
+		assertNotEquals(MethodSource.from("TestClass1", "testMethod1", "int, String"),
+			MethodSource.from("TestClass1", "testMethod2", "int, String"));
 	}
 
 	@Test
 	void twoEqualMethodsWithUnequalParametersShouldHaveUnequalMethodSourceObjects() {
-		assertNotEquals(new MethodSource("TestClass1", "testMethod1", "int, String"),
-			new MethodSource("TestClass1", "testMethod1", "float, int, String"));
+		assertNotEquals(MethodSource.from("TestClass1", "testMethod1", "int, String"),
+			MethodSource.from("TestClass1", "testMethod1", "float, int, String"));
 	}
 
 	@Test
 	void twoEqualMethodsWithEqualParametersShouldHaveEqualMethodSourceHashCodes() {
-		assertEquals(new MethodSource("TestClass1", "testMethod1", "int, String").hashCode(),
-			new MethodSource("TestClass1", "testMethod1", "int, String").hashCode());
+		assertEquals(MethodSource.from("TestClass1", "testMethod1", "int, String").hashCode(),
+			MethodSource.from("TestClass1", "testMethod1", "int, String").hashCode());
 	}
 
 	@Test
 	void twoEqualMethodsWithUnequalParametersShouldHaveUnequalMethodSourceHashCodes() {
-		assertNotEquals(new MethodSource("TestClass1", "testMethod1", "int, String").hashCode(),
-			new MethodSource("TestClass1", "testMethod1", "float, int, String"));
+		assertNotEquals(MethodSource.from("TestClass1", "testMethod1", "int, String").hashCode(),
+			MethodSource.from("TestClass1", "testMethod1", "float, int, String"));
 	}
 
 	@Test
 	void aReflectedMethodsClassNameShouldBeConsistent() throws Exception {
 		Method m = String.class.getDeclaredMethod("valueOf", int.class);
 
-		assertEquals("java.lang.String", new MethodSource(m).getClassName());
+		assertEquals("java.lang.String", MethodSource.from(m).getClassName());
 	}
 
 	@Test
 	void aReflectedMethodsMethodNameShouldBeConsistent() throws Exception {
 		Method m = String.class.getDeclaredMethod("valueOf", int.class);
 
-		assertEquals("valueOf", new MethodSource(m).getMethodName());
+		assertEquals("valueOf", MethodSource.from(m).getMethodName());
 	}
 
 	@Test
 	void aReflectedMethodsParameterTypesShouldBeConsistent() throws Exception {
 		Method m = String.class.getDeclaredMethod("valueOf", float.class);
 
-		assertEquals("float", new MethodSource(m).getMethodParameterTypes());
+		assertEquals("float", MethodSource.from(m).getMethodParameterTypes());
 	}
 
 	@Test
@@ -126,7 +126,7 @@ class MethodSourceTests {
 		Method m1 = String.class.getDeclaredMethod("valueOf", int.class);
 		Method m2 = String.class.getDeclaredMethod("valueOf", int.class);
 
-		assertEquals(new MethodSource(m1), new MethodSource(m2));
+		assertEquals(MethodSource.from(m1), MethodSource.from(m2));
 	}
 
 	@Test
@@ -134,7 +134,7 @@ class MethodSourceTests {
 		Method m1 = String.class.getDeclaredMethod("valueOf", int.class);
 		Method m2 = String.class.getDeclaredMethod("valueOf", int.class);
 
-		assertEquals(new MethodSource(m1).hashCode(), new MethodSource(m2).hashCode());
+		assertEquals(MethodSource.from(m1).hashCode(), MethodSource.from(m2).hashCode());
 	}
 
 	@Test
@@ -142,7 +142,7 @@ class MethodSourceTests {
 		Method m1 = String.class.getDeclaredMethod("valueOf", int.class);
 		Method m2 = Byte.class.getDeclaredMethod("byteValue");
 
-		assertNotEquals(new MethodSource(m1), new MethodSource(m2));
+		assertNotEquals(MethodSource.from(m1), MethodSource.from(m2));
 	}
 
 	@Test
@@ -150,7 +150,7 @@ class MethodSourceTests {
 		Method m1 = String.class.getDeclaredMethod("valueOf", int.class);
 		Method m2 = Byte.class.getDeclaredMethod("byteValue");
 
-		assertNotEquals(new MethodSource(m1).hashCode(), new MethodSource(m2).hashCode());
+		assertNotEquals(MethodSource.from(m1).hashCode(), MethodSource.from(m2).hashCode());
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestEngine.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DemoHierarchicalTestEngine.java
@@ -51,7 +51,7 @@ public final class DemoHierarchicalTestEngine extends HierarchicalTestEngine<Dem
 
 	public DemoHierarchicalTestDescriptor addTest(Method testMethod, Runnable executeBlock) {
 		UniqueId uniqueId = engineDescriptor.getUniqueId().append("test", testMethod.getName());
-		MethodSource source = new MethodSource(testMethod);
+		MethodSource source = MethodSource.from(testMethod);
 		DemoHierarchicalTestDescriptor child = new DemoHierarchicalTestDescriptor(uniqueId, testMethod.getName(),
 			source, executeBlock);
 		engineDescriptor.addChild(child);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
@@ -56,13 +56,13 @@ class TestIdentifierTests {
 	@Test
 	void serialization() throws Exception {
 		TestIdentifier identifier = serializeAndDeserialize(//
-			new TestIdentifier("uniqueId", "displayName", new ClassSource(TestIdentifierTests.class),
+			new TestIdentifier("uniqueId", "displayName", ClassSource.from(TestIdentifierTests.class),
 				singleton(TestTag.create("aTag")), TestDescriptor.Type.TEST, "parentId", "reportingName"));
 
 		assertEquals("uniqueId", identifier.getUniqueId());
 		assertEquals("displayName", identifier.getDisplayName());
 		assertEquals("reportingName", identifier.getLegacyReportingName());
-		assertThat(identifier.getSource()).contains(new ClassSource(TestIdentifierTests.class));
+		assertThat(identifier.getSource()).contains(ClassSource.from(TestIdentifierTests.class));
 		assertEquals(singleton(TestTag.create("aTag")), identifier.getTags());
 		assertEquals(TestDescriptor.Type.TEST, identifier.getType());
 		assertTrue(identifier.isTest());

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listener/SummaryGenerationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listener/SummaryGenerationTests.java
@@ -134,9 +134,10 @@ class SummaryGenerationTests {
 	void canGetListOfFailures() {
 		RuntimeException failedException = new RuntimeException("Pow!");
 		TestDescriptorStub testDescriptor = new TestDescriptorStub(UniqueId.root("root", "1"), "failingTest") {
+
 			@Override
 			public Optional<TestSource> getSource() {
-				return Optional.of(new ClassSource(Object.class));
+				return Optional.of(ClassSource.from(Object.class));
 			}
 		};
 		TestIdentifier failingTest = TestIdentifier.from(testDescriptor);
@@ -158,7 +159,7 @@ class SummaryGenerationTests {
 
 			@Override
 			public Optional<TestSource> getSource() {
-				return Optional.of(new ClassSource(Object.class));
+				return Optional.of(ClassSource.from(Object.class));
 			}
 		};
 		TestIdentifier failed = TestIdentifier.from(testDescriptor);

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -581,10 +581,10 @@ class JUnitPlatformRunnerTests {
 			DemoHierarchicalTestEngine engine = new DemoHierarchicalTestEngine("dummy");
 			Method failingTest = getClass().getDeclaredMethod("failingTest");
 			DemoHierarchicalContainerDescriptor containerDescriptor = engine.addContainer("uniqueContainerName",
-				"containerDisplayName", new ClassSource(getClass()));
+				"containerDisplayName", ClassSource.from(getClass()));
 			containerDescriptor.addChild(
 				new DemoHierarchicalTestDescriptor(containerDescriptor.getUniqueId().append("test", "failingTest"),
-					"testDisplayName", new MethodSource(failingTest), () -> {
+					"testDisplayName", MethodSource.from(failingTest), () -> {
 					}));
 
 			JUnitPlatform platformRunner = new JUnitPlatform(TestClass.class, createLauncher(engine));
@@ -617,10 +617,10 @@ class JUnitPlatformRunnerTests {
 			DemoHierarchicalTestEngine engine = new DemoHierarchicalTestEngine("dummy");
 			Method failingTest = getClass().getDeclaredMethod("failingTest");
 			DemoHierarchicalContainerDescriptor containerDescriptor = engine.addContainer("uniqueContainerName",
-				"containerDisplayName", new ClassSource(getClass()));
+				"containerDisplayName", ClassSource.from(getClass()));
 			containerDescriptor.addChild(
 				new DemoHierarchicalTestDescriptor(containerDescriptor.getUniqueId().append("test", "failingTest"),
-					"testDisplayName", new MethodSource(failingTest), () -> {
+					"testDisplayName", MethodSource.from(failingTest), () -> {
 					}));
 
 			JUnitPlatform platformRunner = new JUnitPlatform(TestClassWithTechnicalNames.class, createLauncher(engine));


### PR DESCRIPTION
## Overview

This pull request includes changes discussed in #939.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
