### PR TITLE
Simplify Jupiter filtering

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/DiscoveryFilterApplier.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/DiscoveryFilterApplier.java
@@ -10,90 +10,37 @@
 
 package org.junit.jupiter.engine;
 
-import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor;
-import org.junit.platform.engine.EngineDiscoveryRequest;
-import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.discovery.ClassNameFilter;
-import org.junit.platform.engine.discovery.PackageNameFilter;
 
 /**
- * Class for applying all {@link org.junit.platform.engine.DiscoveryFilter}s to all
- * children of a {@link TestDescriptor}.
+ * Class for applying filters to all children of a {@link TestDescriptor}.
  *
  * @since 5.0
  */
 class DiscoveryFilterApplier {
 
-	/**
-	 * Apply all filters. Currently only {@link ClassNameFilter} is considered.
-	 */
-	void applyAllFilters(EngineDiscoveryRequest discoveryRequest, TestDescriptor engineDescriptor) {
-		applyClassNameFilters(discoveryRequest.getFiltersByType(ClassNameFilter.class), engineDescriptor);
-		applyPackageNameFilters(discoveryRequest.getFiltersByType(PackageNameFilter.class), engineDescriptor);
-	}
-
-	private void applyPackageNameFilters(List<PackageNameFilter> packageNameFilters, TestDescriptor engineDescriptor) {
-		if (packageNameFilters.isEmpty()) {
-			return;
-		}
-		TestDescriptor.Visitor filteringVisitor = descriptor -> {
-			if (descriptor instanceof ClassTestDescriptor) {
-				if (!includePackage((ClassTestDescriptor) descriptor, packageNameFilters)) {
-					descriptor.removeFromHierarchy();
-				}
-			}
-		};
-		engineDescriptor.accept(filteringVisitor);
-	}
-
-	private boolean includePackage(ClassTestDescriptor classTestDescriptor,
-			List<PackageNameFilter> packageNameFilters) {
-
-		// Nested Tests are never filtered out
-		if (classTestDescriptor instanceof NestedClassTestDescriptor) {
-			return true;
-		}
-
-		Class<?> testClass = classTestDescriptor.getTestClass();
-
-		// @formatter:off
-		return (packageNameFilters.stream()
-				.map(filter -> filter.apply(testClass.getPackage().getName()))
-				.noneMatch(FilterResult::excluded));
-		// @formatter:on
-	}
-
-	private void applyClassNameFilters(List<ClassNameFilter> classNameFilters, TestDescriptor engineDescriptor) {
-		if (classNameFilters.isEmpty()) {
-			return;
-		}
+	void applyClassNamePredicate(Predicate<String> classNamePredicate, TestDescriptor engineDescriptor) {
 		TestDescriptor.Visitor filteringVisitor = descriptor -> {
 			if (descriptor instanceof ClassTestDescriptor
-					&& !includeClass((ClassTestDescriptor) descriptor, classNameFilters)) {
+					&& !includeClass((ClassTestDescriptor) descriptor, classNamePredicate)) {
 				descriptor.removeFromHierarchy();
 			}
 		};
 		engineDescriptor.accept(filteringVisitor);
 	}
 
-	private boolean includeClass(ClassTestDescriptor classTestDescriptor, List<ClassNameFilter> classNameFilters) {
+	private boolean includeClass(ClassTestDescriptor classTestDescriptor, Predicate<String> classNamePredicate) {
 
 		// Nested Tests are never filtered out
 		if (classTestDescriptor instanceof NestedClassTestDescriptor) {
 			return true;
 		}
 
-		Class<?> testClass = classTestDescriptor.getTestClass();
-
-		// @formatter:off
-		return classNameFilters.stream()
-				.map(filter -> filter.apply(testClass.getName()))
-				.noneMatch(FilterResult::excluded);
-		// @formatter:on
+		return classNamePredicate.test(classTestDescriptor.getTestClass().getName());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/JupiterTestEngine.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/JupiterTestEngine.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
@@ -22,6 +23,7 @@ import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.filter.ClasspathScanningSupport;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine;
 
 /**
@@ -71,7 +73,8 @@ public final class JupiterTestEngine extends HierarchicalTestEngine<JupiterEngin
 
 	private void applyDiscoveryFilters(EngineDiscoveryRequest discoveryRequest,
 			JupiterEngineDescriptor engineDescriptor) {
-		new DiscoveryFilterApplier().applyAllFilters(discoveryRequest, engineDescriptor);
+		Predicate<String> classNamePredicate = ClasspathScanningSupport.buildClassNamePredicate(discoveryRequest);
+		new DiscoveryFilterApplier().applyClassNamePredicate(classNamePredicate, engineDescriptor);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/JupiterTestEngine.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/JupiterTestEngine.java
@@ -13,7 +13,6 @@ package org.junit.jupiter.engine;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
@@ -23,7 +22,6 @@ import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.filter.ClasspathScanningSupport;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine;
 
 /**
@@ -60,21 +58,8 @@ public final class JupiterTestEngine extends HierarchicalTestEngine<JupiterEngin
 	@Override
 	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
 		JupiterEngineDescriptor engineDescriptor = new JupiterEngineDescriptor(uniqueId);
-		resolveDiscoveryRequest(discoveryRequest, engineDescriptor);
+		new DiscoverySelectorResolver().resolveSelectors(discoveryRequest, engineDescriptor);
 		return engineDescriptor;
-	}
-
-	private void resolveDiscoveryRequest(EngineDiscoveryRequest discoveryRequest,
-			JupiterEngineDescriptor engineDescriptor) {
-		DiscoverySelectorResolver resolver = new DiscoverySelectorResolver();
-		resolver.resolveSelectors(discoveryRequest, engineDescriptor);
-		applyDiscoveryFilters(discoveryRequest, engineDescriptor);
-	}
-
-	private void applyDiscoveryFilters(EngineDiscoveryRequest discoveryRequest,
-			JupiterEngineDescriptor engineDescriptor) {
-		Predicate<String> classNamePredicate = ClasspathScanningSupport.buildClassNamePredicate(discoveryRequest);
-		new DiscoveryFilterApplier().applyClassNamePredicate(classNamePredicate, engineDescriptor);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoveryFilterApplier.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoveryFilterApplier.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.jupiter.engine;
+package org.junit.jupiter.engine.discovery;
 
 import java.util.function.Predicate;
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -44,8 +44,14 @@ public class DiscoverySelectorResolver {
 	private static final IsScannableTestClass isScannableTestClass = new IsScannableTestClass();
 
 	public void resolveSelectors(EngineDiscoveryRequest request, TestDescriptor engineDescriptor) {
-		JavaElementsResolver javaElementsResolver = createJavaElementsResolver(engineDescriptor);
 		ClassFilter classFilter = buildClassFilter(request, isScannableTestClass);
+		resolve(request, engineDescriptor, classFilter);
+		filter(engineDescriptor, classFilter);
+		pruneTree(engineDescriptor);
+	}
+
+	private void resolve(EngineDiscoveryRequest request, TestDescriptor engineDescriptor, ClassFilter classFilter) {
+		JavaElementsResolver javaElementsResolver = createJavaElementsResolver(engineDescriptor);
 
 		request.getSelectorsByType(ClasspathRootSelector.class).forEach(selector -> {
 			findAllClassesInClasspathRoot(selector.getClasspathRoot(), classFilter).forEach(
@@ -63,7 +69,10 @@ public class DiscoverySelectorResolver {
 		request.getSelectorsByType(UniqueIdSelector.class).forEach(selector -> {
 			javaElementsResolver.resolveUniqueId(selector.getUniqueId());
 		});
-		pruneTree(engineDescriptor);
+	}
+
+	private void filter(TestDescriptor engineDescriptor, ClassFilter classFilter) {
+		new DiscoveryFilterApplier().applyClassNamePredicate(classFilter::match, engineDescriptor);
 	}
 
 	private void pruneTree(TestDescriptor rootDescriptor) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryFilterApplierTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryFilterApplierTests.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.jupiter.engine;
+package org.junit.jupiter.engine.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.engine.descriptor.TestDescriptorBuilder.classTestDescriptor;


### PR DESCRIPTION
This PR includes two refactorings:

- Reuse ClasspathScanningSupport to simplify DiscoveryFilterApplier
- Use same ClassFilter for classpath scanning and post-discovery filtering

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [X] ~Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass