### PR TITLE
Display name for @ParameterizedTest should only include consumed arguments

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.util.AnnotationUtils.findRepeatableAnno
 import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
@@ -52,6 +53,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 				.map(provider -> AnnotationConsumerInitializer.initialize(templateMethod, provider))
 				.flatMap(provider -> arguments(provider, context))
 				.map(Arguments::get)
+				.map(arguments -> consumedArguments(arguments, templateMethod))
 				.map(arguments -> createInvocationContext(formatter, arguments))
 				.peek(invocationContext -> invocationCount.incrementAndGet())
 				.onClose(() ->
@@ -81,6 +83,11 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 		catch (Exception e) {
 			throw ExceptionUtils.throwAsUncheckedException(e);
 		}
+	}
+
+	private Object[] consumedArguments(Object[] arguments, Method templateMethod) {
+		int parametersCount = templateMethod.getParameterCount();
+		return arguments.length > parametersCount ? Arrays.copyOf(arguments, parametersCount) : arguments;
 	}
 
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -59,7 +59,7 @@ class ParameterizedTestIntegrationTests {
 	@Test
 	void executesWithSingleArgumentsProviderWithMultipleInvocations() {
 		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(TestCase.class, "testWithTwoSingleStringArgumentsProvider", String.class.getName()));
+			selectMethod(TestCase.class, "testWithTwoSingleStringArgumentsProvider", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
 				.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
@@ -68,7 +68,7 @@ class ParameterizedTestIntegrationTests {
 	@Test
 	void executesWithCsvSource() {
 		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(TestCase.class, "testWithCsvSource", String.class.getName()));
+			selectMethod(TestCase.class, "testWithCsvSource", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
 				.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
@@ -77,7 +77,7 @@ class ParameterizedTestIntegrationTests {
 	@Test
 	void executesWithCustomName() {
 		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(TestCase.class, "testWithCustomName", String.class.getName() + "," + Integer.TYPE.getName()));
+			selectMethod(TestCase.class, "testWithCustomName", String.class.getName() + "," + Integer.TYPE.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("foo and 23"), finishedWithFailure(message("foo, 23")))) //
 				.haveExactly(1, event(test(), displayName("bar and 42"), finishedWithFailure(message("bar, 42"))));
@@ -86,7 +86,7 @@ class ParameterizedTestIntegrationTests {
 	@Test
 	void executesWithExplicitConverter() {
 		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(TestCase.class, "testWithExplicitConverter", Integer.TYPE.getName()));
+			selectMethod(TestCase.class, "testWithExplicitConverter", Integer.TYPE.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("[1] O"), finishedWithFailure(message("length: 1")))) //
 				.haveExactly(1, event(test(), displayName("[2] XXX"), finishedWithFailure(message("length: 3"))));
@@ -94,8 +94,8 @@ class ParameterizedTestIntegrationTests {
 
 	@Test
 	void executesWithArgumentsSourceProvidingRedundantArguments() {
-		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(RedundantParametersTestCase.class, "testWithTwoRedundantStringArgumentsProvider", String.class.getName()));
+		List<ExecutionEvent> executionEvents = execute(selectMethod(RedundantParametersTestCase.class,
+			"testWithTwoRedundantStringArgumentsProvider", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
 				.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
@@ -103,8 +103,8 @@ class ParameterizedTestIntegrationTests {
 
 	@Test
 	void executesWithCsvSourceContainingRedundantArguments() {
-		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(RedundantParametersTestCase.class, "testWithCsvSourceContainingRedundantArguments", String.class.getName()));
+		List<ExecutionEvent> executionEvents = execute(selectMethod(RedundantParametersTestCase.class,
+			"testWithCsvSourceContainingRedundantArguments", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
 				.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
@@ -112,8 +112,8 @@ class ParameterizedTestIntegrationTests {
 
 	@Test
 	void executesWithCsvFileSourceContainingRedundantArguments() {
-		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(RedundantParametersTestCase.class, "testWithCsvFileSourceContainingRedundantArguments", String.class.getName()));
+		List<ExecutionEvent> executionEvents = execute(selectMethod(RedundantParametersTestCase.class,
+			"testWithCsvFileSourceContainingRedundantArguments", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
 				.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
@@ -121,8 +121,8 @@ class ParameterizedTestIntegrationTests {
 
 	@Test
 	void executesWithMethodSourceProvidingRedundantArguments() {
-		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(RedundantParametersTestCase.class, "testWithMethodSourceProvidingRedundantArguments", String.class.getName()));
+		List<ExecutionEvent> executionEvents = execute(selectMethod(RedundantParametersTestCase.class,
+			"testWithMethodSourceProvidingRedundantArguments", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
 				.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
@@ -169,10 +169,10 @@ class ParameterizedTestIntegrationTests {
 	@Test
 	void failsContainerOnEmptyName() {
 		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(TestCase.class, "testWithEmptyName", String.class.getName()));
+			selectMethod(TestCase.class, "testWithEmptyName", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(container(), displayName("testWithEmptyName(String)"), //
-						finishedWithFailure(message(value -> value.contains("must be declared with a non-empty name")))));
+					finishedWithFailure(message(value -> value.contains("must be declared with a non-empty name")))));
 	}
 
 	private List<ExecutionEvent> execute(DiscoverySelector... selectors) {


### PR DESCRIPTION
Redundant arguments are filtered out in `ParameterizedTestExtension`, so only consumed arguments are passed to invocation context and used in name formatter. Filtering is applied only when number of arguments is greater than number of test method parameters. It should work with other extensions like parameter resolvers - when there are eg. 3 columns provided and only 2 test method parameters consumes them and the 3rd one is resolved by another extension, then exception about incorrect configuration will be thrown.

Please notice that some unchanged code in `ParameterizedTestIntegrationTests.java` is reformatted. I used formatter from `junit5/src/eclipse` and assume it was formatted incorrectly before. If it was correct, please let me know and I'll revert those changes.