### PR TITLE
Introduce method getConfigurationParameter() in ExtensionContext

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -47,6 +47,8 @@ on GitHub.
 
 ==== New Features and Improvements
 
+* New `getConfigurationParameter(String key)` method in interface `ExtensionContext`.
+  Extensions can now access and evaluate configuration parameter values at runtime.
 * Due to a change in the JUnit Platform's `AnnotationUtils` class, non-inherited
   _composed annotations_ which are meta-annotated with a given `@Inherited` annotation
   are now considered to be implicitly _inherited_ when searching for the given

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -222,6 +222,24 @@ public interface ExtensionContext {
 	Optional<Throwable> getExecutionException();
 
 	/**
+	 * Get the configuration parameter stored under the specified {@code key}.
+	 *
+	 * <p>If no such key is present in this {@code ConfigurationParameters},
+	 * an attempt will be made to look up the value as a JVM system property.
+	 * If no such system property exists, an attempt will be made to look up
+	 * the value in the {@code JUnit Platform properties file}.
+	 *
+	 * @param key the key to look up; never {@code null} or blank
+	 * @return an {@code Optional} containing the value; never {@code null}
+	 * but potentially empty
+	 *
+	 * @see System#getProperty(String)
+	 * @since 5.1
+	 */
+	@API(status = STABLE, since = "5.1")
+	Optional<String> getConfigurationParameter(String key);
+
+	/**
 	 * Publish a map of key-value pairs to be consumed by an
 	 * {@code org.junit.platform.engine.EngineExecutionListener}.
 	 *

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.execution.ExtensionValuesStore;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
@@ -34,13 +35,15 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 	private final ExtensionContext parent;
 	private final EngineExecutionListener engineExecutionListener;
 	private final T testDescriptor;
+	private final ConfigurationParameters configurationParameters;
 	private final ExtensionValuesStore valuesStore;
 
-	AbstractExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
-			T testDescriptor) {
+	AbstractExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener, T testDescriptor,
+			ConfigurationParameters configurationParameters) {
 		this.parent = parent;
 		this.engineExecutionListener = engineExecutionListener;
 		this.testDescriptor = testDescriptor;
+		this.configurationParameters = configurationParameters;
 		this.valuesStore = createStore(parent);
 	}
 
@@ -95,4 +98,8 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 		return testDescriptor.getTags().stream().map(TestTag::getName).collect(toCollection(LinkedHashSet::new));
 	}
 
+	@Override
+	public Optional<String> getConfigurationParameter(String key) {
+		return configurationParameters.get(key);
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassExtensionContext.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.execution.ThrowableCollector;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 
 /**
@@ -31,9 +32,10 @@ public final class ClassExtensionContext extends AbstractExtensionContext<ClassT
 	private Object testInstance;
 
 	public ClassExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
-			ClassTestDescriptor testDescriptor, ThrowableCollector throwableCollector) {
+			ClassTestDescriptor testDescriptor, ConfigurationParameters configurationParameters,
+			ThrowableCollector throwableCollector) {
 
-		super(parent, engineExecutionListener, testDescriptor);
+		super(parent, engineExecutionListener, testDescriptor, configurationParameters);
 		this.throwableCollector = throwableCollector;
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -130,7 +130,7 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 
 		ThrowableCollector throwableCollector = new ThrowableCollector();
 		ClassExtensionContext extensionContext = new ClassExtensionContext(context.getExtensionContext(),
-			context.getExecutionListener(), this, throwableCollector);
+			context.getExecutionListener(), this, context.getConfigurationParameters(), throwableCollector);
 
 		// @formatter:off
 		return context.extend()

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
@@ -33,10 +33,11 @@ public class JupiterEngineDescriptor extends EngineDescriptor implements Node<Ju
 	}
 
 	@Override
-	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) throws Exception {
+	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) {
 		ExtensionRegistry extensionRegistry = createRegistryWithDefaultExtensions(context.getConfigurationParameters());
 		EngineExecutionListener executionListener = context.getExecutionListener();
-		ExtensionContext extensionContext = new JupiterEngineExtensionContext(executionListener, this);
+		ExtensionContext extensionContext = new JupiterEngineExtensionContext(executionListener, this,
+			context.getConfigurationParameters());
 
 		// @formatter:off
 		return context.extend()

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineExtensionContext.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 
 /**
@@ -26,8 +27,8 @@ import org.junit.platform.engine.EngineExecutionListener;
 public final class JupiterEngineExtensionContext extends AbstractExtensionContext<JupiterEngineDescriptor> {
 
 	public JupiterEngineExtensionContext(EngineExecutionListener engineExecutionListener,
-			JupiterEngineDescriptor testDescriptor) {
-		super(null, engineExecutionListener, testDescriptor);
+			JupiterEngineDescriptor testDescriptor, ConfigurationParameters configurationParameters) {
+		super(null, engineExecutionListener, testDescriptor, configurationParameters);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodExtensionContext.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.execution.ThrowableCollector;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 
 /**
@@ -32,9 +33,10 @@ public final class MethodExtensionContext extends AbstractExtensionContext<TestM
 	private final ThrowableCollector throwableCollector;
 
 	public MethodExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
-			TestMethodTestDescriptor testDescriptor, Object testInstance, ThrowableCollector throwableCollector) {
+			TestMethodTestDescriptor testDescriptor, ConfigurationParameters configurationParameters,
+			Object testInstance, ThrowableCollector throwableCollector) {
 
-		super(parent, engineExecutionListener, testDescriptor);
+		super(parent, engineExecutionListener, testDescriptor, configurationParameters);
 
 		this.testInstance = testInstance;
 		this.throwableCollector = throwableCollector;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -80,7 +80,8 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 		Object testInstance = context.getTestInstanceProvider().getTestInstance(Optional.of(registry));
 		ThrowableCollector throwableCollector = new ThrowableCollector();
 		ExtensionContext extensionContext = new MethodExtensionContext(context.getExtensionContext(),
-			context.getExecutionListener(), this, testInstance, throwableCollector);
+			context.getExecutionListener(), this, context.getConfigurationParameters(), testInstance,
+			throwableCollector);
 
 		// @formatter:off
 		return context.extend()

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateExtensionContext.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 
 /**
@@ -25,9 +26,10 @@ final class TestTemplateExtensionContext extends AbstractExtensionContext<TestTe
 	private final Object testInstance;
 
 	TestTemplateExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
-			TestTemplateTestDescriptor testDescriptor, Object testInstance) {
+			TestTemplateTestDescriptor testDescriptor, ConfigurationParameters configurationParameters,
+			Object testInstance) {
 
-		super(parent, engineExecutionListener, testDescriptor);
+		super(parent, engineExecutionListener, testDescriptor, configurationParameters);
 		this.testInstance = testInstance;
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -61,7 +61,7 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor {
 		Object testInstance = context.getExtensionContext().getTestInstance().orElse(null);
 
 		ExtensionContext extensionContext = new TestTemplateExtensionContext(context.getExtensionContext(),
-			context.getExecutionListener(), this, testInstance);
+			context.getExecutionListener(), this, context.getConfigurationParameters(), testInstance);
 
 		// @formatter:off
 		return context.extend()

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
@@ -15,13 +15,18 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.engine.descriptor.ClassExtensionContext;
@@ -32,6 +37,7 @@ import org.junit.jupiter.engine.descriptor.MethodExtensionContext;
 import org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.platform.commons.util.PreconditionViolationException;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
@@ -54,7 +60,8 @@ class ExtensionContextTests {
 		JupiterEngineDescriptor engineTestDescriptor = new JupiterEngineDescriptor(
 			UniqueId.root("engine", "junit-jupiter"));
 
-		JupiterEngineExtensionContext engineContext = new JupiterEngineExtensionContext(null, engineTestDescriptor);
+		JupiterEngineExtensionContext engineContext = new JupiterEngineExtensionContext(null, engineTestDescriptor,
+			null);
 
 		// @formatter:off
 		assertAll("engineContext",
@@ -77,7 +84,8 @@ class ExtensionContextTests {
 		ClassTestDescriptor nestedClassDescriptor = nestedClassDescriptor();
 		ClassTestDescriptor outerClassDescriptor = outerClassDescriptor(nestedClassDescriptor);
 
-		ClassExtensionContext outerExtensionContext = new ClassExtensionContext(null, null, outerClassDescriptor, null);
+		ClassExtensionContext outerExtensionContext = new ClassExtensionContext(null, null, outerClassDescriptor, null,
+			null);
 
 		// @formatter:off
 		assertAll("outerContext",
@@ -94,7 +102,7 @@ class ExtensionContextTests {
 		// @formatter:on
 
 		ClassExtensionContext nestedExtensionContext = new ClassExtensionContext(outerExtensionContext, null,
-			nestedClassDescriptor, null);
+			nestedClassDescriptor, null, null);
 		assertThat(nestedExtensionContext.getParent()).containsSame(outerExtensionContext);
 	}
 
@@ -105,18 +113,19 @@ class ExtensionContextTests {
 		TestMethodTestDescriptor methodTestDescriptor = methodDescriptor();
 		outerClassDescriptor.addChild(methodTestDescriptor);
 
-		ClassExtensionContext outerExtensionContext = new ClassExtensionContext(null, null, outerClassDescriptor, null);
+		ClassExtensionContext outerExtensionContext = new ClassExtensionContext(null, null, outerClassDescriptor, null,
+			null);
 
 		assertThat(outerExtensionContext.getTags()).containsExactly("outer-tag");
 		assertThat(outerExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 
 		ClassExtensionContext nestedExtensionContext = new ClassExtensionContext(outerExtensionContext, null,
-			nestedClassDescriptor, null);
+			nestedClassDescriptor, null, null);
 		assertThat(nestedExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "nested-tag");
 		assertThat(nestedExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 
 		MethodExtensionContext methodExtensionContext = new MethodExtensionContext(outerExtensionContext, null,
-			methodTestDescriptor, new OuterClass(), new ThrowableCollector());
+			methodTestDescriptor, null, new OuterClass(), new ThrowableCollector());
 		assertThat(methodExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "method-tag");
 		assertThat(methodExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 	}
@@ -131,12 +140,12 @@ class ExtensionContextTests {
 		Object testInstance = new OuterClass();
 		Method testMethod = methodTestDescriptor.getTestMethod();
 
-		JupiterEngineExtensionContext engineExtensionContext = new JupiterEngineExtensionContext(null,
-			engineDescriptor);
+		JupiterEngineExtensionContext engineExtensionContext = new JupiterEngineExtensionContext(null, engineDescriptor,
+			null);
 		ClassExtensionContext classExtensionContext = new ClassExtensionContext(engineExtensionContext, null,
-			classTestDescriptor, null);
+			classTestDescriptor, null, null);
 		MethodExtensionContext methodExtensionContext = new MethodExtensionContext(classExtensionContext, null,
-			methodTestDescriptor, testInstance, new ThrowableCollector());
+			methodTestDescriptor, null, testInstance, new ThrowableCollector());
 
 		// @formatter:off
 		assertAll("methodContext",
@@ -159,7 +168,7 @@ class ExtensionContextTests {
 		ClassTestDescriptor classTestDescriptor = outerClassDescriptor(null);
 		EngineExecutionListener engineExecutionListener = Mockito.spy(EngineExecutionListener.class);
 		ExtensionContext extensionContext = new ClassExtensionContext(null, engineExecutionListener,
-			classTestDescriptor, null);
+			classTestDescriptor, null, null);
 
 		Map<String, String> map1 = Collections.singletonMap("key", "value");
 		Map<String, String> map2 = Collections.singletonMap("other key", "other value");
@@ -185,9 +194,9 @@ class ExtensionContextTests {
 	void usingStore() {
 		TestMethodTestDescriptor methodTestDescriptor = methodDescriptor();
 		ClassTestDescriptor classTestDescriptor = outerClassDescriptor(methodTestDescriptor);
-		ExtensionContext parentContext = new ClassExtensionContext(null, null, classTestDescriptor, null);
+		ExtensionContext parentContext = new ClassExtensionContext(null, null, classTestDescriptor, null, null);
 		MethodExtensionContext childContext = new MethodExtensionContext(parentContext, null, methodTestDescriptor,
-			new OuterClass(), new ThrowableCollector());
+			null, new OuterClass(), new ThrowableCollector());
 
 		ExtensionContext.Store childStore = childContext.getStore(Namespace.GLOBAL);
 		ExtensionContext.Store parentStore = parentContext.getStore(Namespace.GLOBAL);
@@ -216,6 +225,20 @@ class ExtensionContextTests {
 		parentStore.put(parentKey, parentValue);
 		assertEquals(parentValue, childStore.getOrComputeIfAbsent(parentKey, k -> "a different value"));
 		assertEquals(parentValue, childStore.get(parentKey));
+	}
+
+	@TestFactory
+	Stream<DynamicTest> configurationParameter() {
+		ConfigurationParameters echo = new EchoParameters();
+		String key = "123";
+		Optional<String> expected = Optional.of(key);
+
+		return Stream.of( //
+			(ExtensionContext) new JupiterEngineExtensionContext(null, null, echo), //
+			new ClassExtensionContext(null, null, null, echo, null), //
+			new MethodExtensionContext(null, null, null, echo, null, null) //
+		).map(context -> dynamicTest(context.getClass().getSimpleName(),
+			() -> assertEquals(expected, context.getConfigurationParameter(key))));
 	}
 
 	private ClassTestDescriptor nestedClassDescriptor() {
@@ -251,6 +274,24 @@ class ExtensionContextTests {
 
 		@Tag("method-tag")
 		void aMethod() {
+		}
+	}
+
+	private static class EchoParameters implements ConfigurationParameters {
+
+		@Override
+		public Optional<String> get(String key) {
+			return Optional.of(key);
+		}
+
+		@Override
+		public Optional<Boolean> getBoolean(String key) {
+			throw new UnsupportedOperationException("getBoolean(String) should not be called");
+		}
+
+		@Override
+		public int size() {
+			throw new UnsupportedOperationException("size() should not be called");
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/JUnit5EngineExecutionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/JUnit5EngineExecutionContextTests.java
@@ -47,7 +47,7 @@ class JupiterEngineExecutionContextTests {
 
 	@Test
 	void extendWithAllAttributes() {
-		ClassExtensionContext extensionContext = new ClassExtensionContext(null, null, null, null);
+		ClassExtensionContext extensionContext = new ClassExtensionContext(null, null, null, null, null);
 		ExtensionRegistry extensionRegistry = ExtensionRegistry.createRegistryWithDefaultExtensions(configParams);
 		TestInstanceProvider testInstanceProvider = mock(TestInstanceProvider.class);
 		JupiterEngineExecutionContext newContext = originalContext.extend() //
@@ -63,10 +63,10 @@ class JupiterEngineExecutionContextTests {
 
 	@Test
 	void canOverrideAttributeWhenContextIsExtended() {
-		ClassExtensionContext extensionContext = new ClassExtensionContext(null, null, null, null);
+		ClassExtensionContext extensionContext = new ClassExtensionContext(null, null, null, null, null);
 		ExtensionRegistry extensionRegistry = ExtensionRegistry.createRegistryWithDefaultExtensions(configParams);
 		TestInstanceProvider testInstanceProvider = mock(TestInstanceProvider.class);
-		ClassExtensionContext newExtensionContext = new ClassExtensionContext(extensionContext, null, null, null);
+		ClassExtensionContext newExtensionContext = new ClassExtensionContext(extensionContext, null, null, null, null);
 
 		JupiterEngineExecutionContext newContext = originalContext.extend() //
 				.withExtensionContext(extensionContext) //

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -161,6 +161,11 @@ class ParameterizedTestExtensionTests {
 			}
 
 			@Override
+			public Optional<String> getConfigurationParameter(String key) {
+				return Optional.empty();
+			}
+
+			@Override
 			public void publishReportEntry(Map<String, String> map) {
 			}
 


### PR DESCRIPTION
## Overview

Provide access to configuration parameters via adding method `Optional<String> getConfigurationParameter(String key)` to interface `ExtensionContext`.

Closes #1196

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
