### PR TITLE
Introduce before and after callbacks at the Jupiter engine-level

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk: oraclejdk9
 
 install:
-  - ./gradlew install -x test
+  - ./gradlew install -x test --no-daemon --stacktrace

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterEngineExecution.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterEngineExecution.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * TODO ...
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = STABLE, since = "5.1")
+public @interface AfterEngineExecution {
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeEngineExecution.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/BeforeEngineExecution.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * TODO ...
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = STABLE, since = "5.1")
+public @interface BeforeEngineExecution {
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AfterEngineExecutionCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AfterEngineExecutionCallback.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+
+@FunctionalInterface
+@API(status = STABLE, since = "5.1")
+public interface AfterEngineExecutionCallback extends Extension {
+
+	ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(AfterEngineExecutionCallback.class);
+
+	default Optional<Class<?>> getTestInstanceClass() {
+		return Optional.empty();
+	}
+
+	default void setTestInstance(Object testInstance) {
+	}
+
+	void afterEngineExecution(ExtensionContext context) throws Exception;
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/BeforeEngineExecutionCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/BeforeEngineExecutionCallback.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import org.apiguardian.api.API;
+
+@FunctionalInterface
+@API(status = STABLE, since = "5.1")
+public interface BeforeEngineExecutionCallback extends Extension {
+
+	void beforeEngineExecution(ExtensionContext context) throws Exception;
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEngineExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -149,7 +150,10 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 			// Eagerly load test instance for BeforeAllCallbacks, if necessary,
 			// and store the instance in the ExtensionContext.
 			ClassExtensionContext extensionContext = (ClassExtensionContext) context.getExtensionContext();
-			extensionContext.setTestInstance(context.getTestInstanceProvider().getTestInstance(Optional.empty()));
+			Object instance = context.getTestInstanceProvider().getTestInstance(Optional.empty());
+			extensionContext.setTestInstance(instance);
+			// Also store the instance in the engine-level store.
+			storeTestInstanceForAfterEngineExecutionCallbacks(extensionContext.getRoot(), instance);
 		}
 
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
@@ -163,6 +167,10 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 		throwableCollector.assertEmpty();
 
 		return context;
+	}
+
+	private void storeTestInstanceForAfterEngineExecutionCallbacks(ExtensionContext context, Object instance) {
+		context.getStore(AfterEngineExecutionCallback.NAMESPACE).put(instance.getClass(), instance);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
@@ -13,9 +13,16 @@ package org.junit.jupiter.engine.descriptor;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.extension.ExtensionRegistry.createRegistryWithDefaultExtensions;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.AfterEngineExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeEngineExecutionCallback;
+import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.jupiter.engine.execution.ThrowableCollector;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.UniqueId;
@@ -28,22 +35,75 @@ import org.junit.platform.engine.support.hierarchical.Node;
 @API(status = INTERNAL, since = "5.0")
 public class JupiterEngineDescriptor extends EngineDescriptor implements Node<JupiterEngineExecutionContext> {
 
+	private List<Extension> engineLevelExtensions = new ArrayList<>();
+
 	public JupiterEngineDescriptor(UniqueId uniqueId) {
 		super(uniqueId, "JUnit Jupiter");
 	}
 
+	public void registerExtension(Extension extension) {
+		engineLevelExtensions.add(extension);
+	}
+
 	@Override
-	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) throws Exception {
+	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) {
 		ExtensionRegistry extensionRegistry = createRegistryWithDefaultExtensions(context.getConfigurationParameters());
 		EngineExecutionListener executionListener = context.getExecutionListener();
 		ExtensionContext extensionContext = new JupiterEngineExtensionContext(executionListener, this);
+		ThrowableCollector throwableCollector = new ThrowableCollector();
+
+		// Register all discovered engine-level extensions.
+		engineLevelExtensions.forEach(extension -> extensionRegistry.registerExtension(extension, this));
 
 		// @formatter:off
 		return context.extend()
 				.withExtensionRegistry(extensionRegistry)
 				.withExtensionContext(extensionContext)
+                .withThrowableCollector(throwableCollector)
 				.build();
 		// @formatter:on
 	}
 
+	@Override
+	public JupiterEngineExecutionContext before(JupiterEngineExecutionContext context) {
+		invokeAllBeforeEngineExecutionCallbacks(context);
+		return context;
+	}
+
+	private void invokeAllBeforeEngineExecutionCallbacks(JupiterEngineExecutionContext context) {
+		ExtensionRegistry registry = context.getExtensionRegistry();
+		ExtensionContext extensionContext = context.getExtensionContext();
+		ThrowableCollector throwableCollector = context.getThrowableCollector();
+
+		for (BeforeEngineExecutionCallback callback : registry.getExtensions(BeforeEngineExecutionCallback.class)) {
+			throwableCollector.execute(() -> callback.beforeEngineExecution(extensionContext));
+			if (throwableCollector.isNotEmpty()) {
+				break;
+			}
+		}
+	}
+
+	@Override
+	public void after(JupiterEngineExecutionContext context) {
+		invokeAllAfterEngineExecutionCallbacks(context);
+	}
+
+	private void invokeAllAfterEngineExecutionCallbacks(JupiterEngineExecutionContext context) {
+		ExtensionRegistry registry = context.getExtensionRegistry();
+		ExtensionContext extensionContext = context.getExtensionContext();
+		ThrowableCollector throwableCollector = context.getThrowableCollector();
+
+		ExtensionContext.Store store = extensionContext.getStore(AfterEngineExecutionCallback.NAMESPACE);
+
+		registry.getReversedExtensions(AfterEngineExecutionCallback.class) //
+				.forEach(extension -> throwableCollector.execute(() -> {
+					extension.getTestInstanceClass().ifPresent(key -> extension.setTestInstance(store.get(key)));
+					extension.afterEngineExecution(extensionContext);
+				}));
+
+		// TODO Handle collected throwable...
+		if (throwableCollector.isNotEmpty()) {
+			throwableCollector.getThrowable().printStackTrace();
+		}
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsScannableTestClass;
 import org.junit.platform.commons.util.ClassFilter;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -45,14 +46,15 @@ public class DiscoverySelectorResolver {
 
 	private static final IsScannableTestClass isScannableTestClass = new IsScannableTestClass();
 
-	public void resolveSelectors(EngineDiscoveryRequest request, TestDescriptor engineDescriptor) {
+	public void resolveSelectors(EngineDiscoveryRequest request, JupiterEngineDescriptor engineDescriptor) {
 		ClassFilter classFilter = buildClassFilter(request, isScannableTestClass);
 		resolve(request, engineDescriptor, classFilter);
 		filter(engineDescriptor, classFilter);
 		pruneTree(engineDescriptor);
 	}
 
-	private void resolve(EngineDiscoveryRequest request, TestDescriptor engineDescriptor, ClassFilter classFilter) {
+	private void resolve(EngineDiscoveryRequest request, JupiterEngineDescriptor engineDescriptor,
+			ClassFilter classFilter) {
 		JavaElementsResolver javaElementsResolver = createJavaElementsResolver(engineDescriptor);
 
 		request.getSelectorsByType(ClasspathRootSelector.class).forEach(selector -> {
@@ -84,13 +86,14 @@ public class DiscoverySelectorResolver {
 		rootDescriptor.accept(TestDescriptor::prune);
 	}
 
-	private JavaElementsResolver createJavaElementsResolver(TestDescriptor engineDescriptor) {
+	private JavaElementsResolver createJavaElementsResolver(JupiterEngineDescriptor engineDescriptor) {
 		Set<ElementResolver> resolvers = new LinkedHashSet<>();
 		resolvers.add(new TestContainerResolver());
 		resolvers.add(new NestedTestsResolver());
 		resolvers.add(new TestMethodResolver());
 		resolvers.add(new TestFactoryMethodResolver());
 		resolvers.add(new TestTemplateMethodResolver());
+		resolvers.add(new EngineExecutionCallbackResolver(engineDescriptor));
 		return new JavaElementsResolver(engineDescriptor, resolvers);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/EngineExecutionCallbackResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/EngineExecutionCallbackResolver.java
@@ -10,11 +10,13 @@
 
 package org.junit.jupiter.engine.discovery;
 
+import static org.junit.platform.commons.util.AnnotationUtils.findRepeatableAnnotations;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.BOTTOM_UP;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.AfterEngineExecution;
 import org.junit.jupiter.api.BeforeEngineExecution;
 import org.junit.jupiter.api.extension.AfterEngineExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeEngineExecutionCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.platform.commons.util.AnnotationUtils;
@@ -45,6 +48,18 @@ class EngineExecutionCallbackResolver implements ElementResolver {
 
 	@Override
 	public Set<TestDescriptor> resolveElement(AnnotatedElement element, TestDescriptor parent) {
+		// @formatter:off
+		findRepeatableAnnotations(element, ExtendWith.class)
+				.stream()
+				.map(ExtendWith::value)
+				.flatMap(Arrays::stream)
+				.map(ReflectionUtils::newInstance)
+				.filter(x -> x instanceof BeforeEngineExecutionCallback)
+				.filter(x -> x instanceof AfterEngineExecutionCallback)
+				.forEach(engineDescriptor::registerExtension);
+				//.forEach(System.out::println);
+		// @formatter:on
+
 		if ((element instanceof Class)) {
 			//@formatter:off
 			AnnotationUtils.findAnnotatedMethods((Class<?>) element, BeforeEngineExecution.class, TOP_DOWN)

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/EngineExecutionCallbackResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/EngineExecutionCallbackResolver.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.discovery;
+
+import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.BOTTOM_UP;
+import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEngineExecution;
+import org.junit.jupiter.api.BeforeEngineExecution;
+import org.junit.jupiter.api.extension.AfterEngineExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeEngineExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+class EngineExecutionCallbackResolver implements ElementResolver {
+
+	private final JupiterEngineDescriptor engineDescriptor;
+
+	EngineExecutionCallbackResolver(JupiterEngineDescriptor engineDescriptor) {
+		this.engineDescriptor = engineDescriptor;
+	}
+
+	@Override
+	public Optional<TestDescriptor> resolveUniqueId(UniqueId.Segment segment, TestDescriptor parent) {
+		return Optional.empty();
+	}
+
+	@Override
+	public Set<TestDescriptor> resolveElement(AnnotatedElement element, TestDescriptor parent) {
+		if ((element instanceof Class)) {
+			//@formatter:off
+			AnnotationUtils.findAnnotatedMethods((Class<?>) element, BeforeEngineExecution.class, TOP_DOWN)
+                    .stream()
+                    .map(EngineExecutionCallbackResolver::synthesizeBeforeSuiteCallback)
+                    .forEach(engineDescriptor::registerExtension);
+			AnnotationUtils.findAnnotatedMethods((Class<?>) element, AfterEngineExecution.class, BOTTOM_UP)
+                    .stream()
+                    .map(EngineExecutionCallbackResolver::synthesizeAfterSuiteCallback)
+                    .forEach(engineDescriptor::registerExtension);
+            //@formatter:on
+		}
+		return Collections.emptySet();
+	}
+
+	private static BeforeEngineExecutionCallback synthesizeBeforeSuiteCallback(Method method) {
+		if (method.getParameterCount() == 0) {
+			return context -> ReflectionUtils.invokeMethod(method, null);
+		}
+		return context -> ReflectionUtils.invokeMethod(method, null, context);
+	}
+
+	private static AfterEngineExecutionCallback synthesizeAfterSuiteCallback(Method method) {
+		return new DefaultAfterEngineExecutionCallback(method);
+	}
+
+	private static class DefaultAfterEngineExecutionCallback implements AfterEngineExecutionCallback {
+
+		private final Method method;
+		private Object testInstance;
+
+		DefaultAfterEngineExecutionCallback(Method method) {
+			this.method = method;
+			this.testInstance = null;
+		}
+
+		@Override
+		public Optional<Class<?>> getTestInstanceClass() {
+			return Optional.of(method.getDeclaringClass());
+		}
+
+		@Override
+		public void setTestInstance(Object testInstance) {
+			this.testInstance = testInstance;
+		}
+
+		@Override
+		public void afterEngineExecution(ExtensionContext context) {
+			if (method.getParameterCount() == 0) {
+				ReflectionUtils.invokeMethod(method, testInstance);
+				return;
+			}
+			ReflectionUtils.invokeMethod(method, testInstance, context);
+		}
+	}
+
+}

--- a/junit-platform-commons-java-9/src/test/java/integration/JupiterIntegrationTests.java
+++ b/junit-platform-commons-java-9/src/test/java/integration/JupiterIntegrationTests.java
@@ -24,7 +24,6 @@ import org.junit.platform.commons.util.ModuleUtils;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.discovery.ModuleSelector;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 
 /**
  * Integration tests for {@link ModuleUtils} using JUnit Jupiter.
@@ -60,7 +59,7 @@ class JupiterIntegrationTests {
 		ModuleSelector selector = DiscoverySelectors.selectModule(getClass().getModule().getName());
 		assertEquals(getClass().getModule().getName(), selector.getModuleName());
 
-		EngineDescriptor engine = new JupiterEngineDescriptor(UniqueId.forEngine(JupiterTestEngine.ENGINE_ID));
+		JupiterEngineDescriptor engine = new JupiterEngineDescriptor(UniqueId.forEngine(JupiterTestEngine.ENGINE_ID));
 		DiscoverySelectorResolver resolver = new DiscoverySelectorResolver();
 
 		resolver.resolveSelectors(request().selectors(selector).build(), engine);


### PR DESCRIPTION
## Overview

Addresses #456 

This PR is a basis for discussion. Error handling and documentation are left out on-purpose.

### Usage
```java
@BeforeEngineExecution
static void before0() {
	countBefore0++;
}

@BeforeEngineExecution
static void before0(ExtensionContext context) {
	context.getStore(ExtensionContext.Namespace.GLOBAL).put("alpha", "omega");
	countBefore0++;
}

@AfterEngineExecution
static void after0(ExtensionContext context) {
	assertEquals("omega", context.getStore(ExtensionContext.Namespace.GLOBAL).get("alpha"));
	countAfter0++;
}

@AfterEngineExecution
void after0NonStatic(ExtensionContext context) {
	assertEquals("omega", context.getStore(ExtensionContext.Namespace.GLOBAL).get("alpha"));
	countAfter0++;
}
```

### Implementation notes

* If a single parameter `ExtensionContext` is declared in an annotated method, the root `ExtensionContext` of `JupiterEngineExecutionContext` is injected at runtime.
* `@BeforeEngineExecution`-annotated methods must be `static`.
* `@AfterEngineExecution`-annotated methods must be `static`. If you're using `@TestInstance(TestInstance.Lifecycle.PER_CLASS)`, `@AfterEngineExecution`-annotated methods don't have be `static`.
* ~~`@ExtendWith(AlphaOmega.class)` does **not** work at the moment.~~

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
