### PR TITLE
Cache downloaded external dependencies and Gradle Wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,14 @@ script:
   - ./gradlew -version
 # Build JUnit 5
   - ./gradlew build --scan --stacktrace -Dkotlin.compiler.execution.strategy="in-process"
+
+# Do not store unnecessary files from Gradle dependency cache
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+# Store Gradle dependency cache and Wrapper for next execution
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
-# Store Gradle dependency cache and Wrapper for next execution
+# Store Gradle dependency cache and Gradle Wrapper files for next execution
 cache:
   directories:
     - $HOME/.gradle/caches/


### PR DESCRIPTION
## Overview

As [suggested by Travis](https://docs.travis-ci.com/user/languages/java/#Caching), cache downloaded, external dependencies and Gradle Wrapper. Subsequent builds will reuse existing files which should significantly speed up CI execution.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
