### PR TITLE
Issue #1151 : Added option to skipHeaderLines in CsvFileSource

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
@@ -39,6 +39,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	private String[] resources;
 	private Charset charset;
 	private CsvParserSettings settings;
+	private int skipHeaderLines;
 
 	CsvFileArgumentsProvider() {
 		this(Class::getResourceAsStream);
@@ -52,6 +53,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 	public void accept(CsvFileSource annotation) {
 		resources = annotation.resources();
 		charset = Charset.forName(annotation.encoding());
+		skipHeaderLines = annotation.skipHeaderLines();
 		settings = new CsvParserSettings();
 		settings.getFormat().setDelimiter(annotation.delimiter());
 		settings.getFormat().setLineSeparator(annotation.lineSeparator());
@@ -85,6 +87,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 
 	private Stream<Arguments> toStream(CsvParser csvParser) {
 		return stream(spliteratorUnknownSize(new CsvParserIterator(csvParser), Spliterator.ORDERED), false) //
+				.skip(skipHeaderLines) //
 				.onClose(csvParser::stopParsing);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -69,4 +69,10 @@ public @interface CsvFileSource {
 	 */
 	char delimiter() default ',';
 
+	/**
+	 * The number of lines to skip, if the CSV files have header rows.
+	 *
+	 * <p>Defaults to {@code 0}</p>
+	 */
+	int skipHeaderLines() default 0;
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -93,12 +93,47 @@ class CsvFileArgumentsProviderTests {
 		assertThat(exception).hasMessageContaining("Classpath resource does not exist: does-not-exist.csv");
 	}
 
+	@Test
+	void readsFromSingleClasspathResourceWithHeaders() {
+		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', 1, "/single-column.csv");
+
+		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
+
+		assertThat(arguments).containsExactly(new Object[] { "bar" }, new Object[] { "baz" }, new Object[] { "qux" },
+				new Object[] { "" });
+	}
+
+	@Test
+	void readsFromSingleClasspathResourceWithMoreHeadersThanLines() {
+		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', 10, "/single-column.csv");
+
+		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
+
+		assertThat(arguments).containsExactly();
+	}
+
+	@Test
+	void readsFromMultipleClasspathResourcesWithHeaders() {
+		CsvFileSource annotation = annotation("ISO-8859-1", "\n", ',', 1, "/single-column.csv", "/single-column.csv");
+
+		Stream<Object[]> arguments = provide(new CsvFileArgumentsProvider(), annotation);
+
+		assertThat(arguments).containsExactly(new Object[] { "bar" }, new Object[] { "baz" }, new Object[] { "qux" },
+				new Object[] { "" }, new Object[] { "bar" }, new Object[] { "baz" }, new Object[] { "qux" },
+				new Object[] { "" });
+	}
+
 	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, String... resources) {
+		return annotation(charset, lineSeparator, delimiter, 0, resources);
+	}
+
+	private CsvFileSource annotation(String charset, String lineSeparator, char delimiter, int skipHeaderLines, String... resources) {
 		CsvFileSource annotation = mock(CsvFileSource.class);
 		when(annotation.resources()).thenReturn(resources);
 		when(annotation.encoding()).thenReturn(charset);
 		when(annotation.lineSeparator()).thenReturn(lineSeparator);
 		when(annotation.delimiter()).thenReturn(delimiter);
+		when(annotation.skipHeaderLines()).thenReturn(skipHeaderLines);
 		return annotation;
 	}
 


### PR DESCRIPTION
## Overview

**Feature request** @CsvFileSource skip headers option
I've implemented the feature as suggested by @marcphilipp 

I've not added instructions to the user guide though, is that under the gh-pages-branch?

It was less work dropping my only branch and and copying the changeSet, to get a rebase, than I-dont-know-what would be the option when rebasing while being in conflict.
Old merge request: https://github.com/junit-team/junit5/pull/1156 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
