### PR TITLE
Integrate codecov with Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,8 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+# Run clover report and send report to codecov after build success for JDK 9 builds
+after_success:
+  - test "$JDK_RELEASE" = "JDK 9" && ./gradlew -PenableClover clean cloverXmlReport || true
+  - test "$JDK_RELEASE" = "JDK 9" && bash <(curl -s https://codecov.io/bash) || true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Ask JUnit 5 related questions on [StackOverflow] or chat with the team and the c
 
 ## Code Coverage
 
+[![codecov](https://codecov.io/gh/junit-team/junit5/branch/master/graph/badge.svg)](https://codecov.io/gh/junit-team/junit5)
+
 Code coverage using [OpenClover] for the latest build is available on the
 [Jenkins CI server].
 


### PR DESCRIPTION
## Overview

Integrates codecov with Travis build.

Example result from my fork: https://codecov.io/gh/hisener/junit5

Also, adds the codecov badge to `README.md`. It looks like this:
[![codecov](https://codecov.io/gh/hisener/junit5/branch/master/graph/badge.svg)](https://codecov.io/gh/hisener/junit5)

Related issue: #240 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
