### PR TITLE
Avoid use of Gradle's internal APIs for testing

### DIFF
--- a/junit-platform-gradle-plugin/gradle/functional-test.gradle
+++ b/junit-platform-gradle-plugin/gradle/functional-test.gradle
@@ -1,0 +1,49 @@
+sourceSets {
+	functionalTest {
+		groovy.srcDir file('src/functTest/groovy')
+		resources.srcDir file('src/functTest/resources')
+		compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
+		runtimeClasspath += output + compileClasspath
+	}
+}
+
+task functionalTest(type: Test) {
+	description = 'Runs the functional tests.'
+	group = 'verification'
+	testClassesDirs = sourceSets.functionalTest.output.classesDirs
+	classpath = sourceSets.functionalTest.runtimeClasspath
+	mustRunAfter test
+
+	reports {
+		html.destination = project.file("$html.destination/functional")
+		junitXml.destination = project.file("$junitXml.destination/functional")
+	}
+}
+
+check.dependsOn functionalTest
+
+gradlePlugin {
+	testSourceSets sourceSets.functionalTest
+}
+
+task createClasspathManifests {
+	description = 'Generate classpath manifests for functional tests so that they can reference locally built libraries for use with Gradle Test Kit'
+
+	ext.functionalTestClasspathsDir = file("$buildDir/functionalTestClasspathManifests")
+	inputs.files configurations.functionalTestCompile
+	inputs.files configurations.functionalTestRuntime
+	outputs.dir functionalTestClasspathsDir
+
+	doLast {
+		functionalTestClasspathsDir.mkdirs()
+		file("$functionalTestClasspathsDir/test-compile-classpath.txt").text = configurations.functionalTestCompile.join(System.lineSeparator())
+		file("$functionalTestClasspathsDir/test-runtime-classpath.txt").text = configurations.functionalTestRuntime.join(System.lineSeparator())
+	}
+}
+
+dependencies {
+	functionalTestCompile project(':junit-jupiter-api')
+	functionalTestRuntime project(':junit-platform-console')
+	functionalTestRuntime project(':junit-jupiter-engine')
+	testRuntimeOnly files(createClasspathManifests)
+}

--- a/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
+++ b/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
@@ -1,47 +1,14 @@
 apply plugin: 'groovy'
