### PR TITLE
Add argument conversions for Currency, Locale, and URI

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -65,6 +65,8 @@ on GitHub.
   extension context lifecycle ends it closes its associated store. All stored values
   that are instances of `ExtensionContext.Store.CloseableResource` are notified by
   an invocation of their `close()` method.
+* New implicit conversions are introduced for `java.net.URI`, `java.util.Currency`,
+  and `java.util.Locale` in `DefaultArgumentConverter` class.
 
 [[release-notes-5.1.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/writing-tests.adoc
@@ -812,6 +812,7 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=implicit_conversion_e
 | `float`/`Float` | `"1.0"` → `1.0f`
 | `double`/`Double` | `"1.0"` → `1.0d`
 | `Enum` subclass | `"SECONDS"` → `TimeUnit.SECONDS`
+| `java.net.URI` | `"http://java.sun.com/j2se/1.3/"` → `URI.create("http://java.sun.com/j2se/1.3/")`
 | `java.time.Instant` | `"1970-01-01T00:00:00Z"` → `Instant.ofEpochMilli(0)`
 | `java.time.LocalDate` | `"2017-03-14"` → `LocalDate.of(2017, 3, 14)`
 | `java.time.LocalDateTime` | `"2017-03-14T12:34:56.789"` → `LocalDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000)`
@@ -821,6 +822,8 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=implicit_conversion_e
 | `java.time.Year` | `"2017"` → `Year.of(2017)`
 | `java.time.YearMonth` | `"2017-03"` → `YearMonth.of(2017, 3)`
 | `java.time.ZonedDateTime` | `"2017-03-14T12:34:56.789Z"` → `ZonedDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC)`
+| `java.util.Currency` | `"JPY"` → `Currency.getInstance("JPY")`
+| `java.util.Locale` | `"en"` → `new Locale("en")`
 |===
 
 [[writing-tests-parameterized-tests-argument-conversion-explicit]]

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.params.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -22,6 +23,8 @@ import java.time.Year;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Currency;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
@@ -80,6 +83,21 @@ class DefaultArgumentConverterTests {
 		assertConverts("2017-03", YearMonth.class, YearMonth.of(2017, 3));
 		assertConverts("2017-03-14T12:34:56.789Z", ZonedDateTime.class,
 			ZonedDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC));
+	}
+
+	@Test
+	void convertsStringsToURIInstances() {
+		assertConverts("http://java.sun.com/j2se/1.3/", URI.class, URI.create("http://java.sun.com/j2se/1.3/"));
+	}
+
+	@Test
+	void convertsStringsToCurrencyInstances() {
+		assertConverts("JPY", Currency.class, Currency.getInstance("JPY"));
+	}
+
+	@Test
+	void convertsStringsToLocaleInstances() {
+		assertConverts("en", Locale.class, new Locale("en"));
 	}
 
 	private void assertConverts(Object input, Class<?> targetClass, Object expectedOutput) {


### PR DESCRIPTION
## Overview

Add argument conversions for [Currency](https://docs.oracle.com/javase/8/docs/api/java/util/Currency.html), [Locale](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html), and [URI](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html)

Related issue: #1218

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
