### PR TITLE
Introduce @EnabledIf execution condition

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -35,6 +35,8 @@ test {
 */
 
 dependencies {
+	runtimeOnly('org.codehaus.groovy:groovy-jsr223:2.4.12')
+
 	testImplementation(project(':junit-jupiter-api'))
 	testImplementation(project(path: ':junit-jupiter-params', configuration: 'shadow'))
 	testImplementation(project(':junit-platform-runner'))

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -147,7 +147,8 @@ _@API Guardian_ JAR _mandatory_ again.
    example, `fail<Nothing>("Some message")`. These new top-level functions remove this
    requirement by returning
    https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-nothing.html[`Nothing`].
-
+* New `@EnabledIf` execution condition added. Supply a script, default language is
+  `JavaScript`, that controls whether the container or test is executed.
 
 [[release-notes-5.1.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -164,6 +164,17 @@ And here's a test case with a disabled test method.
 include::{testDir}/example/DisabledTestsDemo.java[tags=user_guide]
 ----
 
+[[writing-tests-conditional]]
+=== Conditional Test Execution
+
+Here are some tests that are enabled or disabled depending
+on the evaluation of the script passed to the `@EnabledIf` annotation.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/EnabledIfTestsDemo.java[tags=user_guide]
+----
+
 [[writing-tests-tagging-and-filtering]]
 === Tagging and Filtering
 

--- a/documentation/src/test/java/example/EnabledIfTestsDemo.java
+++ b/documentation/src/test/java/example/EnabledIfTestsDemo.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example;
+
+// tag::user_guide[]
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.EnabledIf;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+class EnabledIfTestsDemo {
+
+	@Test // Static JavaScript expression
+	@EnabledIf("1 == 1")
+	void testWillBeExecuted() {
+		assertTrue(1 == 1);
+	}
+
+	@RepeatedTest(10) // Dynamic JavaScript expression
+	@EnabledIf("Math.random() >= 0.314159")
+	void testWillNeverOrSometimesBeExecuted() {
+	}
+
+	@Test // Regular expression testing bound system property.
+	@EnabledIf("/64/.test(systemProperties.get('os.arch'))")
+	void testWillBeExecutedIfOsArchitectureContains64() {
+		assertTrue(System.getProperty("os.arch").contains("64"));
+	}
+
+	@Test // Multi-line script and import Java package names.
+	@EnabledIf(imports = "java.nio.file", //
+			value = { //
+					"path = Files.createTempFile('volatile-', '.temp')", //
+					"systemProperties.put('volatile', path)", //
+					"Files.exists(path)" })
+	void importJavaPackages() {
+		assertTrue(Files.exists((Path) System.getProperties().get("volatile")));
+	}
+
+	@Test // Select Groovy as ScriptEngine.
+	@EnabledIf(engine = "groovy", //
+			imports = { "java.nio.file.Files", "java.nio.file.Paths" }, //
+			value = "Files.isWritable(Paths.get(System.properties['user.home']))")
+	void groovy() {
+		assertTrue(Files.isWritable(Paths.get(System.getProperty("user.home"))));
+	}
+}
+// end::user_guide[]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/EnabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/EnabledIf.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code @EnabledIf} is used to control whether the annotated test class or
+ * test method is executed or not.
+ *
+ * <p>The decision is controlled by the return value of a script that is
+ * evaluated:
+ * <ul>
+ * <li>{@code true} - if and only if the String-representation of the returned
+ * value is parsed by {@link Boolean#parseBoolean(String)} to {@code true}.</li>
+ * <li>{@code ConditionEvaluationResult} - an instance of
+ *  {@link org.junit.jupiter.api.extension.ConditionEvaluationResult ConditionEvaluationResult}
+ *  is passed directly to the framework.</li>
+ *  </ul>
+ *
+ * <p>When this annotation with a script that evaluates to {@code false}
+ * is applied at the class level, all test methods within that class
+ * are automatically disabled as well.
+ *
+ * @since 5.1
+ * @see org.junit.jupiter.api.extension.ExecutionCondition
+ * @see org.junit.jupiter.api.extension.ConditionEvaluationResult#enabled(String)
+ * @see org.junit.jupiter.api.extension.ConditionEvaluationResult#disabled(String)
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = STABLE, since = "5.1")
+public @interface EnabledIf {
+
+	/**
+	 * Script predicate to evaluate.
+	 *
+	 * @return lines of the script predicate
+	 */
+	String[] value();
+
+	/**
+	 * Short name of the {@link javax.script.ScriptEngine ScriptEngine} to use.
+	 *
+	 * <p>An empty string is interpreted as {@code "javascript"}.
+	 *
+	 * @return script engine name
+	 * @see javax.script.ScriptEngineManager#getEngineByName(String)
+	 */
+	String engine() default "";
+
+	/**
+	 * Delimiter separating script lines.
+	 *
+	 * @return the line separator or an empty String indicating {@link System#lineSeparator()}
+	 */
+	String delimiter() default "";
+
+	/**
+	 * Names to import.
+	 *
+	 * <p><b>JavaScript</b>
+	 * {@code JavaImporter} takes a variable number of arguments
+	 * as Java packages, and the returned object is used in a {@code with} statement
+	 * whose scope includes the specified package imports. The global JavaScript
+	 * scope is not affected.
+	 *
+	 * <p><b>Groovy</b>
+	 * Each name is inserted as {@code import name} at the top of the script.
+	 *
+	 * @return names to import
+	 */
+	String[] imports() default {};
+
+	/**
+	 * Bind the active {@link org.junit.jupiter.api.extension.ExtensionContext ExtensionContext}
+	 * to {@code jupiterExtensionContext}.
+	 *
+	 * @return name of binding, an empty String prevents the binding
+	 * @see javax.script.Bindings
+	 */
+	String bindExtensionContext() default "jupiterExtensionContext";
+
+	/**
+	 * Bind {@link System#getProperties()} to {@code systemProperties}.
+	 *
+	 * @return name of binding, an empty String prevents the binding
+	 * @see javax.script.Bindings
+	 */
+	String bindSystemProperties() default "systemProperties";
+
+	/**
+	 * Reason why the container or test should be enabled.
+	 *
+	 * @return the reason why the container or test should be enabled
+	 */
+	String reason() default "";
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -85,6 +85,13 @@ public final class Constants {
 	 */
 	public static final String DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME = "junit.jupiter.testinstance.lifecycle.default";
 
+	/**
+	 * Name of the default {@link javax.script.ScriptEngine}.
+	 *
+	 * @see org.junit.jupiter.engine.extension.EnabledIfCondition
+	 */
+	public static final String DEFAULT_ENABLED_IF_SCRIPT_ENGINE_PROPERTY_NAME = "junit.jupiter.enabledif.scriptengine.default";
+
 	private Constants() {
 		/* no-op */
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/EnabledIfCondition.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/EnabledIfCondition.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.jupiter.engine.Constants.DEFAULT_ENABLED_IF_SCRIPT_ENGINE_PROPERTY_NAME;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+import org.junit.jupiter.api.EnabledIf;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * {@link ExecutionCondition} that supports the {@link EnabledIf @EnabledIf} annotation.
+ *
+ * @since 5.1
+ * @see #evaluateExecutionCondition(ExtensionContext)
+ */
+class EnabledIfCondition implements ExecutionCondition {
+
+	private static final Logger logger = LoggerFactory.getLogger(EnabledIfCondition.class);
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		Optional<AnnotatedElement> element = context.getElement();
+		Optional<EnabledIf> optionalAnnotation = findAnnotation(element, EnabledIf.class);
+		if (!optionalAnnotation.isPresent()) {
+			return enabled("@EnabledIf is not present");
+		}
+
+		EnabledIf annotation = optionalAnnotation.get();
+		Preconditions.notEmpty(annotation.value(), "String[] returned by @EnabledIf.value() must not be empty");
+
+		// Find script engine
+		String engine = annotation.engine();
+		if (engine.isEmpty()) {
+			engine = context.getConfigurationParameter(DEFAULT_ENABLED_IF_SCRIPT_ENGINE_PROPERTY_NAME) //
+					.orElse("javascript");
+		}
+		ScriptEngine scriptEngine = findScriptEngine(engine);
+		logger.debug(() -> "ScriptEngine: " + scriptEngine);
+
+		// Prepare bindings
+		Bindings bindings = scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
+		if (!annotation.bindExtensionContext().isEmpty()) {
+			bindings.put(annotation.bindExtensionContext(), context);
+		}
+		if (!annotation.bindSystemProperties().isEmpty()) {
+			bindings.put(annotation.bindSystemProperties(), System.getProperties());
+		}
+		logger.debug(() -> "Bindings: " + bindings);
+
+		// Build actual script text from annotation properties
+		String script = createScript(annotation, scriptEngine.getFactory().getLanguageName());
+		logger.debug(() -> "Script: " + script);
+
+		return evaluate(annotation, scriptEngine, script);
+	}
+
+	private ConditionEvaluationResult evaluate(EnabledIf annotation, ScriptEngine scriptEngine, String script) {
+		Object result;
+		try {
+			result = scriptEngine.eval(script);
+		}
+		catch (ScriptException e) {
+			logger.warn(e, () -> "Evaluation of @EnabledIf script failed, disabling execution");
+			return disabled(e.toString());
+		}
+
+		// Trivial case: script returned a custom ConditionEvaluationResult instance.
+		if (result instanceof ConditionEvaluationResult) {
+			return (ConditionEvaluationResult) result;
+		}
+
+		// Parse result for "true" (ignoring case) and prepare reason message.
+		boolean ok = Boolean.parseBoolean(String.valueOf(result));
+		String reason = annotation.reason();
+		if (reason.isEmpty()) {
+			reason = String.format("Script `%s` evaluated to: %s", script, result);
+		}
+		return ok ? enabled(reason) : disabled(reason);
+	}
+
+	ScriptEngine findScriptEngine(String string) {
+		ScriptEngineManager manager = new ScriptEngineManager();
+		ScriptEngine scriptEngine = manager.getEngineByName(string);
+		if (scriptEngine == null) {
+			scriptEngine = manager.getEngineByExtension(string);
+		}
+		if (scriptEngine == null) {
+			scriptEngine = manager.getEngineByMimeType(string);
+		}
+		Preconditions.notNull(scriptEngine, "Script engine not found: " + string);
+		return scriptEngine;
+	}
+
+	String createScript(EnabledIf annotation, String language) {
+		// trivial case: no imports, single script line
+		if (annotation.imports().length == 0 && annotation.value().length == 1) {
+			return annotation.value()[0];
+		}
+
+		switch (language) {
+			case "ECMAScript":
+				return createJavaScript(annotation);
+			case "Groovy":
+				return createGroovyScript(annotation);
+			default:
+				return joinLines(annotation.delimiter(), Arrays.asList(annotation.value()));
+		}
+	}
+
+	private String createJavaScript(EnabledIf annotation) {
+		boolean injectJavaImporterStatements = annotation.imports().length > 0;
+		List<String> lines = new ArrayList<>();
+		if (injectJavaImporterStatements) {
+			String imports = String.join(", ", annotation.imports());
+			lines.add("var javaImporter = new JavaImporter(" + imports + ")");
+			lines.add("with (javaImporter) {");
+		}
+		for (String line : annotation.value()) {
+			if (injectJavaImporterStatements) {
+				line = "  " + line;
+			}
+			lines.add(line);
+		}
+		if (injectJavaImporterStatements) {
+			lines.add("}");
+			lines.add("");
+		}
+		return joinLines(annotation.delimiter(), lines);
+	}
+
+	private String createGroovyScript(EnabledIf annotation) {
+		List<String> lines = new ArrayList<>();
+		for (String importLine : annotation.imports()) {
+			importLine = "import " + importLine;
+			lines.add(importLine);
+		}
+		if (!lines.isEmpty()) {
+			lines.add("");
+		}
+		lines.addAll(Arrays.asList(annotation.value()));
+		return joinLines(annotation.delimiter(), lines);
+	}
+
+	private String joinLines(String delimiter, Iterable<? extends CharSequence> elements) {
+		if (delimiter.isEmpty()) {
+			delimiter = System.lineSeparator();
+		}
+		return String.join(delimiter, elements);
+	}
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
@@ -52,6 +52,7 @@ public class ExtensionRegistry {
 	private static final Logger logger = LoggerFactory.getLogger(ExtensionRegistry.class);
 
 	private static final List<Extension> DEFAULT_EXTENSIONS = Collections.unmodifiableList(Arrays.asList(//
+		new EnabledIfCondition(), //
 		new DisabledCondition(), //
 		new RepeatedTestExtension(), //
 		new TestInfoParameterResolver(), //

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/EnabledIfConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/EnabledIfConditionTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.script.ScriptEngine;
+
+import org.junit.jupiter.api.EnabledIf;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.PreconditionViolationException;
+import org.mockito.Mockito;
+
+class EnabledIfConditionTests {
+
+	@Test
+	void findJavaScriptEngine() {
+		assertAll("Names", //
+			() -> findJavaScriptEngine("nashorn"), //
+			() -> findJavaScriptEngine("javascript"), //
+			() -> findJavaScriptEngine("ecmascript") //
+		);
+
+		assertAll("File extension", //
+			() -> findJavaScriptEngine("js") //
+		);
+
+		assertAll("MIME types", //
+			() -> findJavaScriptEngine("application/javascript"), //
+			() -> findJavaScriptEngine("application/ecmascript"), //
+			() -> findJavaScriptEngine("text/javascript"), //
+			() -> findJavaScriptEngine("text/ecmascript") //
+		);
+
+		assertThrows(PreconditionViolationException.class, () -> findJavaScriptEngine("?!"));
+	}
+
+	private void findJavaScriptEngine(String string) {
+		EnabledIfCondition condition = new EnabledIfCondition();
+		ScriptEngine engine = condition.findScriptEngine(string);
+		assertNotNull(engine);
+	}
+
+	@Test
+	void trivialJavaScript() {
+		String script = "true";
+		EnabledIf enabled = mockEnabled(script);
+		String actual = new EnabledIfCondition().createScript(enabled, "ECMAScript");
+		assertSame(script, actual);
+	}
+
+	@Test
+	void trivialGroovyScript() {
+		String script = "true";
+		EnabledIf enabled = mockEnabled(script);
+		String actual = new EnabledIfCondition().createScript(enabled, "Groovy");
+		assertSame(script, actual);
+	}
+
+	@Test
+	void trivialNonJavaScript() {
+		EnabledIf enabled = mockEnabled("one", "two");
+		Mockito.when(enabled.delimiter()).thenReturn("/");
+		String actual = new EnabledIfCondition().createScript(enabled, "unknown language");
+		assertEquals("one/two", actual);
+	}
+
+	@Test
+	void createJavaScriptMultipleLines() {
+		EnabledIf enabled = mockEnabled("m1()", "m2()");
+		assertLinesMatchCreatedScript(Arrays.asList("m1()", "m2()"), enabled, "ECMAScript");
+	}
+
+	@Test
+	void createJavaScriptMultipleLinesWithImports() {
+		EnabledIf enabled = mockEnabled("m1()", "m2()");
+		Mockito.when(enabled.imports()).thenReturn(new String[] { "a", "b" });
+		List<String> expected = new ArrayList<>();
+		expected.add("var javaImporter = new JavaImporter(a, b)");
+		expected.add("with (javaImporter) {");
+		expected.add("  m1()");
+		expected.add("  m2()");
+		expected.add("}");
+		assertLinesMatchCreatedScript(expected, enabled, "ECMAScript");
+	}
+
+	@Test
+	void createGroovyScriptMultipleLinesWithImports() {
+		EnabledIf enabled = mockEnabled("m1()", "m2()");
+		Mockito.when(enabled.imports()).thenReturn(new String[] { "a", "b" });
+		List<String> expected = new ArrayList<>();
+		expected.add("import a");
+		expected.add("import b");
+		expected.add("");
+		expected.add("m1()");
+		expected.add("m2()");
+		assertLinesMatchCreatedScript(expected, enabled, "Groovy");
+	}
+
+	private void assertLinesMatchCreatedScript(List<String> expectedLines, EnabledIf enabled, String language) {
+		EnabledIfCondition condition = new EnabledIfCondition();
+		String actual = condition.createScript(enabled, language);
+		assertLinesMatch(expectedLines, Arrays.asList(actual.split("\\R")));
+	}
+
+	private EnabledIf mockEnabled(String... value) {
+		EnabledIf enabled = Mockito.mock(EnabledIf.class);
+		Mockito.when(enabled.value()).thenReturn(value);
+		try {
+			Mockito.when(enabled.bindExtensionContext()).thenReturn(
+				(String) EnabledIf.class.getDeclaredMethod("bindExtensionContext").getDefaultValue());
+			Mockito.when(enabled.bindSystemProperties()).thenReturn(
+				(String) EnabledIf.class.getDeclaredMethod("bindSystemProperties").getDefaultValue());
+			Mockito.when(enabled.delimiter()).thenReturn(
+				(String) EnabledIf.class.getDeclaredMethod("delimiter").getDefaultValue());
+			Mockito.when(enabled.engine()).thenReturn(
+				(String) EnabledIf.class.getDeclaredMethod("engine").getDefaultValue());
+			Mockito.when(enabled.reason()).thenReturn(
+				(String) EnabledIf.class.getDeclaredMethod("reason").getDefaultValue());
+			Mockito.when(enabled.imports()).thenReturn(
+				(String[]) EnabledIf.class.getDeclaredMethod("imports").getDefaultValue());
+		}
+		catch (NoSuchMethodException e) {
+			throw new AssertionError(e);
+		}
+		return enabled;
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistryTests.java
@@ -49,7 +49,7 @@ class ExtensionRegistryTests {
 	void newRegistryWithoutParentHasDefaultExtensions() {
 		List<Extension> extensions = registry.getExtensions(Extension.class);
 
-		assertEquals(4, extensions.size());
+		assertEquals(5, extensions.size());
 		assertDefaultGlobalExtensionsAreRegistered();
 	}
 
@@ -62,7 +62,7 @@ class ExtensionRegistryTests {
 
 		List<Extension> extensions = registry.getExtensions(Extension.class);
 
-		assertEquals(5, extensions.size());
+		assertEquals(6, extensions.size());
 		assertDefaultGlobalExtensionsAreRegistered();
 
 		assertExtensionRegistered(registry, ServiceLoaderExtension.class);
@@ -155,13 +155,14 @@ class ExtensionRegistryTests {
 	}
 
 	private void assertDefaultGlobalExtensionsAreRegistered() {
+		assertExtensionRegistered(registry, EnabledIfCondition.class);
 		assertExtensionRegistered(registry, DisabledCondition.class);
 		assertExtensionRegistered(registry, RepeatedTestExtension.class);
 		assertExtensionRegistered(registry, TestInfoParameterResolver.class);
 		assertExtensionRegistered(registry, TestReporterParameterResolver.class);
 
 		assertEquals(2, countExtensions(registry, ParameterResolver.class));
-		assertEquals(1, countExtensions(registry, ExecutionCondition.class));
+		assertEquals(2, countExtensions(registry, ExecutionCondition.class));
 		assertEquals(1, countExtensions(registry, TestTemplateInvocationContextProvider.class));
 	}
 

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.EnabledIf;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Script-based execution condition evaluation tests.
+ *
+ * @since 1.1
+ */
+@EnabledIf("true")
+class EnabledIfTests {
+
+	@Test
+	@EnabledIf("true")
+	void justTrue() {
+	}
+
+	@Test
+	@EnabledIf("false")
+	void justFalse() {
+		fail("test must not be executed");
+	}
+
+	@Test
+	@EnabledIf("1 == 2")
+	void oneEqualsTwo() {
+		fail("test must not be executed");
+	}
+
+	@Test
+	@EnabledIf("org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled('Go!')")
+	void customResultEnabled() {
+	}
+
+	@Test
+	@EnabledIf("org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled('No go.')")
+	void customResultDisabled() {
+		fail("test must not be executed");
+	}
+
+	@Test
+	@EnabledIf("java.lang.Boolean.getBoolean('is-not-set')")
+	void getBoolean() {
+		fail("test must not be executed");
+	}
+
+	@Test
+	@EnabledIf(imports = "java.nio.file", value = "Files.exists(Files.createTempFile('temp-', '.txt'))")
+	void filesExists() {
+	}
+
+	@Test
+	@EnabledIf(value = "junit$context.publishReportEntry('foo', 'bar')", reason = "no result, no execution")
+	void publishReportEntry() {
+		fail("test must not be executed");
+	}
+
+	@Test
+	@EnabledIf(value = "syntactically, something is not right")
+	void syntaxFailure() {
+		fail("test must not be executed");
+	}
+
+	@Test
+	@EnabledIf("java.lang.System.getProperty('os.name').toLowerCase().contains('win')")
+	void win() {
+		assertTrue(System.getProperty("os.name").toLowerCase().contains("win"));
+	}
+
+	@Test
+	@EnabledIf("/64/.test(sysprops.get('os.arch'))")
+	void osArch() {
+		assertTrue(System.getProperty("os.arch").contains("64"));
+	}
+
+	@Test
+	@EnabledIf(engine = "groovy", value = { "System.properties['jsr'] = '233'", "'233' == System.properties['jsr']" })
+	void groovy() {
+		assertEquals("233", System.getProperty("jsr"));
+	}
+
+	@Test
+	@EnabledIf(engine = "groovy", imports = "java.nio.file.*", value = "Files.exists(Paths.get('foo', 'bar'))")
+	void groovyImports() {
+		fail("test must not be executed");
+	}
+
+	@Test
+	@EnabledIf("true")
+	@Disabled
+	void enabledAndDisabled() {
+		fail("test must not be executed");
+	}
+
+	@Test
+	@Disabled
+	@EnabledIf("true")
+	void disabledAndEnabled() {
+		fail("test must not be executed");
+	}
+
+	@RepeatedTest(10)
+	@CoinToss
+	void gamble() {
+	}
+
+	@Target({ ElementType.TYPE, ElementType.METHOD })
+	@Retention(RetentionPolicy.RUNTIME)
+	@EnabledIf("Math.random() >= 0.5")
+	@interface CoinToss {
+	}
+}


### PR DESCRIPTION
# Evaluate predicate to en- or disable test execution

Addresses #219

## Examples

`JavaScript` examples

```java
@EnabledIf("true")
@EnabledIf("false")
@EnabledIf("1 == 2")
@EnabledIf("java.lang.Boolean.getBoolean('is-not-set')")
@EnabledIf(imports = "java.nio.file", value = "Files.exists(Paths.get('dir', 'file.txt'))")
@EnabledIf("java.lang.System.getProperty('os.name').toLowerCase().contains('win')")
@EnabledIf("/64/.test(systemProperties.get('os.arch'))")
```

More `Groovy`

```java
@Conditional(engine = "groovy", // Select Groovy as language.
	delimiter = "\n", // Set delimiter to Unix-style line separator.
	bindExtensionContext = false, // Not needed here.
	bindSystemProperties = false, // Not needed here, Groovy auto-imports "java.lang.*".
	value = { //
			"System.properties['jsr'] = '233'", //
			"'233' == System.properties['jsr']" }, //
	reason = "Groovy as script language, multiple lines, self-fulfilling.")
@Test
void groovy() {
	assertEquals("233", System.getProperty("jsr"));
}
```

### Supported script languages

All JSR-223 ScriptEngine compatible languages, like:

- `javascript` http://openjdk.java.net/projects/nashorn/

### Just mount the script engine at runtime...

- `groovy` http://docs.groovy-lang.org/latest/html/api/org/codehaus/groovy/jsr223/GroovyScriptEngineFactory.html
- `bsh` http://beanshell.org

### Other script languages

- `jshell` https://github.com/dmac100/JShellScriptEngine
- `SpEL` https://jira.spring.io/browse/SPR-7651

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
