### PR TITLE
Add type bounds to `TestTemplateInvocationContextProvider.provideTest…

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -82,6 +82,6 @@ public interface TestTemplateInvocationContextProvider extends Extension {
 	 * @see #supportsTestTemplate
 	 * @see ExtensionContext
 	 */
-	Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context);
+	Stream<? extends TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context);
 
 }


### PR DESCRIPTION
…TemplateInvocationContexts`

issue https://github.com/junit-team/junit5/issues/1226

Signed-off-by: Mike Kobit <mkobit@gmail.com>

## Overview

see issue https://github.com/junit-team/junit5/issues/1226

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
