### PR TITLE
IncludeTags and excludeTags accept empty strings

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.1.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.1.0-M1.adoc
@@ -41,6 +41,7 @@ on GitHub.
 * New console launcher option `--scan-module-path` for selecting all resolved modules
   available on the boot layer configuration.
 * Maven Surefire: Add support for the `redirectTestOutputToFile` feature.
+* Maven Surefire: Add support to accept empty strings in `@IncludeTags` and `@ExcludeTags`.
 
 [[release-notes-5.1.0-junit-jupiter]]
 ==== JUnit Jupiter

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/JUnitPlatformProvider.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/JUnitPlatformProvider.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.apache.maven.surefire.providerapi.AbstractProvider;
 import org.apache.maven.surefire.providerapi.ProviderParameters;
@@ -48,6 +49,7 @@ import org.apache.maven.surefire.testset.TestSetFailedException;
 import org.apache.maven.surefire.util.TestsToRun;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -182,8 +184,9 @@ public class JUnitPlatformProvider extends AbstractProvider {
 	private Optional<List<String>> getPropertiesList(String key) {
 		List<String> compoundProperties = null;
 		String property = parameters.getProviderProperties().get(key);
-		if (property != null) {
-			compoundProperties = Arrays.asList(property.split("[, ]+"));
+		if (StringUtils.isNotBlank(property)) {
+			compoundProperties = Arrays.stream(property.split("[, ]+")).filter(StringUtils::isNotBlank).collect(
+				Collectors.toList());
 		}
 		return Optional.ofNullable(compoundProperties);
 	}

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/JUnitPlatformProviderTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/JUnitPlatformProviderTests.java
@@ -192,6 +192,34 @@ class JUnitPlatformProviderTests {
 	}
 
 	@Test
+	void noFiltersAreCreatedIfTagsAreEmpty() throws Exception {
+		Map<String, String> properties = new HashMap<>();
+		properties.put(JUnitPlatformProvider.INCLUDE_TAGS, "");
+		properties.put(JUnitPlatformProvider.INCLUDE_GROUPS, "");
+
+		ProviderParameters providerParameters = providerParametersMock(TestClass1.class);
+		when(providerParameters.getProviderProperties()).thenReturn(properties);
+
+		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
+		assertEquals(0, provider.includeAndExcludeFilters.length);
+	}
+
+	@Test
+	void filtersWithEmptyTagsAreNotRegistered() throws Exception {
+		Map<String, String> properties = new HashMap<>();
+
+		// Here only tagOne is registered as a valid tag and other tags are ignored as they are empty
+		properties.put(JUnitPlatformProvider.EXCLUDE_GROUPS, "tagOne,");
+		properties.put(JUnitPlatformProvider.EXCLUDE_TAGS, "");
+
+		ProviderParameters providerParameters = providerParametersMock(TestClass1.class);
+		when(providerParameters.getProviderProperties()).thenReturn(properties);
+
+		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
+		assertEquals(1, provider.includeAndExcludeFilters.length);
+	}
+
+	@Test
 	void bothIncludeAndExcludeAreAllowed() throws Exception {
 		Map<String, String> properties = new HashMap<>();
 		properties.put(JUnitPlatformProvider.INCLUDE_TAGS, "tagOne, tagTwo");


### PR DESCRIPTION
Issue: #1126

## Overview

IncludeTags and ExcludeTags are modified to accept empty strings as input parameter.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
