### PR TITLE
Surefire: Run all TestsToRun in one execution using a single TestPlan

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.1.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.1.0-M1.adoc
@@ -40,6 +40,9 @@ on GitHub.
 * New console launcher option `--scan-modules` for scanning all resolved Java 9
   modules available on the boot layer configuration for test discovery.
   - This is an alternative to the existing classpath scanning support.
+* The JUnit Platform Maven Surefire provider now runs all specified tests in a single
+  test run, i.e. all registered `TestExecutionListeners` will receive a single `TestPlan`.
+  Previously, a separate `TestPlan` was discovered and executed for each test class.
 
 
 [[release-notes-5.1.0-junit-jupiter]]

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
@@ -21,6 +21,8 @@ import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
 import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.surefire.report.PojoStackTraceWriter;
 import org.apache.maven.surefire.report.RunListener;
@@ -39,36 +41,42 @@ import org.junit.platform.launcher.TestPlan;
  */
 final class RunListenerAdapter implements TestExecutionListener {
 
-	private final Class<?> testClass;
 	private final RunListener runListener;
-	private Optional<TestPlan> testPlan = Optional.empty();
+	private TestPlan testPlan;
+	private Set<TestIdentifier> testSetNodes = ConcurrentHashMap.newKeySet();
 
-	public RunListenerAdapter(Class<?> testClass, RunListener runListener) {
-		this.testClass = testClass;
+	RunListenerAdapter(RunListener runListener) {
 		this.runListener = runListener;
 	}
 
 	@Override
 	public void testPlanExecutionStarted(TestPlan testPlan) {
-		this.testPlan = Optional.of(testPlan);
+		updateTestPlan(testPlan);
 	}
 
 	@Override
 	public void testPlanExecutionFinished(TestPlan testPlan) {
-		this.testPlan = Optional.empty();
+		updateTestPlan(null);
 	}
 
 	@Override
 	public void executionStarted(TestIdentifier testIdentifier) {
+		if (testIdentifier.isContainer()
+				&& testIdentifier.getSource().filter(ClassSource.class::isInstance).isPresent()) {
+			startTestSetIfPossible(testIdentifier);
+		}
 		if (testIdentifier.isTest()) {
+			ensureTestSetStarted(testIdentifier);
 			runListener.testStarting(createReportEntry(testIdentifier));
 		}
 	}
 
 	@Override
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+		ensureTestSetStarted(testIdentifier);
 		String source = sourceLegacyReportingName(testIdentifier);
 		runListener.testSkipped(ignored(source, testIdentifier.getLegacyReportingName(), reason));
+		completeTestSetIfNecessary(testIdentifier);
 	}
 
 	@Override
@@ -82,6 +90,54 @@ final class RunListenerAdapter implements TestExecutionListener {
 		else if (testIdentifier.isTest()) {
 			runListener.testSucceeded(createReportEntry(testIdentifier));
 		}
+		completeTestSetIfNecessary(testIdentifier);
+	}
+
+	private void updateTestPlan(TestPlan testPlan) {
+		this.testPlan = testPlan;
+		testSetNodes.clear();
+	}
+
+	private void ensureTestSetStarted(TestIdentifier testIdentifier) {
+		if (isTestSetStarted(testIdentifier)) {
+			return;
+		}
+		if (testIdentifier.isTest()) {
+			startTestSet(testPlan.getParent(testIdentifier).orElse(testIdentifier));
+		}
+		else {
+			startTestSet(testIdentifier);
+		}
+	}
+
+	private boolean isTestSetStarted(TestIdentifier testIdentifier) {
+		if (testSetNodes.contains(testIdentifier)) {
+			return true;
+		}
+		Optional<TestIdentifier> parent = testPlan.getParent(testIdentifier);
+		return parent.isPresent() && isTestSetStarted(parent.get());
+	}
+
+	private void startTestSetIfPossible(TestIdentifier testIdentifier) {
+		if (!isTestSetStarted(testIdentifier)) {
+			startTestSet(testIdentifier);
+		}
+	}
+
+	private void completeTestSetIfNecessary(TestIdentifier testIdentifier) {
+		if (testSetNodes.contains(testIdentifier)) {
+			completeTestSet(testIdentifier);
+		}
+	}
+
+	private void startTestSet(TestIdentifier testIdentifier) {
+		runListener.testSetStarting(createTestSetReportEntry(testIdentifier));
+		testSetNodes.add(testIdentifier);
+	}
+
+	private void completeTestSet(TestIdentifier testIdentifier) {
+		runListener.testSetCompleted(createTestSetReportEntry(testIdentifier));
+		testSetNodes.remove(testIdentifier);
 	}
 
 	private void reportFailedTest(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
@@ -92,6 +148,10 @@ final class RunListenerAdapter implements TestExecutionListener {
 		else {
 			runListener.testError(reportEntry);
 		}
+	}
+
+	private SimpleReportEntry createTestSetReportEntry(TestIdentifier testIdentifier) {
+		return new SimpleReportEntry(JUnitPlatformProvider.class.getName(), testIdentifier.getLegacyReportingName());
 	}
 
 	private SimpleReportEntry createReportEntry(TestIdentifier testIdentifier) {
@@ -111,7 +171,7 @@ final class RunListenerAdapter implements TestExecutionListener {
 
 	private String sourceLegacyReportingName(TestIdentifier testIdentifier) {
 		// @formatter:off
-		return testPlan.flatMap(plan -> plan.getParent(testIdentifier))
+		return testPlan.getParent(testIdentifier)
 				.map(TestIdentifier::getLegacyReportingName)
 				.orElse("<unrooted>");
 		// @formatter:on
@@ -142,9 +202,9 @@ final class RunListenerAdapter implements TestExecutionListener {
 			return ((MethodSource) testSource).getClassName();
 		}
 		// @formatter:off
-		return testPlan.flatMap(plan -> plan.getParent(testIdentifier))
+		return testPlan.getParent(testIdentifier)
 				.map(this::getClassName)
-				.orElseGet(testClass::getName);
+				.orElse("");
 		// @formatter:on
 	}
 

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
@@ -111,11 +111,8 @@ final class RunListenerAdapter implements TestExecutionListener {
 	}
 
 	private boolean isTestSetStarted(TestIdentifier testIdentifier) {
-		if (testSetNodes.contains(testIdentifier)) {
-			return true;
-		}
-		Optional<TestIdentifier> parent = testPlan.getParent(testIdentifier);
-		return parent.isPresent() && isTestSetStarted(parent.get());
+		return testSetNodes.contains(testIdentifier)
+				|| testPlan.getParent(testIdentifier).map(this::isTestSetStarted).orElse(false);
 	}
 
 	private void startTestSetIfPossible(TestIdentifier testIdentifier) {


### PR DESCRIPTION
Fixes #1113.

- Move testSetStarting/testSetCompleted into RunListenerAdapter
- Start a test set for every child of an engine descriptor that
  is a container and has a ClassSource
- Ensure every reported test belongs to a test set (for engines
  that do not use ClassSource)

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
