### PR TITLE
Add --select-module support to Gradle JUnitPlatformPlugin

### DIFF
--- a/documentation/src/docs/asciidoc/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/running-tests.adoc
@@ -166,6 +166,8 @@ junitPlatform {
 		method 'com.example.app.Application#run(java.lang.String[])' <6>
 		resources '/bar.csv', '/foo/input.json'
 		resource '/com/acme/my.properties' <7>
+		modules 'foo', 'bar'
+		module 'baz' <8>
 	}
 	// ...
 }
@@ -177,6 +179,7 @@ junitPlatform {
 <5> Classes, fully qualified class names
 <6> Methods, fully qualified method names (see {DiscoverySelectors_selectMethod})
 <7> Classpath resources
+<8> Module names
 
 [[running-tests-build-gradle-filters]]
 ===== Configuring Filters

--- a/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
+++ b/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
@@ -52,6 +52,11 @@ processResources {
 	}
 }
 
+compileGroovy.doLast {
+	// Enable JAR manifest generation
+	parent.generateManifest = true
+}
+
 jar {
 	manifest {
 		attributes(

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformExtension.groovy
@@ -93,6 +93,12 @@ class JUnitPlatformExtension {
 	 */
 	Details details = Details.NONE
 
+	/**
+	 * Whether or not the JPMS (Jigsaw) {@code --module-path} should be enabled.
+	 *
+	 * <p>Defaults to {@code false}.
+	 */
+	boolean enableModulePath = false
 
 	/**
 	 * Configure the {@link SelectorsExtension} for this plugin.

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -126,7 +126,8 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 					'--add-modules',
 					'ALL-MODULE-PATH'
 				]
-				classpath = []
+				classpath = files()
+				main = ConsoleLauncher.class.getModule().getName()
 			} else {
 				// Build the classpath from the user's test runtime classpath and the JUnit
 				// Platform modules.
@@ -136,8 +137,8 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 				// via the junitPlatform configuration... leading to zero code coverage for
 				// the respective modules.
 				classpath = project.sourceSets.test.runtimeClasspath + project.configurations.junitPlatform
+				main = ConsoleLauncher.class.getName()
 			}
-			main = ConsoleLauncher.class.getName()
 			args buildArgs(project, junitExtension, reportsDir)
 		}
 	}

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -119,15 +119,18 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 			configureTaskDependencies(project, it, junitExtension)
 
 			if (junitExtension.enableModulePath) {
-				// Set module-path and clear classpath.
+				// Set module-path and clear classpath and main class.
 				jvmArgs = [
 					'--module-path',
-					project.sourceSets.test.runtimeClasspath + project.configurations.junitPlatform,
+					project.files(project.sourceSets.test.runtimeClasspath, project.configurations.junitPlatform).asPath,
 					'--add-modules',
-					'ALL-MODULE-PATH'
+					'ALL-MODULE-PATH',
+					//'--module',
+					//'org.junit.platform.console' ... args will cover that
 				]
-				classpath = files()
-				main = ConsoleLauncher.class.getModule().getName()
+
+				classpath = project.files()
+				main = ""
 			} else {
 				// Build the classpath from the user's test runtime classpath and the JUnit
 				// Platform modules.
@@ -155,6 +158,10 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 	private List<String> buildArgs(project, junitExtension, reportsDir) {
 
 		def args = []
+
+		if (junitExtension.enableModulePath) {
+			args.addAll('--module', 'org.junit.platform.console')
+		}
 
 		if (junitExtension.details) {
 			args.add('--details')
@@ -205,7 +212,7 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 		def selectors = junitExtension.selectors
 		if (selectors.empty) {
 			if (junitExtension.enableModulePath) {
-				args '--scan-module-path'
+				args.add('--scan-module-path')
 				return
 			}
 			def rootDirs = []

--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/SelectorsExtension.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/SelectorsExtension.groovy
@@ -57,6 +57,11 @@ class SelectorsExtension {
 	List<String> resources = []
 
 	/**
+	 * A list of <em>modules</em> that are to be used for test discovery.
+	 */
+	List<String> modules = []
+
+	/**
 	 * Add a <em>URI</em> to be used for test discovery.
 	 */
 	void uri(String uri) {
@@ -154,8 +159,22 @@ class SelectorsExtension {
 		this.resources.addAll resources
 	}
 
+	/**
+	 * Add a <em>module</em> to be used for test discovery.
+	 */
+	void module(String module) {
+		modules(module)
+	}
+
+	/**
+	 * Add one or more <em>modules</em> to be used for test discovery.
+	 */
+	void modules(String... modules) {
+		this.modules.addAll modules
+	}
+
 	protected boolean isEmpty() {
-		return uris.empty && files.empty && directories.empty && packages.empty && classes.empty && methods.empty && resources.empty
+		return uris.empty && files.empty && directories.empty && packages.empty && classes.empty && methods.empty && resources.empty && modules.empty
 	}
 
 }

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -122,6 +122,7 @@ class JUnitPlatformPluginSpec extends Specification {
 			it.method 'com.example.app.Application#run(java.lang.String[])'
 			it.resources '/bar.csv', '/foo/input.json'
 			it.resource '/com/acme/my.properties'
+			it.module 'foo.bar'
 		}
 		junitPlatform.filters {
 			it.includeClassNamePattern '.*Tests?'
@@ -306,6 +307,8 @@ class JUnitPlatformPluginSpec extends Specification {
 				method 'com.example.app.Application#run(java.lang.String[])'
 				resources '/bar.csv', '/foo/input.json'
 				resource '/com/acme/my.properties'
+				modules 'foo', 'bar'
+				module 'baz'
 			}
 		}
 		project.evaluate()
@@ -323,6 +326,7 @@ class JUnitPlatformPluginSpec extends Specification {
 		junitTask.args.containsAll('-c', 'com.acme.Foo', '-c', 'com.acme.Bar', '-c', 'com.example.app.Application')
 		junitTask.args.containsAll('-m', 'com.acme.Foo#a', '-m', 'com.acme.Foo#b', '-m', 'com.example.app.Application#run(java.lang.String[])')
 		junitTask.args.containsAll('-r', '/bar.csv', '-r', '/foo/input.json', '-r', '/com/acme/my.properties')
+		junitTask.args.containsAll('-o', 'foo', '-o', 'bar', '-o', 'baz')
 	}
 
 	def "configuration parameters can be specified"() {


### PR DESCRIPTION
## Overview

Add --select-module support to Gradle JUnitPlatformPlugin.

Test it using jitpack: https://jitpack.io/com/github/junit-team/junit5/issues~1119-gradle-plugin-modules-support-SNAPSHOT/build.log

Closes #1119

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
