### PR TITLE
Surefire support for running set of methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -56,6 +56,9 @@ _@API Guardian_ JAR _mandatory_ again.
 * Non-inherited _composed annotations_ which are meta-annotated with a given `@Inherited`
   annotation are now considered to be implicitly _inherited_ when searching for the given
   meta-annotation within a class hierarchy.
+* The JUnit Platform Maven Surefire provider now supports `-Dtest=...` system property.
+  This system property tells Surefire to only execute a subset of the tests that match
+  given pattern.
 
 
 [[release-notes-5.1.0-M2-junit-jupiter]]

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/JUnitPlatformProvider.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/JUnitPlatformProvider.java
@@ -44,7 +44,9 @@ import org.apache.maven.surefire.report.ReporterException;
 import org.apache.maven.surefire.report.ReporterFactory;
 import org.apache.maven.surefire.report.RunListener;
 import org.apache.maven.surefire.suite.RunResult;
+import org.apache.maven.surefire.testset.TestListResolver;
 import org.apache.maven.surefire.testset.TestSetFailedException;
+import org.apache.maven.surefire.util.ScanResult;
 import org.apache.maven.surefire.util.TestsToRun;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
@@ -76,7 +78,7 @@ public class JUnitPlatformProvider extends AbstractProvider {
 
 	private final ProviderParameters parameters;
 	private final Launcher launcher;
-	final Filter<?>[] includeAndExcludeFilters;
+	final Filter<?>[] filters;
 	final Map<String, String> configurationParameters;
 
 	public JUnitPlatformProvider(ProviderParameters parameters) {
@@ -86,7 +88,7 @@ public class JUnitPlatformProvider extends AbstractProvider {
 	JUnitPlatformProvider(ProviderParameters parameters, Launcher launcher) {
 		this.parameters = parameters;
 		this.launcher = launcher;
-		this.includeAndExcludeFilters = getIncludeAndExcludeFilters();
+		this.filters = getFilters();
 		this.configurationParameters = getConfigurationParameters();
 		Logger.getLogger("org.junit").setLevel(Level.WARNING);
 	}
@@ -114,8 +116,9 @@ public class JUnitPlatformProvider extends AbstractProvider {
 	}
 
 	private TestsToRun scanClasspath() {
-		TestsToRun scannedClasses = parameters.getScanResult().applyFilter(
-			new TestPlanScannerFilter(launcher, includeAndExcludeFilters), parameters.getTestClassLoader());
+		TestPlanScannerFilter filter = new TestPlanScannerFilter(launcher, filters);
+		ScanResult scanResult = parameters.getScanResult();
+		TestsToRun scannedClasses = scanResult.applyFilter(filter, parameters.getTestClassLoader());
 		return parameters.getRunOrderCalculator().orderTestClasses(scannedClasses);
 	}
 
@@ -135,16 +138,18 @@ public class JUnitPlatformProvider extends AbstractProvider {
 	}
 
 	private LauncherDiscoveryRequest buildLauncherDiscoveryRequest(TestsToRun testsToRun) {
-		LauncherDiscoveryRequestBuilder builder = request() //
-				.filters(includeAndExcludeFilters) //
+		// @formatter:off
+		LauncherDiscoveryRequestBuilder builder = request()
+				.filters(filters)
 				.configurationParameters(configurationParameters);
+		// @formatter:on
 		for (Class<?> testClass : testsToRun) {
 			builder.selectors(selectClass(testClass));
 		}
 		return builder.build();
 	}
 
-	private Filter<?>[] getIncludeAndExcludeFilters() {
+	private Filter<?>[] getFilters() {
 		List<Filter<?>> filters = new ArrayList<>();
 
 		Optional<List<String>> includes = getGroupsOrTags(getPropertiesList(INCLUDE_GROUPS),
@@ -154,6 +159,11 @@ public class JUnitPlatformProvider extends AbstractProvider {
 		Optional<List<String>> excludes = getGroupsOrTags(getPropertiesList(EXCLUDE_GROUPS),
 			getPropertiesList(EXCLUDE_TAGS));
 		excludes.map(TagFilter::excludeTags).ifPresent(filters::add);
+
+		TestListResolver testListResolver = parameters.getTestRequest().getTestListResolver();
+		if (!testListResolver.isEmpty()) {
+			filters.add(new TestMethodFilter(testListResolver));
+		}
 
 		return filters.toArray(new Filter<?>[filters.size()]);
 	}

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/TestMethodFilter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/TestMethodFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.junit.platform.surefire.provider;
+
+import org.apache.maven.surefire.testset.TestListResolver;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+
+public class TestMethodFilter implements PostDiscoveryFilter {
+
+	private final TestListResolver testListResolver;
+
+	public TestMethodFilter(TestListResolver testListResolver) {
+		this.testListResolver = testListResolver;
+	}
+
+	@Override
+	public FilterResult apply(TestDescriptor descriptor) {
+		// @formatter:off
+		boolean shouldRun = descriptor.getSource()
+				.filter(source -> source instanceof MethodSource)
+				.map(source -> (MethodSource) source)
+				.map(this::shouldRun)
+				.orElse(true);
+		// @formatter:on
+
+		return FilterResult.includedIf(shouldRun);
+	}
+
+	private boolean shouldRun(MethodSource source) {
+		String testClass = TestListResolver.toClassFileName(source.getClassName());
+		String testMethod = source.getMethodName();
+		return testListResolver.shouldRun(testClass, testMethod);
+	}
+}

--- a/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/TestMethodFilter.java
+++ b/junit-platform-surefire-provider/src/main/java/org/junit/platform/surefire/provider/TestMethodFilter.java
@@ -22,11 +22,11 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.PostDiscoveryFilter;
 
-public class TestMethodFilter implements PostDiscoveryFilter {
+class TestMethodFilter implements PostDiscoveryFilter {
 
 	private final TestListResolver testListResolver;
 
-	public TestMethodFilter(TestListResolver testListResolver) {
+	TestMethodFilter(TestListResolver testListResolver) {
 		this.testListResolver = testListResolver;
 	}
 

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/JUnitPlatformProviderTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/JUnitPlatformProviderTests.java
@@ -18,6 +18,7 @@ package org.junit.platform.surefire.provider;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,6 +42,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.maven.surefire.providerapi.ProviderParameters;
 import org.apache.maven.surefire.report.ConsoleOutputReceiver;
@@ -48,6 +50,8 @@ import org.apache.maven.surefire.report.ReportEntry;
 import org.apache.maven.surefire.report.ReporterFactory;
 import org.apache.maven.surefire.report.RunListener;
 import org.apache.maven.surefire.report.SimpleReportEntry;
+import org.apache.maven.surefire.testset.TestListResolver;
+import org.apache.maven.surefire.testset.TestRequest;
 import org.apache.maven.surefire.testset.TestSetFailedException;
 import org.apache.maven.surefire.util.RunOrderCalculator;
 import org.apache.maven.surefire.util.ScanResult;
@@ -56,10 +60,12 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.PreconditionViolationException;
 import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import org.junit.platform.launcher.listeners.TestExecutionSummary.Failure;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -129,7 +135,7 @@ class JUnitPlatformProviderTests {
 
 	@Test
 	void allDiscoveredTestsAreInvokedForNullArgument() throws Exception {
-		RunListener runListener = mock(RunListener.class, withSettings().extraInterfaces(ConsoleOutputReceiver.class));
+		RunListener runListener = runListenerMock();
 		ProviderParameters providerParameters = providerParametersMock(runListener, TestClass1.class, TestClass2.class);
 		Launcher launcher = LauncherFactory.create();
 		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters, launcher);
@@ -162,7 +168,7 @@ class JUnitPlatformProviderTests {
 	@Test
 	void outputIsCaptured() throws Exception {
 		Launcher launcher = LauncherFactory.create();
-		RunListener runListener = mock(RunListener.class, withSettings().extraInterfaces(ConsoleOutputReceiver.class));
+		RunListener runListener = runListenerMock();
 		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParametersMock(runListener), launcher);
 
 		invokeProvider(provider, VerboseTestClass.class);
@@ -205,7 +211,7 @@ class JUnitPlatformProviderTests {
 
 		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
 
-		assertEquals(1, provider.includeAndExcludeFilters.length);
+		assertEquals(1, provider.filters.length);
 	}
 
 	@Test
@@ -218,7 +224,7 @@ class JUnitPlatformProviderTests {
 
 		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
 
-		assertEquals(1, provider.includeAndExcludeFilters.length);
+		assertEquals(1, provider.filters.length);
 	}
 
 	@Test
@@ -231,7 +237,7 @@ class JUnitPlatformProviderTests {
 		when(providerParameters.getProviderProperties()).thenReturn(properties);
 
 		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
-		assertEquals(0, provider.includeAndExcludeFilters.length);
+		assertEquals(0, provider.filters.length);
 	}
 
 	@Test
@@ -246,7 +252,7 @@ class JUnitPlatformProviderTests {
 		when(providerParameters.getProviderProperties()).thenReturn(properties);
 
 		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
-		assertEquals(1, provider.includeAndExcludeFilters.length);
+		assertEquals(1, provider.filters.length);
 	}
 
 	@Test
@@ -260,7 +266,7 @@ class JUnitPlatformProviderTests {
 
 		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
 
-		assertEquals(2, provider.includeAndExcludeFilters.length);
+		assertEquals(2, provider.filters.length);
 	}
 
 	@Test
@@ -269,7 +275,7 @@ class JUnitPlatformProviderTests {
 
 		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
 
-		assertEquals(0, provider.includeAndExcludeFilters.length);
+		assertEquals(0, provider.filters.length);
 	}
 
 	@Test
@@ -297,6 +303,83 @@ class JUnitPlatformProviderTests {
 		assertEquals("EOF", provider.configurationParameters.get("qux"));
 	}
 
+	@Test
+	void executesSingleTestIncludedByName() throws Exception {
+		// following is equivalent of adding '-Dtest=TestClass3#prefix1Suffix1'
+		// '*' needed because it's a nested class and thus has name prefixed with '$'
+		String pattern = "*TestClass3#prefix1Suffix1";
+
+		testExecutionOfMatchingTestMethods(TestClass3.class, pattern, "prefix1Suffix1()");
+	}
+
+	@Test
+	void executesMultipleTestsIncludedByName() throws Exception {
+		// following is equivalent of adding '-Dtest=TestClass3#prefix1Suffix1+prefix2Suffix1'
+		// '*' needed because it's a nested class and thus has name prefixed with '$'
+		String pattern = "*TestClass3#prefix1Suffix1+prefix2Suffix1";
+
+		testExecutionOfMatchingTestMethods(TestClass3.class, pattern, "prefix1Suffix1()", "prefix2Suffix1()");
+	}
+
+	@Test
+	void executesMultipleTestsIncludedByNamePattern() throws Exception {
+		// following is equivalent of adding '-Dtest=TestClass3#prefix1*'
+		// '*' needed because it's a nested class and thus has name prefixed with '$'
+		String pattern = "*TestClass3#prefix1*";
+
+		testExecutionOfMatchingTestMethods(TestClass3.class, pattern, "prefix1Suffix1()", "prefix1Suffix2()");
+	}
+
+	@Test
+	void executesMultipleTestsIncludedByNamePatternWithQuestionMark() throws Exception {
+		// following is equivalent of adding '-Dtest=TestClass3#prefix?Suffix2'
+		// '*' needed because it's a nested class and thus has name prefixed with '$'
+		String pattern = "*TestClass3#prefix?Suffix2";
+
+		testExecutionOfMatchingTestMethods(TestClass3.class, pattern, "prefix1Suffix2()", "prefix2Suffix2()");
+	}
+
+	@Test
+	void doesNotExecuteTestsExcludedByName() throws Exception {
+		// following is equivalent of adding '-Dtest=!TestClass3#prefix1Suffix2'
+		// '*' needed because it's a nested class and thus has name prefixed with '$'
+		String pattern = "!*TestClass3#prefix1Suffix2";
+
+		testExecutionOfMatchingTestMethods(TestClass3.class, pattern, "prefix1Suffix1()", "prefix2Suffix1()",
+			"prefix2Suffix2()");
+	}
+
+	@Test
+	void doesNotExecuteTestsExcludedByNamePattern() throws Exception {
+		// following is equivalent of adding '-Dtest=!TestClass3#prefix2*'
+		// '*' needed because it's a nested class and thus has name prefixed with '$'
+		String pattern = "!*TestClass3#prefix2*";
+
+		testExecutionOfMatchingTestMethods(TestClass3.class, pattern, "prefix1Suffix1()", "prefix1Suffix2()");
+	}
+
+	void testExecutionOfMatchingTestMethods(Class<?> testClass, String pattern, String... expectedTestNames)
+			throws Exception {
+		TestListResolver testListResolver = new TestListResolver(pattern);
+		ProviderParameters providerParameters = providerParametersMock(testListResolver, testClass);
+		Launcher launcher = LauncherFactory.create();
+		JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters, launcher);
+
+		TestPlanSummaryListener executionListener = new TestPlanSummaryListener();
+		launcher.registerTestExecutionListeners(executionListener);
+
+		invokeProvider(provider, null);
+
+		assertEquals(1, executionListener.summaries.size());
+		TestExecutionSummary summary = executionListener.summaries.get(0);
+		int expectedCount = expectedTestNames.length;
+		assertEquals(expectedCount, summary.getTestsFoundCount());
+		assertEquals(expectedCount, summary.getTestsFailedCount());
+		assertEquals(expectedCount, summary.getFailures().size());
+
+		assertThat(failedTestDisplayNames(summary)).contains(expectedTestNames);
+	}
+
 	private void verifyPreconditionViolationException(Map<String, String> properties) {
 		ProviderParameters providerParameters = providerParametersMock(TestClass1.class);
 		when(providerParameters.getProviderProperties()).thenReturn(properties);
@@ -308,11 +391,21 @@ class JUnitPlatformProviderTests {
 	}
 
 	private static ProviderParameters providerParametersMock(Class<?>... testClasses) {
-		RunListener runListener = mock(RunListener.class, withSettings().extraInterfaces(ConsoleOutputReceiver.class));
-		return providerParametersMock(runListener, testClasses);
+		return providerParametersMock(runListenerMock(), testClasses);
 	}
 
 	private static ProviderParameters providerParametersMock(RunListener runListener, Class<?>... testClasses) {
+		TestListResolver testListResolver = new TestListResolver("");
+		return providerParametersMock(runListener, testListResolver, testClasses);
+	}
+
+	private static ProviderParameters providerParametersMock(TestListResolver testListResolver,
+			Class<?>... testClasses) {
+		return providerParametersMock(runListenerMock(), testListResolver, testClasses);
+	}
+
+	private static ProviderParameters providerParametersMock(RunListener runListener, TestListResolver testListResolver,
+			Class<?>... testClasses) {
 		TestsToRun testsToRun = newTestsToRun(testClasses);
 
 		ScanResult scanResult = mock(ScanResult.class);
@@ -324,12 +417,30 @@ class JUnitPlatformProviderTests {
 		ReporterFactory reporterFactory = mock(ReporterFactory.class);
 		when(reporterFactory.createReporter()).thenReturn(runListener);
 
+		TestRequest testRequest = mock(TestRequest.class);
+		when(testRequest.getTestListResolver()).thenReturn(testListResolver);
+
 		ProviderParameters providerParameters = mock(ProviderParameters.class);
 		when(providerParameters.getScanResult()).thenReturn(scanResult);
 		when(providerParameters.getRunOrderCalculator()).thenReturn(runOrderCalculator);
 		when(providerParameters.getReporterFactory()).thenReturn(reporterFactory);
+		when(providerParameters.getTestRequest()).thenReturn(testRequest);
 
 		return providerParameters;
+	}
+
+	private static RunListener runListenerMock() {
+		return mock(RunListener.class, withSettings().extraInterfaces(ConsoleOutputReceiver.class));
+	}
+
+	private static Set<String> failedTestDisplayNames(TestExecutionSummary summary) {
+		// @formatter:off
+		return summary.getFailures()
+				.stream()
+				.map(Failure::getTestIdentifier)
+				.map(TestIdentifier::getDisplayName)
+				.collect(toSet());
+		// @formatter:on
 	}
 
 	private static TestsToRun newTestsToRun(Class<?>... testClasses) {
@@ -456,5 +567,27 @@ class JUnitPlatformProviderTests {
 	}
 
 	static class Sub2Tests extends AbstractTestClass {
+	}
+
+	static class TestClass3 {
+		@Test
+		void prefix1Suffix1() {
+			throw new RuntimeException();
+		}
+
+		@Test
+		void prefix2Suffix1() {
+			throw new RuntimeException();
+		}
+
+		@Test
+		void prefix1Suffix2() {
+			throw new RuntimeException();
+		}
+
+		@Test
+		void prefix2Suffix2() {
+			throw new RuntimeException();
+		}
 	}
 }

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/TestMethodFilterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/TestMethodFilterTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.junit.platform.surefire.provider;
+
+import static org.apache.maven.surefire.testset.TestListResolver.toClassFileName;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+
+import org.apache.maven.surefire.testset.TestListResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+
+class TestMethodFilterTests {
+
+	@Test
+	void includesBasedOnTestListResolver() throws Exception {
+		TestListResolver resolver = mock(TestListResolver.class);
+		when(resolver.shouldRun(toClassFileName(TestClass.class), "testMethod")).thenReturn(true);
+
+		TestMethodFilter filter = new TestMethodFilter(resolver);
+		TestDescriptor descriptor = newTestMethodDescriptor();
+
+		FilterResult result = filter.apply(descriptor);
+
+		assertTrue(result.included());
+		assertFalse(result.excluded());
+	}
+
+	@Test
+	void excludesBasedOnTestListResolver() throws Exception {
+		TestListResolver resolver = mock(TestListResolver.class);
+		when(resolver.shouldRun(toClassFileName(TestClass.class), "testMethod")).thenReturn(false);
+
+		TestMethodFilter filter = new TestMethodFilter(resolver);
+		TestDescriptor descriptor = newTestMethodDescriptor();
+
+		FilterResult result = filter.apply(descriptor);
+
+		assertFalse(result.included());
+		assertTrue(result.excluded());
+	}
+
+	@Test
+	void includesTestDescriptorWithClassSource() throws Exception {
+		TestListResolver resolver = mock(TestListResolver.class);
+		TestMethodFilter filter = new TestMethodFilter(resolver);
+		ClassTestDescriptor descriptor = newClassTestDescriptor();
+
+		FilterResult result = filter.apply(descriptor);
+
+		assertTrue(result.included());
+		assertFalse(result.excluded());
+	}
+
+	private static TestMethodTestDescriptor newTestMethodDescriptor() throws Exception {
+		UniqueId uniqueId = UniqueId.forEngine("method");
+		Class<TestClass> testClass = TestClass.class;
+		Method testMethod = testClass.getMethod("testMethod");
+		return new TestMethodTestDescriptor(uniqueId, testClass, testMethod);
+	}
+
+	private static ClassTestDescriptor newClassTestDescriptor() throws Exception {
+		UniqueId uniqueId = UniqueId.forEngine("class");
+		return new ClassTestDescriptor(uniqueId, TestClass.class);
+	}
+
+	public static class TestClass {
+		public void testMethod() {
+		}
+	}
+}


### PR DESCRIPTION
## Overview

This PR makes surefire provider able to recognize `-Dtest=...` system property and filter discovered/executed tests based on its value.

Surefire parses provided system property value into `TestListResolver` which represents included and excluded tests as an object model. Model can be queried if particular class & method pair is included or not using `#shouldRun(String, String)` method. This PR wraps `TestListResolver` into a `PostDiscoveryFilter`, which is used to discover and execute actual tests with the `Launcher`.

Fixes #1193

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
