### PR TITLE
Print initial lines of failure stack traces

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -27,6 +27,8 @@ on GitHub.
 * New `SUMMARY` details mode for the `ConsoleLauncher` and Gradle plugin which prints
   the table of success and failure counts at the end of test plan execution. This new
   mode is analogous to the previous behavior of the `NONE` details mode.
+* The summary table of a console launcher run now contains the initial ten stack trace
+  lines to better describe the location of the failure.
 * Non-inherited _composed annotations_ which are meta-annotated with a given `@Inherited`
   annotation are now considered to be implicitly _inherited_ when searching for the given
   meta-annotation within a class hierarchy.

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-none-ascii.out.txt
@@ -6,6 +6,7 @@ Failures (1):
 line
 fail
 message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-none-unicode.out.txt
@@ -6,6 +6,7 @@ Failures (1):
 line
 fail
 message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-summary-ascii.out.txt
@@ -6,6 +6,7 @@ Failures (1):
 line
 fail
 message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-summary-unicode.out.txt
@@ -6,6 +6,7 @@ Failures (1):
 line
 fail
 message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-tree-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-tree-ascii.out.txt
@@ -13,6 +13,7 @@ Failures (1):
 line
 fail
 message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-tree-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithMultiLineMessage-tree-unicode.out.txt
@@ -13,6 +13,7 @@ Failures (1):
 line
 fail
 message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-none-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-none-ascii.out.txt
@@ -3,6 +3,7 @@ Failures (1):
   JUnit Jupiter:Fail:failWithSingleLineMessage()
     MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
     => org.opentest4j.AssertionFailedError: single line fail message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-none-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-none-unicode.out.txt
@@ -3,6 +3,7 @@ Failures (1):
   JUnit Jupiter:Fail:failWithSingleLineMessage()
     MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
     => org.opentest4j.AssertionFailedError: single line fail message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-summary-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-summary-ascii.out.txt
@@ -3,6 +3,7 @@ Failures (1):
   JUnit Jupiter:Fail:failWithSingleLineMessage()
     MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
     => org.opentest4j.AssertionFailedError: single line fail message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-summary-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-summary-unicode.out.txt
@@ -3,6 +3,7 @@ Failures (1):
   JUnit Jupiter:Fail:failWithSingleLineMessage()
     MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
     => org.opentest4j.AssertionFailedError: single line fail message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-tree-ascii.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-tree-ascii.out.txt
@@ -7,6 +7,7 @@ Failures (1):
   JUnit Jupiter:Fail:failWithSingleLineMessage()
     MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
     => org.opentest4j.AssertionFailedError: single line fail message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]

--- a/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-tree-unicode.out.txt
+++ b/platform-tests/src/test/resources/console/details/fail/Fail-failWithSingleLineMessage-tree-unicode.out.txt
@@ -7,6 +7,7 @@ Failures (1):
   JUnit Jupiter:Fail:failWithSingleLineMessage()
     MethodSource [className = 'org.junit.platform.console.ConsoleDetailsTests$Fail', methodName = 'failWithSingleLineMessage', methodParameterTypes = '']
     => org.opentest4j.AssertionFailedError: single line fail message
+>> STACKTRACE >>
 
 Test run finished after [\d]+ ms
 [         2 containers found      ]


### PR DESCRIPTION
## Overview

Prior to this commit only the "toString()" representation of the failure throwable was printed.

Now some of the initial stack trace lines are printed by the console launcher to better describe the location of the failure.

Closes #1203

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
