### PR TITLE
Issue #1151 csvfile source skip headers option

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes-5.1.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes-5.1.0-M1.adoc
@@ -43,6 +43,8 @@ on GitHub.
 * The JUnit Platform Maven Surefire provider now runs all specified tests in a single
   test run, i.e. all registered `TestExecutionListeners` will receive a single `TestPlan`.
   Previously, a separate `TestPlan` was discovered and executed for each test class.
+* `@CsvFileSource` now accepts a `numLinesToSkip` parameter, to support writing headers in
+  your CSV files.
 
 
 [[release-notes-5.1.0-junit-jupiter]]

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -162,7 +162,7 @@ class ParameterizedTestDemo {
 
 	// tag::CsvFileSource_example[]
 	@ParameterizedTest
-	@CsvFileSource(resources = "/two-column.csv")
+	@CsvFileSource(resources = "/two-column.csv", numLinesToSkip = 1)
 	void testWithCsvFileSource(String first, int second) {
 		assertNotNull(first);
 		assertNotEquals(0, second);

--- a/documentation/src/test/resources/two-column.csv
+++ b/documentation/src/test/resources/two-column.csv
@@ -1,3 +1,4 @@
-foo, 1
-bar, 2
-"baz, qux", 3
+Country, reference
+Sweden, 1
+Poland, 2
+"United States of America", 3

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
@@ -39,7 +39,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	private String[] resources;
 	private Charset charset;
 	private CsvParserSettings settings;
-	private boolean hasHeaders;
+	private int skipHeaderLines;
 
 	CsvFileArgumentsProvider() {
 		this(Class::getResourceAsStream);
@@ -53,7 +53,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	public void accept(CsvFileSource annotation) {
 		resources = annotation.resources();
 		charset = Charset.forName(annotation.encoding());
-		hasHeaders = annotation.hasHeaders();
+		skipHeaderLines = annotation.skipHeaderLines();
 		settings = new CsvParserSettings();
 		settings.getFormat().setDelimiter(annotation.delimiter());
 		settings.getFormat().setLineSeparator(annotation.lineSeparator());
@@ -87,7 +87,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 
 	private Stream<Arguments> toStream(CsvParser csvParser) {
 		return stream(spliteratorUnknownSize(new CsvParserIterator(csvParser), Spliterator.ORDERED), false) //
-				.skip(hasHeaders ? 1 : 0) //
+				.skip(skipHeaderLines) //
 				.onClose(csvParser::stopParsing);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
@@ -39,7 +39,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	private String[] resources;
 	private Charset charset;
 	private CsvParserSettings settings;
-	private int skipLines;
+	private int numLinesToSkip;
 
 	CsvFileArgumentsProvider() {
 		this(Class::getResourceAsStream);
@@ -53,7 +53,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	public void accept(CsvFileSource annotation) {
 		resources = annotation.resources();
 		charset = Charset.forName(annotation.encoding());
-		skipLines = annotation.skipLines();
+		numLinesToSkip = annotation.numLinesToSkip();
 		settings = new CsvParserSettings();
 		settings.getFormat().setDelimiter(annotation.delimiter());
 		settings.getFormat().setLineSeparator(annotation.lineSeparator());
@@ -87,7 +87,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 
 	private Stream<Arguments> toStream(CsvParser csvParser) {
 		return stream(spliteratorUnknownSize(new CsvParserIterator(csvParser), Spliterator.ORDERED), false) //
-				.skip(skipLines) //
+				.skip(numLinesToSkip) //
 				.onClose(csvParser::stopParsing);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
@@ -39,6 +39,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	private String[] resources;
 	private Charset charset;
 	private CsvParserSettings settings;
+	private boolean hasHeaders;
 
 	CsvFileArgumentsProvider() {
 		this(Class::getResourceAsStream);
@@ -52,6 +53,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	public void accept(CsvFileSource annotation) {
 		resources = annotation.resources();
 		charset = Charset.forName(annotation.encoding());
+		hasHeaders = annotation.hasHeaders();
 		settings = new CsvParserSettings();
 		settings.getFormat().setDelimiter(annotation.delimiter());
 		settings.getFormat().setLineSeparator(annotation.lineSeparator());
@@ -85,6 +87,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 
 	private Stream<Arguments> toStream(CsvParser csvParser) {
 		return stream(spliteratorUnknownSize(new CsvParserIterator(csvParser), Spliterator.ORDERED), false) //
+				.skip(hasHeaders ? 1 : 0) //
 				.onClose(csvParser::stopParsing);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
@@ -39,7 +39,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	private String[] resources;
 	private Charset charset;
 	private CsvParserSettings settings;
-	private int skipHeaderLines;
+	private int skipLines;
 
 	CsvFileArgumentsProvider() {
 		this(Class::getResourceAsStream);
@@ -53,7 +53,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	public void accept(CsvFileSource annotation) {
 		resources = annotation.resources();
 		charset = Charset.forName(annotation.encoding());
-		skipHeaderLines = annotation.skipHeaderLines();
+		skipLines = annotation.skipLines();
 		settings = new CsvParserSettings();
 		settings.getFormat().setDelimiter(annotation.delimiter());
 		settings.getFormat().setLineSeparator(annotation.lineSeparator());
@@ -87,7 +87,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 
 	private Stream<Arguments> toStream(CsvParser csvParser) {
 		return stream(spliteratorUnknownSize(new CsvParserIterator(csvParser), Spliterator.ORDERED), false) //
-				.skip(skipHeaderLines) //
+				.skip(skipLines) //
 				.onClose(csvParser::stopParsing);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -70,9 +70,9 @@ public @interface CsvFileSource {
 	char delimiter() default ',';
 
 	/**
-	 * The number of lines to skip, if the CSV files have header rows.
+	 * The number of lines to skip parsing. Could be used for skipping header lines.
 	 *
 	 * <p>Defaults to {@code 0}</p>
 	 */
-	int skipHeaderLines() default 0;
+	int skipLines() default 0;
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -69,4 +69,9 @@ public @interface CsvFileSource {
 	 */
 	char delimiter() default ',';
 
+	/**
+	 * If the CSV file resources have headers in their first line; This will activate the behaviour to skip the first
+	 * line lines for test purposes.
+	 */
+	boolean hasHeaders() default false;
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -72,6 +72,8 @@ public @interface CsvFileSource {
 	/**
 	 * If the CSV file resources have headers in their first line; This will activate the behaviour to skip the first
 	 * line lines for test purposes.
+	 *
+	 * <p>Defaults to {@code "false"}</p>
 	 */
 	boolean hasHeaders() default false;
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -74,5 +74,5 @@ public @interface CsvFileSource {
 	 *
 	 * <p>Defaults to {@code 0}</p>
 	 */
-	int skipLines() default 0;
+	int numLinesToSkip() default 0;
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -70,10 +70,9 @@ public @interface CsvFileSource {
 	char delimiter() default ',';
 
 	/**
-	 * If the CSV file resources have headers in their first line; This will activate the behaviour to skip the first
-	 * line lines for test purposes.
+	 * The number of lines to skip, if the CSV files have header rows.
 	 *
-	 * <p>Defaults to {@code "false"}</p>
+	 * <p>Defaults to {@code 0}</p>
 	 */
-	boolean hasHeaders() default false;
+	int skipHeaderLines() default 0;
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -89,7 +89,8 @@ class CsvFileArgumentsProviderTests {
 
 		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
 
-		assertThat(arguments).hasSize(4);
+		assertThat(arguments).containsExactly(new Object[] { "bar" }, new Object[] { "baz" }, new Object[] { "qux" },
+			new Object[] { "" });
 	}
 
 	@Test
@@ -99,7 +100,9 @@ class CsvFileArgumentsProviderTests {
 
 		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
 
-		assertThat(arguments).hasSize(8);
+		assertThat(arguments).containsExactly(new Object[] { "bar" }, new Object[] { "baz" }, new Object[] { "qux" },
+			new Object[] { "" }, new Object[] { "bar" }, new Object[] { "baz" }, new Object[] { "qux" },
+			new Object[] { "" });
 	}
 
 	@Test

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -85,7 +85,7 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void readsFromSingleClasspathResourceWithHeaders() {
-		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', true, "/single-column.csv");
+		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', 1, "/single-column.csv");
 
 		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
 
@@ -94,9 +94,17 @@ class CsvFileArgumentsProviderTests {
 	}
 
 	@Test
+	void readsFromSingleClasspathResourceWithMoreHeadersThanLines() {
+		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', 10, "/single-column.csv");
+
+		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
+
+		assertThat(arguments).containsExactly();
+	}
+
+	@Test
 	void readsFromMultipleClasspathResourcesWithHeaders() {
-		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', true, "/single-column.csv",
-			"/single-column.csv");
+		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', 1, "/single-column.csv", "/single-column.csv");
 
 		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
 
@@ -116,17 +124,17 @@ class CsvFileArgumentsProviderTests {
 	}
 
 	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, String... resources) {
-		return annotation(charset, lineSeparator, delimiter, false, resources);
+		return annotation(charset, lineSeparator, delimiter, 0, resources);
 	}
 
-	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, boolean hasHeaders,
+	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, int skipHeaderLines,
 			String... resources) {
 		CsvFileSource annotation = mock(CsvFileSource.class);
 		when(annotation.resources()).thenReturn(resources);
 		when(annotation.encoding()).thenReturn(charset);
 		when(annotation.lineSeparator()).thenReturn(lineSeparator);
 		when(annotation.delimiter()).thenReturn(delimiter);
-		when(annotation.hasHeaders()).thenReturn(hasHeaders);
+		when(annotation.skipHeaderLines()).thenReturn(skipHeaderLines);
 		return annotation;
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -127,14 +127,14 @@ class CsvFileArgumentsProviderTests {
 		return annotation(charset, lineSeparator, delimiter, 0, resources);
 	}
 
-	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, int skipLines,
+	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, int numLinesToSkip,
 			String... resources) {
 		CsvFileSource annotation = mock(CsvFileSource.class);
 		when(annotation.resources()).thenReturn(resources);
 		when(annotation.encoding()).thenReturn(charset);
 		when(annotation.lineSeparator()).thenReturn(lineSeparator);
 		when(annotation.delimiter()).thenReturn(delimiter);
-		when(annotation.skipLines()).thenReturn(skipLines);
+		when(annotation.numLinesToSkip()).thenReturn(numLinesToSkip);
 		return annotation;
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -99,7 +99,7 @@ class CsvFileArgumentsProviderTests {
 
 		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
 
-		assertThat(arguments).containsExactly();
+		assertThat(arguments).isEmpty();
 	}
 
 	@Test
@@ -127,14 +127,14 @@ class CsvFileArgumentsProviderTests {
 		return annotation(charset, lineSeparator, delimiter, 0, resources);
 	}
 
-	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, int skipHeaderLines,
+	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, int skipLines,
 			String... resources) {
 		CsvFileSource annotation = mock(CsvFileSource.class);
 		when(annotation.resources()).thenReturn(resources);
 		when(annotation.encoding()).thenReturn(charset);
 		when(annotation.lineSeparator()).thenReturn(lineSeparator);
 		when(annotation.delimiter()).thenReturn(delimiter);
-		when(annotation.skipHeaderLines()).thenReturn(skipHeaderLines);
+		when(annotation.skipLines()).thenReturn(skipLines);
 		return annotation;
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -84,6 +84,16 @@ class CsvFileArgumentsProviderTests {
 	}
 
 	@Test
+	void readsFromSingleClasspathResourceWithHeaders() {
+		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', true, "/single-column.csv");
+
+		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
+
+		assertThat(arguments).containsExactly(new Object[] { "bar" }, new Object[] { "baz" }, new Object[] { "qux" },
+			new Object[] { "" });
+	}
+
+	@Test
 	void throwsExceptionForMissingClasspathResource() {
 		CsvFileSource annotation = annotation("UTF-8", "\n", ',', "does-not-exist.csv");
 
@@ -94,11 +104,17 @@ class CsvFileArgumentsProviderTests {
 	}
 
 	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, String... resources) {
+		return annotation(charset, lineSeparator, delimiter, false, resources);
+	}
+
+	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, boolean hasHeaders,
+			String... resources) {
 		CsvFileSource annotation = mock(CsvFileSource.class);
 		when(annotation.resources()).thenReturn(resources);
 		when(annotation.encoding()).thenReturn(charset);
 		when(annotation.lineSeparator()).thenReturn(lineSeparator);
 		when(annotation.delimiter()).thenReturn(delimiter);
+		when(annotation.hasHeaders()).thenReturn(hasHeaders);
 		return annotation;
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -89,8 +89,17 @@ class CsvFileArgumentsProviderTests {
 
 		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
 
-		assertThat(arguments).containsExactly(new Object[] { "bar" }, new Object[] { "baz" }, new Object[] { "qux" },
-			new Object[] { "" });
+		assertThat(arguments).hasSize(4);
+	}
+
+	@Test
+	void readsFromMultipleClasspathResourcesWithHeaders() {
+		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', true, "/single-column.csv",
+			"/single-column.csv");
+
+		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
+
+		assertThat(arguments).hasSize(8);
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

**Feature request** @CsvFileSource skip headers option
I've implemented the feature as suggested by @marcphilipp 

I've not added instructions to the user guide though, is that under the gh-pages-branch?

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
