### PR TITLE
Fix Javadoc @value tag usages issue

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
@@ -104,9 +104,9 @@ public @interface RepeatedTest {
 	 *
 	 * <h4>Supported placeholders</h4>
 	 * <ul>
-	 * <li>{@value #DISPLAY_NAME_PLACEHOLDER}</li>
-	 * <li>{@value #CURRENT_REPETITION_PLACEHOLDER}</li>
-	 * <li>{@value #TOTAL_REPETITIONS_PLACEHOLDER}</li>
+	 * <li>{displayName}</li>
+	 * <li>{currentRepetition}</li>
+	 * <li>{totalRepetitions}</li>
 	 * </ul>
 	 *
 	 * <p>Defaults to {@link #SHORT_DISPLAY_NAME}, resulting in


### PR DESCRIPTION
Issue: #1098

## Overview

Hardcoded values as no other syntax is being resolved in java 9.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
