### PR TITLE
Ensure stackTraceWriter is always present

### DIFF
--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/JUnitPlatformProvider.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/JUnitPlatformProvider.java
@@ -120,7 +120,6 @@ public class JUnitPlatformProvider extends AbstractProvider {
 		ReporterFactory reporterFactory = parameters.getReporterFactory();
 		try {
 			RunListener runListener = reporterFactory.createReporter();
-			launcher.registerTestExecutionListeners(new RunListenerAdapter(runListener));
 
 			for (Class<?> testClass : testsToRun) {
 				invokeSingleClass(testClass, runListener);
@@ -141,7 +140,7 @@ public class JUnitPlatformProvider extends AbstractProvider {
 				.filters(includeAndExcludeFilters) //
 				.configurationParameters(configurationParameters) //
 				.build();
-		launcher.execute(discoveryRequest);
+		launcher.execute(discoveryRequest, new RunListenerAdapter(testClass, runListener));
 
 		runListener.testSetCompleted(classEntry);
 	}

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
@@ -110,13 +110,18 @@ final class RunListenerAdapter implements TestExecutionListener {
 
 	private Optional<String> getClassName(TestIdentifier testIdentifier) {
 		TestSource testSource = testIdentifier.getSource().orElse(null);
-		if (testSource instanceof ClassSource) {
-			return Optional.of(((ClassSource) testSource).getJavaClass().getName());
+
+		if (testSource != null) {
+			if (testSource instanceof ClassSource) {
+				return Optional.of(((ClassSource) testSource).getJavaClass().getName());
+			}
+			if (testSource instanceof MethodSource) {
+				return Optional.of(((MethodSource) testSource).getClassName());
+			}
 		}
-		if (testSource instanceof MethodSource) {
-			return Optional.of(((MethodSource) testSource).getClassName());
-		}
-		return Optional.empty();
+
+		return testPlan.flatMap(plan -> plan.getParent(testIdentifier))
+			.flatMap(this::getClassName);
 	}
 
 	private Optional<String> getMethodName(TestIdentifier testIdentifier) {

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
@@ -196,7 +196,8 @@ class RunListenerAdapterTests {
 		TestPlan plan = TestPlan.from(Collections.singletonList(new EngineDescriptor(newId(), "Some Plan")));
 		adapter.testPlanExecutionStarted(plan);
 
-		TestIdentifier child = newSourcelessChildIdentifierWithParent(plan, "Parent", ClassSource.from(MyTestClass.class));
+		TestIdentifier child = newSourcelessChildIdentifierWithParent(plan, "Parent",
+			ClassSource.from(MyTestClass.class));
 		adapter.executionFinished(child, TestExecutionResult.failed(new RuntimeException()));
 		ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
 		verify(listener).testError(entryCaptor.capture());
@@ -248,7 +249,8 @@ class RunListenerAdapterTests {
 		return new ClassTestDescriptor(UniqueId.forEngine("class"), MyTestClass.class);
 	}
 
-	private static TestIdentifier newSourcelessChildIdentifierWithParent(TestPlan testPlan, String parentDisplay, TestSource parentTestSource) {
+	private static TestIdentifier newSourcelessChildIdentifierWithParent(TestPlan testPlan, String parentDisplay,
+			TestSource parentTestSource) {
 		// A parent test identifier with a name.
 		TestDescriptor parent = mock(TestDescriptor.class);
 		when(parent.getUniqueId()).thenReturn(newId());


### PR DESCRIPTION
Resolves #1130

## Overview

Maven surefire always assume that a `stackTraceWriter` is present, however `RunListenerAdapter` only provides a value when the `TestIdentifier` has a `ClassSource` or `MethodSource`. To fix this, we traverse the whole test hierarchy to find the appropriate `TestIdentifier`.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
