### PR TITLE
Fix compile errors in Eclipse.

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -55,7 +55,7 @@ class DynamicContainerTestDescriptor extends JupiterTestDescriptor {
 		AtomicInteger index = new AtomicInteger(1);
 		try (Stream<? extends DynamicNode> children = dynamicContainer.getChildren()) {
 			// @formatter:off
-			children.peek(child -> Preconditions.notNull(child, "individual dynamic node must not be null"))
+			children.peek(child -> Preconditions.<DynamicNode>notNull(child, "individual dynamic node must not be null"))
 					.map(child -> toDynamicDescriptor(index.getAndIncrement(), child))
 					.forEachOrdered(dynamicTestExecutor::execute);
 			// @formatter:on

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -49,7 +49,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 				.stream()
 				.map(ArgumentsSource::value)
 				.map(ReflectionUtils::newInstance)
-				.map(provider -> AnnotationConsumerInitializer.initialize(templateMethod, provider))
+				.map(provider -> AnnotationConsumerInitializer.<ArgumentsProvider>initialize(templateMethod, provider))
 				.flatMap(provider -> arguments(provider, context))
 				.map(Arguments::get)
 				.map(arguments -> createInvocationContext(formatter, arguments))

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/Preconditions.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/Preconditions.java
@@ -220,7 +220,7 @@ public final class Preconditions {
 			throws PreconditionViolationException {
 
 		if (collection != null) {
-			collection.forEach(object -> notNull(object, messageSupplier));
+			collection.forEach((Object object) -> notNull(object, messageSupplier));
 		}
 		return collection;
 	}


### PR DESCRIPTION
## Overview
Fix compile errors in Eclipse. Eclipse uses a different compiler, which is sometimes better--
but sometimes worse--at inferring arguments.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
