### PR TITLE
Introduce lifecycle support for objects stored in ExtensionContext.Store

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -60,7 +60,11 @@ on GitHub.
 * Extensions for JUnit Jupiter can now access JUnit Platform configuration parameters at
   runtime via the new `getConfigurationParameter(String key)` method in the
   `ExtensionContext` API.
-
+* New callback interface `CloseableResource` introduced in `ExtensionContext.Store`.
+  An extension context store is bound to its extension context lifecycle. When an
+  extension context lifecycle ends it closes its associated store. All stored values
+  that are instances of `ExtensionContext.Store.CloseableResource` are notified by
+  an invocation of their `close()` method.
 
 [[release-notes-5.1.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -266,6 +266,11 @@ public interface ExtensionContext {
 	 *
 	 * <p>Use {@code getStore(Namespace.GLOBAL)} to get the default, global {@link Namespace}.
 	 *
+	 * <p>A store is bound to its extension context lifecycle. When an extension
+	 * context lifecycle ends it closes its associated store. All stored values
+	 * that are instances of {@link ExtensionContext.Store.CloseableResource} are
+	 * notified by invoking their {@code close()} method.
+	 *
 	 * @param namespace the {@code Namespace} to get the store for; never {@code null}
 	 * @return the store in which to put and get objects for other invocations
 	 * working in the same namespace; never {@code null}
@@ -277,6 +282,19 @@ public interface ExtensionContext {
 	 * {@code Store} provides methods for extensions to save and retrieve data.
 	 */
 	interface Store {
+
+		/**
+		 * Classes implementing this interface indicate that they want to close
+		 * some underlying resources when the store is closed.
+		 */
+		interface CloseableResource {
+			/**
+			 * Close underlying resources.
+			 *
+			 * @throws Throwable any throwable is collected and rethrown.
+			 */
+			void close() throws Throwable;
+		}
 
 		/**
 		 * Get the value that is stored under the supplied {@code key}.
@@ -330,6 +348,10 @@ public interface ExtensionContext {
 		 * <p>See {@link #getOrComputeIfAbsent(Object, Function, Class)} for
 		 * further details.
 		 *
+		 * <p>If {@code type} implements {@link ExtensionContext.Store.CloseableResource}
+		 * the {@code close()} method will be invoked on the stored object when
+		 * the store is closed.
+		 *
 		 * @param type the type of object to retrieve; never {@code null}
 		 * @param <V> the key and value type
 		 * @return the object; never {@code null}
@@ -353,6 +375,10 @@ public interface ExtensionContext {
 		 * <p>For greater type safety, consider using
 		 * {@link #getOrComputeIfAbsent(Object, Function, Class)} instead.
 		 *
+		 * <p>If the created value is an instance of {@link ExtensionContext.Store.CloseableResource}
+		 * the {@code close()} method will be invoked on the stored object when
+		 * the store is closed.
+		 *
 		 * @param key the key; never {@code null}
 		 * @param defaultCreator the function called with the supplied {@code key}
 		 * to create a new value; never {@code null}
@@ -375,6 +401,10 @@ public interface ExtensionContext {
 		 * a new value will be computed by the {@code defaultCreator} (given
 		 * the {@code key} as input), stored, and returned.
 		 *
+		 * <p>If {@code requiredType} implements {@link ExtensionContext.Store.CloseableResource}
+		 * the {@code close()} method will be invoked on the stored object when
+		 * the store is closed.
+		 *
 		 * @param key the key; never {@code null}
 		 * @param defaultCreator the function called with the supplied {@code key}
 		 * to create a new value; never {@code null}
@@ -393,6 +423,10 @@ public interface ExtensionContext {
 		 * <p>A stored {@code value} is visible in child {@link ExtensionContext
 		 * ExtensionContexts} for the store's {@code Namespace} unless they
 		 * overwrite it.
+		 *
+		 * <p>If the {@code value} is an instance of {@link ExtensionContext.Store.CloseableResource}
+		 * the {@code close()} method will be invoked on the stored object when
+		 * the store is closed.
 		 *
 		 * @param key the key under which the value should be stored; never
 		 * {@code null}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -32,7 +32,7 @@ import org.junit.platform.engine.reporting.ReportEntry;
 /**
  * @since 5.0
  */
-abstract class AbstractExtensionContext<T extends TestDescriptor> implements ExtensionContext {
+abstract class AbstractExtensionContext<T extends TestDescriptor> implements ExtensionContext, AutoCloseable {
 
 	private final ExtensionContext parent;
 	private final EngineExecutionListener engineExecutionListener;
@@ -63,6 +63,10 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 			parentStore = ((AbstractExtensionContext<?>) parent).valuesStore;
 		}
 		return new ExtensionValuesStore(parentStore);
+	}
+
+	public void close() {
+		valuesStore.closeAllStoredCloseableValues();
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -28,13 +28,13 @@ import org.junit.platform.engine.UniqueId;
  *
  * @since 5.0
  */
-class DynamicContainerTestDescriptor extends JupiterTestDescriptor {
+class DynamicContainerTestDescriptor extends DynamicNodeTestDescriptor {
 
 	private final DynamicContainer dynamicContainer;
 	private final TestSource testSource;
 
 	DynamicContainerTestDescriptor(UniqueId uniqueId, DynamicContainer dynamicContainer, TestSource testSource) {
-		super(uniqueId, dynamicContainer.getDisplayName(), testSource);
+		super(uniqueId, dynamicContainer, testSource);
 		this.dynamicContainer = dynamicContainer;
 		this.testSource = testSource;
 	}
@@ -42,11 +42,6 @@ class DynamicContainerTestDescriptor extends JupiterTestDescriptor {
 	@Override
 	public Type getType() {
 		return Type.CONTAINER;
-	}
-
-	@Override
-	public SkipResult shouldBeSkipped(JupiterEngineExecutionContext context) throws Exception {
-		return SkipResult.doNotSkip();
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * Base {@link TestDescriptor} for a {@link DynamicNode}.
+ *
+ * @since 5.1
+ */
+abstract class DynamicNodeTestDescriptor extends JupiterTestDescriptor {
+
+	DynamicNodeTestDescriptor(UniqueId uniqueId, DynamicNode dynamicNode, TestSource testSource) {
+		super(uniqueId, dynamicNode.getDisplayName(), testSource);
+	}
+
+	@Override
+	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) throws Exception {
+		return context.extend().withExtensionContext(null).build();
+	}
+
+	@Override
+	public SkipResult shouldBeSkipped(JupiterEngineExecutionContext context) throws Exception {
+		return SkipResult.doNotSkip();
+	}
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
@@ -21,23 +21,18 @@ import org.junit.platform.engine.UniqueId;
  *
  * @since 5.0
  */
-class DynamicTestTestDescriptor extends JupiterTestDescriptor {
+class DynamicTestTestDescriptor extends DynamicNodeTestDescriptor {
 
 	private final DynamicTest dynamicTest;
 
 	DynamicTestTestDescriptor(UniqueId uniqueId, DynamicTest dynamicTest, TestSource source) {
-		super(uniqueId, dynamicTest.getDisplayName(), source);
+		super(uniqueId, dynamicTest, source);
 		this.dynamicTest = dynamicTest;
 	}
 
 	@Override
 	public Type getType() {
 		return Type.TEST;
-	}
-
-	@Override
-	public SkipResult shouldBeSkipped(JupiterEngineExecutionContext context) throws Exception {
-		return SkipResult.doNotSkip();
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
@@ -47,4 +47,8 @@ public class JupiterEngineDescriptor extends EngineDescriptor implements Node<Ju
 		// @formatter:on
 	}
 
+	@Override
+	public void cleanUp(JupiterEngineExecutionContext context) throws Exception {
+		context.close();
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -123,6 +123,17 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 		return SkipResult.doNotSkip();
 	}
 
+	/**
+	 * Must be overridden and return a new context so cleanUp() does not accidentally close the parent context.
+	 */
+	@Override
+	public abstract JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) throws Exception;
+
+	@Override
+	public void cleanUp(JupiterEngineExecutionContext context) throws Exception {
+		context.close();
+	}
+
 	protected ExtensionRegistry populateNewExtensionRegistryFromExtendWith(AnnotatedElement annotatedElement,
 			ExtensionRegistry existingExtensionRegistry) {
 		// @formatter:off

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionValuesStore.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionValuesStore.java
@@ -43,6 +43,24 @@ public class ExtensionValuesStore {
 		this.parentStore = parentStore;
 	}
 
+	/**
+	 * Close all values that implement {@link ExtensionContext.Store.CloseableResource}.
+	 *
+	 * @implNote Only close values stored in this instance. This implementation
+	 * does not close values in parent stores.
+	 */
+	public void closeAllStoredCloseableValues() {
+		ThrowableCollector throwableCollector = new ThrowableCollector();
+		for (Supplier<Object> supplier : storedValues.values()) {
+			Object value = supplier.get();
+			if (value instanceof ExtensionContext.Store.CloseableResource) {
+				ExtensionContext.Store.CloseableResource resource = (ExtensionContext.Store.CloseableResource) value;
+				throwableCollector.execute(resource::close);
+			}
+		}
+		throwableCollector.assertEmpty();
+	}
+
 	Object get(Namespace namespace, Object key) {
 		Supplier<Object> storedValue = getStoredValue(new CompositeKey(namespace, key));
 		return (storedValue != null ? storedValue.get() : null);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContext.java
@@ -44,7 +44,6 @@ public class JupiterEngineExecutionContext implements EngineExecutionContext {
 		this.state = state;
 	}
 
-	@Override
 	public void close() throws Exception {
 		ExtensionContext extensionContext = getExtensionContext();
 		if (extensionContext instanceof AutoCloseable) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContext.java
@@ -16,6 +16,8 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
@@ -25,6 +27,8 @@ import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
  */
 @API(status = INTERNAL, since = "5.0")
 public class JupiterEngineExecutionContext implements EngineExecutionContext {
+
+	private static final Logger logger = LoggerFactory.getLogger(JupiterEngineExecutionContext.class);
 
 	private final State state;
 
@@ -38,6 +42,20 @@ public class JupiterEngineExecutionContext implements EngineExecutionContext {
 
 	private JupiterEngineExecutionContext(State state) {
 		this.state = state;
+	}
+
+	@Override
+	public void close() throws Exception {
+		ExtensionContext extensionContext = getExtensionContext();
+		if (extensionContext instanceof AutoCloseable) {
+			try {
+				((AutoCloseable) extensionContext).close();
+			}
+			catch (Exception e) {
+				logger.error(e, () -> "Caught exception while closing extension context: " + extensionContext);
+				throw e;
+			}
+		}
 	}
 
 	public EngineExecutionListener getExecutionListener() {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/EngineExecutionContext.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/EngineExecutionContext.java
@@ -23,13 +23,4 @@ import org.apiguardian.api.API;
  */
 @API(status = MAINTAINED, since = "1.0")
 public interface EngineExecutionContext {
-	/**
-	 * Close this context, close any underlying resources.
-	 *
-	 * <p>This default implementation does nothing.
-	 *
-	 * @since 1.1
-	 */
-	default void close() throws Exception {
-	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/EngineExecutionContext.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/EngineExecutionContext.java
@@ -23,4 +23,13 @@ import org.apiguardian.api.API;
  */
 @API(status = MAINTAINED, since = "1.0")
 public interface EngineExecutionContext {
+	/**
+	 * Close this context, close any underlying resources.
+	 *
+	 * <p>This default implementation does nothing.
+	 *
+	 * @since 1.1
+	 */
+	default void close() throws Exception {
+	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
@@ -78,7 +78,9 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 			if (executionErrors.isEmpty() && !skipResult.isSkipped()) {
 				executeRecursively(tracker);
 			}
-			cleanUp();
+			if (context != null) {
+				cleanUp();
+			}
 			reportDone();
 		}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -33,6 +33,8 @@ public interface Node<C extends EngineExecutionContext> {
 	 * Prepare the supplied {@code context} prior to execution.
 	 *
 	 * <p>The default implementation returns the supplied {@code context} unmodified.
+	 *
+	 * @see #cleanUp(EngineExecutionContext)
 	 */
 	default C prepare(C context) throws Exception {
 		return context;
@@ -41,11 +43,12 @@ public interface Node<C extends EngineExecutionContext> {
 	/**
 	 * Cleanup the supplied {@code context} after execution.
 	 *
-	 * <p>The default implementation invokes {@link EngineExecutionContext#close()}
-	 * on the supplied context.
+	 * <p>The default implementation does nothing.
+	 *
+	 * @since 1.1
+	 * @see #prepare(EngineExecutionContext)
 	 */
 	default void cleanUp(C context) throws Exception {
-		context.close();
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -39,6 +39,16 @@ public interface Node<C extends EngineExecutionContext> {
 	}
 
 	/**
+	 * Cleanup the supplied {@code context} after execution.
+	 *
+	 * <p>The default implementation invokes {@link EngineExecutionContext#close()}
+	 * on the supplied context.
+	 */
+	default void cleanUp(C context) throws Exception {
+		context.close();
+	}
+
+	/**
 	 * Determine if the execution of the supplied {@code context} should be
 	 * <em>skipped</em>.
 	 *

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/Heavyweight.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/Heavyweight.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class Heavyweight implements ParameterResolver {
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext context) {
+		return Resource.class.equals(parameterContext.getParameter().getType());
+	}
+
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context) {
+		ExtensionContext engineContext = context.getRoot();
+		Store store = engineContext.getStore(ExtensionContext.Namespace.GLOBAL);
+		ResourceValue resource = store.getOrComputeIfAbsent(ResourceValue.class);
+		resource.usages.incrementAndGet();
+		return resource;
+	}
+
+	interface Resource {
+		int usages();
+	}
+
+	/**
+	 * Demo resource class.
+	 *
+	 * <p>The class implements interface {@link CloseableResource}
+	 * and interface {@link AutoCloseable} to show and ensure that a single
+	 * {@link ResourceValue#close()} method implementation is needed to comply
+	 * with both interfaces.
+	 */
+	private static class ResourceValue implements Resource, CloseableResource, AutoCloseable {
+
+		private static final AtomicInteger creations = new AtomicInteger();
+		private final AtomicInteger usages = new AtomicInteger();
+
+		ResourceValue() {
+			// Open long-living resources here.
+			assertEquals(1, creations.incrementAndGet(), "Singleton pattern failure!");
+		}
+
+		@Override
+		public void close() {
+			// Close resources here.
+			assertEquals(9, usages.get(), "Usage counter mismatch!");
+		}
+
+		@Override
+		public int usages() {
+			return usages.get();
+		}
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/HeavyweightAlphaTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/HeavyweightAlphaTests.java
@@ -12,10 +12,15 @@ package org.junit.jupiter.extensions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -35,9 +40,9 @@ class HeavyweightAlphaTests {
 		mark = resource.usages();
 	}
 
-	@Test
-	void alpha1(Heavyweight.Resource resource) {
-		assertTrue(resource.usages() > 1);
+	@TestFactory
+	Stream<DynamicTest> alpha1(Heavyweight.Resource resource) {
+		return Stream.of(dynamicTest("foo", () -> assertTrue(resource.usages() > 1)));
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/HeavyweightAlphaTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/HeavyweightAlphaTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Unit tests for {@link org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource}
+ * stored values.
+ *
+ * @since 1.1
+ */
+@ExtendWith(Heavyweight.class)
+class HeavyweightAlphaTests {
+
+	private static int mark;
+
+	@BeforeAll
+	static void setMark(Heavyweight.Resource resource) {
+		assertTrue(resource.usages() > 0);
+		mark = resource.usages();
+	}
+
+	@Test
+	void alpha1(Heavyweight.Resource resource) {
+		assertTrue(resource.usages() > 1);
+	}
+
+	@Test
+	void alpha2(Heavyweight.Resource resource) {
+		assertTrue(resource.usages() > 1);
+	}
+
+	@Test
+	void alpha3(Heavyweight.Resource resource) {
+		assertTrue(resource.usages() > 1);
+	}
+
+	@AfterAll
+	static void checkMark(Heavyweight.Resource resource) {
+		assertEquals(mark, resource.usages() - 4);
+	}
+}

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/HeavyweightBetaTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/HeavyweightBetaTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Unit tests for {@link org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource}
+ * stored values.
+ *
+ * @since 1.1
+ */
+@ExtendWith(Heavyweight.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HeavyweightBetaTests {
+
+	private int mark;
+
+	@BeforeAll
+	void beforeAll(Heavyweight.Resource resource) {
+		assertTrue(resource.usages() > 0);
+		mark = resource.usages();
+	}
+
+	@BeforeEach
+	void beforeEach(Heavyweight.Resource resource) {
+		assertTrue(resource.usages() > 1);
+	}
+
+	@Test
+	void beta(Heavyweight.Resource resource) {
+		assertTrue(resource.usages() > 2);
+	}
+
+	@AfterAll
+	void afterAll(Heavyweight.Resource resource) {
+		assertEquals(mark, resource.usages() - 3);
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -140,6 +140,7 @@ class HierarchicalTestExecutorTests {
 		inOrder.verify(listener).executionStarted(root);
 		inOrder.verify(child).prepare(rootContext);
 		inOrder.verify(child).shouldBeSkipped(rootContext);
+		inOrder.verify(child).cleanUp(rootContext);
 		inOrder.verify(listener).executionFinished(eq(root), any(TestExecutionResult.class));
 
 		verify(listener, never()).executionStarted(child);
@@ -161,6 +162,7 @@ class HierarchicalTestExecutorTests {
 		inOrder.verify(listener).executionStarted(root);
 		inOrder.verify(child).prepare(rootContext);
 		inOrder.verify(child).shouldBeSkipped(rootContext);
+		inOrder.verify(child).cleanUp(rootContext);
 		inOrder.verify(listener).executionFinished(eq(root), any(TestExecutionResult.class));
 
 		verify(listener, never()).executionStarted(child);
@@ -184,6 +186,7 @@ class HierarchicalTestExecutorTests {
 		inOrder.verify(listener).executionStarted(root);
 		inOrder.verify(child).prepare(rootContext);
 		inOrder.verify(child).shouldBeSkipped(rootContext);
+		inOrder.verify(child).cleanUp(rootContext);
 		inOrder.verify(listener).executionStarted(child);
 		inOrder.verify(listener).executionFinished(eq(child), childExecutionResult.capture());
 		inOrder.verify(listener).executionFinished(eq(root), any(TestExecutionResult.class));


### PR DESCRIPTION
## Overview

An extension context store is bound to its extension context lifecycle. When an extension context lifecycle ends it closes its associated store. All stored values that are instances of `ExtensionContext.Store.CloseableResource` are notified by invoking their `close()` method.

Addresses https://github.com/junit-team/junit5/issues/456#issuecomment-341120548 -- enhance the "engine level context store" with a **cleanup** hook.

Closes #742

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
