### PR TITLE
Add a kotlin test with a name with strange characters

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleTests.java
@@ -54,9 +54,11 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.engine.kotlin.ArbitraryNamingKotlinTestCase;
 import org.junit.jupiter.engine.kotlin.InstancePerClassKotlinTestCase;
 import org.junit.jupiter.engine.kotlin.InstancePerMethodKotlinTestCase;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 
 /**
@@ -550,6 +552,20 @@ class TestInstanceLifecycleTests extends AbstractJupiterTestEngineTests {
 				.containsEntry("beforeEach", 1) //
 				.containsEntry("test", 1) //
 				.containsEntry("afterEach", 1);
+	}
+
+	@Test
+	void kotlinTestWithAVeryStrangeName() {
+		Class<?> testClass = ArbitraryNamingKotlinTestCase.class;
+
+		ExecutionEventRecorder eventRecorder = executeTestsForClass(testClass);
+		assertThat(eventRecorder.getTestFinishedCount()).isEqualTo(1);
+		final ExecutionEvent executionEvent = eventRecorder.getSuccessfulTestFinishedEvents().get(0);
+		assertAll(
+			() -> assertEquals(ArbitraryNamingKotlinTestCase.METHOD_NAME + "()",
+				executionEvent.getTestDescriptor().getDisplayName()),
+			() -> assertEquals(ArbitraryNamingKotlinTestCase.METHOD_NAME + "()",
+				executionEvent.getTestDescriptor().getLegacyReportingName()));
 	}
 
 	private void performAssertions(Class<?> testClass, int containers, int tests,

--- a/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/engine/kotlin/ArbitraryNamingKotlinTestCase.kt
+++ b/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/engine/kotlin/ArbitraryNamingKotlinTestCase.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.engine.kotlin
+
+import org.junit.jupiter.api.Test
+
+class ArbitraryNamingKotlinTestCase {
+    companion object {
+        @JvmField
+        val METHOD_NAME = "\uD83E\uDD86 ~|~test with a really, (really) terrible name & that needs to be changed!~|~"
+    }
+
+    @Test
+    fun `🦆 ~|~test with a really, (really) terrible name & that needs to be changed!~|~`() { }
+}


### PR DESCRIPTION
## Overview

Just want to make sure that tests with names having strange characters will continue to work moving forward.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
