### PR TITLE
Update Spotless plugin from 3.5.2 to 3.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 		maven { url 'http://repo.spring.io/plugins-release' }
 	}
 	dependencies {
-		classpath('com.diffplug.spotless:spotless-plugin-gradle:3.5.2')
+		classpath('com.diffplug.spotless:spotless-plugin-gradle:3.6.0')
 		classpath('com.github.ben-manes:gradle-versions-plugin:0.15.0')
 		classpath('io.spring.gradle:propdeps-plugin:0.0.9.RELEASE')
 		classpath('org.ajoberstar:gradle-git-publish:0.3.2-rc.1')


### PR DESCRIPTION
## Overview

Fixes a bug regarding Kotlin files. See the plugin's changelog: https://github.com/diffplug/spotless/blob/master/plugin-gradle/CHANGES.md

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
