### PR TITLE
selectively execute arguments from method source using only

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -38,6 +38,10 @@ public interface Arguments {
 	 */
 	Object[] get();
 
+	default boolean only() {
+		return false;
+	}
+
 	/**
 	 * Factory method for creating an instance of {@code Arguments} based on
 	 * the supplied {@code arguments}.
@@ -51,4 +55,17 @@ public interface Arguments {
 		return () -> arguments;
 	}
 
+	static Arguments only(Object... arguments) {
+		return new Arguments() {
+			@Override
+			public Object[] get() {
+				return arguments;
+			}
+
+			@Override
+			public boolean only() {
+				return true;
+			}
+		};
+	}
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -78,6 +78,13 @@ class MethodArgumentsProviderTests {
 	}
 
 	@Test
+	void providesOnlyArgumentsUsingArgumentsStream() {
+		Stream<Object[]> arguments = provideArguments("argumentsStreamProviderOnly");
+
+		assertThat(arguments).containsExactly(array("bar"));
+	}
+
+	@Test
 	void providesArgumentsUsingObjectArrays() {
 		Stream<Object[]> arguments = provideArguments("objectArrayProvider");
 
@@ -255,6 +262,10 @@ class MethodArgumentsProviderTests {
 
 		static Stream<Arguments> argumentsStreamProvider() {
 			return Stream.of("foo", "bar").map(Arguments::of);
+		}
+
+		static Stream<Arguments> argumentsStreamProviderOnly() {
+			return Stream.of(Arguments.of("foo"), Arguments.only("bar"));
 		}
 
 		static Iterable<Object[]> objectArrayProvider() {


### PR DESCRIPTION
## Overview

Debugging a single case of a parameterized test is quiet cumbersome. To make this easier this pull requests adds a new factory method `only` on `Arguments`.

As soon as at least a single Argument in a `MethodSource` is flagged as `only` only those are executed. If no Argument is flagged with `only` all elements of the MethodSource are executed.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
