### PR TITLE
Issue-1258 Issue-880 Removed unnecessary creation of BooleanSupplier

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTrue.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTrue.java
@@ -32,11 +32,13 @@ class AssertTrue {
 	///CLOVER:ON
 
 	static void assertTrue(boolean condition) {
-		assertTrue(() -> condition, () -> null);
+		assertTrue(condition, () -> null);
 	}
 
 	static void assertTrue(boolean condition, Supplier<String> messageSupplier) {
-		assertTrue(() -> condition, messageSupplier);
+		if (!condition) {
+			fail(format(true, false, nullSafeGet(messageSupplier)));
+		}
 	}
 
 	static void assertTrue(BooleanSupplier booleanSupplier) {
@@ -48,7 +50,7 @@ class AssertTrue {
 	}
 
 	static void assertTrue(boolean condition, String message) {
-		assertTrue(() -> condition, () -> message);
+		assertTrue(condition, () -> message);
 	}
 
 	static void assertTrue(BooleanSupplier booleanSupplier, Supplier<String> messageSupplier) {


### PR DESCRIPTION
## Overview

BooleanSupplier is an object that is created every time assertion is called. This affects performance. My pull request changes that. If condition comes as a boolean, that specific boolean is checked.

It's non-functional change, therefore I didn't put any tests for that. Also no other assertion classes except of AssertTrue were checked against performance. 