### PR TITLE
Polishing

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -124,7 +124,7 @@ class AvailableOptions {
 		selectedUris = parser.acceptsAll(asList("u", "select-uri"), //
 			"Select a URI for test discovery. This option can be repeated.") //
 				.withRequiredArg() //
-				.withValuesConvertedBy(new URIConverter());
+				.withValuesConvertedBy(new UriConverter());
 
 		selectedFiles = parser.acceptsAll(asList("f", "select-file"), //
 			"Select a file for test discovery. This option can be repeated.") //

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/UriConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/UriConverter.java
@@ -20,7 +20,7 @@ import joptsimple.ValueConverter;
 /**
  * @since 1.0
  */
-class URIConverter implements ValueConverter<URI> {
+class UriConverter implements ValueConverter<URI> {
 
 	@Override
 	public URI convert(String value) {


### PR DESCRIPTION
## Overview

This PR is a smaller separated part of #1049, as requested by @sbrannen. It does the following:
- Rename `URIConverter` to `UriConverter` for consistency with `UriSelector`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
