### PR TITLE
Make dependency on "javax.script" optional

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionCondition.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionCondition.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ScriptEvaluationException;
 import org.junit.jupiter.engine.script.Script;
 
 /**
@@ -160,14 +160,14 @@ class ScriptExecutionCondition implements ExecutionCondition {
 	}
 
 	/**
-	 * Evaluator implementation that always throws an {@link ScriptEvaluationException}.
+	 * Evaluator implementation that always throws an {@link ExtensionConfigurationException}.
 	 */
 	static class ThrowingEvaluator implements Evaluator {
 
-		final ScriptEvaluationException exception;
+		final ExtensionConfigurationException exception;
 
 		ThrowingEvaluator(String message, Throwable cause) {
-			this.exception = new ScriptEvaluationException(message, cause);
+			this.exception = new ExtensionConfigurationException(message, cause);
 		}
 
 		@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionCondition.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionCondition.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.script.Script;
+import org.junit.platform.commons.util.BlacklistedExceptions;
 
 /**
  * {@link ExecutionCondition} that supports the {@link DisabledIf} and {@link EnabledIf} annotation.
@@ -138,6 +139,7 @@ class ScriptExecutionCondition implements ExecutionCondition {
 				Class.forName(nameOfScriptEngine);
 			}
 			catch (Throwable cause) {
+				BlacklistedExceptions.rethrowIfBlacklisted(cause);
 				String message = "Class `" + nameOfScriptEngine + "` is not loadable, " //
 						+ "script-based test execution is disabled. " //
 						+ "If the originating cause is a `NoClassDefFoundError: javax/script/...` and " //

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluator.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluator.java
@@ -31,7 +31,9 @@ import org.junit.jupiter.engine.script.ScriptExecutionManager;
 /**
  * Encapsulates javax.script-related evaluation work.
  *
- * <p>This class is instantiated via reflection.
+ * <p>This class is instantiated via reflection in class {@link ScriptExecutionCondition}.
+ *
+ * @since 5.1
  */
 class ScriptExecutionEvaluator implements ScriptExecutionCondition.Evaluator {
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluator.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+
+import java.util.List;
+
+import javax.script.Bindings;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ScriptEvaluationException;
+import org.junit.jupiter.engine.script.Script;
+import org.junit.jupiter.engine.script.ScriptAccessor;
+import org.junit.jupiter.engine.script.ScriptExecutionManager;
+
+/**
+ * Encapsulates javax.script-related evaluation work.
+ *
+ * <p>This class is instantiated via reflection.
+ */
+class ScriptExecutionEvaluator implements ScriptExecutionCondition.Evaluator {
+
+	private static final ConditionEvaluationResult ENABLED_ALL = enabled("All results are enabled");
+
+	private final ScriptExecutionManager scriptExecutionManager = new ScriptExecutionManager();
+
+	@Override
+	public ConditionEvaluationResult evaluate(ExtensionContext context, List<Script> scripts) {
+		Bindings bindings = createBindings(context);
+		for (Script script : scripts) {
+			ConditionEvaluationResult result = evaluate(scriptExecutionManager, script, bindings);
+			// Report the first result that is disabled, preventing evaluation of remaining scripts.
+			if (result.isDisabled()) {
+				return result;
+			}
+		}
+
+		return ENABLED_ALL;
+	}
+
+	private Bindings createBindings(ExtensionContext context) {
+		ScriptAccessor configurationParameterAccessor = new ScriptAccessor.ConfigurationParameterAccessor(context);
+		Bindings bindings = new SimpleBindings();
+		bindings.put(Script.BIND_JUNIT_TAGS, context.getTags());
+		bindings.put(Script.BIND_JUNIT_UNIQUE_ID, context.getUniqueId());
+		bindings.put(Script.BIND_JUNIT_DISPLAY_NAME, context.getDisplayName());
+		bindings.put(Script.BIND_JUNIT_CONFIGURATION_PARAMETER, configurationParameterAccessor);
+		return bindings;
+	}
+
+	ConditionEvaluationResult evaluate(ScriptExecutionManager manager, Script script, Bindings bindings) {
+		if (script == null) {
+			return null;
+		}
+		try {
+			Object result = manager.evaluate(script, bindings);
+			return computeConditionEvaluationResult(script, result);
+		}
+		catch (ScriptException e) {
+			throw new ScriptEvaluationException("Script evaluation failed for: " + script.getAnnotationAsString(), e);
+		}
+	}
+
+	ConditionEvaluationResult computeConditionEvaluationResult(Script script, Object result) {
+		// Treat "null" result as an error.
+		if (result == null) {
+			throw new ScriptEvaluationException("Script returned `null`: " + script.getAnnotationAsString());
+		}
+
+		// Trivial case: script returned a custom ConditionEvaluationResult instance.
+		if (result instanceof ConditionEvaluationResult) {
+			return (ConditionEvaluationResult) result;
+		}
+
+		String resultAsString = String.valueOf(result);
+		String reason = script.toReasonString(resultAsString);
+
+		// Cast or parse result to a boolean value.
+		boolean isTrue;
+		if (result instanceof Boolean) {
+			isTrue = (Boolean) result;
+		}
+		else {
+			isTrue = Boolean.parseBoolean(resultAsString);
+		}
+
+		// Flip enabled/disabled result based on the associated annotation type.
+		if (script.getAnnotationType() == EnabledIf.class) {
+			return isTrue ? enabled(reason) : disabled(reason);
+		}
+		if (script.getAnnotationType() == DisabledIf.class) {
+			return isTrue ? disabled(reason) : enabled(reason);
+		}
+
+		// Still here? Not so good.
+		throw new ScriptEvaluationException("Unsupported annotation type: " + script.getAnnotationType());
+	}
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/script/ScriptExecutionManager.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/script/ScriptExecutionManager.java
@@ -24,7 +24,6 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 
 import org.apiguardian.api.API;
-import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -33,7 +32,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  */
 @API(status = INTERNAL, since = "5.1")
-public class ScriptExecutionManager implements CloseableResource {
+public class ScriptExecutionManager {
 
 	private final ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
 	private final ConcurrentMap<String, ScriptEngine> scriptEngines = new ConcurrentHashMap<>();
@@ -44,12 +43,6 @@ public class ScriptExecutionManager implements CloseableResource {
 
 	// package-private for testing purposes -- make it configurable?
 	boolean forceScriptEvaluation = false;
-
-	@Override
-	public void close() {
-		compiledScripts.clear();
-		scriptEngines.clear();
-	}
 
 	/**
 	 * Evaluate the script using the given bindings.

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionConditionTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.extension;
 
 import static org.assertj.core.api.Assertions.allOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -58,7 +59,6 @@ class ScriptExecutionConditionTests extends AbstractJupiterTestEngineTests {
 			() -> assertEquals(3, eventRecorder.getTestStartedCount(), "# tests started"), //
 			() -> assertEquals(1, eventRecorder.getTestSkippedCount(), "# tests skipped"), //
 			() -> assertEquals(1, eventRecorder.getTestFailedCount(), "# tests started") //
-
 		);
 
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getFailedTestFinishedEvents(), //
@@ -122,11 +122,10 @@ class ScriptExecutionConditionTests extends AbstractJupiterTestEngineTests {
 		ScriptExecutionCondition.Evaluator evaluator = ScriptExecutionCondition.Evaluator.forName(nameOfScriptEngine,
 			name);
 		Exception e = assertThrows(Exception.class, () -> evaluator.evaluate(null, null));
-		assertTrue(e instanceof ExtensionConfigurationException);
-		String message = e.getMessage();
-		System.out.println(message);
-		assertTrue(message.startsWith("Class `" + nameOfScriptEngine + "` is not loadable"));
-		assertTrue(message.endsWith("`--add-modules ...,java.scripting`"));
+		assertThat(e) //
+				.isInstanceOf(ExtensionConfigurationException.class) //
+				.hasMessageStartingWith("Class `" + nameOfScriptEngine + "` is not loadable") //
+				.hasMessageEndingWith("`--add-modules ...,java.scripting`");
 	}
 
 	@Test
@@ -137,8 +136,10 @@ class ScriptExecutionConditionTests extends AbstractJupiterTestEngineTests {
 		AnnotatedElement element = SimpleTestCases.class.getDeclaredMethod("testIsEnabled");
 		Mockito.when(context.getElement()).thenReturn(Optional.of(element));
 		Exception e = assertThrows(Exception.class, () -> condition.evaluateExecutionCondition(context));
-		assertTrue(e instanceof ExtensionConfigurationException);
-		assertTrue(e.getMessage().startsWith("Creating instance of class `" + name + "` failed"));
+		assertThat(e) //
+				.isInstanceOf(ExtensionConfigurationException.class) //
+				.hasMessageStartingWith("Creating instance of class `" + name + "` failed");
+
 	}
 
 	static class SimpleTestCases {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionConditionTests.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ScriptEvaluationException;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
@@ -88,7 +88,8 @@ class ScriptExecutionConditionTests extends AbstractJupiterTestEngineTests {
 		String message = "Mock for message";
 		ReflectiveOperationException cause = new ReflectiveOperationException("Mock for ReflectiveOperationException");
 		ScriptExecutionCondition.Evaluator evaluator = new ScriptExecutionCondition.ThrowingEvaluator(message, cause);
-		Exception e = assertThrows(ScriptEvaluationException.class, () -> evaluator.evaluate(null, null));
+		Exception e = assertThrows(Exception.class, () -> evaluator.evaluate(null, null));
+		assertTrue(e instanceof ExtensionConfigurationException);
 		assertEquals(message, e.getMessage());
 	}
 
@@ -121,6 +122,7 @@ class ScriptExecutionConditionTests extends AbstractJupiterTestEngineTests {
 		ScriptExecutionCondition.Evaluator evaluator = ScriptExecutionCondition.Evaluator.forName(nameOfScriptEngine,
 			name);
 		Exception e = assertThrows(Exception.class, () -> evaluator.evaluate(null, null));
+		assertTrue(e instanceof ExtensionConfigurationException);
 		String message = e.getMessage();
 		System.out.println(message);
 		assertTrue(message.startsWith("Class `" + nameOfScriptEngine + "` is not loadable"));
@@ -135,6 +137,7 @@ class ScriptExecutionConditionTests extends AbstractJupiterTestEngineTests {
 		AnnotatedElement element = SimpleTestCases.class.getDeclaredMethod("testIsEnabled");
 		Mockito.when(context.getElement()).thenReturn(Optional.of(element));
 		Exception e = assertThrows(Exception.class, () -> condition.evaluateExecutionCondition(context));
+		assertTrue(e instanceof ExtensionConfigurationException);
 		assertTrue(e.getMessage().startsWith("Creating instance of class `" + name + "` failed"));
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluatorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluatorTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ScriptEvaluationException;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.engine.script.Script;
+import org.junit.jupiter.engine.script.ScriptExecutionManager;
+
+/**
+ * Unit tests for {@link ScriptExecutionEvaluator}.
+ *
+ * @since 5.1
+ */
+class ScriptExecutionEvaluatorTests extends AbstractJupiterTestEngineTests {
+
+	private final Bindings bindings = createDefaultContextBindings();
+	private final ScriptExecutionManager manager = new ScriptExecutionManager();
+	private final ScriptExecutionEvaluator evaluator = new ScriptExecutionEvaluator();
+
+	@Test
+	void nullAsScriptReturnsNullAsResult() {
+		assertSame(null, evaluate(null));
+	}
+
+	@Test
+	void computeConditionEvaluationResultWithDefaultReasonMessage() {
+		Script script = script(EnabledIf.class, "?");
+		String actual = evaluator.computeConditionEvaluationResult(script, "!").getReason().orElseThrow(Error::new);
+		assertEquals("Script `?` evaluated to: !", actual);
+	}
+
+	@TestFactory
+	Stream<DynamicTest> computeConditionEvaluationResultFailsForUnsupportedAnnotationType() {
+		return Stream.of(Override.class, Deprecated.class, Object.class) //
+				.map(type -> dynamicTest("computationFailsFor(" + type + ")", //
+					() -> computeConditionEvaluationResultFailsForUnsupportedAnnotationType(type)));
+	}
+
+	private void computeConditionEvaluationResultFailsForUnsupportedAnnotationType(Type type) {
+		Script script = new Script(type, "annotation", "engine", "source", "reason");
+		Exception e = assertThrows(ScriptEvaluationException.class,
+			() -> evaluator.computeConditionEvaluationResult(script, "!"));
+		String expected = "Unsupported annotation type: " + type;
+		String actual = e.getMessage();
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void defaultConditionEvaluationResultProperties() {
+		Script script = script(EnabledIf.class, "true");
+		ConditionEvaluationResult result = evaluate(script);
+		assertFalse(result.isDisabled());
+		assertThat(result.toString()).contains("ConditionEvaluationResult", "enabled", "true", "reason");
+	}
+
+	@Test
+	void getJUnitConfigurationParameterWithJavaScript() {
+		Script script = script(DisabledIf.class, "junitConfigurationParameter.get('XXX')");
+		Exception exception = assertThrows(ScriptEvaluationException.class, () -> evaluate(script));
+		assertThat(exception.getMessage()).contains("Script returned `null`");
+	}
+
+	@Test
+	void getJUnitConfigurationParameterWithJavaScriptAndCheckForNull() {
+		Script script = script(DisabledIf.class, "junitConfigurationParameter.get('XXX') == null");
+		ConditionEvaluationResult result = evaluate(script);
+		assertTrue(result.isDisabled());
+		String actual = result.getReason().orElseThrow(() -> new AssertionError("causeless"));
+		assertEquals("Script `junitConfigurationParameter.get('XXX') == null` evaluated to: true", actual);
+	}
+
+	private ConditionEvaluationResult evaluate(Script script) {
+		return evaluator.evaluate(manager, script, bindings);
+	}
+
+	private Script script(Type type, String... lines) {
+		return new Script( //
+			type, //
+			"Mock for " + type, //
+			Script.DEFAULT_SCRIPT_ENGINE_NAME, //
+			String.join("\n", lines), //
+			Script.DEFAULT_SCRIPT_REASON_PATTERN //
+		);
+	}
+
+	private Bindings createDefaultContextBindings() {
+		Bindings bindings = new SimpleBindings();
+		bindings.put(Script.BIND_JUNIT_TAGS, Collections.emptySet());
+		bindings.put(Script.BIND_JUNIT_UNIQUE_ID, "Mock for UniqueId");
+		bindings.put(Script.BIND_JUNIT_DISPLAY_NAME, "Mock for DisplayName");
+		bindings.put(Script.BIND_JUNIT_CONFIGURATION_PARAMETER, Collections.emptyMap());
+		return bindings;
+	}
+
+}


### PR DESCRIPTION
## Overview

Copied from http://mail.openjdk.java.net/pipermail/jigsaw-dev/2018-February/013581.html
> [...] The more general issue is of course that you are 
deploying a module that does not know what modules it depends. In these 
cases you have to help the module system by specifying --add-modules to 
force the modules that it depends on to be resolved. You got lucky with 
the Oracle JDK build because jdk.deploy pulled in the java.scripting module.

Addresses #1282

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