-
-configurations {
-	functionalTestRuntimeTestCompile {
-		description = 'Local dependencies used for compiling tests source code inside of Gradle functional tests'
-	}
-	functionalTestRuntimeTestRuntime {
-		description = 'Local dependencies used for tests runtime inside of Gradle functional tests'
-	}
-}
-
-// Write the plugin's classpath to a file to share with the tests.
-// See https://docs.gradle.org/current/userguide/test_kit.html
-Task createClasspathManifests = tasks.create('createClasspathManifests') {
-	description = 'Generate classpath manifests for functional tests so that they can reference locally built libraries for use with Gradle Test Kit'
-	File functionalTestClasspathsDir = file("$buildDir/functionalTestClasspathManifests")
-
-	inputs.files sourceSets.main.runtimeClasspath
-	inputs.files configurations.functionalTestRuntimeTestCompile
-	inputs.files configurations.functionalTestRuntimeTestRuntime
-	outputs.dir functionalTestClasspathsDir
-
-	doLast {
-		functionalTestClasspathsDir.mkdirs()
-		file("$functionalTestClasspathsDir/plugin-classpath.txt").text = sourceSets.main.runtimeClasspath.join(System.lineSeparator())
-		file("$functionalTestClasspathsDir/test-compile-classpath.txt").text = configurations.functionalTestRuntimeTestCompile.join(System.lineSeparator())
-		file("$functionalTestClasspathsDir/test-runtime-classpath.txt").text = configurations.functionalTestRuntimeTestRuntime.join(System.lineSeparator())
-	}
-}
+apply plugin: 'java-gradle-plugin'
+apply from: 'gradle/functional-test.gradle'
 
 dependencies {
-	implementation(localGroovy())
-	implementation(gradleApi())
 	api(project(path: ':junit-platform-console', configuration: 'shadow'))
 	api(project(':junit-platform-launcher'))
 	testRuntimeOnly("junit:junit:${junit4Version}")
 	testImplementation('org.spockframework:spock-core:1.1-groovy-2.4') {
 		exclude module: 'groovy-all'
 	}
-	testImplementation(gradleTestKit())
-	functionalTestRuntimeTestCompile(project(':junit-jupiter-api'))
-	functionalTestRuntimeTestRuntime(project(':junit-platform-console'))
-	functionalTestRuntimeTestRuntime(project(':junit-jupiter-engine'))
-	testRuntimeOnly(files(createClasspathManifests))
 }
 
 processResources {

--- a/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/AbstractFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/AbstractFunctionalSpec.groovy
@@ -1,0 +1,51 @@
+package org.junit.platform.gradle.plugin
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+abstract class AbstractFunctionalSpec extends Specification {
+
+	@Rule
+	TemporaryFolder temporaryFolder = new TemporaryFolder()
+	File projectDir
+	File buildFile
+	File settingsFile
+
+	def setup() {
+		projectDir = temporaryFolder.root
+		buildFile = temporaryFolder.newFile('build.gradle')
+		settingsFile = temporaryFolder.newFile('settings.gradle')
+
+		buildFile << """
+			plugins {
+				id 'org.junit.platform.gradle.plugin'
+			}
+		"""
+		settingsFile << """
+			rootProject.name = '$temporaryFolder.root.name'
+		"""
+	}
+
+	protected BuildResult build(String... arguments) {
+		createAndConfigureGradleRunner(arguments).build()
+	}
+
+	protected BuildResult buildAndFail(String... arguments) {
+		createAndConfigureGradleRunner(arguments).buildAndFail()
+	}
+
+	private GradleRunner createAndConfigureGradleRunner(String... arguments) {
+		GradleRunner.create().withProjectDir(projectDir).withArguments(arguments).withPluginClasspath()
+	}
+
+	static String mavenCentral() {
+		"""
+			repositories {
+				mavenCentral()
+			}
+		"""
+	}
+}

--- a/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/AbstractFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/AbstractFunctionalSpec.groovy
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
 package org.junit.platform.gradle.plugin
 
 import org.gradle.testkit.runner.BuildResult
@@ -48,4 +57,5 @@ abstract class AbstractFunctionalSpec extends Specification {
 			}
 		"""
 	}
+
 }

--- a/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginDependenciesFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginDependenciesFunctionalSpec.groovy
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
 package org.junit.platform.gradle.plugin
 
 class JUnitPlatformPluginDependenciesFunctionalSpec extends AbstractFunctionalSpec {
@@ -15,7 +24,7 @@ class JUnitPlatformPluginDependenciesFunctionalSpec extends AbstractFunctionalSp
 			task $VERIFICATION_TASK_NAME {
 				doLast {
 					def allDeps = configurations.junitPlatform.incoming.dependencies
-					def expectedDeps = allDeps.findAll { 
+					def expectedDeps = allDeps.findAll {
 						(it.group == 'org.junit.platform' && it.name == 'junit-platform-launcher' && it.version == '1.0.0') || (it.group == 'org.junit.platform' && it.name == 'junit-platform-console' && it.version == '1.0.0')
 					}
 					assert expectedDeps.size() == 2
@@ -46,9 +55,10 @@ class JUnitPlatformPluginDependenciesFunctionalSpec extends AbstractFunctionalSp
 
 	static String platformVersion() {
 		"""
-			junitPlatform { 
-				platformVersion '1.0.0' 
+			junitPlatform {
+				platformVersion '1.0.0'
 			}
 		"""
 	}
+
 }

--- a/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginDependenciesFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginDependenciesFunctionalSpec.groovy
@@ -1,0 +1,54 @@
+package org.junit.platform.gradle.plugin
+
+class JUnitPlatformPluginDependenciesFunctionalSpec extends AbstractFunctionalSpec {
+
+	private static final String VERIFICATION_TASK_NAME = 'verifyJUnitDependencies'
+
+	def setup() {
+		buildFile << mavenCentral()
+	}
+
+	def "can configure custom configuration and adds dependencies if platform version is configured"() {
+		given:
+		buildFile << platformVersion()
+		buildFile << """
+			task $VERIFICATION_TASK_NAME {
+				doLast {
+					def allDeps = configurations.junitPlatform.incoming.dependencies
+					def expectedDeps = allDeps.findAll { 
+						(it.group == 'org.junit.platform' && it.name == 'junit-platform-launcher' && it.version == '1.0.0') || (it.group == 'org.junit.platform' && it.name == 'junit-platform-console' && it.version == '1.0.0')
+					}
+					assert expectedDeps.size() == 2
+				}
+			}
+		"""
+
+		expect:
+		build(VERIFICATION_TASK_NAME)
+	}
+
+	def "can configure custom configuration and adds dependencies if platform version is not configured"() {
+		buildFile << """
+			task $VERIFICATION_TASK_NAME {
+				doLast {
+					def allDeps = configurations.junitPlatform.incoming.dependencies
+					def expectedDeps = allDeps.findAll { it.group == 'org.junit.platform' }
+											  .collect { it.version }
+											  .findAll { (it.startsWith('1.') && !version.contains('+')) || version == '@VERSION' }
+					assert expectedDeps.size() == 2
+				}
+			}
+		"""
+
+		expect:
+		build(VERIFICATION_TASK_NAME)
+	}
+
+	static String platformVersion() {
+		"""
+			junitPlatform { 
+				platformVersion '1.0.0' 
+			}
+		"""
+	}
+}

--- a/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
@@ -9,39 +9,21 @@
  */
 package org.junit.platform.gradle.plugin
 
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
+class JUnitPlatformPluginFunctionalSpec extends AbstractFunctionalSpec {
 
-class JUnitPlatformPluginFunctionalSpec extends Specification {
-
-	@Rule
-	final TemporaryFolder testProjectDir = new TemporaryFolder()
-	private File buildFile
-	private List<File> pluginClasspath
 	private List<File> testCompileClasspath
 	private List<File> testRuntimeClasspath
 
 	def setup() {
-		pluginClasspath = loadClassPathManifestResource('plugin-classpath.txt')
 		testCompileClasspath = loadClassPathManifestResource('test-compile-classpath.txt')
 		testRuntimeClasspath = loadClassPathManifestResource('test-runtime-classpath.txt')
-		buildFile = testProjectDir.newFile('build.gradle')
-		buildFile << """
-buildscript {
-	dependencies {
-		classpath files(${splitClasspath(pluginClasspath)})
-	}
-}
-apply plugin: 'org.junit.platform.gradle.plugin'
-"""
 	}
 
 	def "can be used with 'java' plugin"() {
@@ -51,11 +33,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 		succeedingTestFile()
 
 		when:
-		BuildResult result = GradleRunner.create()
-				.withProjectDir(testProjectDir.root)
-				.withPluginClasspath(pluginClasspath)
-				.withArguments('build')
-				.build()
+		BuildResult result = build('build')
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
@@ -70,11 +48,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 		javaLibraryPlugin()
 
 		when:
-		BuildResult result = GradleRunner.create()
-				.withProjectDir(testProjectDir.root)
-				.withPluginClasspath(pluginClasspath)
-				.withArguments('build')
-				.build()
+		BuildResult result = build('build')
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
@@ -89,11 +63,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 		javaPlugin()
 
 		when:
-		BuildResult result = GradleRunner.create()
-				.withProjectDir(testProjectDir.root)
-				.withPluginClasspath(pluginClasspath)
-				.withArguments('build')
-				.buildAndFail()
+		BuildResult result = buildAndFail('build')
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.FAILED
@@ -107,11 +77,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 		javaLibraryPlugin()
 
 		when:
-		BuildResult result = GradleRunner.create()
-				.withProjectDir(testProjectDir.root)
-				.withPluginClasspath(pluginClasspath)
-				.withArguments('build')
-				.buildAndFail()
+		BuildResult result = buildAndFail('build')
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.FAILED
@@ -176,7 +142,7 @@ junitPlatform {
 	}
 
 	private void javaFile() {
-		Path javaFile = Paths.get(testProjectDir.root.toString(), 'src', 'main', 'java', 'org', 'junit', 'gradletest', 'Adder.java')
+		Path javaFile = Paths.get(temporaryFolder.root.toString(), 'src', 'main', 'java', 'org', 'junit', 'gradletest', 'Adder.java')
 		Files.createDirectories(javaFile.parent)
 		javaFile.withWriter {
 			it.write(
@@ -193,7 +159,7 @@ public class Adder {
 	}
 
 	private void failingTestFile() {
-		Path testPath = Paths.get(testProjectDir.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
+		Path testPath = Paths.get(temporaryFolder.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
 		Files.createDirectories(testPath.parent)
 		testPath.withWriter {
 			it.write(
@@ -222,28 +188,20 @@ class AdderTest {
 		succeedingTestFile()
 
 		when:
-		BuildResult result = GradleRunner.create()
-				.withProjectDir(testProjectDir.root)
-				.withPluginClasspath(pluginClasspath)
-				.withArguments('test')
-				.build()
+		BuildResult result = build('test')
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.SUCCESS
 
 		when:
-		result = GradleRunner.create()
-				.withProjectDir(testProjectDir.root)
-				.withPluginClasspath(pluginClasspath)
-				.withArguments('test')
-				.build()
+		result = build('test')
 
 		then:
 		result.task(':junitPlatformTest').outcome == TaskOutcome.UP_TO_DATE
 	}
 
 	private void succeedingTestFile() {
-		Path testPath = Paths.get(testProjectDir.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
+		Path testPath = Paths.get(temporaryFolder.root.toString(), 'src', 'test', 'java', 'org', 'junit', 'gradletest', 'AdderTest.java')
 		Files.createDirectories(testPath.parent)
 		testPath.withWriter { it.write('''
 package org.junit.gradletest;
@@ -269,5 +227,4 @@ class AdderTest {
 		}
 		return classpathResource.readLines().collect { new File(it) }
 	}
-
 }

--- a/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
+++ b/junit-platform-gradle-plugin/src/functTest/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginFunctionalSpec.groovy
@@ -9,12 +9,12 @@
  */
 package org.junit.platform.gradle.plugin
 
-import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.TaskOutcome
-
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 
 class JUnitPlatformPluginFunctionalSpec extends AbstractFunctionalSpec {
 
@@ -227,4 +227,5 @@ class AdderTest {
 		}
 		return classpathResource.readLines().collect { new File(it) }
 	}
+
 }

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -9,13 +9,9 @@
  */
 package org.junit.platform.gradle.plugin
 
-import static java.util.Collections.singletonMap
-
 import groovy.transform.CompileStatic
-
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.tasks.JavaExec
@@ -24,10 +20,11 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.platform.commons.util.PreconditionViolationException
 import org.junit.platform.console.ConsoleLauncher
 import org.junit.platform.engine.discovery.ClassNameFilter
-
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import static java.util.Collections.singletonMap
 
 /**
  * @since 1.0
@@ -367,48 +364,6 @@ class JUnitPlatformPluginSpec extends Specification {
 		[foo: null]               | 'value must not be null for key: "foo"'
 		['f=o': 'bar']            | 'key must not contain \'=\': "f=o"'
 		null                      | 'parameters must not be null'
-	}
-
-	def "adds dependencies to configuration"() {
-		given:
-		project.apply plugin: 'org.junit.platform.gradle.plugin'
-
-		when:
-		project.junitPlatform { platformVersion '1.0.0' }
-		project.evaluate()
-
-		then:
-		Configuration configuration = project.configurations.getByName("junitPlatform")
-		configuration.runDependencyActions()
-
-		configuration.getAllDependencies().contains(
-				project.dependencies.create("org.junit.platform:junit-platform-launcher:1.0.0"),
-				)
-
-		configuration.getAllDependencies().contains(
-				project.dependencies.create("org.junit.platform:junit-platform-console:1.0.0"))
-	}
-
-	def "adds dependencies with fixed version when not explicitly configured"() {
-		given:
-		project.apply plugin: 'org.junit.platform.gradle.plugin'
-
-		when:
-		project.evaluate()
-
-		then:
-		Configuration configuration = project.configurations.getByName("junitPlatform")
-		configuration.runDependencyActions()
-
-		configuration.getAllDependencies()
-				.findAll { dependency -> "org.junit.platform" == dependency.getGroup() }
-				.collect { dependency -> dependency.getVersion() }
-				// The version will be @VERSION if the placeholder in
-				// src/main/resources/org/junit/platform/gradle/plugin/version.properties
-				// did not get replaced by the Gradle build (e.g., when executing tests
-				// in an IDE).
-				.findAll { version -> (version.startsWith("1.") && !version.contains("+")) || version.equals("@VERSION") }
-				.size() == 2
 	}
 
 	@Issue('https://github.com/junit-team/junit5/issues/708')

--- a/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
+++ b/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy
@@ -9,7 +9,10 @@
  */
 package org.junit.platform.gradle.plugin
 
+import static java.util.Collections.singletonMap
+
 import groovy.transform.CompileStatic
+
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.JavaPlugin
@@ -20,11 +23,10 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.platform.commons.util.PreconditionViolationException
 import org.junit.platform.console.ConsoleLauncher
 import org.junit.platform.engine.discovery.ClassNameFilter
+
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import static java.util.Collections.singletonMap
 
 /**
  * @since 1.0


### PR DESCRIPTION
## Overview

`ProjectBuilder` should be avoided for writing functional tests. The runtime behavior has its quirks and sometimes requires [calling an internal Gradle API](https://github.com/junit-team/junit5/blob/master/junit-platform-gradle-plugin/src/test/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPluginSpec.groovy#L401) (which might break if you change Gradle versions). The appropriate API to use here is TestKit.

Refactors the setup logic for TestKit and separates build logic needed for functional testing. Translates two existing tests from the use of `ProjectBuilder` to TestKit. No more internal API is required.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
