### PR TITLE
Fixes for XML reporting

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -37,8 +37,17 @@ _@API Guardian_ JAR _mandatory_ again.
   current module layer is the one that the class loader for the `ModuleUtils` class
   returns. If the current layer cannot be obtained, the algorithm falls back to the boot
   layer.
-* The XML report produced by the `ConsoleLauncher` is no longer invalid when the exception
-  message of a failed test contains the XML CDATA end marker `]]>`.
+* The XML report produced by the `ConsoleLauncher` and Gradle plugin is no longer invalid
+  when the exception message of a failed test contains the XML CDATA end marker `]]>`.
+* The `ConsoleLauncher`, the Gradle plugin, and the Maven Surefire provider now attempt to
+  write a valid class name into the `classname` attribute of `<testcase/>` elements in the
+  XML reports. In addition, the `name` attribute of dynamic tests and test template
+  invocations (such as repeated and parameterized tests) is now suffixed with the index of
+  the invocation so they are distinguishable by reporting tools.
+* The Maven Surefire provider now includes the method parameter types when writing the
+  `name` attribute of `<testcase/>` elements into XML reports. However, due to a
+  limitation of Maven Surefire, instead of `methodName(Type)` they are written as
+  `methodName{Type}`.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -33,8 +33,9 @@ class DynamicContainerTestDescriptor extends DynamicNodeTestDescriptor {
 	private final DynamicContainer dynamicContainer;
 	private final TestSource testSource;
 
-	DynamicContainerTestDescriptor(UniqueId uniqueId, DynamicContainer dynamicContainer, TestSource testSource) {
-		super(uniqueId, dynamicContainer, testSource);
+	DynamicContainerTestDescriptor(UniqueId uniqueId, int index, DynamicContainer dynamicContainer,
+			TestSource testSource) {
+		super(uniqueId, index, dynamicContainer, testSource);
 		this.dynamicContainer = dynamicContainer;
 		this.testSource = testSource;
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
@@ -23,8 +23,21 @@ import org.junit.platform.engine.UniqueId;
  */
 abstract class DynamicNodeTestDescriptor extends JupiterTestDescriptor {
 
-	DynamicNodeTestDescriptor(UniqueId uniqueId, DynamicNode dynamicNode, TestSource testSource) {
+	private final int index;
+
+	DynamicNodeTestDescriptor(UniqueId uniqueId, int index, DynamicNode dynamicNode, TestSource testSource) {
 		super(uniqueId, dynamicNode.getDisplayName(), testSource);
+		this.index = index;
+	}
+
+	@Override
+	public String getLegacyReportingName() {
+		// @formatter:off
+		return getParent()
+				.map(TestDescriptor::getLegacyReportingName)
+				.orElseGet(this::getDisplayName)
+						+ "[" + index + "]";
+		// @formatter:on
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
@@ -25,8 +25,8 @@ class DynamicTestTestDescriptor extends DynamicNodeTestDescriptor {
 
 	private final DynamicTest dynamicTest;
 
-	DynamicTestTestDescriptor(UniqueId uniqueId, DynamicTest dynamicTest, TestSource source) {
-		super(uniqueId, dynamicTest, source);
+	DynamicTestTestDescriptor(UniqueId uniqueId, int index, DynamicTest dynamicTest, TestSource source) {
+		super(uniqueId, index, dynamicTest, source);
 		this.dynamicTest = dynamicTest;
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -102,12 +102,12 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor {
 		if (node instanceof DynamicTest) {
 			DynamicTest test = (DynamicTest) node;
 			UniqueId uniqueId = parent.getUniqueId().append(DYNAMIC_TEST_SEGMENT_TYPE, "#" + index);
-			descriptor = new DynamicTestTestDescriptor(uniqueId, test, source);
+			descriptor = new DynamicTestTestDescriptor(uniqueId, index, test, source);
 		}
 		else {
 			DynamicContainer container = (DynamicContainer) node;
 			UniqueId uniqueId = parent.getUniqueId().append(DYNAMIC_CONTAINER_SEGMENT_TYPE, "#" + index);
-			descriptor = new DynamicContainerTestDescriptor(uniqueId, container, source);
+			descriptor = new DynamicContainerTestDescriptor(uniqueId, index, container, source);
 		}
 		parent.addChild(descriptor);
 		return descriptor;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
@@ -33,11 +33,18 @@ public class TestTemplateInvocationTestDescriptor extends TestMethodTestDescript
 	public static final String SEGMENT_TYPE = "test-template-invocation";
 
 	private TestTemplateInvocationContext invocationContext;
+	private final int index;
 
 	TestTemplateInvocationTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method templateMethod,
 			TestTemplateInvocationContext invocationContext, int index) {
 		super(uniqueId, invocationContext.getDisplayName(index), testClass, templateMethod);
 		this.invocationContext = invocationContext;
+		this.index = index;
+	}
+
+	@Override
+	public String getLegacyReportingName() {
+		return super.getLegacyReportingName() + "[" + index + "]";
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.assertRecordedExecutionEventsContainsExactly;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.displayName;
@@ -139,6 +140,23 @@ class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 				event(test("test-template-invocation:#2"),
 					finishedWithFailure(message("invocation is expected to fail"))), //
 				event(container("templateWithTwoRegisteredExtensions"), finishedSuccessfully())));
+	}
+
+	@Test
+	void legacyReportingNames() {
+		LauncherDiscoveryRequest request = request().selectors(
+			selectMethod(MyTestTemplateTestCase.class, "templateWithTwoRegisteredExtensions")).build();
+
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		// @formatter:off
+		Stream<String> legacyReportingNames = eventRecorder.getExecutionEvents().stream()
+				.filter(event -> event.getType() == DYNAMIC_TEST_REGISTERED)
+				.map(ExecutionEvent::getTestDescriptor)
+				.map(TestDescriptor::getLegacyReportingName);
+		// @formatter:off
+		assertThat(legacyReportingNames).containsExactly("templateWithTwoRegisteredExtensions()[1]",
+						"templateWithTwoRegisteredExtensions()[2]");
 	}
 
 	@Test

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.displayName;
 import static org.junit.platform.engine.test.event.ExecutionEventConditions.event;
@@ -48,6 +49,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 
@@ -81,6 +83,21 @@ class ParameterizedTestIntegrationTests {
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("foo and 23"), finishedWithFailure(message("foo, 23")))) //
 				.haveExactly(1, event(test(), displayName("bar and 42"), finishedWithFailure(message("bar, 42"))));
+	}
+
+	@Test
+	void legacyReportingNames() {
+		List<ExecutionEvent> executionEvents = execute(
+			selectMethod(TestCase.class, "testWithCustomName", String.class.getName() + "," + Integer.TYPE.getName()));
+
+		// @formatter:off
+		Stream<String> legacyReportingNames = executionEvents.stream()
+				.filter(event -> event.getType() == DYNAMIC_TEST_REGISTERED)
+				.map(ExecutionEvent::getTestDescriptor)
+				.map(TestDescriptor::getLegacyReportingName);
+		// @formatter:off
+		assertThat(legacyReportingNames).containsExactly("testWithCustomName(String, int)[1]",
+				"testWithCustomName(String, int)[2]");
 	}
 
 	@Test

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/XmlReportWriter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/XmlReportWriter.java
@@ -158,7 +158,7 @@ class XmlReportWriter {
 	}
 
 	private String getClassName(TestIdentifier testIdentifier) {
-		return LegacyReportingUtils.getLegacyReportingClassName(this.reportData.getTestPlan(), testIdentifier);
+		return LegacyReportingUtils.getClassName(this.reportData.getTestPlan(), testIdentifier);
 	}
 
 	private void writeSkippedOrErrorOrFailureElement(TestIdentifier testIdentifier, XMLStreamWriter writer)

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/XmlReportWriter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/XmlReportWriter.java
@@ -36,6 +36,7 @@ import javax.xml.stream.XMLStreamWriter;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.listeners.LegacyReportingUtils;
 
 /**
  * {@code XmlReportWriter} writes an XML report whose format is compatible
@@ -157,11 +158,7 @@ class XmlReportWriter {
 	}
 
 	private String getClassName(TestIdentifier testIdentifier) {
-		// @formatter:off
-		return this.reportData.getTestPlan().getParent(testIdentifier)
-				.map(TestIdentifier::getLegacyReportingName)
-				.orElse("<unrooted>");
-		// @formatter:on
+		return LegacyReportingUtils.getLegacyReportingClassName(this.reportData.getTestPlan(), testIdentifier);
 	}
 
 	private void writeSkippedOrErrorOrFailureElement(TestIdentifier testIdentifier, XMLStreamWriter writer)

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -130,6 +130,7 @@ public final class TestIdentifier implements Serializable {
 	 *
 	 * @return the legacy reporting name; never {@code null} or blank
 	 * @see org.junit.platform.engine.TestDescriptor#getLegacyReportingName()
+	 * @see org.junit.platform.launcher.listeners.LegacyReportingUtils
 	 */
 	public String getLegacyReportingName() {
 		return this.legacyReportingName;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LegacyReportingUtils.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LegacyReportingUtils.java
@@ -10,17 +10,48 @@
 
 package org.junit.platform.launcher.listeners;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
-@API(status = EXPERIMENTAL, since = "1.1")
+/**
+ * Utility methods for dealing with legacy reporting infrastructure, such as
+ * reporting systems built on the Ant-based XML reporting format for JUnit 4.
+ *
+ * @since 1.1
+ */
+@API(status = MAINTAINED, since = "1.1")
 public class LegacyReportingUtils {
 
-	public static String getLegacyReportingClassName(TestPlan testPlan, TestIdentifier testIdentifier) {
+	///CLOVER:OFF
+	private LegacyReportingUtils() {
+		/* no-op */
+	}
+	///CLOVER:ON
+
+	/**
+	 * Get the class name for the supplied {@link TestIdentifier} using the
+	 * supplied {@link TestPlan}.
+	 *
+	 * <p>This implementation attempts to find the closest test identifier with
+	 * a {@link ClassSource} by traversing the hierarchy upwards towards the
+	 * root starting with the supplied test identifier. In case no such source
+	 * is found, it falls back to using the parent's
+	 * {@linkplain TestIdentifier#getLegacyReportingName legacy reporting name}.
+	 *
+	 * @param testPlan the test plan that contains the {@code TestIdentifier};
+	 *                 never {@code null}
+	 * @param testIdentifier the identifier to determine the class name for;
+	 *                 never {@code null}
+	 * @see TestIdentifier#getLegacyReportingName
+	 */
+	public static String getClassName(TestPlan testPlan, TestIdentifier testIdentifier) {
+		Preconditions.notNull(testPlan, "testPlan must not be null");
+		Preconditions.notNull(testIdentifier, "testIdentifier must not be null");
 		for (TestIdentifier current = testIdentifier; current != null; current = getParent(testPlan, current)) {
 			ClassSource source = getClassSource(current);
 			if (source != null) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LegacyReportingUtils.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LegacyReportingUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+@API(status = EXPERIMENTAL, since = "1.1")
+public class LegacyReportingUtils {
+
+	public static String getLegacyReportingClassName(TestPlan testPlan, TestIdentifier testIdentifier) {
+		for (TestIdentifier current = testIdentifier; current != null; current = getParent(testPlan, current)) {
+			ClassSource source = getClassSource(current);
+			if (source != null) {
+				return source.getClassName();
+			}
+		}
+		return getParentLegacyReportingName(testPlan, testIdentifier);
+	}
+
+	private static TestIdentifier getParent(TestPlan testPlan, TestIdentifier testIdentifier) {
+		return testPlan.getParent(testIdentifier).orElse(null);
+	}
+
+	private static ClassSource getClassSource(TestIdentifier current) {
+		// @formatter:off
+		return current.getSource()
+				.filter(ClassSource.class::isInstance)
+				.map(ClassSource.class::cast)
+				.orElse(null);
+		// @formatter:on
+	}
+
+	private static String getParentLegacyReportingName(TestPlan testPlan, TestIdentifier testIdentifier) {
+		// @formatter:off
+		return testPlan.getParent(testIdentifier)
+				.map(TestIdentifier::getLegacyReportingName)
+				.orElse("<unrooted>");
+		// @formatter:on
+	}
+}

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
@@ -35,6 +35,7 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.listeners.LegacyReportingUtils;
 
 /**
  * @since 1.0
@@ -167,11 +168,7 @@ final class RunListenerAdapter implements TestExecutionListener {
 	}
 
 	private String sourceLegacyReportingName(TestIdentifier testIdentifier) {
-		// @formatter:off
-		return testPlan.getParent(testIdentifier)
-				.map(TestIdentifier::getLegacyReportingName)
-				.orElse("<unrooted>");
-		// @formatter:on
+		return LegacyReportingUtils.getLegacyReportingClassName(testPlan, testIdentifier);
 	}
 
 	private StackTraceWriter getStackTraceWriter(TestIdentifier testIdentifier,

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
@@ -75,8 +75,8 @@ final class RunListenerAdapter implements TestExecutionListener {
 	@Override
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
 		ensureTestSetStarted(testIdentifier);
-		String source = sourceLegacyReportingName(testIdentifier);
-		runListener.testSkipped(ignored(source, testIdentifier.getLegacyReportingName(), reason));
+		String source = getLegacyReportingClassName(testIdentifier);
+		runListener.testSkipped(ignored(source, getLegacyReportingName(testIdentifier), reason));
 		completeTestSetIfNecessary(testIdentifier);
 	}
 
@@ -162,12 +162,20 @@ final class RunListenerAdapter implements TestExecutionListener {
 	}
 
 	private SimpleReportEntry createReportEntry(TestIdentifier testIdentifier, StackTraceWriter stackTraceWriter) {
-		String source = sourceLegacyReportingName(testIdentifier);
-		String name = testIdentifier.getLegacyReportingName();
+		String source = getLegacyReportingClassName(testIdentifier);
+		String name = getLegacyReportingName(testIdentifier);
+
 		return SimpleReportEntry.withException(source, name, stackTraceWriter);
 	}
 
-	private String sourceLegacyReportingName(TestIdentifier testIdentifier) {
+	private String getLegacyReportingName(TestIdentifier testIdentifier) {
+		// Surefire cuts off the name at the first '(' character. Thus, we have to pick a different
+		// character to represent parentheses. "()" are removed entirely to maximize compatibility with
+		// existing reporting tools because in the old days test methods used to not have parameters.
+		return testIdentifier.getLegacyReportingName().replace("()", "").replace('(', '{').replace(')', '}');
+	}
+
+	private String getLegacyReportingClassName(TestIdentifier testIdentifier) {
 		return LegacyReportingUtils.getLegacyReportingClassName(testPlan, testIdentifier);
 	}
 

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/RunListenerAdapter.java
@@ -176,7 +176,7 @@ final class RunListenerAdapter implements TestExecutionListener {
 	}
 
 	private String getLegacyReportingClassName(TestIdentifier testIdentifier) {
-		return LegacyReportingUtils.getLegacyReportingClassName(testPlan, testIdentifier);
+		return LegacyReportingUtils.getClassName(testPlan, testIdentifier);
 	}
 
 	private StackTraceWriter getStackTraceWriter(TestIdentifier testIdentifier,

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
@@ -221,7 +221,7 @@ class RunListenerAdapterTests {
 
 		ReportEntry entry = entryCaptor.getValue();
 		assertTrue(MyTestClass.class.getTypeName().contains(entry.getName()));
-		assertEquals("engine", entry.getSourceName());
+		assertEquals(MyTestClass.class.getTypeName(), entry.getSourceName());
 	}
 
 	@Test
@@ -265,7 +265,7 @@ class RunListenerAdapterTests {
 		verify(listener).testFailed(entryCaptor.capture());
 
 		ReportEntry entry = entryCaptor.getValue();
-		assertEquals("engine", entry.getSourceName());
+		assertEquals(MyTestClass.class.getTypeName(), entry.getSourceName());
 		assertNotNull(entry.getStackTraceWriter());
 	}
 

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
@@ -87,7 +87,26 @@ class RunListenerAdapterTests {
 		verify(listener).testStarting(entryCaptor.capture());
 
 		ReportEntry entry = entryCaptor.getValue();
-		assertEquals(MY_TEST_METHOD_NAME + "()", entry.getName());
+		assertEquals(MY_TEST_METHOD_NAME, entry.getName());
+		assertEquals(MyTestClass.class.getName(), entry.getSourceName());
+		assertNull(entry.getStackTraceWriter());
+	}
+
+	@Test
+	void notifiedWithCompatibleNameForMethodWithArguments() throws Exception {
+		ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+
+		TestPlan testPlan = TestPlan.from(Collections.singletonList(new EngineDescriptor(newId(), "Luke's Plan")));
+		adapter.testPlanExecutionStarted(testPlan);
+
+		TestIdentifier methodIdentifier = identifiersAsParentOnTestPlan(testPlan, newClassDescriptor(),
+			newMethodDescriptor(String.class));
+
+		adapter.executionStarted(methodIdentifier);
+		verify(listener).testStarting(entryCaptor.capture());
+
+		ReportEntry entry = entryCaptor.getValue();
+		assertEquals(MY_TEST_METHOD_NAME + "{String}", entry.getName());
 		assertEquals(MyTestClass.class.getName(), entry.getSourceName());
 		assertNull(entry.getStackTraceWriter());
 	}
@@ -109,11 +128,11 @@ class RunListenerAdapterTests {
 		verifyNoMoreInteractions(listener);
 
 		adapter.executionStarted(TestIdentifier.from(child));
-		verify(listener).testStarting(new SimpleReportEntry(MyTestClass.class.getName(), MY_TEST_METHOD_NAME + "()"));
+		verify(listener).testStarting(new SimpleReportEntry(MyTestClass.class.getName(), MY_TEST_METHOD_NAME));
 		verifyNoMoreInteractions(listener);
 
 		adapter.executionFinished(TestIdentifier.from(child), successful());
-		verify(listener).testSucceeded(new SimpleReportEntry(MyTestClass.class.getName(), MY_TEST_METHOD_NAME + "()"));
+		verify(listener).testSucceeded(new SimpleReportEntry(MyTestClass.class.getName(), MY_TEST_METHOD_NAME));
 		verifyNoMoreInteractions(listener);
 
 		adapter.executionFinished(TestIdentifier.from(parent), successful());
@@ -357,16 +376,16 @@ class RunListenerAdapterTests {
 
 		ReportEntry value = entryCaptor.getValue();
 
-		assertEquals("myNamedTestMethod()", value.getName());
+		assertEquals("myNamedTestMethod", value.getName());
 	}
 
 	private static TestIdentifier newMethodIdentifier() throws Exception {
 		return TestIdentifier.from(newMethodDescriptor());
 	}
 
-	private static TestDescriptor newMethodDescriptor() throws Exception {
+	private static TestDescriptor newMethodDescriptor(Class<?>... parameterTypes) throws Exception {
 		return new TestMethodTestDescriptor(UniqueId.forEngine("method"), MyTestClass.class,
-			MyTestClass.class.getDeclaredMethod(MY_TEST_METHOD_NAME));
+			MyTestClass.class.getDeclaredMethod(MY_TEST_METHOD_NAME, parameterTypes));
 	}
 
 	private static TestIdentifier newClassIdentifier() {
@@ -392,6 +411,7 @@ class RunListenerAdapterTests {
 		TestDescriptor child = mock(TestDescriptor.class);
 		when(child.getUniqueId()).thenReturn(newId());
 		when(child.getType()).thenReturn(Type.TEST);
+		when(child.getLegacyReportingName()).thenReturn("child");
 
 		// Ensure the child source is null yet that there is a parent -- the special case to be tested.
 		when(child.getSource()).thenReturn(Optional.empty());
@@ -443,6 +463,10 @@ class RunListenerAdapterTests {
 	private static class MyTestClass {
 		@Test
 		void myTestMethod() {
+		}
+
+		@Test
+		void myTestMethod(String foo) {
 		}
 
 		@DisplayName("name")

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/LegacyReportingUtilsTest.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/LegacyReportingUtilsTest.java
@@ -32,8 +32,8 @@ class LegacyReportingUtilsTest {
 		TestDescriptor testDescriptor = createTestDescriptor(uniqueId, "Bar", null);
 		engineDescriptor.addChild(testDescriptor);
 
-		assertThat(getLegacyReportingClassName(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
-		assertThat(getLegacyReportingClassName(uniqueId)).isEqualTo("Foo");
+		assertThat(getClassName(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
+		assertThat(getClassName(uniqueId)).isEqualTo("Foo");
 	}
 
 	@Test
@@ -51,16 +51,15 @@ class LegacyReportingUtilsTest {
 		TestDescriptor subSubDescriptor = createTestDescriptor(subSubUniqueId, "Qux", null);
 		subDescriptor.addChild(subSubDescriptor);
 
-		assertThat(getLegacyReportingClassName(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
-		assertThat(getLegacyReportingClassName(classUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
-		assertThat(getLegacyReportingClassName(subUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
-		assertThat(getLegacyReportingClassName(subSubUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
+		assertThat(getClassName(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
+		assertThat(getClassName(classUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
+		assertThat(getClassName(subUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
+		assertThat(getClassName(subSubUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
 	}
 
-	private String getLegacyReportingClassName(UniqueId uniqueId) {
+	private String getClassName(UniqueId uniqueId) {
 		TestPlan testPlan = TestPlan.from(singleton(engineDescriptor));
-		return LegacyReportingUtils.getLegacyReportingClassName(testPlan,
-			testPlan.getTestIdentifier(uniqueId.toString()));
+		return LegacyReportingUtils.getClassName(testPlan, testPlan.getTestIdentifier(uniqueId.toString()));
 	}
 
 	private TestDescriptor createTestDescriptor(UniqueId uniqueId, String displayName, TestSource source) {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/LegacyReportingUtilsTest.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/LegacyReportingUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+import org.junit.platform.launcher.TestPlan;
+
+class LegacyReportingUtilsTest {
+
+	private TestDescriptor engineDescriptor = new EngineDescriptor(UniqueId.forEngine("foo"), "Foo");
+
+	@Test
+	void legacyReportingClassNameForTestIdentifierWithoutClassSourceIsParentLegacyReportingName() {
+		UniqueId uniqueId = engineDescriptor.getUniqueId().append("child", "bar");
+		TestDescriptor testDescriptor = createTestDescriptor(uniqueId, "Bar", null);
+		engineDescriptor.addChild(testDescriptor);
+
+		assertThat(getLegacyReportingClassName(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
+		assertThat(getLegacyReportingClassName(uniqueId)).isEqualTo("Foo");
+	}
+
+	@Test
+	void legacyReportingClassNameForDescendantOfTestIdentifierWithClassSourceIsClassName() {
+		UniqueId classUniqueId = engineDescriptor.getUniqueId().append("class", "class");
+		TestDescriptor classDescriptor = createTestDescriptor(classUniqueId, "Class",
+			ClassSource.from(LegacyReportingUtilsTest.class));
+		engineDescriptor.addChild(classDescriptor);
+
+		UniqueId subUniqueId = classUniqueId.append("sub", "baz");
+		TestDescriptor subDescriptor = createTestDescriptor(subUniqueId, "Baz", null);
+		classDescriptor.addChild(subDescriptor);
+
+		UniqueId subSubUniqueId = subUniqueId.append("subsub", "qux");
+		TestDescriptor subSubDescriptor = createTestDescriptor(subSubUniqueId, "Qux", null);
+		subDescriptor.addChild(subSubDescriptor);
+
+		assertThat(getLegacyReportingClassName(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
+		assertThat(getLegacyReportingClassName(classUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
+		assertThat(getLegacyReportingClassName(subUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
+		assertThat(getLegacyReportingClassName(subSubUniqueId)).isEqualTo(LegacyReportingUtilsTest.class.getName());
+	}
+
+	private String getLegacyReportingClassName(UniqueId uniqueId) {
+		TestPlan testPlan = TestPlan.from(singleton(engineDescriptor));
+		return LegacyReportingUtils.getLegacyReportingClassName(testPlan,
+			testPlan.getTestIdentifier(uniqueId.toString()));
+	}
+
+	private TestDescriptor createTestDescriptor(UniqueId uniqueId, String displayName, TestSource source) {
+		return new AbstractTestDescriptor(uniqueId, displayName, source) {
+			@Override
+			public Type getType() {
+				return Type.CONTAINER_AND_TEST;
+			}
+		};
+	}
+}


### PR DESCRIPTION
## Overview

Fixes #1182. This pull request provides fixes related to XML reports emitted by `ConsoleLauncher`, Gradle plugin, and Maven Surefire.

1. Output class name also for dynamic tests and test template invocations
1. Suffix names with invocation indexes for dynamic tests and test template invocations
1. Output method parameter types also for Maven Surefire but as `testMethod{Type}` instead of `testMethod(Type)` due to a limitation of Surefire

Here's a reference test:

```java
class JUnit5Tests {

  @Test
  void myNormalTest() {}

  @RepeatedTest(3)
  void myRepeatedTest() {}

  @ParameterizedTest
  @ValueSource(strings = {
    "hello",
    "world"
  })
  void myParametrizedTest(String s) {}

  @TestFactory
  Stream<DynamicNode> myTestFactory() {
    return Stream.of(dynamicContainer("foo", Stream.of(dynamicTest("bar", () -> {}))));
  }

  @Nested
  class MyNestedTest {

    @Test
    void myNormalTest() {}

    @RepeatedTest(3)
    void myRepeatedTest() {}

    @ParameterizedTest
    @ValueSource(strings = {
            "hello",
            "world"
    })
    void myParametrizedTest(String s) {}

    @TestFactory
    Stream<DynamicNode> myTestFactory() {
      return Stream.of(dynamicContainer("foo", Stream.of(dynamicTest("bar", () -> {}))));
    }
  }
}
```

Here is its output when executed using Maven:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd" name="com.example.project.JUnit5Tests" time="0.055" tests="14" errors="0" skipped="0" failures="0">
  <properties>...</properties>
  <testcase name="myRepeatedTest[1]" classname="com.example.project.JUnit5Tests" time="0"/>
  <testcase name="myRepeatedTest[1]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0"/>
  <testcase name="myRepeatedTest[2]" classname="com.example.project.JUnit5Tests" time="0"/>
  <testcase name="myRepeatedTest[2]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0"/>
  <testcase name="myRepeatedTest[3]" classname="com.example.project.JUnit5Tests" time="0"/>
  <testcase name="myRepeatedTest[3]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0"/>
  <testcase name="myParametrizedTest{String}[1]" classname="com.example.project.JUnit5Tests" time="0.02"/>
  <testcase name="myParametrizedTest{String}[1]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0"/>
  <testcase name="myParametrizedTest{String}[2]" classname="com.example.project.JUnit5Tests" time="0"/>
  <testcase name="myParametrizedTest{String}[2]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0"/>
  <testcase name="myNormalTest" classname="com.example.project.JUnit5Tests" time="0"/>
  <testcase name="myNormalTest" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0"/>
  <testcase name="myTestFactory[1][1]" classname="com.example.project.JUnit5Tests" time="0"/>
  <testcase name="myTestFactory[1][1]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0"/>
</testsuite>
```

And here's the output for Gradle:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="JUnit Jupiter" tests="14" skipped="0" failures="0" errors="0" time="0.045" timestamp="2018-01-09T20:21:42">
<properties>...</properties>
<testcase name="myNormalTest()" classname="com.example.project.JUnit5Tests" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[method:myNormalTest()]
display-name: myNormalTest()
]]></system-out>
</testcase>
<testcase name="myRepeatedTest()[1]" classname="com.example.project.JUnit5Tests" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[test-template:myRepeatedTest()]/[test-template-invocation:#1]
display-name: repetition 1 of 3
]]></system-out>
</testcase>
<testcase name="myRepeatedTest()[2]" classname="com.example.project.JUnit5Tests" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[test-template:myRepeatedTest()]/[test-template-invocation:#2]
display-name: repetition 2 of 3
]]></system-out>
</testcase>
<testcase name="myRepeatedTest()[3]" classname="com.example.project.JUnit5Tests" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[test-template:myRepeatedTest()]/[test-template-invocation:#3]
display-name: repetition 3 of 3
]]></system-out>
</testcase>
<testcase name="myParametrizedTest(String)[1]" classname="com.example.project.JUnit5Tests" time="0.013">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[test-template:myParametrizedTest(java.lang.String)]/[test-template-invocation:#1]
display-name: [1] hello
]]></system-out>
</testcase>
<testcase name="myParametrizedTest(String)[2]" classname="com.example.project.JUnit5Tests" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[test-template:myParametrizedTest(java.lang.String)]/[test-template-invocation:#2]
display-name: [2] world
]]></system-out>
</testcase>
<testcase name="myTestFactory()[1][1]" classname="com.example.project.JUnit5Tests" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[test-factory:myTestFactory()]/[dynamic-container:#1]/[dynamic-test:#1]
display-name: bar
]]></system-out>
</testcase>
<testcase name="myNormalTest()" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[nested-class:MyNestedTest]/[method:myNormalTest()]
display-name: myNormalTest()
]]></system-out>
</testcase>
<testcase name="myRepeatedTest()[1]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[nested-class:MyNestedTest]/[test-template:myRepeatedTest()]/[test-template-invocation:#1]
display-name: repetition 1 of 3
]]></system-out>
</testcase>
<testcase name="myRepeatedTest()[2]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[nested-class:MyNestedTest]/[test-template:myRepeatedTest()]/[test-template-invocation:#2]
display-name: repetition 2 of 3
]]></system-out>
</testcase>
<testcase name="myRepeatedTest()[3]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[nested-class:MyNestedTest]/[test-template:myRepeatedTest()]/[test-template-invocation:#3]
display-name: repetition 3 of 3
]]></system-out>
</testcase>
<testcase name="myParametrizedTest(String)[1]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[nested-class:MyNestedTest]/[test-template:myParametrizedTest(java.lang.String)]/[test-template-invocation:#1]
display-name: [1] hello
]]></system-out>
</testcase>
<testcase name="myParametrizedTest(String)[2]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[nested-class:MyNestedTest]/[test-template:myParametrizedTest(java.lang.String)]/[test-template-invocation:#2]
display-name: [2] world
]]></system-out>
</testcase>
<testcase name="myTestFactory()[1][1]" classname="com.example.project.JUnit5Tests$MyNestedTest" time="0">
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]/[class:com.example.project.JUnit5Tests]/[nested-class:MyNestedTest]/[test-factory:myTestFactory()]/[dynamic-container:#1]/[dynamic-test:#1]
display-name: bar
]]></system-out>
</testcase>
<system-out><![CDATA[
unique-id: [engine:junit-jupiter]
display-name: JUnit Jupiter
]]></system-out>
</testsuite>
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [X] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
