### PR TITLE
Collecting launcher

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/CollectingLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/CollectingLauncher.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import org.apiguardian.api.API;
+
+/**
+ * A {@link Launcher} implementation that allows the caller to collect tests
+ * and filter them before executing the tests.
+ *
+ * @since 1.1
+ * @see LauncherDiscoveryRequest
+ * @see TestPlan
+ * @see TestExecutionListener
+ * @see org.junit.platform.launcher.core.LauncherFactory
+ * @see org.junit.platform.engine.TestEngine
+ */
+@API(status = STABLE, since = "1.1")
+public interface CollectingLauncher extends Launcher {
+
+	/**
+	 * Collect tests according to the supplied {@link LauncherDiscoveryRequest}
+	 * by querying all registered engines and collecting their results.
+	 *
+	 * <p>Any {@link TestExecutionListener} instances registered before this
+	 * call will be notified if {@link TestCollection#execute(TestExecutionListener...)}
+	 * is called.
+	 *
+	 * @param launcherDiscoveryRequest the launcher discovery request; never {@code null}
+	 * @return a {@code Request} instance built from all resolved {@linkplain
+	 * TestIdentifier identifiers} from all registered engines
+	 */
+	TestCollection collect(LauncherDiscoveryRequest launcherDiscoveryRequest);
+
+	default TestPlan discover(LauncherDiscoveryRequest launcherDiscoveryRequest) {
+		return collect(launcherDiscoveryRequest).testPlan();
+	}
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestCollection.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestCollection.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import org.apiguardian.api.API;
+
+/**
+ * A collection of tests that can be examined, filtered and executed.
+ *
+ * @since 1.1
+ */
+@API(status = STABLE, since = "1.1")
+public interface TestCollection {
+
+	/**
+	 * Get the {@link TestPlan} created from processing the
+	 * {@link LauncherDiscoveryRequest}.
+	 */
+	TestPlan testPlan();
+
+	/**
+	 * Apply the given filters to the discovered tests.
+	 */
+	void applyPostDiscoveryFilters(PostDiscoveryFilter... filters);
+
+	/**
+	 * Execute the tests and notify {@linkplain #registerTestExecutionListeners
+	 * registered listeners} about the progress and results of the execution.
+	 *
+	 * <p>Supplied test execution listeners are registered in addition to listeners
+	 * that were registered at the time this {@code DiscoveredTests} instance was
+	 * created.
+	 *
+	 * @param listeners additional test execution listeners; never {@code null}
+	 */
+	void execute(TestExecutionListener... listeners);
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultTestCollection.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultTestCollection.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import java.util.Arrays;
+
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestCollection;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+
+/**
+ * Default implementation of the {@link TestCollection} API.
+ *
+ * @since 1.1
+ * @see Launcher
+ */
+class DefaultTestCollection implements TestCollection {
+
+	private static final Logger logger = LoggerFactory.getLogger(DefaultTestCollection.class);
+
+	private final Root root;
+	private final TestExecutionListenerRegistry listenerRegistry;
+	private final ConfigurationParameters configurationParameters;
+
+	DefaultTestCollection(Root root, TestExecutionListenerRegistry listenerRegistry,
+			ConfigurationParameters configurationParameters) {
+		this.root = root;
+		this.listenerRegistry = new TestExecutionListenerRegistry(listenerRegistry);
+		this.configurationParameters = configurationParameters;
+	}
+
+	@Override
+	public TestPlan testPlan() {
+		return TestPlan.from(root.getEngineDescriptors());
+	}
+
+	@Override
+	public void applyPostDiscoveryFilters(PostDiscoveryFilter... filters) {
+		root.applyPostDiscoveryFilters(Arrays.asList(filters));
+	}
+
+	@Override
+	public void execute(TestExecutionListener... listeners) {
+		Preconditions.notNull(listeners, "TestExecutionListener array must not be null");
+		Preconditions.containsNoNullElements(listeners, "individual listeners must not be null");
+		TestExecutionListener testExecutionListener = buildListenerRegistryForExecution(
+			listeners).getCompositeTestExecutionListener();
+		TestPlan testPlan = testPlan();
+		ExecutionListenerAdapter engineExecutionListener = new ExecutionListenerAdapter(testPlan,
+			testExecutionListener);
+
+		testExecutionListener.testPlanExecutionStarted(testPlan);
+		for (TestEngine testEngine : root.getTestEngines()) {
+			TestDescriptor testDescriptor = root.getTestDescriptorFor(testEngine);
+			execute(testEngine, new ExecutionRequest(testDescriptor, engineExecutionListener, configurationParameters));
+		}
+		testExecutionListener.testPlanExecutionFinished(testPlan);
+	}
+
+	private TestExecutionListenerRegistry buildListenerRegistryForExecution(TestExecutionListener... listeners) {
+		if (listeners.length == 0) {
+			return this.listenerRegistry;
+		}
+		TestExecutionListenerRegistry registry = new TestExecutionListenerRegistry(this.listenerRegistry);
+		registry.registerListeners(listeners);
+		return registry;
+	}
+
+	private static void execute(TestEngine testEngine, ExecutionRequest executionRequest) {
+		try {
+			testEngine.execute(executionRequest);
+		}
+		catch (Throwable throwable) {
+			handleThrowable(testEngine, throwable);
+		}
+	}
+
+	private static void handleThrowable(TestEngine testEngine, Throwable throwable) {
+		logger.warn(throwable,
+			() -> String.format("TestEngine with ID '%s' failed to execute tests", testEngine.getId()));
+		BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+	}
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.PreconditionViolationException;
+import org.junit.platform.launcher.CollectingLauncher;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.TestExecutionListener;
 
@@ -55,8 +56,8 @@ public class LauncherFactory {
 	 *
 	 * @throws PreconditionViolationException if no test engines are detected
 	 */
-	public static Launcher create() throws PreconditionViolationException {
-		Launcher launcher = new DefaultLauncher(new ServiceLoaderTestEngineRegistry().loadTestEngines());
+	public static CollectingLauncher create() throws PreconditionViolationException {
+		CollectingLauncher launcher = new DefaultLauncher(new ServiceLoaderTestEngineRegistry().loadTestEngines());
 		for (TestExecutionListener listener : new ServiceLoaderTestExecutionListenerRegistry().loadListeners()) {
 			launcher.registerTestExecutionListeners(listener);
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
@@ -14,12 +14,13 @@ import static org.junit.platform.engine.Filter.composeFilters;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
-import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.PostDiscoveryFilter;
 
 /**
  * Represents the root of all discovered {@link TestEngine TestEngines} and
@@ -50,14 +51,15 @@ class Root {
 		return this.testEngineDescriptors.get(testEngine);
 	}
 
-	void applyPostDiscoveryFilters(LauncherDiscoveryRequest discoveryRequest) {
-		Filter<TestDescriptor> postDiscoveryFilter = composeFilters(discoveryRequest.getPostDiscoveryFilters());
+	void applyPostDiscoveryFilters(List<PostDiscoveryFilter> filters) {
+		Filter<TestDescriptor> postDiscoveryFilter = composeFilters(filters);
 		TestDescriptor.Visitor removeExcludedTestDescriptors = descriptor -> {
 			if (!descriptor.isRoot() && isExcluded(descriptor, postDiscoveryFilter)) {
 				descriptor.removeFromHierarchy();
 			}
 		};
 		acceptInAllTestEngines(removeExcludedTestDescriptors);
+		prune();
 	}
 
 	/**
@@ -67,7 +69,7 @@ class Root {
 	 * <p>If a {@link TestEngine} ends up with no {@code TestDescriptors} after
 	 * pruning, it will <strong>not</strong> be removed.
 	 */
-	void prune() {
+	private void prune() {
 		acceptInAllTestEngines(TestDescriptor::prune);
 	}
 

--- a/platform-tests/platform-tests.gradle
+++ b/platform-tests/platform-tests.gradle
@@ -23,6 +23,7 @@ dependencies {
 	testImplementation(project(path: ':junit-platform-console', configuration: 'shadow'))
 	testImplementation(project(':junit-platform-engine'))
 	testImplementation(project(':junit-platform-launcher'))
+	testImplementation(project(':junit-jupiter-engine'))
 
 	// --- Things we are testing with ---------------------------------------------
 	testImplementation(project(':junit-jupiter-api'))
@@ -36,7 +37,6 @@ dependencies {
 	testImplementation("io.github.lukehutch:fast-classpath-scanner:2.4.7")
 
 	// --- Test run-time dependencies ---------------------------------------------
-	testRuntimeOnly(project(':junit-jupiter-engine'))
 	testRuntimeOnly(project(':junit-vintage-engine'))
 	testRuntimeOnly(project(':junit-jupiter-migrationsupport')) // included for @API report
 	testRuntimeOnly(project(':junit-platform-gradle-plugin')) // included for @API report

--- a/platform-tests/platform-tests.gradle
+++ b/platform-tests/platform-tests.gradle
@@ -23,10 +23,10 @@ dependencies {
 	testImplementation(project(path: ':junit-platform-console', configuration: 'shadow'))
 	testImplementation(project(':junit-platform-engine'))
 	testImplementation(project(':junit-platform-launcher'))
-	testImplementation(project(':junit-jupiter-engine'))
 
 	// --- Things we are testing with ---------------------------------------------
 	testImplementation(project(':junit-jupiter-api'))
+	testImplementation(project(':junit-jupiter-engine'))
 	testImplementation(project(':junit-jupiter-params'))
 	testImplementation(project(':junit-platform-runner'))
 	testImplementation(project(path: ':junit-platform-engine', configuration: 'testArtifacts'))

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -43,6 +43,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.engine.JupiterTestEngine;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
@@ -55,7 +56,6 @@ import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.PackageNameFilter;
 import org.junit.platform.engine.discovery.PackageSelector;
-import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
@@ -95,7 +95,7 @@ import org.mockito.InOrder;
  *
  * @since 1.0
  */
-class JUnitPlatformRunnerTests {
+public class JUnitPlatformRunnerTests {
 
 	@Nested
 	class Discovery {
@@ -435,47 +435,71 @@ class JUnitPlatformRunnerTests {
 
 		@Test
 		void appliesFilter() throws Exception {
+			JUnitPlatform runner = new JUnitPlatform(TestClass.class, createLauncher(new JupiterTestEngine()));
+			Description outerClassDescription = runner.getDescription();
+			assertEquals(createSuiteDescription(TestClass.class), outerClassDescription);
 
-			TestDescriptor originalParent1 = new TestDescriptorStub(UniqueId.root("root", "parent1"), "parent1");
-			originalParent1.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf1"), "leaf1"));
-			TestDescriptor originalParent2 = new TestDescriptorStub(UniqueId.root("root", "parent2"), "parent2");
-			originalParent2.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2a"), "leaf2a"));
-			originalParent2.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2b"), "leaf2b"));
-			TestPlan fullTestPlan = TestPlan.from(asList(originalParent1, originalParent2));
+			// @formatter:off
+			UniqueId uniqueId = UniqueId.forEngine("junit-jupiter")
+					.append("class", TestClass.class.getName())
+					.append("nested-class", "Parent2")
+					.append("method", "leaf2b()");
+			// @formatter:on
+			Description testToInclude = Description.createTestDescription("Parent2", "leaf2b()", uniqueId.toString());
 
-			TestDescriptor filteredParent = new TestDescriptorStub(UniqueId.root("root", "parent2"), "parent2");
-			filteredParent.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2b"), "leaf2b"));
-			TestPlan filteredTestPlan = TestPlan.from(singleton(filteredParent));
+			runner.filter(matchMethodDescription(testToInclude));
 
-			Launcher launcher = mock(Launcher.class);
-			ArgumentCaptor<LauncherDiscoveryRequest> captor = ArgumentCaptor.forClass(LauncherDiscoveryRequest.class);
-			when(launcher.discover(captor.capture())).thenReturn(fullTestPlan).thenReturn(filteredTestPlan);
+			// After filtering, there should be one leaf. Find it.
+			outerClassDescription = runner.getDescription();
+			assertEquals(createSuiteDescription(TestClass.class), outerClassDescription);
+			Description testDescription = outerClassDescription;
+			while (testDescription.isSuite()) {
+				expectNumChildrenEquals(1, testDescription);
+				testDescription = testDescription.getChildren().get(0);
+			}
+			assertEquals(Description.createTestDescription("Parent2", "leaf2b()", uniqueId.toString()),
+				testDescription);
+		}
 
-			JUnitPlatform runner = new JUnitPlatform(TestClass.class, launcher);
-			runner.filter(matchMethodDescription(testDescription("[root:leaf2b]")));
+		@Test
+		void onlyFilteredTestsRun() throws Exception {
+			// @formatter:off
+			UniqueId uniqueId = UniqueId.forEngine("junit-jupiter")
+					.append("class", TestClass.class.getName())
+					.append("nested-class", "Parent2")
+					.append("method", "leaf2b()");
+			// @formatter:on
+			Description testToInclude = Description.createTestDescription("Parent2", "leaf2b()", uniqueId.toString());
 
-			LauncherDiscoveryRequest lastDiscoveryRequest = captor.getValue();
-			List<UniqueIdSelector> uniqueIdSelectors = lastDiscoveryRequest.getSelectorsByType(UniqueIdSelector.class);
-			assertEquals("[root:leaf2b]", getOnlyElement(uniqueIdSelectors).getUniqueId().toString());
+			RunListener runListener = mock(RunListener.class);
+			RunNotifier notifier = new RunNotifier();
+			notifier.addListener(runListener);
+			JUnitPlatform runner = new JUnitPlatform(TestClass.class, createLauncher(new JupiterTestEngine()));
+			runner.filter(matchMethodDescription(testToInclude));
 
-			Description parentDescription = getOnlyElement(runner.getDescription().getChildren());
-			assertEquals(suiteDescription("[root:parent2]"), parentDescription);
+			runner.run(notifier);
 
-			Description testDescription = getOnlyElement(parentDescription.getChildren());
-			assertEquals(testDescription("[root:leaf2b]"), testDescription);
+			InOrder inOrder = inOrder(runListener);
+
+			inOrder.verify(runListener).testStarted(testToInclude);
+			inOrder.verify(runListener).testFinished(testToInclude);
+			inOrder.verifyNoMoreInteractions();
 		}
 
 		@Test
 		void throwsNoTestsRemainExceptionWhenNoTestIdentifierMatchesFilter() throws Exception {
-			TestPlan testPlan = TestPlan.from(singleton(new TestDescriptorStub(UniqueId.root("root", "test"), "test")));
-
-			Launcher launcher = mock(Launcher.class);
-			when(launcher.discover(any())).thenReturn(testPlan);
+			Launcher launcher = createLauncher(new JupiterTestEngine());
 
 			JUnitPlatform runner = new JUnitPlatform(TestClass.class, launcher);
 
 			assertThrows(NoTestsRemainException.class,
 				() -> runner.filter(matchMethodDescription(suiteDescription("[root:doesNotExist]"))));
+		}
+
+		private void expectNumChildrenEquals(int expectedChildCount, Description description) {
+			List<Description> children = description.getChildren();
+			assertEquals(expectedChildCount, children.size(),
+				() -> String.format("Expected %s to have %d children", description, expectedChildCount));
 		}
 
 	}
@@ -713,6 +737,23 @@ class JUnitPlatformRunnerTests {
 	}
 
 	private static class TestClass {
+		@Nested
+		class Parent1 {
+			@Test
+			void leaf1() {
+			}
+		}
+
+		@Nested
+		class Parent2 {
+			@Test
+			void leaf2a() {
+			}
+
+			@Test
+			void leaf2b() {
+			}
+		}
 	}
 
 	@UseTechnicalNames

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -43,6 +43,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.engine.JupiterTestEngine;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
@@ -55,7 +56,6 @@ import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.PackageNameFilter;
 import org.junit.platform.engine.discovery.PackageSelector;
-import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
@@ -65,10 +65,12 @@ import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestDescri
 import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestEngine;
 import org.junit.platform.engine.test.TestDescriptorStub;
 import org.junit.platform.engine.test.TestEngineStub;
+import org.junit.platform.launcher.CollectingLauncher;
 import org.junit.platform.launcher.EngineFilter;
-import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestCollection;
+import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.suite.api.ExcludeClassNamePatterns;
 import org.junit.platform.suite.api.ExcludeEngines;
@@ -406,8 +408,8 @@ class JUnitPlatformRunnerTests {
 			container2.addChild(new TestDescriptorStub(UniqueId.root("root", "test2b"), "test2b"));
 			TestPlan testPlan = TestPlan.from(asList(container1, container2));
 
-			Launcher launcher = mock(Launcher.class);
-			when(launcher.discover(any())).thenReturn(testPlan);
+			CollectingLauncher launcher = mock(CollectingLauncher.class);
+			when(launcher.collect(any())).thenReturn(new FakeTestCollection(testPlan));
 
 			JUnitPlatform runner = new JUnitPlatform(TestClass.class, launcher);
 
@@ -435,47 +437,71 @@ class JUnitPlatformRunnerTests {
 
 		@Test
 		void appliesFilter() throws Exception {
+			JUnitPlatform runner = new JUnitPlatform(TestClass.class, createLauncher(new JupiterTestEngine()));
+			Description outerClassDescription = runner.getDescription();
+			assertEquals(createSuiteDescription(TestClass.class), outerClassDescription);
 
-			TestDescriptor originalParent1 = new TestDescriptorStub(UniqueId.root("root", "parent1"), "parent1");
-			originalParent1.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf1"), "leaf1"));
-			TestDescriptor originalParent2 = new TestDescriptorStub(UniqueId.root("root", "parent2"), "parent2");
-			originalParent2.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2a"), "leaf2a"));
-			originalParent2.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2b"), "leaf2b"));
-			TestPlan fullTestPlan = TestPlan.from(asList(originalParent1, originalParent2));
+			// @formatter:off
+			UniqueId uniqueId = UniqueId.forEngine("junit-jupiter")
+					.append("class", TestClass.class.getName())
+					.append("nested-class", "Parent2")
+					.append("method", "leaf2b()");
+			// @formatter:on
+			Description testToInclude = Description.createTestDescription("Parent2", "leaf2b()", uniqueId.toString());
 
-			TestDescriptor filteredParent = new TestDescriptorStub(UniqueId.root("root", "parent2"), "parent2");
-			filteredParent.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2b"), "leaf2b"));
-			TestPlan filteredTestPlan = TestPlan.from(singleton(filteredParent));
+			runner.filter(matchMethodDescription(testToInclude));
 
-			Launcher launcher = mock(Launcher.class);
-			ArgumentCaptor<LauncherDiscoveryRequest> captor = ArgumentCaptor.forClass(LauncherDiscoveryRequest.class);
-			when(launcher.discover(captor.capture())).thenReturn(fullTestPlan).thenReturn(filteredTestPlan);
+			// After filtering, there should be one leaf. Find it.
+			outerClassDescription = runner.getDescription();
+			assertEquals(createSuiteDescription(TestClass.class), outerClassDescription);
+			Description testDescription = outerClassDescription;
+			while (testDescription.isSuite()) {
+				expectNumChildrenEquals(1, testDescription);
+				testDescription = testDescription.getChildren().get(0);
+			}
+			assertEquals(Description.createTestDescription("Parent2", "leaf2b()", uniqueId.toString()),
+				testDescription);
+		}
 
-			JUnitPlatform runner = new JUnitPlatform(TestClass.class, launcher);
-			runner.filter(matchMethodDescription(testDescription("[root:leaf2b]")));
+		@Test
+		void onlyFilteredTestsRun() throws Exception {
+			// @formatter:off
+			UniqueId uniqueId = UniqueId.forEngine("junit-jupiter")
+					.append("class", TestClass.class.getName())
+					.append("nested-class", "Parent2")
+					.append("method", "leaf2b()");
+			// @formatter:on
+			Description testToInclude = Description.createTestDescription("Parent2", "leaf2b()", uniqueId.toString());
 
-			LauncherDiscoveryRequest lastDiscoveryRequest = captor.getValue();
-			List<UniqueIdSelector> uniqueIdSelectors = lastDiscoveryRequest.getSelectorsByType(UniqueIdSelector.class);
-			assertEquals("[root:leaf2b]", getOnlyElement(uniqueIdSelectors).getUniqueId().toString());
+			RunListener runListener = mock(RunListener.class);
+			RunNotifier notifier = new RunNotifier();
+			notifier.addListener(runListener);
+			JUnitPlatform runner = new JUnitPlatform(TestClass.class, createLauncher(new JupiterTestEngine()));
+			runner.filter(matchMethodDescription(testToInclude));
 
-			Description parentDescription = getOnlyElement(runner.getDescription().getChildren());
-			assertEquals(suiteDescription("[root:parent2]"), parentDescription);
+			runner.run(notifier);
 
-			Description testDescription = getOnlyElement(parentDescription.getChildren());
-			assertEquals(testDescription("[root:leaf2b]"), testDescription);
+			InOrder inOrder = inOrder(runListener);
+
+			inOrder.verify(runListener).testStarted(testToInclude);
+			inOrder.verify(runListener).testFinished(testToInclude);
+			inOrder.verifyNoMoreInteractions();
 		}
 
 		@Test
 		void throwsNoTestsRemainExceptionWhenNoTestIdentifierMatchesFilter() throws Exception {
-			TestPlan testPlan = TestPlan.from(singleton(new TestDescriptorStub(UniqueId.root("root", "test"), "test")));
-
-			Launcher launcher = mock(Launcher.class);
-			when(launcher.discover(any())).thenReturn(testPlan);
+			CollectingLauncher launcher = createLauncher(new JupiterTestEngine());
 
 			JUnitPlatform runner = new JUnitPlatform(TestClass.class, launcher);
 
 			assertThrows(NoTestsRemainException.class,
 				() -> runner.filter(matchMethodDescription(suiteDescription("[root:doesNotExist]"))));
+		}
+
+		private void expectNumChildrenEquals(int expectedChildCount, Description description) {
+			List<Description> children = description.getChildren();
+			assertEquals(expectedChildCount, children.size(),
+				() -> String.format("Expected %s to have %d children", description, expectedChildCount));
 		}
 
 	}
@@ -703,9 +729,9 @@ class JUnitPlatformRunnerTests {
 
 	private LauncherDiscoveryRequest instantiateRunnerAndCaptureGeneratedRequest(Class<?> testClass)
 			throws InitializationError {
-		Launcher launcher = mock(Launcher.class);
+		CollectingLauncher launcher = mock(CollectingLauncher.class);
 		ArgumentCaptor<LauncherDiscoveryRequest> captor = ArgumentCaptor.forClass(LauncherDiscoveryRequest.class);
-		when(launcher.discover(captor.capture())).thenReturn(TestPlan.from(emptySet()));
+		when(launcher.collect(captor.capture())).thenReturn(new FakeTestCollection(TestPlan.from(emptySet())));
 
 		new JUnitPlatform(testClass, launcher);
 
@@ -713,6 +739,23 @@ class JUnitPlatformRunnerTests {
 	}
 
 	private static class TestClass {
+		@Nested
+		class Parent1 {
+			@Test
+			void leaf1() {
+			}
+		}
+
+		@Nested
+		class Parent2 {
+			@Test
+			void leaf2a() {
+			}
+
+			@Test
+			void leaf2b() {
+			}
+		}
 	}
 
 	@UseTechnicalNames
@@ -824,6 +867,30 @@ class JUnitPlatformRunnerTests {
 		public Type getType() {
 			return Type.CONTAINER_AND_TEST;
 		}
+	}
+
+	private static class FakeTestCollection implements TestCollection {
+		private final TestPlan testPlan;
+
+		FakeTestCollection(TestPlan testPlan) {
+			this.testPlan = testPlan;
+		}
+
+		@Override
+		public TestPlan testPlan() {
+			return testPlan;
+		}
+
+		@Override
+		public void applyPostDiscoveryFilters(PostDiscoveryFilter... filters) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void execute(TestExecutionListener... listeners) {
+			throw new UnsupportedOperationException();
+		}
+
 	}
 
 }


### PR DESCRIPTION
## Overview

Add CollectingLauncher which provides access to TestCollection.
    
The TestCollection allows users of Launcher to review the test plan,
do additional filtering, and execute the tests, without going through
a potentially expensive discovery stage more than once.

This pull contains three commits. Please don't squash them.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
