### PR TITLE
Part I - Introduce ModuleUtils with ClassFinder SPI

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -11,6 +11,8 @@
 package org.junit.jupiter.engine.discovery;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.junit.platform.commons.util.ModuleUtils.findAllClassesInModule;
+import static org.junit.platform.commons.util.ModuleUtils.findAllClassesInModulepath;
 import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInClasspathRoot;
 import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInPackage;
 import static org.junit.platform.engine.support.filter.ClasspathScanningSupport.buildClassNamePredicate;
@@ -26,6 +28,8 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.ClasspathRootSelector;
 import org.junit.platform.engine.discovery.MethodSelector;
+import org.junit.platform.engine.discovery.ModuleSelector;
+import org.junit.platform.engine.discovery.ModulepathSelector;
 import org.junit.platform.engine.discovery.PackageSelector;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
 
@@ -50,6 +54,14 @@ public class DiscoverySelectorResolver {
 		request.getSelectorsByType(ClasspathRootSelector.class).forEach(selector -> {
 			findAllClassesInClasspathRoot(selector.getClasspathRoot(), isScannableTestClass,
 				classNamePredicate).forEach(javaElementsResolver::resolveClass);
+		});
+		request.getSelectorsByType(ModulepathSelector.class).forEach(selector -> {
+			findAllClassesInModulepath(isScannableTestClass, classNamePredicate).forEach(
+				javaElementsResolver::resolveClass);
+		});
+		request.getSelectorsByType(ModuleSelector.class).forEach(selector -> {
+			findAllClassesInModule(selector.getModuleName(), isScannableTestClass, classNamePredicate).forEach(
+				javaElementsResolver::resolveClass);
 		});
 		request.getSelectorsByType(PackageSelector.class).forEach(selector -> {
 			findAllClassesInPackage(selector.getPackageName(), isScannableTestClass, classNamePredicate).forEach(

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassFilter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+
+/**
+ * Scan-able class predicate holder used by reflection utilities.
+ *
+ * <h3>DISCLAIMER</h3>
+ *
+ * <p>These utilities are intended solely for usage within the JUnit framework
+ * itself. <strong>Any usage by external parties is not supported.</strong>
+ * Use at your own risk!
+ *
+ * @since 1.1
+ */
+@API(status = INTERNAL, since = "1.1")
+public class ClassFilter {
+
+	public static ClassFilter of(Predicate<Class<?>> classPredicate, Predicate<String> namePredicate) {
+		Preconditions.notNull(classPredicate, "class predicate must not be null");
+		Preconditions.notNull(namePredicate, "name predicate must not be null");
+
+		return new ClassFilter(classPredicate, namePredicate);
+	}
+
+	private final Predicate<Class<?>> classPredicate;
+	private final Predicate<String> namePredicate;
+
+	private ClassFilter(Predicate<Class<?>> classPredicate, Predicate<String> namePredicate) {
+		this.classPredicate = classPredicate;
+		this.namePredicate = namePredicate;
+	}
+
+	public boolean test(Class<?> type) {
+		return classPredicate.test(type);
+	}
+
+	public boolean test(String name) {
+		return namePredicate.test(name);
+	}
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleClassFinder.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleClassFinder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+
+/**
+ * Class finder service providing interface.
+ *
+ * <h3>DISCLAIMER</h3>
+ *
+ * <p>These utilities are intended solely for usage within the JUnit framework
+ * itself. <strong>Any usage by external parties is not supported.</strong>
+ * Use at your own risk!
+ *
+ * @since 1.1
+ */
+@API(status = INTERNAL, since = "1.1")
+public interface ModuleClassFinder {
+
+	/**
+	 * Special name indicating a search for all classes in all modules on the module-path.
+	 */
+	String ALL_MODULE_PATH = "ALL-MODULE-PATH";
+
+	/**
+	 * Return list of classes found in the named module that may contain testable methods.
+	 *
+	 * @param moduleName name of the module to inspect or {@code ALL-MODULE-PATH}
+	 * @param classTester filter to apply to each class instance
+	 * @param classNameFilter filter to apply to the fully qualified class name
+	 * @return list of test classes
+	 *
+	 * @see #ALL_MODULE_PATH
+	 */
+	List<Class<?>> findAllClassesInModule(String moduleName, Predicate<Class<?>> classTester,
+			Predicate<String> classNameFilter);
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleClassFinder.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleClassFinder.java
@@ -12,8 +12,8 @@ package org.junit.platform.commons.util;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
+import java.nio.file.Path;
 import java.util.List;
-import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 
@@ -32,20 +32,30 @@ import org.apiguardian.api.API;
 public interface ModuleClassFinder {
 
 	/**
-	 * Special name indicating a search for all classes in all modules on the module-path.
-	 */
-	String ALL_MODULE_PATH = "ALL-MODULE-PATH";
-
-	/**
 	 * Return list of classes found in the named module that may contain testable methods.
 	 *
-	 * @param moduleName name of the module to inspect or {@code ALL-MODULE-PATH}
-	 * @param classTester filter to apply to each class instance
-	 * @param classNameFilter filter to apply to the fully qualified class name
+	 * @param filter filter to apply to each class candidate
+	 * @param moduleName name of the module to inspect
 	 * @return list of test classes
-	 *
-	 * @see #ALL_MODULE_PATH
 	 */
-	List<Class<?>> findAllClassesInModule(String moduleName, Predicate<Class<?>> classTester,
-			Predicate<String> classNameFilter);
+	List<Class<?>> findAllClassesInModule(ClassFilter filter, String moduleName);
+
+	/**
+	 * Return list of classes found on the boot module-path that may contain testable methods.
+	 *
+	 * @param filter filter to apply to each class candidate
+	 * @return list of test classes
+	 */
+	List<Class<?>> findAllClassesOnModulePath(ClassFilter filter);
+
+	/**
+	 * Return list of classes found at the given path roots that may contain testable methods.
+	 *
+	 * @param filter filter to apply to each class candidate
+	 * @param parent class loader instance to used the parent class loader
+	 * @param entries a possibly-empty array of paths to directories of modules or paths to packaged or exploded modules
+	 * @return list of test classes
+	 * @see <a href="http://download.java.net/java/jdk9/docs/api/java/lang/module/ModuleFinder.html">ModuleFinder</a>
+	 */
+	List<Class<?>> findAllClassesOnModulePath(ClassFilter filter, ClassLoader parent, Path... entries);
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+
+/**
+ * Collection of utilities for working with modules.
+ *
+ * <h3>DISCLAIMER</h3>
+ *
+ * <p>These utilities are intended solely for usage within the JUnit framework
+ * itself. <strong>Any usage by external parties is not supported.</strong>
+ * Use at your own risk!
+ *
+ * @since 1.1
+ */
+@API(status = INTERNAL, since = "1.1")
+public final class ModuleUtils {
+
+	private static final Logger logger = LoggerFactory.getLogger(ModuleUtils.class);
+
+	///CLOVER:OFF
+	private ModuleUtils() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
+	/**
+	 * Convenient short-cut for finding all classes in all modules that are on the module-path.
+	 */
+	public static List<Class<?>> findAllClassesInModulepath(Predicate<Class<?>> classTester,
+			Predicate<String> classNameFilter) {
+		return findAllClassesInModule(ModuleClassFinder.ALL_MODULE_PATH, classTester, classNameFilter);
+	}
+
+	/**
+	 * Find all classes in the specified module.
+	 *
+	 * @param moduleName name of the module to inspect or {@code ALL-MODULE-PATH}
+	 * @param classTester filter to apply to each class instance
+	 * @param classNameFilter filter to apply to the fully qualified class name
+	 * @return list of classes matching the passed-in criteria
+	 */
+	public static List<Class<?>> findAllClassesInModule(String moduleName, Predicate<Class<?>> classTester,
+			Predicate<String> classNameFilter) {
+		Preconditions.notBlank(moduleName, "module name must not be null or blank");
+		Preconditions.notNull(classTester, "class tester must not be null");
+		Preconditions.notNull(classNameFilter, "class name filter must not be null");
+
+		ClassLoader classLoader = ClassLoaderUtils.getDefaultClassLoader();
+		List<Class<?>> classes = new ArrayList<>();
+
+		logger.config(() -> "Loading auto-detected class finders...");
+		int serviceCounter = 0;
+		for (ModuleClassFinder classFinder : ServiceLoader.load(ModuleClassFinder.class, classLoader)) {
+			classes.addAll(classFinder.findAllClassesInModule(moduleName, classTester, classNameFilter));
+			serviceCounter++;
+		}
+		if (serviceCounter == 0) {
+			logger.warn(() -> "No module class finder service registered! No test classes found.");
+		}
+		return Collections.unmodifiableList(classes);
+	}
+
+}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -50,6 +50,8 @@ class AvailableOptions {
 	private final OptionSpec<URI> selectedUris;
 	private final OptionSpec<String> selectedFiles;
 	private final OptionSpec<String> selectedDirectories;
+	private final OptionSpec<Void> scanModulePath;
+	private final OptionSpec<String> selectedModules;
 	private final OptionSpec<String> selectedPackages;
 	private final OptionSpec<String> selectedClasses;
 	private final OptionSpec<String> selectedMethods;
@@ -150,6 +152,16 @@ class AvailableOptions {
 			"Select a classpath resource for test discovery. This option can be repeated.") //
 				.withRequiredArg();
 
+		// --- Java Platform Module System -------------------------------------
+
+		scanModulePath = parser.acceptsAll(asList("scan-modulepath", "scan-module-path"), //
+			"EXPERIMENTAL: Scan all modules on the module-path for test discovery.");
+
+		selectedModules = parser.acceptsAll(asList("o", "select-module"), //
+			"EXPERIMENTAL: Select single module for test discovery. This option can be repeated.") //
+				.withRequiredArg() //
+				.describedAs("module name");
+
 		// --- Filters ---------------------------------------------------------
 
 		includeClassNamePattern = parser.acceptsAll(asList("n", "include-classname"),
@@ -217,6 +229,8 @@ class AvailableOptions {
 		result.setSelectedUris(detectedOptions.valuesOf(this.selectedUris));
 		result.setSelectedFiles(detectedOptions.valuesOf(this.selectedFiles));
 		result.setSelectedDirectories(detectedOptions.valuesOf(this.selectedDirectories));
+		result.setScanModulepath(detectedOptions.has(this.scanModulePath));
+		result.setSelectedModules(detectedOptions.valuesOf(this.selectedModules));
 		result.setSelectedPackages(detectedOptions.valuesOf(this.selectedPackages));
 		result.setSelectedClasses(detectedOptions.valuesOf(this.selectedClasses));
 		result.setSelectedMethods(detectedOptions.valuesOf(this.selectedMethods));

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
@@ -45,9 +45,12 @@ public class CommandLineOptions {
 	private boolean scanClasspath;
 	private List<Path> selectedClasspathEntries = emptyList();
 
+	private boolean scanModulepath;
+
 	private List<URI> selectedUris = emptyList();
 	private List<String> selectedFiles = emptyList();
 	private List<String> selectedDirectories = emptyList();
+	private List<String> selectedModules = emptyList();
 	private List<String> selectedPackages = emptyList();
 	private List<String> selectedClasses = emptyList();
 	private List<String> selectedMethods = emptyList();
@@ -92,6 +95,14 @@ public class CommandLineOptions {
 		this.scanClasspath = scanClasspath;
 	}
 
+	public boolean isScanModulepath() {
+		return scanModulepath;
+	}
+
+	public void setScanModulepath(boolean scanModulepath) {
+		this.scanModulepath = scanModulepath;
+	}
+
 	public Details getDetails() {
 		return details;
 	}
@@ -130,6 +141,14 @@ public class CommandLineOptions {
 
 	public void setSelectedDirectories(List<String> selectedDirectories) {
 		this.selectedDirectories = selectedDirectories;
+	}
+
+	public List<String> getSelectedModules() {
+		return selectedModules;
+	}
+
+	public void setSelectedModules(List<String> selectedModules) {
+		this.selectedModules = selectedModules;
 	}
 
 	public List<String> getSelectedPackages() {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
@@ -23,6 +23,7 @@ import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.r
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -55,6 +56,9 @@ class DiscoveryRequestCreator {
 				"Scanning the classpath and using explicit selectors at the same time is not supported");
 			return createClasspathRootSelectors(options);
 		}
+		if (options.isScanModulepath()) {
+			return Collections.singletonList(DiscoverySelectors.selectModulepath());
+		}
 		return createExplicitDiscoverySelectors(options);
 	}
 
@@ -77,6 +81,7 @@ class DiscoveryRequestCreator {
 		options.getSelectedUris().stream().map(DiscoverySelectors::selectUri).forEach(selectors::add);
 		options.getSelectedFiles().stream().map(DiscoverySelectors::selectFile).forEach(selectors::add);
 		options.getSelectedDirectories().stream().map(DiscoverySelectors::selectDirectory).forEach(selectors::add);
+		options.getSelectedModules().stream().map(DiscoverySelectors::selectModule).forEach(selectors::add);
 		options.getSelectedPackages().stream().map(DiscoverySelectors::selectPackage).forEach(selectors::add);
 		options.getSelectedClasses().stream().map(DiscoverySelectors::selectClass).forEach(selectors::add);
 		options.getSelectedMethods().stream().map(DiscoverySelectors::selectMethod).forEach(selectors::add);

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
@@ -57,7 +57,7 @@ class DiscoveryRequestCreator {
 			return createClasspathRootSelectors(options);
 		}
 		if (options.isScanModulepath()) {
-			return Collections.singletonList(DiscoverySelectors.selectModulepath());
+			return Collections.singletonList(DiscoverySelectors.selectModulePath());
 		}
 		return createExplicitDiscoverySelectors(options);
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine.discovery;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
 
@@ -238,6 +239,31 @@ public final class DiscoverySelectors {
 	public static ClasspathResourceSelector selectClasspathResource(String classpathResourceName) {
 		Preconditions.notBlank(classpathResourceName, "Classpath resource name must not be null or blank");
 		return new ClasspathResourceSelector(classpathResourceName);
+	}
+
+	/**
+	 * Create a {@code ModulepathSelector} for scanning all modules on the module-path.
+	 *
+	 * @see ModulepathSelector
+	 */
+	@API(status = EXPERIMENTAL, since = "1.1")
+	public static ModulepathSelector selectModulepath() {
+		return new ModulepathSelector();
+	}
+
+	/**
+	 * Create a {@code ModuleSelector} for the supplied module name.
+	 *
+	 * <p>The unnamed module is not supported.
+	 *
+	 * @param moduleName the module name to select; never {@code null} and
+	 * never blank
+	 * @see ModuleSelector
+	 */
+	@API(status = EXPERIMENTAL, since = "1.1")
+	public static ModuleSelector selectModule(String moduleName) {
+		Preconditions.notBlank(moduleName, "Module name must not be null or blank");
+		return new ModuleSelector(moduleName.trim());
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -242,13 +243,34 @@ public final class DiscoverySelectors {
 	}
 
 	/**
-	 * Create a {@code ModulepathSelector} for scanning all modules on the module-path.
+	 * Create a {@code ModulePathSelector} for scanning all modules on the module-path.
 	 *
-	 * @see ModulepathSelector
+	 * @see ModulePathSelector
 	 */
 	@API(status = EXPERIMENTAL, since = "1.1")
-	public static ModulepathSelector selectModulepath() {
-		return new ModulepathSelector();
+	public static ModulePathSelector selectModulePath() {
+		return new ModulePathSelector();
+	}
+
+	/**
+	 * Create a {@code ModulePathSelector} for scanning all modules on the module-path.
+	 *
+	 * @see ModuleFinderSelector
+	 */
+	@API(status = EXPERIMENTAL, since = "1.1")
+	public static ModuleFinderSelector selectModuleFinder(ClassLoader loader, Path... entries) {
+		String[] strings = Arrays.stream(entries).map(Path::toString).toArray(String[]::new);
+		return new ModuleFinderSelector(loader, strings);
+	}
+
+	/**
+	 * Create a {@code ModulePathSelector} for scanning all modules on the module-path.
+	 *
+	 * @see ModuleFinderSelector
+	 */
+	@API(status = EXPERIMENTAL, since = "1.1")
+	public static ModuleFinderSelector selectModuleFinder(ClassLoader loader, String... entries) {
+		return new ModuleFinderSelector(loader, entries);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModuleFinderSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModuleFinderSelector.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.discovery;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.util.ToStringBuilder;
+import org.junit.platform.engine.DiscoverySelector;
+
+/**
+ * A {@link DiscoverySelector} that selects all modules on the custom module-path
+ * so that {@link org.junit.platform.engine.TestEngine TestEngines} can discover
+ * tests or containers based on the custom module-path.
+ *
+ * @since 1.1
+ */
+@API(status = EXPERIMENTAL, since = "1.1")
+public class ModuleFinderSelector implements DiscoverySelector {
+
+	private final ClassLoader classLoader;
+	private final String[] entries;
+
+	ModuleFinderSelector(ClassLoader classLoader, String[] entries) {
+		this.classLoader = classLoader;
+		this.entries = entries;
+	}
+
+	public ClassLoader getClassLoader() {
+		return classLoader;
+	}
+
+	public String[] getEntries() {
+		return entries;
+	}
+
+	public Path[] getPaths() {
+		return Arrays.stream(entries).map(Paths::get).toArray(Path[]::new);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).append("entries", this.entries).toString();
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModulePathSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModulePathSelector.java
@@ -24,9 +24,9 @@ import org.junit.platform.engine.DiscoverySelector;
  * @since 1.1
  */
 @API(status = EXPERIMENTAL, since = "1.1")
-public class ModulepathSelector implements DiscoverySelector {
+public class ModulePathSelector implements DiscoverySelector {
 
-	ModulepathSelector() {
+	ModulePathSelector() {
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModuleSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModuleSelector.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.discovery;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.util.ToStringBuilder;
+import org.junit.platform.engine.DiscoverySelector;
+
+/**
+ * A {@link DiscoverySelector} that selects a module name so that
+ * {@link org.junit.platform.engine.TestEngine TestEngines} can discover
+ * tests or containers based on modules.
+ *
+ * @since 1.1
+ */
+@API(status = EXPERIMENTAL, since = "1.1")
+public class ModuleSelector implements DiscoverySelector {
+
+	private final String moduleName;
+
+	ModuleSelector(String moduleName) {
+		this.moduleName = moduleName;
+	}
+
+	/**
+	 * Get the selected module name.
+	 */
+	public String getModuleName() {
+		return this.moduleName;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).append("moduleName", this.moduleName).toString();
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModulepathSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModulepathSelector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.discovery;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.util.ToStringBuilder;
+import org.junit.platform.engine.DiscoverySelector;
+
+/**
+ * A {@link DiscoverySelector} that selects all modules on the module-path so that
+ * {@link org.junit.platform.engine.TestEngine TestEngines} can discover
+ * tests or containers based on all resolved modules.
+ *
+ * @since 1.1
+ */
+@API(status = EXPERIMENTAL, since = "1.1")
+public class ModulepathSelector implements DiscoverySelector {
+
+	ModulepathSelector() {
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).toString();
+	}
+
+}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ModuleFinderSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ModuleFinderSelectorResolver.java
@@ -10,31 +10,33 @@
 
 package org.junit.vintage.engine.discovery;
 
-import static org.junit.platform.commons.util.ModuleUtils.findAllClassesInModulepath;
+import static org.junit.platform.commons.util.ModuleUtils.findAllClassesOnModulePath;
 
 import java.util.Collection;
 import java.util.function.Predicate;
 
+import org.junit.platform.commons.util.ClassFilter;
 import org.junit.platform.engine.EngineDiscoveryRequest;
-import org.junit.platform.engine.discovery.ModulepathSelector;
+import org.junit.platform.engine.discovery.ModuleFinderSelector;
 
 /**
  * @since 4.12.1
  */
-class ModulepathSelectorResolver implements DiscoverySelectorResolver {
+class ModuleFinderSelectorResolver implements DiscoverySelectorResolver {
 
 	private final Predicate<String> classNamePredicate;
 
-	ModulepathSelectorResolver(Predicate<String> classNamePredicate) {
+	ModuleFinderSelectorResolver(Predicate<String> classNamePredicate) {
 		this.classNamePredicate = classNamePredicate;
 	}
 
 	@Override
 	public void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector) {
+		ClassFilter filter = ClassFilter.of(classFilter, classNamePredicate);
 		// @formatter:off
-		request.getSelectorsByType(ModulepathSelector.class)
+		request.getSelectorsByType(ModuleFinderSelector.class)
 			.stream()
-			.map(name -> findAllClassesInModulepath(classFilter, classNamePredicate))
+			.map(selector -> findAllClassesOnModulePath(filter, selector.getClassLoader(), selector.getPaths()))
 			.flatMap(Collection::stream)
 			.forEach(collector::addCompletely);
 		// @formatter:on

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ModuleNameSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ModuleNameSelectorResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.discovery;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+
+import org.junit.platform.commons.util.ModuleUtils;
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.discovery.ModuleSelector;
+
+/**
+ * @since 4.12.1
+ */
+class ModuleNameSelectorResolver implements DiscoverySelectorResolver {
+
+	private final Predicate<String> classNamePredicate;
+
+	ModuleNameSelectorResolver(Predicate<String> classNamePredicate) {
+		this.classNamePredicate = classNamePredicate;
+	}
+
+	@Override
+	public void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector) {
+		// @formatter:off
+		request.getSelectorsByType(ModuleSelector.class)
+			.stream()
+			.map(ModuleSelector::getModuleName)
+			.map(name -> ModuleUtils.findAllClassesInModule(name, classFilter, classNamePredicate))
+			.flatMap(Collection::stream)
+			.forEach(collector::addCompletely);
+		// @formatter:on
+	}
+
+}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ModulePathSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ModulePathSelectorResolver.java
@@ -16,16 +16,16 @@ import java.util.function.Predicate;
 import org.junit.platform.commons.util.ClassFilter;
 import org.junit.platform.commons.util.ModuleUtils;
 import org.junit.platform.engine.EngineDiscoveryRequest;
-import org.junit.platform.engine.discovery.ModuleSelector;
+import org.junit.platform.engine.discovery.ModulePathSelector;
 
 /**
  * @since 4.12.1
  */
-class ModuleNameSelectorResolver implements DiscoverySelectorResolver {
+class ModulePathSelectorResolver implements DiscoverySelectorResolver {
 
 	private final Predicate<String> classNamePredicate;
 
-	ModuleNameSelectorResolver(Predicate<String> classNamePredicate) {
+	ModulePathSelectorResolver(Predicate<String> classNamePredicate) {
 		this.classNamePredicate = classNamePredicate;
 	}
 
@@ -33,10 +33,9 @@ class ModuleNameSelectorResolver implements DiscoverySelectorResolver {
 	public void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector) {
 		ClassFilter filter = ClassFilter.of(classFilter, classNamePredicate);
 		// @formatter:off
-		request.getSelectorsByType(ModuleSelector.class)
+		request.getSelectorsByType(ModulePathSelector.class)
 			.stream()
-			.map(ModuleSelector::getModuleName)
-			.map(name -> ModuleUtils.findAllClassesInModule(filter, name))
+			.map(name -> ModuleUtils.findAllClassesOnModulePath(filter))
 			.flatMap(Collection::stream)
 			.forEach(collector::addCompletely);
 		// @formatter:on

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ModulepathSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/ModulepathSelectorResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.discovery;
+
+import static org.junit.platform.commons.util.ModuleUtils.findAllClassesInModulepath;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.discovery.ModulepathSelector;
+
+/**
+ * @since 4.12.1
+ */
+class ModulepathSelectorResolver implements DiscoverySelectorResolver {
+
+	private final Predicate<String> classNamePredicate;
+
+	ModulepathSelectorResolver(Predicate<String> classNamePredicate) {
+		this.classNamePredicate = classNamePredicate;
+	}
+
+	@Override
+	public void resolve(EngineDiscoveryRequest request, Predicate<Class<?>> classFilter, TestClassCollector collector) {
+		// @formatter:off
+		request.getSelectorsByType(ModulepathSelector.class)
+			.stream()
+			.map(name -> findAllClassesInModulepath(classFilter, classNamePredicate))
+			.flatMap(Collection::stream)
+			.forEach(collector::addCompletely);
+		// @formatter:on
+	}
+
+}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
@@ -71,6 +71,8 @@ public class VintageDiscoverer {
 		return asList( //
 			new ClasspathRootSelectorResolver(classNamePredicate), //
 			new PackageNameSelectorResolver(classNamePredicate), //
+			new ModulepathSelectorResolver(classNamePredicate), //
+			new ModuleNameSelectorResolver(classNamePredicate), //
 			new ClassSelectorResolver(), //
 			new MethodSelectorResolver(), //
 			new UniqueIdSelectorResolver(logger)//

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
@@ -71,8 +71,9 @@ public class VintageDiscoverer {
 		return asList( //
 			new ClasspathRootSelectorResolver(classNamePredicate), //
 			new PackageNameSelectorResolver(classNamePredicate), //
-			new ModulepathSelectorResolver(classNamePredicate), //
 			new ModuleNameSelectorResolver(classNamePredicate), //
+			new ModulePathSelectorResolver(classNamePredicate), //
+			new ModuleFinderSelectorResolver(classNamePredicate), //
 			new ClassSelectorResolver(), //
 			new MethodSelectorResolver(), //
 			new UniqueIdSelectorResolver(logger)//

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ModuleTestFinder.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ModuleTestFinder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+public class ModuleTestFinder implements ModuleClassFinder {
+
+	@Test
+	void test() {
+	}
+
+	@Override
+	public List<Class<?>> findAllClassesInModule(String moduleName, Predicate<Class<?>> classTester,
+			Predicate<String> classNameFilter) {
+		return Collections.singletonList(getClass());
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ModuleTestFinder.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ModuleTestFinder.java
@@ -10,21 +10,24 @@
 
 package org.junit.platform.commons.util;
 
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
-
-import org.junit.jupiter.api.Test;
 
 public class ModuleTestFinder implements ModuleClassFinder {
 
-	@Test
-	void test() {
+	@Override
+	public List<Class<?>> findAllClassesInModule(ClassFilter filter, String moduleName) {
+		return Collections.singletonList(getClass());
 	}
 
 	@Override
-	public List<Class<?>> findAllClassesInModule(String moduleName, Predicate<Class<?>> classTester,
-			Predicate<String> classNameFilter) {
+	public List<Class<?>> findAllClassesOnModulePath(ClassFilter filter) {
+		return Collections.singletonList(getClass());
+	}
+
+	@Override
+	public List<Class<?>> findAllClassesOnModulePath(ClassFilter filter, ClassLoader loader, Path... entries) {
 		return Collections.singletonList(getClass());
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ModuleUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ModuleUtilsTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ModuleUtils}.
+ *
+ * @since 1.1
+ */
+class ModuleUtilsTests {
+
+	@Test
+	void loadsTestFinder() {
+		List<Class<?>> classes = ModuleUtils.findAllClassesInModule("*", __ -> true, __ -> true);
+		assertTrue(classes.size() > 0);
+		assertEquals(1, classes.stream().filter(type -> type == ModuleTestFinder.class).count());
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ModuleUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ModuleUtilsTests.java
@@ -26,7 +26,8 @@ class ModuleUtilsTests {
 
 	@Test
 	void loadsTestFinder() {
-		List<Class<?>> classes = ModuleUtils.findAllClassesInModule("*", __ -> true, __ -> true);
+		ClassFilter filter = ClassFilter.of(__ -> true, __ -> true);
+		List<Class<?>> classes = ModuleUtils.findAllClassesInModule(filter, "?");
 		assertTrue(classes.size() > 0);
 		assertEquals(1, classes.stream().filter(type -> type == ModuleTestFinder.class).count());
 	}

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
@@ -54,4 +54,20 @@ class ConsoleLauncherIntegrationTests {
 		);
 	}
 
+	@Test
+	void executeSelectingModuleNames() {
+		String[] args1 = { "-e", "junit-jupiter", "-o", "java.base" };
+		assertEquals(0, new ConsoleLauncherWrapper().execute(args1).getTestsFoundCount());
+		String[] args2 = { "-e", "junit-jupiter", "--select-module", "java.base" };
+		assertEquals(0, new ConsoleLauncherWrapper().execute(args2).getTestsFoundCount());
+	}
+
+	@Test
+	void executeScanModulePath() {
+		String[] args1 = { "-e", "junit-jupiter", "--scan-module-path" };
+		assertEquals(0, new ConsoleLauncherWrapper().execute(args1).getTestsFoundCount());
+		String[] args2 = { "-e", "junit-jupiter", "--scan-modulepath" };
+		assertEquals(0, new ConsoleLauncherWrapper().execute(args2).getTestsFoundCount());
+	}
+
 }

--- a/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
@@ -63,6 +63,9 @@ class JOptSimpleCommandLineOptionsParserTests {
 			() -> assertEquals(Optional.empty(), options.getReportsDir()),
 			() -> assertEquals(emptyList(), options.getSelectedUris()),
 			() -> assertEquals(emptyList(), options.getSelectedFiles()),
+			() -> assertEquals(emptyList(), options.getSelectedModules()),
+			() -> assertEquals(emptyList(), options.getSelectedPackages()),
+			() -> assertEquals(emptyList(), options.getSelectedMethods()),
 			() -> assertEquals(emptyList(), options.getSelectedDirectories()),
 			() -> assertEquals(emptyList(), options.getSelectedClasspathEntries()),
 			() -> assertEquals(emptyMap(), options.getConfigurationParameters())
@@ -347,6 +350,26 @@ class JOptSimpleCommandLineOptionsParserTests {
 	@Test
 	void parseInvalidDirectorySelectors() {
 		assertOptionWithMissingRequiredArgumentThrowsException("-d", "--select-directory");
+	}
+
+	@Test
+	void parseValidModuleSelectors() {
+		// @formatter:off
+		assertAll(
+				() -> assertEquals(singletonList("com.acme.foo"), parseArgLine("-o com.acme.foo").getSelectedModules()),
+				() -> assertEquals(singletonList("com.acme.foo"), parseArgLine("--o com.acme.foo").getSelectedModules()),
+				() -> assertEquals(singletonList("com.acme.foo"), parseArgLine("-select-module com.acme.foo").getSelectedModules()),
+				() -> assertEquals(singletonList("com.acme.foo"), parseArgLine("-select-module=com.acme.foo").getSelectedModules()),
+				() -> assertEquals(singletonList("com.acme.foo"), parseArgLine("--select-module com.acme.foo").getSelectedModules()),
+				() -> assertEquals(singletonList("com.acme.foo"), parseArgLine("--select-module=com.acme.foo").getSelectedModules()),
+				() -> assertEquals(asList("com.acme.foo", "com.example.bar"), parseArgLine("-o com.acme.foo -o com.example.bar").getSelectedModules())
+		);
+		// @formatter:on
+	}
+
+	@Test
+	void parseInvalidModuleSelectors() {
+		assertOptionWithMissingRequiredArgumentThrowsException("-o", "--select-module");
 	}
 
 	@Test

--- a/platform-tests/src/test/resources/META-INF/services/org.junit.platform.commons.util.ModuleClassFinder
+++ b/platform-tests/src/test/resources/META-INF/services/org.junit.platform.commons.util.ModuleClassFinder
@@ -1,0 +1,1 @@
+org.junit.platform.commons.util.ModuleTestFinder


### PR DESCRIPTION
## Overview

This PR prepares the support for selecting Java 9 modules for test discovery.

Basic idea: publish a `String`-based service providing interface for naming module(s) of interest and let an explicit module register a service implementation for actually finding classes in the module graph at runtime. This service implementation should be hosted in a different (sub-) project, like `junit-platform-commons-jpms`. See #1057 

At runtime, using Java 9, the user can add the `org.junit.platform.commons.jpms` module to the module-path and specify which module he wants to test. The `mods` directory contains the JUnit 5 artifacts (loaded as automatic modules), the `org.junit.platform.commons.jpms` module, the application modules (tested objects), and the test modules (classes with `@Test` annotated methods):

```
java
--module-path
  mods
--add-modules
  ALL-MODULE-PATH
--module
  org.junit.platform.console
--select-module
  jpms.integration
```

## New Console Launcher Options

- `--scan-module-path`
Scan all modules on the runtime boot module-path for test discovery.
See http://mail.openjdk.java.net/pipermail/jigsaw-dev/2017-September/013180.html for details.

- `-o` or `--select-module` with single argument `<module name>`
Select single module for test discovery. This option can be repeated.
Same runtime boot module-path as above, but only the test classes of the named modules are selected.

## TODO

- [ ] Add an option handle to (console) launcher that parses an list of paths like `--scan-module-path [entry1[:entry_n]]` and delegates to the `ModuleFinderSelector`
See http://download.java.net/java/jdk9/docs/api/java/lang/module/ModuleFinder.html

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
