### PR TITLE
Polishing

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -53,17 +53,17 @@ class AssertionUtils {
 	}
 
 	static String nullSafeGet(Supplier<String> messageSupplier) {
-		return (messageSupplier != null ? messageSupplier.get() : null);
+		return (messageSupplier != null) ? messageSupplier.get() : null;
 	}
 
 	static String buildPrefix(String message) {
-		return (StringUtils.isNotBlank(message) ? message + " ==> " : "");
+		return StringUtils.isNotBlank(message) ? (message + " ==> ") : "";
 	}
 
 	static String getCanonicalName(Class<?> clazz) {
 		try {
 			String canonicalName = clazz.getCanonicalName();
-			return (canonicalName != null ? canonicalName : clazz.getName());
+			return (canonicalName != null) ? canonicalName : clazz.getName();
 		}
 		catch (Throwable t) {
 			return clazz.getName();
@@ -87,23 +87,25 @@ class AssertionUtils {
 	private static String formatClassAndValue(Object value, String valueString) {
 		String classAndHash = getClassName(value) + toHash(value);
 		// if it's a class, there's no need to repeat the class name contained in the valueString.
-		return (value instanceof Class ? "<" + classAndHash + ">" : classAndHash + "<" + valueString + ">");
+		return (value instanceof Class) ? ("<" + classAndHash + ">") : (classAndHash + "<" + valueString + ">");
 	}
 
 	private static String toString(Object obj) {
-		if (obj instanceof Class) {
-			return getCanonicalName((Class<?>) obj);
-		}
-		return StringUtils.nullSafeToString(obj);
+		return (obj instanceof Class) ? getCanonicalName((Class<?>) obj) : StringUtils.nullSafeToString(obj);
 	}
 
 	private static String toHash(Object obj) {
-		return (obj == null ? "" : "@" + Integer.toHexString(System.identityHashCode(obj)));
+		return (obj == null) ? "" : ("@" + Integer.toHexString(System.identityHashCode(obj)));
 	}
 
 	private static String getClassName(Object obj) {
-		return (obj == null ? "null"
-				: obj instanceof Class ? getCanonicalName((Class<?>) obj) : obj.getClass().getName());
+		if (obj == null) {
+			return "null";
+		}
+		if (obj instanceof Class) {
+				return getCanonicalName((Class<?>) obj);
+		}
+		return obj.getClass().getName();
 	}
 
 	static String formatIndexes(Deque<Integer> indexes) {
@@ -145,10 +147,7 @@ class AssertionUtils {
 	}
 
 	static boolean objectsAreEqual(Object obj1, Object obj2) {
-		if (obj1 == null) {
-			return (obj2 == null);
-		}
-		return obj1.equals(obj2);
+		return (obj1 == null) ? (obj2 == null) : obj1.equals(obj2);
 	}
 
 	private static void failIllegalDelta(String delta) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.classTestDescriptor;
 import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.engineDescriptor;
 import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.nestedClassTestDescriptor;
@@ -18,6 +19,7 @@ import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.r
 import java.util.List;
 import java.util.stream.Collectors;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,7 +36,7 @@ import org.junit.platform.engine.discovery.PackageNameFilter;
  */
 class DiscoveryFilterApplierTests {
 
-	DiscoveryFilterApplier applier = new DiscoveryFilterApplier();
+	private final DiscoveryFilterApplier applier = new DiscoveryFilterApplier();
 
 	@Test
 	void packageNameFilterInclude_nonMatchingPackagesAreExcluded() {
@@ -48,13 +50,13 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(0, includedDescriptors.size());
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors).isEmpty();
+		// @formatter:on
 	}
 
 	@Test
@@ -69,14 +71,14 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(1, includedDescriptors.size());
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors)
+				.containsExactly(UniqueId.root("class", "matching"));
+		// @formatter:on
 	}
 
 	@Test
@@ -91,13 +93,13 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(0, includedDescriptors.size());
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors).isEmpty();
+		// @formatter:on
 	}
 
 	@Test
@@ -112,14 +114,14 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(1, includedDescriptors.size());
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors)
+				.containsExactly(UniqueId.root("class", "matching"));
+		// @formatter:on
 	}
 
 	@Test
@@ -131,18 +133,18 @@ class DiscoveryFilterApplierTests {
 		// @formatter:off
 		TestDescriptor engineDescriptor = engineDescriptor()
 			.with(
-				classTestDescriptor("matching", MatchingClass.class),
-				classTestDescriptor("other", OtherClass.class)
+					classTestDescriptor("matching", MatchingClass.class),
+					classTestDescriptor("other", OtherClass.class)
 			)
 			.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(1, includedDescriptors.size());
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors)
+				.containsExactly(UniqueId.root("class", "matching"));
+		// @formatter:on
 	}
 
 	@Test
@@ -153,19 +155,20 @@ class DiscoveryFilterApplierTests {
 		// @formatter:off
 		TestDescriptor engineDescriptor = engineDescriptor()
 			.with(
-				classTestDescriptor("matching", MatchingClass.class)
-					.with(nestedClassTestDescriptor("nested", MatchingClass.NestedClass.class))
+					classTestDescriptor("matching", MatchingClass.class)
+						.with(nestedClassTestDescriptor("nested", MatchingClass.NestedClass.class))
 			)
 			.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(2, includedDescriptors.size());
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("nested-class", "nested")));
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors).containsExactlyInAnyOrder(
+				UniqueId.root("class", "matching"),
+				UniqueId.root("nested-class", "nested")
+		);
+		// @formatter:on
 	}
 
 	private static class MatchingClass {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -124,7 +124,7 @@ class AvailableOptions {
 		selectedUris = parser.acceptsAll(asList("u", "select-uri"), //
 			"Select a URI for test discovery. This option can be repeated.") //
 				.withRequiredArg() //
-				.withValuesConvertedBy(new URIConverter());
+				.withValuesConvertedBy(new UriConverter());
 
 		selectedFiles = parser.acceptsAll(asList("f", "select-file"), //
 			"Select a file for test discovery. This option can be repeated.") //

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/UriConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/UriConverter.java
@@ -20,7 +20,7 @@ import joptsimple.ValueConverter;
 /**
  * @since 1.0
  */
-class URIConverter implements ValueConverter<URI> {
+class UriConverter implements ValueConverter<URI> {
 
 	@Override
 	public URI convert(String value) {


### PR DESCRIPTION
## Overview

This PR introduces some polishing changes, including:
- Moving parentheses to make the precedence of certain operations clearer.
- Replacing a complicated usage of the ternary operator (?:) with if/else statements.
- Shortening very simple if/else statements to ternary operators.
- Applying `private` and `final` for class fields where applicable.
- Using `Stream` more for brevity and clarity.
- Using AssertJ's assertions over JUnit 5's own assertions more consistently.
- Renaming `URIConverter` to `UriConverter` for consistency with `UriSelector`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)(http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
