### PR TITLE
Introduce Details.SUMMARY and mute output in mode NONE

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/Details.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/Details.java
@@ -26,6 +26,11 @@ public enum Details {
 	NONE,
 
 	/**
+	 * Print summary table of counts only.
+	 */
+	SUMMARY,
+
+	/**
 	 * Test plan execution details are rendered in a flat, line-by-line mode.
 	 */
 	FLAT,

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -65,7 +65,9 @@ public class ConsoleTestExecutor {
 		launcher.execute(discoveryRequest);
 
 		TestExecutionSummary summary = summaryListener.getSummary();
-		printSummary(summary, out);
+		if (summary.getTotalFailureCount() > 0 || options.getDetails() != Details.NONE) {
+			printSummary(summary, out);
+		}
 
 		return summary;
 	}
@@ -105,6 +107,9 @@ public class ConsoleTestExecutor {
 		boolean disableAnsiColors = options.isAnsiColorOutputDisabled();
 		Theme theme = options.getTheme();
 		switch (options.getDetails()) {
+			case SUMMARY:
+				// summary listener is always created and registered
+				return Optional.empty();
 			case FLAT:
 				return Optional.of(new FlatPrintingListener(out, disableAnsiColors));
 			case TREE:
@@ -122,7 +127,7 @@ public class ConsoleTestExecutor {
 
 	private void printSummary(TestExecutionSummary summary, PrintWriter out) {
 		// Otherwise the failures have already been printed in detail
-		if (EnumSet.of(Details.NONE, Details.TREE).contains(options.getDetails())) {
+		if (EnumSet.of(Details.NONE, Details.SUMMARY, Details.TREE).contains(options.getDetails())) {
 			summary.printFailuresTo(out);
 		}
 		summary.printTo(out);

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
@@ -140,6 +140,7 @@ dependencies {
 }
 
 junitPlatform {
+	details 'summary'
 	filters {
 		engines {
 			include 'junit-jupiter'
@@ -164,6 +165,7 @@ dependencies {
 }
 
 junitPlatform {
+	details 'summary'
 	filters {
 		engines {
 			include 'junit-jupiter'

--- a/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-none-ascii.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-none-unicode.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-summary-ascii.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-changeDisplayName-summary-unicode.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/basic/Basic-empty-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-empty-none-ascii.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/basic/Basic-empty-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-empty-none-unicode.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/basic/Basic-empty-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-empty-summary-ascii.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/basic/Basic-empty-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/basic/Basic-empty-summary-unicode.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-summary-ascii.out.txt
@@ -1,0 +1,22 @@
+
+Failures (1):
+  JUnit Jupiter:Fail:failWithMultiLineMessage()
+    MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithMultiLineMessage', methodParameterTypes = '']
+    => org.opentest4j.AssertionFailedError: multi
+line
+fail
+message
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         0 tests successful      ]
+[         1 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-summary-unicode.out.txt
@@ -1,0 +1,22 @@
+
+Failures (1):
+  JUnit Jupiter:Fail:failWithMultiLineMessage()
+    MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithMultiLineMessage', methodParameterTypes = '']
+    => org.opentest4j.AssertionFailedError: multi
+line
+fail
+message
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         0 tests successful      ]
+[         1 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-summary-ascii.out.txt
@@ -1,0 +1,19 @@
+
+Failures (1):
+  JUnit Jupiter:Fail:failWithSingleLineMessage()
+    MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
+    => org.opentest4j.AssertionFailedError: single line fail message
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         0 tests successful      ]
+[         1 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-summary-unicode.out.txt
@@ -1,0 +1,19 @@
+
+Failures (1):
+  JUnit Jupiter:Fail:failWithSingleLineMessage()
+    MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
+    => org.opentest4j.AssertionFailedError: single line fail message
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         0 tests successful      ]
+[         1 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-none-ascii.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-none-unicode.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-summary-ascii.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithMultiMappings-summary-unicode.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-none-ascii.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-none-unicode.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-summary-ascii.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportMultiEntriesWithSingleMapping-summary-unicode.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-none-ascii.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-none-unicode.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         0 tests skipped         ]
-[         1 tests started         ]
-[         0 tests aborted         ]
-[         1 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-summary-ascii.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/report/Report-reportSingleEntryWithSingleMapping-summary-unicode.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         0 tests skipped         ]
+[         1 tests started         ]
+[         0 tests aborted         ]
+[         1 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-none-ascii.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         1 tests skipped         ]
-[         0 tests started         ]
-[         0 tests aborted         ]
-[         0 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-none-unicode.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         1 tests skipped         ]
-[         0 tests started         ]
-[         0 tests aborted         ]
-[         0 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-summary-ascii.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         1 tests skipped         ]
+[         0 tests started         ]
+[         0 tests aborted         ]
+[         0 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithMultiLineMessage-summary-unicode.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         1 tests skipped         ]
+[         0 tests started         ]
+[         0 tests aborted         ]
+[         0 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-none-ascii.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         1 tests skipped         ]
-[         0 tests started         ]
-[         0 tests aborted         ]
-[         0 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-none-unicode.out.txt
@@ -1,14 +1,1 @@
 
-Test run finished after [\d]+ ms
-[         2 containers found      ]
-[         0 containers skipped    ]
-[         2 containers started    ]
-[         0 containers aborted    ]
-[         2 containers successful ]
-[         0 containers failed     ]
-[         1 tests found           ]
-[         1 tests skipped         ]
-[         0 tests started         ]
-[         0 tests aborted         ]
-[         0 tests successful      ]
-[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-summary-ascii.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         1 tests skipped         ]
+[         0 tests started         ]
+[         0 tests aborted         ]
+[         0 tests successful      ]
+[         0 tests failed          ]

--- a/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/skip/Skip-skipWithSingleLineReason-summary-unicode.out.txt
@@ -1,0 +1,14 @@
+
+Test run finished after [\d]+ ms
+[         2 containers found      ]
+[         0 containers skipped    ]
+[         2 containers started    ]
+[         0 containers aborted    ]
+[         2 containers successful ]
+[         0 containers failed     ]
+[         1 tests found           ]
+[         1 tests skipped         ]
+[         0 tests started         ]
+[         0 tests aborted         ]
+[         0 tests successful      ]
+[         0 tests failed          ]


### PR DESCRIPTION
## Overview

Prior to this commit a summary table of counts was printed even when the details mode `Details.NONE` was passed to the console launcher. Now, when mode `Details.NONE` is selected, nothing is printed. Unless a failure was recorded.

The new `Details.SUMMARY` mode prints the same output that was printed before when `Details.NONE` was selected.

Closes #1179

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
