### PR TITLE
Fix junit-platform-commons-java-9 subproject build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ allprojects { subproj ->
 	}
 
 	// See: https://docs.oracle.com/javase/9/tools/javac.htm#JSWOR627
-	compileJava.options*.compilerArgs = [
+	compileJava.options.compilerArgs += [
 		'-Xlint:cast',
 		'-Xlint:classfile',
 		'-Xlint:deprecation',
@@ -168,7 +168,7 @@ allprojects { subproj ->
 	]
 
 	// See: https://docs.oracle.com/javase/9/tools/javac.htm#JSWOR627
-	compileTestJava.options*.compilerArgs = [
+	compileTestJava.options.compilerArgs += [
 		'-Xlint:cast',
 		'-Xlint:classfile',
 		'-Xlint:deprecation',

--- a/build.gradle
+++ b/build.gradle
@@ -137,11 +137,13 @@ allprojects { subproj ->
 	// a sub-project.
 	ext.javacRelease = rootProject.javacRelease
 
-	tasks.withType(JavaCompile) {
-		sourceCompatibility = javacRelease // needed by clover
-		targetCompatibility = javacRelease // needed by clover/asm
-		options.compilerArgs += ['--release', javacRelease]
-		options.encoding = 'UTF-8'
+	subproj.afterEvaluate { evaluatedProject ->
+		evaluatedProject.tasks.withType(JavaCompile) {
+			sourceCompatibility = javacRelease // needed by clover
+			targetCompatibility = javacRelease // needed by clover/asm
+			options.compilerArgs += ['--release', javacRelease]
+			options.encoding = 'UTF-8'
+		}
 	}
 
 	// See: https://docs.oracle.com/javase/9/tools/javac.htm#JSWOR627


### PR DESCRIPTION
## Overview

Update Gradle script so that subproject `junit-platform-commons-java-9` is really built with source, target and API of Java 9.

Before, two things were happening:
 - `--release` compiler option was missing and all modules were compiler against JDK9 API
 - `javacRelease = 9` did not work for the subproject, because compiler settings were configured too early.

This was spotted while trying to import the project to IntelliJ IDEA https://youtrack.jetbrains.com/issue/IDEA-186344 

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] N/A Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] N/A Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] N/A Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
