### PR TITLE
Make @MethodSource `value` attribute optional

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -154,7 +154,8 @@ _@API Guardian_ JAR _mandatory_ again.
    example, `fail<Nothing>("Some message")`. These new top-level functions remove this
    requirement by returning
    https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-nothing.html[`Nothing`].
- * `@MethodSource` no longer requires a 'value' attribute, but uses the current test method name as a default `factory` method name.
+ * `@MethodSource` no longer requires a 'value' attribute, but uses the current test
+   method name as a default `factory` method name.
 
 [[release-notes-5.1.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -154,7 +154,7 @@ _@API Guardian_ JAR _mandatory_ again.
    example, `fail<Nothing>("Some message")`. These new top-level functions remove this
    requirement by returning
    https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-nothing.html[`Nothing`].
-
+ * `@MethodSource` no longer requires a 'value' attribute, but uses the current test method name as a default `factory` method name. 
 
 [[release-notes-5.1.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0-M2.adoc
@@ -154,7 +154,7 @@ _@API Guardian_ JAR _mandatory_ again.
    example, `fail<Nothing>("Some message")`. These new top-level functions remove this
    requirement by returning
    https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-nothing.html[`Nothing`].
- * `@MethodSource` no longer requires a 'value' attribute, but uses the current test method name as a default `factory` method name. 
+ * `@MethodSource` no longer requires a 'value' attribute, but uses the current test method name as a default `factory` method name.
 
 [[release-notes-5.1.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -724,7 +724,7 @@ parameter type as demonstrated by the following example.
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=simple_MethodSource_example]
 ----
-Leaving the 'value' parameter empty causes @Method source to look for a _factory_ method
+Leaving the 'value' argument empty causes @MethodSource to look for a _factory_ method
 that has the same name as the test that is annotated.
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=simple_MethodSource_without_value_example]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -722,6 +722,8 @@ addition, such methods must not accept any arguments. By default such methods mu
 If you only need a single parameter, you can return a `Stream` of instances of the
 parameter type as demonstrated by the following example.
 
+Leaving the 'value' parameter empty causes @Method source to look for a _factory_ method
+that has the same name as the test that is annotated.
 [source,java,indent=0]
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=simple_MethodSource_example]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -721,13 +721,16 @@ addition, such methods must not accept any arguments. By default such methods mu
 
 If you only need a single parameter, you can return a `Stream` of instances of the
 parameter type as demonstrated by the following example.
-
-Leaving the 'value' parameter empty causes @Method source to look for a _factory_ method
-that has the same name as the test that is annotated.
-[source,java,indent=0]
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=simple_MethodSource_example]
 ----
+Leaving the 'value' parameter empty causes @Method source to look for a _factory_ method
+that has the same name as the test that is annotated.
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=simple_MethodSource_without_value_example]
+----
+[source,java,indent=0]
+
 
 Streams for primitive types (`DoubleStream`, `IntStream`, and `LongStream`) are also
 supported as demonstrated by the following example.

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -120,6 +120,19 @@ class ParameterizedTestDemo {
 	}
 	// end::simple_MethodSource_example[]
 
+	// tag::simple_MethodSource_without_value_example[]
+	@ParameterizedTest
+	@MethodSource
+	void testWithSimpleMethodSourceHavingNoValue(String argument) {
+		assertNotNull(argument);
+	}
+
+	static Stream<String> testWithSimpleMethodSourceHavingNoValue() {
+		return Stream.of("foo", "bar");
+	}
+
+	// end::simple_MethodSource_without_value_example[]
+
 	// tag::primitive_MethodSource_example[]
 	@ParameterizedTest
 	@MethodSource("range")

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.params.provider;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -37,6 +38,8 @@ class MethodArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<M
 		Object testInstance = context.getTestInstance().orElse(null);
 		// @formatter:off
 		return Arrays.stream(methodNames)
+				.filter(Objects::nonNull)
+				.map(methodName -> methodName.isEmpty() ? context.getRequiredTestMethod().getName() : methodName)
 				.map(methodName -> ReflectionUtils.findMethod(testClass, methodName)
 					.orElseThrow(() -> new JUnitException("Could not find method: " + methodName)))
 				.map(method -> ReflectionUtils.invokeMethod(method, testInstance))

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -11,7 +11,6 @@
 package org.junit.jupiter.params.provider;
 
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -38,7 +37,6 @@ class MethodArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<M
 		Object testInstance = context.getTestInstance().orElse(null);
 		// @formatter:off
 		return Arrays.stream(methodNames)
-				.filter(Objects::nonNull)
 				.map(methodName -> methodName.isEmpty() && context.getTestMethod().isPresent() ? context.getRequiredTestMethod().getName() : methodName)
 				.map(methodName -> ReflectionUtils.findMethod(testClass, methodName)
 					.orElseThrow(() -> new JUnitException("Could not find method on " + testClass + ": " + methodName)))

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -39,9 +39,9 @@ class MethodArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<M
 		// @formatter:off
 		return Arrays.stream(methodNames)
 				.filter(Objects::nonNull)
-				.map(methodName -> methodName.isEmpty() ? context.getRequiredTestMethod().getName() : methodName)
+				.map(methodName -> methodName.isEmpty() && context.getTestMethod().isPresent() ? context.getRequiredTestMethod().getName() : methodName)
 				.map(methodName -> ReflectionUtils.findMethod(testClass, methodName)
-					.orElseThrow(() -> new JUnitException("Could not find method: " + methodName)))
+					.orElseThrow(() -> new JUnitException("Could not find method on " + testClass + ": " + methodName)))
 				.map(method -> ReflectionUtils.invokeMethod(method, testInstance))
 				.flatMap(CollectionUtils::toStream)
 				.map(MethodArgumentsProvider::toArguments);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -45,8 +45,8 @@ import org.apiguardian.api.API;
 public @interface MethodSource {
 
 	/**
-	 * The names of the test class methods to use as sources for arguments; must
-	 * not be empty.
+	 * The names of the test class methods to use as sources for arguments;
+	 * leave empty if the source method has the name method name as the test method.
 	 */
 	String[] value() default "";
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -46,7 +46,7 @@ public @interface MethodSource {
 
 	/**
 	 * The names of the test class methods to use as sources for arguments;
-	 * leave empty if the source method has the name method name as the test method.
+	 * leave empty if the source method has the same name as the test method.
 	 */
 	String[] value() default "";
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -48,6 +48,6 @@ public @interface MethodSource {
 	 * The names of the test class methods to use as sources for arguments; must
 	 * not be empty.
 	 */
-	String[] value();
+	String[] value() default "";
 
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -77,6 +77,14 @@ class ParameterizedTestIntegrationTests {
 	}
 
 	@Test
+	void executesWithEmptyMethodSource() {
+		List<ExecutionEvent> executionEvents = execute(
+			selectMethod(TestCase.class, "testWithEmptyMethodSource", String.class.getName()));
+		assertThat(executionEvents) //
+				.haveExactly(1, event(test(), finishedWithFailure(message("empty method source")))); //
+	}
+
+	@Test
 	void executesWithCustomName() {
 		List<ExecutionEvent> executionEvents = execute(
 			selectMethod(TestCase.class, "testWithCustomName", String.class.getName() + "," + Integer.TYPE.getName()));
@@ -244,6 +252,16 @@ class ParameterizedTestIntegrationTests {
 		@CsvSource({ "not important" })
 		void testWithEmptyName(String argument) {
 			fail(argument);
+		}
+
+		@ParameterizedTest
+		@MethodSource
+		void testWithEmptyMethodSource(String argument) {
+			fail(argument);
+		}
+
+		static Stream<Arguments> testWithEmptyMethodSource() {
+			return Stream.of(Arguments.of("empty method source"));
 		}
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.params.provider;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.MethodArgumentsProviderTests.TestCaseDefaultValue.TEST_METHOD;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -119,10 +120,9 @@ class MethodArgumentsProviderTests {
 	}
 
 	@Test
-	void providesArgumentsUsingDefaultValue() throws NoSuchMethodException {
+	void providesArgumentsUsingDefaultValue() {
 		Stream<Object[]> arguments = provideArguments(TestCaseDefaultValue.class,
-			TestCaseDefaultValue.class.getDeclaredMethod(TEST_METHOD, String.class), false, "");
-
+			selectMethod(TestCaseDefaultValue.class, TEST_METHOD, String.class.getName()).getJavaMethod(), false, "");
 		assertThat(arguments).containsExactly(array("foo"), array("bar"));
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -12,10 +12,12 @@ package org.junit.jupiter.params.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.MethodArgumentsProviderTests.TestCaseDefaultValue.TEST_METHOD;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Optional;
@@ -65,7 +67,7 @@ class MethodArgumentsProviderTests {
 	@Test
 	void throwsExceptionForIllegalReturnType() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
-			() -> provideArguments("providerWithIllegalReturnType").toArray());
+				() -> provideArguments("providerWithIllegalReturnType").toArray());
 
 		assertThat(exception).hasMessageContaining("Cannot convert instance of java.lang.Integer into a Stream");
 	}
@@ -87,14 +89,14 @@ class MethodArgumentsProviderTests {
 	@Test
 	void throwsExceptionWhenNonStaticMethodIsReferencedAndStaticIsRequired() {
 		JUnitException exception = assertThrows(JUnitException.class,
-			() -> provideArguments(NonStaticTestCase.class, false, "nonStaticStringStreamProvider").toArray());
+				() -> provideArguments(NonStaticTestCase.class, null, false, "nonStaticStringStreamProvider").toArray());
 
 		assertThat(exception).hasMessageContaining("Cannot invoke non-static method");
 	}
 
 	@Test
 	void providesArgumentsFromNonStaticMethodWhenStaticIsNotRequired() {
-		Stream<Object[]> arguments = provideArguments(NonStaticTestCase.class, true, "nonStaticStringStreamProvider");
+		Stream<Object[]> arguments = provideArguments(NonStaticTestCase.class, null, true, "nonStaticStringStreamProvider");
 
 		assertThat(arguments).containsExactly(array("foo"), array("bar"));
 	}
@@ -102,7 +104,7 @@ class MethodArgumentsProviderTests {
 	@Test
 	void throwsExceptionWhenMethodDoesNotExist() {
 		JUnitException exception = assertThrows(JUnitException.class,
-			() -> provideArguments("unknownMethod").toArray());
+				() -> provideArguments("unknownMethod").toArray());
 
 		assertThat(exception).hasMessageContaining("Could not find method");
 	}
@@ -110,9 +112,17 @@ class MethodArgumentsProviderTests {
 	@Test
 	void throwsExceptionWhenNoTestClassIsAvailable() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
-			() -> provideArguments((Class<?>) null, false, "someMethod"));
+				() -> provideArguments((Class<?>) null, null, false, "someMethod"));
 
 		assertThat(exception).hasMessageContaining("required test class is not present");
+	}
+
+	@Test
+	void providesArgumentsUsingDefaultValue() throws NoSuchMethodException {
+		Stream<Object[]> arguments = provideArguments(TestCaseDefaultValue.class, TestCaseDefaultValue.class.getDeclaredMethod(TEST_METHOD, String.class),
+				false, "");
+
+		assertThat(arguments).containsExactly(array("foo"), array("bar"));
 	}
 
 	@Nested
@@ -173,6 +183,7 @@ class MethodArgumentsProviderTests {
 
 			assertThat(arguments).containsExactly(array((short) 47), array(Short.MIN_VALUE));
 		}
+
 	}
 
 	private static Object[] array(Object... objects) {
@@ -180,15 +191,19 @@ class MethodArgumentsProviderTests {
 	}
 
 	private Stream<Object[]> provideArguments(String... methodNames) {
-		return provideArguments(TestCase.class, false, methodNames);
+		return provideArguments(TestCase.class, null, false, methodNames);
 	}
 
-	private Stream<Object[]> provideArguments(Class<?> testClass, boolean allowNonStaticMethod, String... methodNames) {
+	private Stream<Object[]> provideArguments(Class<?> testClass, Method testMethod, boolean allowNonStaticMethod, String... methodNames) {
 		MethodSource annotation = mock(MethodSource.class);
+
 		when(annotation.value()).thenReturn(methodNames);
 
 		ExtensionContext context = mock(ExtensionContext.class);
 		when(context.getTestClass()).thenReturn(Optional.ofNullable(testClass));
+		when(context.getTestMethod()).thenReturn(Optional.ofNullable(testMethod));
+
+		doCallRealMethod().when(context).getRequiredTestMethod();
 		doCallRealMethod().when(context).getRequiredTestClass();
 
 		Object testInstance = allowNonStaticMethod ? ReflectionUtils.newInstance(testClass) : null;
@@ -200,6 +215,18 @@ class MethodArgumentsProviderTests {
 	}
 
 	// -------------------------------------------------------------------------
+
+	static class TestCaseDefaultValue {
+		static final String TEST_METHOD = "testDefaultValue";
+
+		static Stream<String> testDefaultValue() {
+			return Stream.of("foo", "bar");
+		}
+
+		public void testDefaultValue(String param) {
+
+		}
+	}
 
 	static class TestCase {
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -67,7 +67,7 @@ class MethodArgumentsProviderTests {
 	@Test
 	void throwsExceptionForIllegalReturnType() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
-				() -> provideArguments("providerWithIllegalReturnType").toArray());
+			() -> provideArguments("providerWithIllegalReturnType").toArray());
 
 		assertThat(exception).hasMessageContaining("Cannot convert instance of java.lang.Integer into a Stream");
 	}
@@ -89,14 +89,15 @@ class MethodArgumentsProviderTests {
 	@Test
 	void throwsExceptionWhenNonStaticMethodIsReferencedAndStaticIsRequired() {
 		JUnitException exception = assertThrows(JUnitException.class,
-				() -> provideArguments(NonStaticTestCase.class, null, false, "nonStaticStringStreamProvider").toArray());
+			() -> provideArguments(NonStaticTestCase.class, null, false, "nonStaticStringStreamProvider").toArray());
 
 		assertThat(exception).hasMessageContaining("Cannot invoke non-static method");
 	}
 
 	@Test
 	void providesArgumentsFromNonStaticMethodWhenStaticIsNotRequired() {
-		Stream<Object[]> arguments = provideArguments(NonStaticTestCase.class, null, true, "nonStaticStringStreamProvider");
+		Stream<Object[]> arguments = provideArguments(NonStaticTestCase.class, null, true,
+			"nonStaticStringStreamProvider");
 
 		assertThat(arguments).containsExactly(array("foo"), array("bar"));
 	}
@@ -104,7 +105,7 @@ class MethodArgumentsProviderTests {
 	@Test
 	void throwsExceptionWhenMethodDoesNotExist() {
 		JUnitException exception = assertThrows(JUnitException.class,
-				() -> provideArguments("unknownMethod").toArray());
+			() -> provideArguments("unknownMethod").toArray());
 
 		assertThat(exception).hasMessageContaining("Could not find method");
 	}
@@ -112,15 +113,15 @@ class MethodArgumentsProviderTests {
 	@Test
 	void throwsExceptionWhenNoTestClassIsAvailable() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
-				() -> provideArguments((Class<?>) null, null, false, "someMethod"));
+			() -> provideArguments((Class<?>) null, null, false, "someMethod"));
 
 		assertThat(exception).hasMessageContaining("required test class is not present");
 	}
 
 	@Test
 	void providesArgumentsUsingDefaultValue() throws NoSuchMethodException {
-		Stream<Object[]> arguments = provideArguments(TestCaseDefaultValue.class, TestCaseDefaultValue.class.getDeclaredMethod(TEST_METHOD, String.class),
-				false, "");
+		Stream<Object[]> arguments = provideArguments(TestCaseDefaultValue.class,
+			TestCaseDefaultValue.class.getDeclaredMethod(TEST_METHOD, String.class), false, "");
 
 		assertThat(arguments).containsExactly(array("foo"), array("bar"));
 	}
@@ -194,7 +195,8 @@ class MethodArgumentsProviderTests {
 		return provideArguments(TestCase.class, null, false, methodNames);
 	}
 
-	private Stream<Object[]> provideArguments(Class<?> testClass, Method testMethod, boolean allowNonStaticMethod, String... methodNames) {
+	private Stream<Object[]> provideArguments(Class<?> testClass, Method testMethod, boolean allowNonStaticMethod,
+			String... methodNames) {
 		MethodSource annotation = mock(MethodSource.class);
 
 		when(annotation.value()).thenReturn(methodNames);


### PR DESCRIPTION
Issue: #1270

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
