### PR TITLE
Translate `--scan-module-path` into multiple module selectors

### DIFF
--- a/junit-platform-commons-java-9/src/test/java/org/junit/platform/commons/util/ModuleUtilsTests.java
+++ b/junit-platform-commons-java-9/src/test/java/org/junit/platform/commons/util/ModuleUtilsTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.module.ModuleDescriptor;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,14 @@ class ModuleUtilsTests {
 	}
 
 	@Test
-	void find() {
+	void findAllNonSystemBootModuleNames() {
+		Set<String> moduleNames = ModuleUtils.findAllNonSystemBootModuleNames();
+
+		assertTrue(moduleNames.isEmpty());
+	}
+
+	@Test
+	void findAllClassesInModule() {
 		ClassFilter modular = ClassFilter.of(name -> name.contains("Module"), type -> true);
 		List<Class<?>> classes = ModuleUtils.findAllClassesInModule("java.base", modular);
 		assertFalse(classes.isEmpty());

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleUtils.java
@@ -10,10 +10,12 @@
 
 package org.junit.platform.commons.util;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.logging.Logger;
@@ -39,12 +41,18 @@ public class ModuleUtils {
 	 */
 	public static final String VERSION = "base";
 
-	/**
-	 * Special module name to scan all resolved modules found in the boot layer configuration.
-	 */
-	public static final String ALL_MODULES = "ALL-MODULES";
-
 	private static final Logger logger = LoggerFactory.getLogger(ModuleUtils.class);
+
+	/**
+	 * Find all non-system boot modules names.
+	 *
+	 * @return a set of all such module names; never {@code null} but
+	 * potentially empty
+	 */
+	public static Set<String> findAllNonSystemBootModuleNames() {
+		logger.config(() -> "Basic version of findAllNonSystemBootModuleNames() always returns an empty set!");
+		return emptySet();
+	}
 
 	/**
 	 * Find all classes for the given module name.
@@ -56,6 +64,6 @@ public class ModuleUtils {
 	 */
 	public static List<Class<?>> findAllClassesInModule(String moduleName, ClassFilter filter) {
 		logger.config(() -> "Basic version of findAllClassesInModule() always returns an empty list!");
-		return Collections.emptyList();
+		return emptyList();
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
@@ -13,6 +13,7 @@ package org.junit.platform.console.tasks;
 import static org.junit.platform.engine.discovery.ClassNameFilter.excludeClassNamePatterns;
 import static org.junit.platform.engine.discovery.ClassNameFilter.includeClassNamePatterns;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClasspathRoots;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectModules;
 import static org.junit.platform.engine.discovery.PackageNameFilter.excludePackageNames;
 import static org.junit.platform.engine.discovery.PackageNameFilter.includePackageNames;
 import static org.junit.platform.launcher.EngineFilter.excludeEngines;
@@ -23,7 +24,6 @@ import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.r
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,8 +60,7 @@ class DiscoveryRequestCreator {
 		if (options.isScanModulepath()) {
 			Preconditions.condition(!options.hasExplicitSelectors(),
 				"Scanning the module-path and using explicit selectors at the same time is not supported");
-			return Collections.singletonList(DiscoverySelectors.selectModule(ModuleUtils.ALL_MODULES));
-
+			return selectModules(ModuleUtils.findAllNonSystemBootModuleNames());
 		}
 		return createExplicitDiscoverySelectors(options);
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -256,6 +256,27 @@ public final class DiscoverySelectors {
 	}
 
 	/**
+	 * Create a list of {@code ModuleSelectors} for the supplied module names.
+	 *
+	 * <p>The unnamed module is not supported.
+	 *
+	 * @param moduleNames the module names to select; never {@code null}, never
+	 * containing {@code null} or blank
+	 * @see ModuleSelector
+	 */
+	@API(status = EXPERIMENTAL, since = "1.1")
+	public static List<ModuleSelector> selectModules(Set<String> moduleNames) {
+		Preconditions.notNull(moduleNames, "moduleNames must not be null");
+
+		// @formatter:off
+		return moduleNames.stream()
+				.map(DiscoverySelectors::selectModule)
+				// unmodifiable since this is a public, non-internal method
+				.collect(toUnmodifiableList());
+		// @formatter:on
+	}
+
+	/**
 	 * Create a {@code PackageSelector} for the supplied package name.
 	 *
 	 * <p>The default package is represented by an empty string ({@code ""}).


### PR DESCRIPTION
Fixes #1115

## Overview

Please describe your changes here and list any open questions you might have.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [X] ~Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
