### PR TITLE
Use module descriptor for artifact and version information retrieval

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.1.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.1.0-M1.adoc
@@ -28,7 +28,9 @@ on GitHub.
   declaring a custom _display name_ for a test suite.
   - Supported by the `JUnitPlatform` runner for JUnit 4 in the `junit-platform-runner`
     module.
-
+* When running on Java 9 or higher the default implementations of `getVersion()` and
+  `getArtifactId()` in the interface `TestEngine` ask the Java Platform Module System
+  for these information.
 
 [[release-notes-5.1.0-junit-jupiter]]
 ==== JUnit Jupiter

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -378,6 +378,87 @@ public final class ReflectionUtils {
 	}
 
 	/**
+	 * Determine if the current Java runtime supports the Java Platform Module System.
+	 *
+	 * @return {@code true} if the Java Platform Module System is available, otherwise {@code false}
+	 */
+	public static boolean isJavaPlatformModuleSystemAvailable() {
+		try {
+			Class.forName("java.lang.Module");
+			return true;
+		}
+		catch (ClassNotFoundException expected) {
+			return false;
+		}
+	}
+
+	/**
+	 * Chain-call named methods starting on the passed-in root object.
+	 *
+	 * <p>If any {@link JUnitException} is caught while processing the chain of method
+	 * invocations the given defaultValue is returned immediately.
+	 *
+	 * @param defaultValue this value is returned if any {@link JUnitException} is caught
+	 * @param root the initial instance to invoke the first method on; never {@code null}
+	 * @param names the method names to invoke; never {@code null}
+	 * @return the return value of the last method call
+	 * @see #invokeGetters(Object, String...)
+	 * @see Class#getMethod(String, Class[])
+	 */
+	@SuppressWarnings("unchecked")
+	public static <V> V invokeGetters(V defaultValue, Object root, String... names) {
+		try {
+			return (V) invokeGetters(root, names);
+		}
+		catch (JUnitException e) {
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Chain-call named methods starting on the passed-in root object.
+	 *
+	 * <p>Each name of must point to a no-arg method that is a public member method of the
+	 * class or interface represented by its {@link Class} object.
+	 *
+	 * <p>Each method is invoked on the return value of the previous method invocation. If
+	 * an intermediate return value is {@code null} an {@link JUnitException} is thrown.
+	 *
+	 * <p>Example:
+	 * <pre><code>
+	 * invokeGetters(new Object(), "getClass", "getSimpleName", "toString") yields "Object"
+	 * </code></pre>
+	 *
+	 * @param root the initial instance to invoke the first method on; never {@code null}
+	 * @param names the method names to invoke; never {@code null}
+	 * @return the return value of the last method call
+	 * @throws JUnitException if any intermediate return value is {@code null} or a
+	 * {@link ReflectiveOperationException} is caught
+	 * @see Class#getMethod(String, Class[])
+	 */
+	public static Object invokeGetters(Object root, String... names) {
+		Preconditions.notNull(root, "Root object must not be null");
+		Preconditions.notEmpty(names, "names array must not be null or empty");
+		Preconditions.containsNoNullElements(names, "individual names must not be null");
+		Object object = root;
+		for (String name : names) {
+			try {
+				if (object == null) {
+					throw new JUnitException(String.format("Can not invoke method [%s] on null", name));
+				}
+				object = object.getClass().getMethod(name).invoke(object);
+			}
+			catch (ReflectiveOperationException e) {
+				throw new JUnitException(
+					String.format("Failed to find or invoke method named [%s] in class [%s] for [%s] with root = [%s]",
+						name, object.getClass(), object, root),
+					e);
+			}
+		}
+		return object;
+	}
+
+	/**
 	 * @see org.junit.platform.commons.support.ReflectionSupport#invokeMethod(Method, Object, Object...)
 	 */
 	public static Object invokeMethod(Method method, Object target, Object... args) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestEngine.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestEngine.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.PackageUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
  * A {@code TestEngine} facilitates <em>discovery</em> and <em>execution</em> of
@@ -126,6 +127,10 @@ public interface TestEngine {
 	 * <p>Concrete test engine implementations may override this method in
 	 * order to determine the artifact ID by some other means.
 	 *
+	 * <p>implNote: Since JUnit Platform version 1.1 this default implementation
+	 * returns the "module name" stored in the module (modular jar on the
+	 * module-path) of this test engine.
+	 *
 	 * @return an {@code Optional} containing the artifact ID; never
 	 * {@code null} but potentially empty if the artifact ID is unknown
 	 * @see Class#getPackage()
@@ -134,6 +139,10 @@ public interface TestEngine {
 	 * @see #getVersion()
 	 */
 	default Optional<String> getArtifactId() {
+		if (ReflectionUtils.isJavaPlatformModuleSystemAvailable()) {
+			String[] getters = { "getModule", "getDescriptor", "name" };
+			return Optional.of(String.valueOf(ReflectionUtils.invokeGetters(getClass(), getters)));
+		}
 		return PackageUtils.getAttribute(getClass(), Package::getImplementationTitle);
 	}
 
@@ -159,6 +168,10 @@ public interface TestEngine {
 	 * <p>Concrete test engine implementations may override this method to
 	 * determine the version by some other means.
 	 *
+	 * <p>implNote: Since JUnit Platform version 1.1 this default implementation
+	 * honors the "raw version" information stored in the module (modular jar
+	 * on the module-path) of this test engine.
+	 *
 	 * @return an {@code Optional} containing the version; never {@code null}
 	 * but potentially empty if the version is unknown
 	 * @see Class#getPackage()
@@ -171,8 +184,12 @@ public interface TestEngine {
 		if (standalone.isPresent()) {
 			return standalone;
 		}
-		return Optional.of(
-			PackageUtils.getAttribute(getClass(), Package::getImplementationVersion).orElse("DEVELOPMENT"));
+		String fallback = "DEVELOPMENT";
+		if (ReflectionUtils.isJavaPlatformModuleSystemAvailable()) {
+			String[] getters = { "getModule", "getDescriptor", "rawVersion" };
+			return ReflectionUtils.invokeGetters(Optional.of(fallback), getClass(), getters);
+		}
+		return Optional.of(PackageUtils.getAttribute(getClass(), Package::getImplementationVersion).orElse(fallback));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.BOTTOM_UP;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethod;
@@ -1002,6 +1003,31 @@ class ReflectionUtilsTests {
 		for (Method method : PublicClass.class.getMethods()) {
 			assertFalse(ReflectionUtils.isGeneric(method));
 		}
+	}
+
+	@Test
+	void isJavaPlatformModuleSystemAvailable() {
+		boolean expected;
+		try {
+			Class.forName("java.lang.Module");
+			expected = true;
+		}
+		catch (ClassNotFoundException e) {
+			expected = false;
+		}
+		assertEquals(expected, ReflectionUtils.isJavaPlatformModuleSystemAvailable());
+	}
+
+	@Test
+	void invokeGetters() {
+		assertEquals(getClass().getSimpleName(), ReflectionUtils.invokeGetters(this, "getClass", "getSimpleName"));
+	}
+
+	@Test
+	void invokeGettersWithJavaPlatformModuleSystemAvailable() {
+		assumeTrue(ReflectionUtils.isJavaPlatformModuleSystemAvailable());
+		assertEquals("java.base", ReflectionUtils.invokeGetters(Class.class, "getModule", "getName"));
+		assertEquals("java.base", ReflectionUtils.invokeGetters(9, "getClass", "getModule", "getName"));
 	}
 
 	private static void createDirectories(Path... paths) throws IOException {


### PR DESCRIPTION
## Overview

Use module descriptor for artifact and version information retrieval, if the Java Platform Module System in available on the current runtime.

Closes #600

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
