### PR TITLE
Allow executing dynamic tests/test template invocations by unique ID

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -118,6 +118,10 @@ _@API Guardian_ JAR _mandatory_ again.
   extension context ends, the associated store is closed, and each stored value that is
   an instance of `ExtensionContext.Store.CloseableResource` is notified by an invocation
   of its `close()` method.
+* Selected dynamic tests and test template invocations can now be executed separately
+  without running the complete test factory or test template. This allows to rerun single
+  or selected parameterized, repeated or dynamic tests by selecting their unique IDs in
+  subsequent discovery requests.
 
 
 [[release-notes-5.1.0-M2-junit-vintage]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.descriptor;
 
 import static org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor.createDynamicDescriptor;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -32,12 +33,14 @@ class DynamicContainerTestDescriptor extends DynamicNodeTestDescriptor {
 
 	private final DynamicContainer dynamicContainer;
 	private final TestSource testSource;
+	private final DynamicDescendantFilter dynamicDescendantFilter;
 
 	DynamicContainerTestDescriptor(UniqueId uniqueId, int index, DynamicContainer dynamicContainer,
-			TestSource testSource) {
+			TestSource testSource, DynamicDescendantFilter dynamicDescendantFilter) {
 		super(uniqueId, index, dynamicContainer, testSource);
 		this.dynamicContainer = dynamicContainer;
 		this.testSource = testSource;
+		this.dynamicDescendantFilter = dynamicDescendantFilter;
 	}
 
 	@Override
@@ -53,13 +56,15 @@ class DynamicContainerTestDescriptor extends DynamicNodeTestDescriptor {
 			// @formatter:off
 			children.peek(child -> Preconditions.notNull(child, "individual dynamic node must not be null"))
 					.map(child -> toDynamicDescriptor(index.getAndIncrement(), child))
+					.filter(Optional::isPresent)
+					.map(Optional::get)
 					.forEachOrdered(dynamicTestExecutor::execute);
 			// @formatter:on
 		}
 		return context;
 	}
 
-	private JupiterTestDescriptor toDynamicDescriptor(int index, DynamicNode childNode) {
-		return createDynamicDescriptor(this, childNode, index, testSource);
+	private Optional<JupiterTestDescriptor> toDynamicDescriptor(int index, DynamicNode childNode) {
+		return createDynamicDescriptor(this, childNode, index, testSource, dynamicDescendantFilter);
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicDescendantFilter.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicDescendantFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.apiguardian.api.API;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * Filter for dynamic descendants of {@link TestDescriptor TestDescriptors} that
+ * implement {@link Filterable}.
+ *
+ * @since 5.1
+ * @see Filterable
+ */
+@API(status = INTERNAL, since = "5.1")
+public class DynamicDescendantFilter implements Predicate<UniqueId> {
+
+	private final Set<UniqueId> allowed = new HashSet<>();
+	private Mode mode = Mode.EXPLICIT;
+
+	public void allow(UniqueId uniqueId) {
+		if (this.mode == Mode.EXPLICIT) {
+			this.allowed.add(uniqueId);
+		}
+	}
+
+	public void allowAll() {
+		this.mode = Mode.ALLOW_ALL;
+		this.allowed.clear();
+	}
+
+	public boolean test(UniqueId uniqueId) {
+		return allowed.isEmpty() || allowed.stream().anyMatch(allowedUniqueId -> isAllowed(uniqueId, allowedUniqueId));
+	}
+
+	private boolean isAllowed(UniqueId currentUniqueId, UniqueId allowedUniqueId) {
+		return allowedUniqueId.hasPrefix(currentUniqueId) || currentUniqueId.hasPrefix(allowedUniqueId);
+	}
+
+	private enum Mode {
+		EXPLICIT, ALLOW_ALL
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/Filterable.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/Filterable.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code Filterable} is implemented by
+ * {@link org.junit.platform.engine.TestDescriptor TestDescriptors} that may
+ * register dynamic tests during execution and support selective test execution.
+ *
+ * @since 5.1
+ * @see DynamicDescendantFilter
+ */
+@API(status = INTERNAL, since = "5.1")
+public interface Filterable {
+
+	DynamicDescendantFilter getDynamicDescendantFilter();
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -14,6 +14,8 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.lang.reflect.Method;
 import java.util.Iterator;
+import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
@@ -36,15 +38,24 @@ import org.junit.platform.engine.UniqueId;
  * @since 5.0
  */
 @API(status = INTERNAL, since = "5.0")
-public class TestFactoryTestDescriptor extends TestMethodTestDescriptor {
+public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implements Filterable {
 
 	public static final String DYNAMIC_CONTAINER_SEGMENT_TYPE = "dynamic-container";
 	public static final String DYNAMIC_TEST_SEGMENT_TYPE = "dynamic-test";
 
 	private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
 
+	private final DynamicDescendantFilter dynamicDescendantFilter = new DynamicDescendantFilter();
+
 	public TestFactoryTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod) {
 		super(uniqueId, testClass, testMethod);
+	}
+
+	// --- Filterable ----------------------------------------------------------
+
+	@Override
+	public DynamicDescendantFilter getDynamicDescendantFilter() {
+		return dynamicDescendantFilter;
 	}
 
 	// --- TestDescriptor ------------------------------------------------------
@@ -76,8 +87,9 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor {
 				Iterator<DynamicNode> iterator = dynamicNodeStream.iterator();
 				while (iterator.hasNext()) {
 					DynamicNode dynamicNode = iterator.next();
-					JupiterTestDescriptor descriptor = createDynamicDescriptor(this, dynamicNode, index++, source);
-					dynamicTestExecutor.execute(descriptor);
+					Optional<JupiterTestDescriptor> descriptor = createDynamicDescriptor(this, dynamicNode, index++,
+						source, getDynamicDescendantFilter());
+					descriptor.ifPresent(dynamicTestExecutor::execute);
 				}
 			}
 			catch (ClassCastException ex) {
@@ -96,21 +108,27 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor {
 		}
 	}
 
-	static JupiterTestDescriptor createDynamicDescriptor(JupiterTestDescriptor parent, DynamicNode node, int index,
-			TestSource source) {
-		JupiterTestDescriptor descriptor;
+	static Optional<JupiterTestDescriptor> createDynamicDescriptor(JupiterTestDescriptor parent, DynamicNode node,
+			int index, TestSource source, DynamicDescendantFilter dynamicDescendantFilter) {
+		UniqueId uniqueId;
+		Supplier<JupiterTestDescriptor> descriptorCreator;
 		if (node instanceof DynamicTest) {
 			DynamicTest test = (DynamicTest) node;
-			UniqueId uniqueId = parent.getUniqueId().append(DYNAMIC_TEST_SEGMENT_TYPE, "#" + index);
-			descriptor = new DynamicTestTestDescriptor(uniqueId, index, test, source);
+			uniqueId = parent.getUniqueId().append(DYNAMIC_TEST_SEGMENT_TYPE, "#" + index);
+			descriptorCreator = () -> new DynamicTestTestDescriptor(uniqueId, index, test, source);
 		}
 		else {
 			DynamicContainer container = (DynamicContainer) node;
-			UniqueId uniqueId = parent.getUniqueId().append(DYNAMIC_CONTAINER_SEGMENT_TYPE, "#" + index);
-			descriptor = new DynamicContainerTestDescriptor(uniqueId, index, container, source);
+			uniqueId = parent.getUniqueId().append(DYNAMIC_CONTAINER_SEGMENT_TYPE, "#" + index);
+			descriptorCreator = () -> new DynamicContainerTestDescriptor(uniqueId, index, container, source,
+				dynamicDescendantFilter);
 		}
-		parent.addChild(descriptor);
-		return descriptor;
+		if (dynamicDescendantFilter.test(uniqueId)) {
+			JupiterTestDescriptor descriptor = descriptorCreator.get();
+			parent.addChild(descriptor);
+			return Optional.of(descriptor);
+		}
+		return Optional.empty();
 	}
 
 	private JUnitException invalidReturnTypeException(Throwable cause) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestMethodResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestMethodResolver.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.discovery;
 import java.lang.reflect.Method;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsTestMethod;
 import org.junit.platform.engine.TestDescriptor;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
@@ -10,9 +10,14 @@
 
 package org.junit.jupiter.engine;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
+import java.util.Set;
+
+import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
@@ -29,7 +34,11 @@ public abstract class AbstractJupiterTestEngineTests {
 	private final JupiterTestEngine engine = new JupiterTestEngine();
 
 	protected ExecutionEventRecorder executeTestsForClass(Class<?> testClass) {
-		return executeTests(request().selectors(selectClass(testClass)).build());
+		return executeTests(selectClass(testClass));
+	}
+
+	protected ExecutionEventRecorder executeTests(DiscoverySelector... selectors) {
+		return executeTests(request().selectors(selectors).build());
 	}
 
 	protected ExecutionEventRecorder executeTests(LauncherDiscoveryRequest request) {
@@ -39,8 +48,24 @@ public abstract class AbstractJupiterTestEngineTests {
 		return eventRecorder;
 	}
 
+	protected TestDescriptor discoverTests(DiscoverySelector... selectors) {
+		return discoverTests(request().selectors(selectors).build());
+	}
+
 	protected TestDescriptor discoverTests(LauncherDiscoveryRequest request) {
 		return engine.discover(request, UniqueId.forEngine(engine.getId()));
+	}
+
+	protected UniqueId discoverUniqueId(Class<?> clazz, String methodName) {
+		TestDescriptor engineDescriptor = discoverTests(selectMethod(clazz, methodName));
+		Set<? extends TestDescriptor> descendants = engineDescriptor.getDescendants();
+		// @formatter:off
+		TestDescriptor testDescriptor = descendants.stream()
+				.skip(descendants.size() - 1)
+				.findFirst()
+				.orElseGet(() -> fail("no descendants"));
+		// @formatter:on
+		return testDescriptor.getUniqueId();
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DynamicNodeGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/DynamicNodeGenerationTests.java
@@ -18,8 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor.DYNAMIC_CONTAINER_SEGMENT_TYPE;
+import static org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor.DYNAMIC_TEST_SEGMENT_TYPE;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.engine.test.event.ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.assertRecordedExecutionEventsContainsExactly;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
@@ -48,6 +51,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -64,7 +68,7 @@ class DynamicNodeGenerationTests extends AbstractJupiterTestEngineTests {
 	void testFactoryMethodsAreCorrectlyDiscoveredForClassSelector() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(MyDynamicTestCase.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request);
-		assertThat(engineDescriptor.getDescendants()).as("# resolved test descriptors").hasSize(9);
+		assertThat(engineDescriptor.getDescendants()).as("# resolved test descriptors").hasSize(10);
 	}
 
 	@Test
@@ -147,6 +151,25 @@ class DynamicNodeGenerationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	void singleDynamicTestIsExecutedWhenDiscoveredByUniqueId() {
+		UniqueId uniqueId = discoverUniqueId(MyDynamicTestCase.class, "dynamicStream") //
+				.append(DYNAMIC_TEST_SEGMENT_TYPE, "#2");
+
+		ExecutionEventRecorder eventRecorder = executeTests(selectUniqueId(uniqueId));
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(MyDynamicTestCase.class), started()), //
+			event(container("dynamicStream"), started()), //
+			event(dynamicTestRegistered("dynamic-test:#2")), //
+			event(test("dynamic-test:#2", "failingTest"), started()), //
+			event(test("dynamic-test:#2", "failingTest"), finishedWithFailure(message("failing"))), //
+			event(container("dynamicStream"), finishedSuccessfully()), //
+			event(container(MyDynamicTestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
 	void dynamicContainersAreExecutedFromIterable() {
 		LauncherDiscoveryRequest request = request().selectors(
 			selectMethod(MyDynamicTestCase.class, "dynamicContainerWithIterable")).build();
@@ -177,6 +200,62 @@ class DynamicNodeGenerationTests extends AbstractJupiterTestEngineTests {
 			() -> assertEquals(1, eventRecorder.getTestSuccessfulCount(), "# tests succeeded"),
 			() -> assertEquals(1, eventRecorder.getTestFailedCount(), "# tests failed"),
 			() -> assertEquals(4, eventRecorder.getContainerFinishedCount(), "# container finished"));
+	}
+
+	@Test
+	void singleDynamicTestInNestedDynamicContainerIsExecutedWhenDiscoveredByUniqueId() {
+		UniqueId uniqueId = discoverUniqueId(MyDynamicTestCase.class, "twoNestedContainersWithTwoTestsEach") //
+				.append(DYNAMIC_CONTAINER_SEGMENT_TYPE, "#1") //
+				.append(DYNAMIC_CONTAINER_SEGMENT_TYPE, "#1") //
+				.append(DYNAMIC_TEST_SEGMENT_TYPE, "#2");
+
+		ExecutionEventRecorder eventRecorder = executeTests(selectUniqueId(uniqueId));
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(MyDynamicTestCase.class), started()), //
+			event(container("twoNestedContainersWithTwoTestsEach"), started()), //
+			event(dynamicTestRegistered(displayName("a"))), //
+			event(container(displayName("a")), started()), //
+			event(dynamicTestRegistered(displayName("a1"))), //
+			event(container(displayName("a1")), started()), //
+			event(dynamicTestRegistered("dynamic-test:#2")), //
+			event(test("dynamic-test:#2", "failingTest"), started()), //
+			event(test("dynamic-test:#2", "failingTest"), finishedWithFailure(message("failing"))), //
+			event(container(displayName("a1")), finishedSuccessfully()), //
+			event(container(displayName("a")), finishedSuccessfully()), //
+			event(container("twoNestedContainersWithTwoTestsEach"), finishedSuccessfully()), //
+			event(container(MyDynamicTestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void allDynamicTestInNestedDynamicContainerAreExecutedWhenContainerIsDiscoveredByUniqueId() {
+		UniqueId uniqueId = discoverUniqueId(MyDynamicTestCase.class, "twoNestedContainersWithTwoTestsEach") //
+				.append(DYNAMIC_CONTAINER_SEGMENT_TYPE, "#2") //
+				.append(DYNAMIC_CONTAINER_SEGMENT_TYPE, "#1");
+
+		ExecutionEventRecorder eventRecorder = executeTests(selectUniqueId(uniqueId));
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(MyDynamicTestCase.class), started()), //
+			event(container("twoNestedContainersWithTwoTestsEach"), started()), //
+			event(dynamicTestRegistered(displayName("b"))), //
+			event(container(displayName("b")), started()), //
+			event(dynamicTestRegistered(displayName("b1"))), //
+			event(container(displayName("b1")), started()), //
+			event(dynamicTestRegistered("dynamic-test:#1")), //
+			event(test("dynamic-test:#1", "succeedingTest"), started()), //
+			event(test("dynamic-test:#1", "succeedingTest"), finishedSuccessfully()), //
+			event(dynamicTestRegistered("dynamic-test:#2")), //
+			event(test("dynamic-test:#2", "failingTest"), started()), //
+			event(test("dynamic-test:#2", "failingTest"), finishedWithFailure(message("failing"))), //
+			event(container(displayName("b1")), finishedSuccessfully()), //
+			event(container(displayName("b")), finishedSuccessfully()), //
+			event(container("twoNestedContainersWithTwoTestsEach"), finishedSuccessfully()), //
+			event(container(MyDynamicTestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
 	}
 
 	@Test
@@ -324,6 +403,14 @@ class DynamicNodeGenerationTests extends AbstractJupiterTestEngineTests {
 		@TestFactory
 		Iterable<DynamicNode> nestedDynamicContainers() {
 			return singleton(dynamicContainer("gift wrap", singleton(dynamicContainer("box", list))));
+		}
+
+		@TestFactory
+		Stream<DynamicNode> twoNestedContainersWithTwoTestsEach() {
+			return Stream.of( //
+				dynamicContainer("a", singleton(dynamicContainer("a1", list))), //
+				dynamicContainer("b", singleton(dynamicContainer("b1", list))) //
+			);
 		}
 
 		@TestFactory

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.engine.test.event.ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.assertRecordedExecutionEventsContainsExactly;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
@@ -66,7 +67,9 @@ import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.engine.descriptor.TestTemplateInvocationTestDescriptor;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -173,6 +176,24 @@ class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 				event(test("test-template-invocation:#1"), started()), //
 				event(test("test-template-invocation:#1"),
 					finishedWithFailure(message("invocation is expected to fail"))), //
+				event(dynamicTestRegistered("test-template-invocation:#2"), displayName("[2]")), //
+				event(test("test-template-invocation:#2"), started()), //
+				event(test("test-template-invocation:#2"),
+					finishedWithFailure(message("invocation is expected to fail"))), //
+				event(container("templateWithTwoInvocationsFromSingleExtension"), finishedSuccessfully())));
+	}
+
+	@Test
+	void singleInvocationIsExecutedWhenDiscoveredByUniqueId() {
+		UniqueId uniqueId = discoverUniqueId(MyTestTemplateTestCase.class,
+			"templateWithTwoInvocationsFromSingleExtension") //
+					.append(TestTemplateInvocationTestDescriptor.SEGMENT_TYPE, "#2");
+
+		ExecutionEventRecorder eventRecorder = executeTests(selectUniqueId(uniqueId));
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
+				event(container("templateWithTwoInvocationsFromSingleExtension"), started()), //
 				event(dynamicTestRegistered("test-template-invocation:#2"), displayName("[2]")), //
 				event(test("test-template-invocation:#2"), started()), //
 				event(test("test-template-invocation:#2"),

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TrackLogRecords.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TrackLogRecords.java
@@ -41,7 +41,7 @@ import org.junit.platform.commons.logging.LoggerFactory;
  * @see LoggerFactory
  * @see LogRecordListener
  */
-@Target(ElementType.TYPE)
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(TrackLogRecords.Extension.class)
 public @interface TrackLogRecords {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -11,7 +11,6 @@
 package org.junit.jupiter.engine.discovery;
 
 import static java.util.Collections.singleton;
-import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -224,14 +223,8 @@ class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request, engineDescriptor);
 		assertTrue(engineDescriptor.getDescendants().isEmpty());
-		// @formatter:off
-		assertThat(listener.stream()
-				.filter(logRecord -> logRecord.getLevel() == Level.WARNING)
-				.filter(logRecord -> JavaElementsResolver.class.getName().equals(logRecord.getLoggerName()))
-				.map(LogRecord::getMessage)
-				.filter(isEqual("Unique ID '" + uniqueId + "' could not be resolved."))
-		).hasSize(1);
-		// @formatter:on
+		assertThat(listener.stream(JavaElementsResolver.class, Level.WARNING).map(LogRecord::getMessage)) //
+				.contains("Unique ID '" + uniqueId + "' could not be resolved.");
 	}
 
 	@Test
@@ -309,11 +302,7 @@ class DiscoverySelectorResolverTests {
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertThat(uniqueIds).contains(uniqueIdForClass(HerTestClass.class));
 		assertThat(uniqueIds).contains(uniqueIdForMethod(HerTestClass.class, "test7(java.lang.String)"));
-		// @formatter:off
-		assertThat(listener.stream()
-				.filter(logRecord -> JavaElementsResolver.class.getName().equals(logRecord.getLoggerName()))
-		).isEmpty();
-		// @formatter:on
+		assertThat(listener.stream(JavaElementsResolver.class)).isEmpty();
 	}
 
 	@Test
@@ -324,16 +313,10 @@ class DiscoverySelectorResolverTests {
 
 		resolver.resolveSelectors(request, engineDescriptor);
 		assertTrue(engineDescriptor.getDescendants().isEmpty());
-		// @formatter:off
-		assertThat(listener.stream()
-				.filter(logRecord -> logRecord.getLevel() == Level.WARNING)
-				.filter(logRecord -> JavaElementsResolver.class.getName().equals(logRecord.getLoggerName()))
-				.map(LogRecord::getMessage)
-				.filter(isEqual("Unique ID '" + uniqueId + "' could only be partially resolved. "
+		assertThat(listener.stream(JavaElementsResolver.class, Level.WARNING).map(LogRecord::getMessage)) //
+				.contains("Unique ID '" + uniqueId + "' could only be partially resolved. "
 						+ "All resolved segments will be executed; however, the following segments "
-						+ "could not be resolved: [Segment [type = 'method', value = 'test7(java.math.BigDecimal)']]"))
-		).hasSize(1);
-		// @formatter:on
+						+ "could not be resolved: [Segment [type = 'method', value = 'test7(java.math.BigDecimal)']]");
 	}
 
 	@Test
@@ -580,11 +563,7 @@ class DiscoverySelectorResolverTests {
 		assertThat(dynamicDescendantFilter.test(dynamicTestUid)).isTrue();
 		assertThat(dynamicDescendantFilter.test(differentDynamicTestUid)).isFalse();
 
-		// @formatter:off
-		assertThat(listener.stream()
-				.filter(logRecord -> JavaElementsResolver.class.getName().equals(logRecord.getLoggerName()))
-		).isEmpty();
-		// @formatter:on
+		assertThat(listener.stream(JavaElementsResolver.class)).isEmpty();
 	}
 
 	@Test
@@ -609,11 +588,7 @@ class DiscoverySelectorResolverTests {
 		assertThat(dynamicDescendantFilter.test(differentDynamicContainerUid)).isFalse();
 		assertThat(dynamicDescendantFilter.test(differentDynamicTestUid)).isFalse();
 
-		// @formatter:off
-		assertThat(listener.stream()
-				.filter(logRecord -> JavaElementsResolver.class.getName().equals(logRecord.getLoggerName()))
-		).isEmpty();
-		// @formatter:on
+		assertThat(listener.stream(JavaElementsResolver.class)).isEmpty();
 	}
 
 	@Test

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -77,8 +77,6 @@ public class UniqueId implements Cloneable, Serializable {
 	 * @see #forEngine(String)
 	 */
 	public static UniqueId root(String segmentType, String value) {
-		Preconditions.notBlank(segmentType, "segmentType must not be null or blank");
-		Preconditions.notBlank(value, "value must not be null or blank");
 		return new UniqueId(UniqueIdFormat.getDefault(), new Segment(segmentType, value));
 	}
 
@@ -138,11 +136,41 @@ public class UniqueId implements Cloneable, Serializable {
 	 * @param value the value of the segment; never {@code null} or blank
 	 */
 	public final UniqueId append(String segmentType, String value) {
-		Preconditions.notBlank(segmentType, "segmentType must not be null or blank");
-		Preconditions.notBlank(value, "value must not be null or blank");
+		return append(new Segment(segmentType, value));
+	}
+
+	/**
+	 * Construct a new {@code UniqueId} by appending a new {@link Segment} to
+	 * the end of this {@code UniqueId}.
+	 *
+	 * <p>This {@code UniqueId} will not be modified.
+	 *
+	 * @param segment the segment to be appended; never {@code null}
+	 *
+	 * @since 1.1
+	 */
+	@API(status = STABLE, since = "1.1")
+	public final UniqueId append(Segment segment) {
+		Preconditions.notNull(segment, "segment must not be null");
 		List<Segment> baseSegments = new ArrayList<>(this.segments);
-		baseSegments.add(new Segment(segmentType, value));
+		baseSegments.add(segment);
 		return new UniqueId(this.uniqueIdFormat, baseSegments);
+	}
+
+	/**
+	 * Determine if the supplied {@code UniqueId} is a prefix for this
+	 * {@code UniqueId}.
+	 *
+	 * @param potentialPrefix the {@code UniqueId} to be checked; never {@code null}
+	 *
+	 * @since 1.1
+	 */
+	@API(status = STABLE, since = "1.1")
+	public boolean hasPrefix(UniqueId potentialPrefix) {
+		Preconditions.notNull(potentialPrefix, "potentialPrefix must not be null");
+		int size = this.segments.size();
+		int prefixSize = potentialPrefix.segments.size();
+		return size >= prefixSize && this.segments.subList(0, prefixSize).equals(potentialPrefix.segments);
 	}
 
 	@Override
@@ -197,6 +225,8 @@ public class UniqueId implements Cloneable, Serializable {
 		 * @param value the value of this segment
 		 */
 		Segment(String type, String value) {
+			Preconditions.notBlank(type, "type must not be null or blank");
+			Preconditions.notBlank(value, "value must not be null or blank");
 			this.type = type;
 			this.value = value;
 		}

--- a/platform-tests/src/test/java/org/junit/platform/engine/UniqueIdTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/UniqueIdTests.java
@@ -10,8 +10,10 @@
 
 package org.junit.platform.engine;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
@@ -20,17 +22,18 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.commons.util.PreconditionViolationException;
 import org.junit.platform.engine.UniqueId.Segment;
 
 /**
  * Unit tests for {@link UniqueId}.
  *
  * @since 1.0
- * @see org.junit.jupiter.engine.execution.UniqueIdParsingForArrayParameterTests
+ * @see org.junit.jupiter.engine.execution.UniqueIdParsingForArrayParameterIntegrationTests
  */
 class UniqueIdTests {
 
-	static final String ENGINE_ID = "junit-jupiter";
+	private static final String ENGINE_ID = "junit-jupiter";
 
 	@Nested
 	class Creation {
@@ -46,7 +49,7 @@ class UniqueIdTests {
 		@Test
 		void retrievingOptionalEngineId() {
 			UniqueId uniqueIdWithEngine = UniqueId.forEngine(ENGINE_ID);
-			assertEquals("junit-jupiter", uniqueIdWithEngine.getEngineId().get());
+			assertThat(uniqueIdWithEngine.getEngineId()).contains("junit-jupiter");
 
 			UniqueId uniqueIdWithoutEngine = UniqueId.root("root", "avalue");
 			assertEquals(Optional.empty(), uniqueIdWithoutEngine.getEngineId());
@@ -64,7 +67,7 @@ class UniqueIdTests {
 		void rootSegmentCanBeRetrieved() {
 			UniqueId uniqueId = UniqueId.root("aType", "aValue");
 
-			assertEquals(new Segment("aType", "aValue"), uniqueId.getRoot().get());
+			assertThat(uniqueId.getRoot()).contains(new Segment("aType", "aValue"));
 		}
 
 		@Test
@@ -72,7 +75,7 @@ class UniqueIdTests {
 			UniqueId engineId = UniqueId.root("engine", ENGINE_ID);
 			UniqueId classId = engineId.append("class", "org.junit.MyClass");
 
-			assertEquals(2, classId.getSegments().size());
+			assertThat(classId.getSegments()).hasSize(2);
 			assertSegment(classId.getSegments().get(0), "engine", ENGINE_ID);
 			assertSegment(classId.getSegments().get(1), "class", "org.junit.MyClass");
 		}
@@ -82,7 +85,7 @@ class UniqueIdTests {
 			UniqueId uniqueId = UniqueId.root("engine", ENGINE_ID);
 			uniqueId.append("class", "org.junit.MyClass");
 
-			assertEquals(1, uniqueId.getSegments().size());
+			assertThat(uniqueId.getSegments()).hasSize(1);
 			assertSegment(uniqueId.getSegments().get(0), "engine", ENGINE_ID);
 		}
 
@@ -91,11 +94,32 @@ class UniqueIdTests {
 			UniqueId engineId = UniqueId.root("engine", ENGINE_ID);
 			UniqueId uniqueId = engineId.append("t1", "v1").append("t2", "v2").append("t3", "v3");
 
-			assertEquals(4, uniqueId.getSegments().size());
+			assertThat(uniqueId.getSegments()).hasSize(4);
 			assertSegment(uniqueId.getSegments().get(0), "engine", ENGINE_ID);
 			assertSegment(uniqueId.getSegments().get(1), "t1", "v1");
 			assertSegment(uniqueId.getSegments().get(2), "t2", "v2");
 			assertSegment(uniqueId.getSegments().get(3), "t3", "v3");
+		}
+
+		@Test
+		void appendingSegmentInstance() {
+			UniqueId uniqueId = UniqueId.forEngine(ENGINE_ID).append("t1", "v1");
+
+			uniqueId = uniqueId.append(new Segment("t2", "v2"));
+
+			assertThat(uniqueId.getSegments()).hasSize(3);
+			assertSegment(uniqueId.getSegments().get(0), "engine", ENGINE_ID);
+			assertSegment(uniqueId.getSegments().get(1), "t1", "v1");
+			assertSegment(uniqueId.getSegments().get(2), "t2", "v2");
+		}
+
+		@Test
+		void appendingNullIsNotAllowed() {
+			UniqueId uniqueId = UniqueId.forEngine(ENGINE_ID);
+
+			assertThrows(PreconditionViolationException.class, () -> uniqueId.append(null));
+			assertThrows(PreconditionViolationException.class, () -> uniqueId.append(null, "foo"));
+			assertThrows(PreconditionViolationException.class, () -> uniqueId.append("foo", null));
 		}
 
 	}
@@ -191,6 +215,48 @@ class UniqueIdTests {
 			assertFalse(id1.equals(id2));
 			assertFalse(id2.equals(id1));
 		}
+	}
+
+	@Nested
+	class Prefixing {
+
+		@Test
+		void nullIsNotAPrefix() {
+			UniqueId id = UniqueId.forEngine(ENGINE_ID);
+
+			assertThrows(PreconditionViolationException.class, () -> id.hasPrefix(null));
+		}
+
+		@Test
+		void uniqueIdIsPrefixForItself() {
+			UniqueId id = UniqueId.forEngine(ENGINE_ID).append("t1", "v1").append("t2", "v2");
+
+			assertTrue(id.hasPrefix(id));
+		}
+
+		@Test
+		void uniqueIdIsPrefixForUniqueIdWithAdditionalSegments() {
+			UniqueId id1 = UniqueId.forEngine(ENGINE_ID);
+			UniqueId id2 = id1.append("t1", "v1");
+			UniqueId id3 = id2.append("t2", "v2");
+
+			assertFalse(id1.hasPrefix(id2));
+			assertFalse(id1.hasPrefix(id3));
+			assertTrue(id2.hasPrefix(id1));
+			assertFalse(id2.hasPrefix(id3));
+			assertTrue(id3.hasPrefix(id1));
+			assertTrue(id3.hasPrefix(id2));
+		}
+
+		@Test
+		void completelyUnrelatedUniqueIdsAreNotPrefixesForEachOther() {
+			UniqueId id1 = UniqueId.forEngine("foo");
+			UniqueId id2 = UniqueId.forEngine("bar");
+
+			assertFalse(id1.hasPrefix(id2));
+			assertFalse(id2.hasPrefix(id1));
+		}
+
 	}
 
 	private void assertSegment(Segment segment, String expectedType, String expectedValue) {


### PR DESCRIPTION
Resolves #1025.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [X] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
