### PR TITLE
Polishing

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
@@ -45,11 +45,11 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
+		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
 		assertThat(engineDescriptor.getDescendants()).isEmpty();
-		// @formatter:on
 	}
 
 	@Test
@@ -85,11 +85,11 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
+		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
 		assertThat(engineDescriptor.getDescendants()).isEmpty();
-		// @formatter:on
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
@@ -10,15 +10,14 @@
 
 package org.junit.jupiter.engine;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.classTestDescriptor;
 import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.engineDescriptor;
 import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.nestedClassTestDescriptor;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -34,7 +33,7 @@ import org.junit.platform.engine.discovery.PackageNameFilter;
  */
 class DiscoveryFilterApplierTests {
 
-	DiscoveryFilterApplier applier = new DiscoveryFilterApplier();
+	private final DiscoveryFilterApplier applier = new DiscoveryFilterApplier();
 
 	@Test
 	void packageNameFilterInclude_nonMatchingPackagesAreExcluded() {
@@ -48,13 +47,13 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(0, includedDescriptors.size());
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors).isEmpty();
+		// @formatter:on
 	}
 
 	@Test
@@ -69,14 +68,14 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(1, includedDescriptors.size());
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors)
+				.containsExactly(UniqueId.root("class", "matching"));
+		// @formatter:on
 	}
 
 	@Test
@@ -91,13 +90,13 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(0, includedDescriptors.size());
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors).isEmpty();
+		// @formatter:on
 	}
 
 	@Test
@@ -112,14 +111,14 @@ class DiscoveryFilterApplierTests {
 						classTestDescriptor("matching", MatchingClass.class)
 				)
 				.build();
-		// @formatter:on
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(1, includedDescriptors.size());
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors)
+				.containsExactly(UniqueId.root("class", "matching"));
+		// @formatter:on
 	}
 
 	@Test
@@ -130,19 +129,19 @@ class DiscoveryFilterApplierTests {
 
 		// @formatter:off
 		TestDescriptor engineDescriptor = engineDescriptor()
-			.with(
-				classTestDescriptor("matching", MatchingClass.class),
-				classTestDescriptor("other", OtherClass.class)
-			)
-			.build();
-		// @formatter:on
+				.with(
+						classTestDescriptor("matching", MatchingClass.class),
+						classTestDescriptor("other", OtherClass.class)
+				)
+				.build();
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(1, includedDescriptors.size());
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors)
+				.containsExactly(UniqueId.root("class", "matching"));
+		// @formatter:on
 	}
 
 	@Test
@@ -152,20 +151,21 @@ class DiscoveryFilterApplierTests {
 
 		// @formatter:off
 		TestDescriptor engineDescriptor = engineDescriptor()
-			.with(
-				classTestDescriptor("matching", MatchingClass.class)
-					.with(nestedClassTestDescriptor("nested", MatchingClass.NestedClass.class))
-			)
-			.build();
-		// @formatter:on
+				.with(
+						classTestDescriptor("matching", MatchingClass.class)
+								.with(nestedClassTestDescriptor("nested", MatchingClass.NestedClass.class))
+				)
+				.build();
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		List<UniqueId> includedDescriptors = engineDescriptor.getDescendants().stream().map(
-			TestDescriptor::getUniqueId).collect(Collectors.toList());
-		Assertions.assertEquals(2, includedDescriptors.size());
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("class", "matching")));
-		Assertions.assertTrue(includedDescriptors.contains(UniqueId.root("nested-class", "nested")));
+		Stream<UniqueId> includedDescriptors =
+				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
+		assertThat(includedDescriptors).containsExactlyInAnyOrder(
+				UniqueId.root("class", "matching"),
+				UniqueId.root("nested-class", "nested")
+		);
+		// @formatter:on
 	}
 
 	private static class MatchingClass {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
@@ -50,9 +50,7 @@ class DiscoveryFilterApplierTests {
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		Stream<UniqueId> includedDescriptors =
-				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
-		assertThat(includedDescriptors).isEmpty();
+		assertThat(engineDescriptor.getDescendants()).isEmpty();
 		// @formatter:on
 	}
 
@@ -71,9 +69,8 @@ class DiscoveryFilterApplierTests {
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		Stream<UniqueId> includedDescriptors =
-				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
-		assertThat(includedDescriptors)
+		assertThat(engineDescriptor.getDescendants())
+				.extracting(TestDescriptor::getUniqueId)
 				.containsExactly(UniqueId.root("class", "matching"));
 		// @formatter:on
 	}
@@ -93,9 +90,7 @@ class DiscoveryFilterApplierTests {
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		Stream<UniqueId> includedDescriptors =
-				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
-		assertThat(includedDescriptors).isEmpty();
+		assertThat(engineDescriptor.getDescendants()).isEmpty();
 		// @formatter:on
 	}
 
@@ -114,9 +109,8 @@ class DiscoveryFilterApplierTests {
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		Stream<UniqueId> includedDescriptors =
-				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
-		assertThat(includedDescriptors)
+		assertThat(engineDescriptor.getDescendants())
+				.extracting(TestDescriptor::getUniqueId)
 				.containsExactly(UniqueId.root("class", "matching"));
 		// @formatter:on
 	}
@@ -137,9 +131,8 @@ class DiscoveryFilterApplierTests {
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		Stream<UniqueId> includedDescriptors =
-				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
-		assertThat(includedDescriptors)
+		assertThat(engineDescriptor.getDescendants())
+				.extracting(TestDescriptor::getUniqueId)
 				.containsExactly(UniqueId.root("class", "matching"));
 		// @formatter:on
 	}
@@ -159,12 +152,12 @@ class DiscoveryFilterApplierTests {
 
 		applier.applyAllFilters(request, engineDescriptor);
 
-		Stream<UniqueId> includedDescriptors =
-				engineDescriptor.getDescendants().stream().map(TestDescriptor::getUniqueId);
-		assertThat(includedDescriptors).containsExactlyInAnyOrder(
-				UniqueId.root("class", "matching"),
-				UniqueId.root("nested-class", "nested")
-		);
+		assertThat(engineDescriptor.getDescendants())
+				.extracting(TestDescriptor::getUniqueId)
+				.containsExactlyInAnyOrder(
+						UniqueId.root("class", "matching"),
+						UniqueId.root("nested-class", "nested")
+				);
 		// @formatter:on
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DiscoveryFilterApplierTests.java
@@ -16,8 +16,6 @@ import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.engineDe
 import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.nestedClassTestDescriptor;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.EngineDiscoveryRequest;


### PR DESCRIPTION
## Overview

This PR is a smaller separated part of #1049, as requested by @sbrannen. It does the following:
- Apply `private` and `final` to an applicable class field.
- Remove usages of `Collectors.toList()` and use `Stream` directly for brevity.
- Use AssertJ's assertions over JUnit 5's more for consistency and clarity.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
