### PR TITLE
Issue1191 conversion of multiple args

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -818,6 +818,19 @@ results in one invocation of the parameterized test.
 include::{testDir}/example/ParameterizedTestDemo.java[tags=CsvFileSource_example]
 ----
 
+Individual fields comprising a line from a CSV file can be coalesced into a
+custom class for clarity.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=CsvFileSourceWithConverter_example]
+----
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ExampleCsvFileRowConverter.java[tags=ExampleCsvFileRowConverter_example]
+----
+
 [source,csv,indent=0]
 .two-column.csv
 ----

--- a/documentation/src/test/java/example/ExampleCsvFileRowConverter.java
+++ b/documentation/src/test/java/example/ExampleCsvFileRowConverter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example;
+
+import org.junit.jupiter.params.converter.CsvFileRowConverter;
+
+// tag::ExampleCsvFileRowConverter_example[]
+public class ExampleCsvFileRowConverter extends CsvFileRowConverter {
+	public ExampleCsvFileRowConverter(Object[] fields) {
+		super(fields);
+	}
+	public String getCountry() {
+		return String.valueOf(fields[0]);
+	}
+	public int getReference() {
+		return Integer.valueOf(String.valueOf(fields[1]));
+	}
+}
+// end::ExampleCsvFileRowConverter_example[]

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -181,6 +181,15 @@ class ParameterizedTestDemo {
 	}
 	// end::CsvFileSource_example[]
 
+	// tag::CsvFileSourceWithConverter_example[]
+	@ParameterizedTest
+	@CsvFileSource(resources = "/two-column.csv", numLinesToSkip = 1, converter = ExampleCsvFileRowConverter.class)
+	void testWithCsvFileSource(ExampleCsvFileRowConverter converter) {
+		assertNotNull(converter.getCountry());
+		assertNotEquals(0, converter.getReference());
+	}
+	// end::CsvFileSourceWithConverter_example[]
+
 	// tag::ArgumentsSource_example[]
 	@ParameterizedTest
 	@ArgumentsSource(MyArgumentsProvider.class)

--- a/documentation/src/test/resources/two-column.csv
+++ b/documentation/src/test/resources/two-column.csv
@@ -1,4 +1,4 @@
-Country, reference
+Country, Reference
 Sweden, 1
 Poland, 2
 "United States of America", 3

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/CsvFileRowConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/CsvFileRowConverter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.converter;
+
+/**
+ * {@code @CsvFileRowConverter} is an abstract parent for CSV file row converters.
+ *
+ * <p> It ensures that converters are constructed with an {@code Object} array of fields.
+ *
+ * @see org.junit.jupiter.params.provider.CsvFileArgumentsProvider
+ * @see org.junit.jupiter.params.provider.CsvFileSource
+ * @since 5.0
+ */
+public class CsvFileRowConverter {
+
+	protected Object[] fields;
+
+	public CsvFileRowConverter(Object[] fields) {
+		this.fields = fields;
+	}
+
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultCsvFileRowConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultCsvFileRowConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.converter;
+
+/**
+ * {@code @DefaultCsvFileRowConverter} is a marker class used as a default in {@code CsvFileSource}
+ * and to control row conversion in {@code CsvFileArgumentsProvider}.
+ *
+ * @see org.junit.jupiter.params.provider.CsvFileArgumentsProvider
+ * @see org.junit.jupiter.params.provider.CsvFileSource
+ * @since 5.0
+ */
+public class DefaultCsvFileRowConverter extends CsvFileRowConverter {
+
+	private DefaultCsvFileRowConverter(Object[] fields) {
+		super(fields);
+	}
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -19,6 +19,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.params.converter.CsvFileRowConverter;
+import org.junit.jupiter.params.converter.DefaultCsvFileRowConverter;
 
 /**
  * {@code @CsvFileSource} is an {@link ArgumentsSource} which is used to
@@ -77,4 +79,11 @@ public @interface CsvFileSource {
 	 * <p>Defaults to {@code 0}.
 	 */
 	int numLinesToSkip() default 0;
+
+	/**
+	 * The converter to transform a row of CSV file parameters into a single object.
+	 *
+	 * <p>Defaults to {@code DefaultCsvFileRowConverter.class}.
+	 */
+	Class<? extends CsvFileRowConverter> converter() default DefaultCsvFileRowConverter.class;
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/TestCsvFileRowConverter.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/TestCsvFileRowConverter.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import org.junit.jupiter.params.converter.CsvFileRowConverter;
+
+public class TestCsvFileRowConverter extends CsvFileRowConverter {
+
+	public TestCsvFileRowConverter(Object[] fields) {
+		super(fields);
+	}
+
+	public String getFirst() {
+		return String.valueOf(fields[0]);
+	}
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -333,7 +333,34 @@ public final class ReflectionUtils {
 
 	/**
 	 * Create a new instance of type {@code T} by invoking the supplied constructor
-	 * with the supplied arguments.
+	 * with the supplied arguments array.
+	 *
+	 * <p>The constructor will be made accessible if necessary, and any checked
+	 * exception will be {@linkplain ExceptionUtils#throwAsUncheckedException masked}
+	 * as an unchecked exception.
+	 *
+	 * @param clazz the class to construct; never {@code null}
+	 * @param args the array of arguments to pass to the constructor; never {@code null}
+	 * @return the new instance; never {@code null}
+	 * @see #newInstance(Class, Object...)
+	 * @see ExceptionUtils#throwAsUncheckedException(Throwable)
+	 */
+	public static <T> T newInstanceForArray(Class<T> clazz, Object[] args) {
+		Preconditions.notNull(clazz, "Class must not be null");
+		Preconditions.notNull(args, "Argument array must not be null");
+		Preconditions.containsNoNullElements(args, "Individual arguments must not be null");
+		try {
+			Class<?>[] parameterTypes = new Class<?>[] { Object[].class };
+			return newInstance(clazz.getDeclaredConstructor(parameterTypes), new Object[] { args });
+		}
+		catch (Throwable t) {
+			throw ExceptionUtils.throwAsUncheckedException(getUnderlyingCause(t));
+		}
+	}
+
+	/**
+	 * Create a new instance of type {@code T} by invoking the supplied constructor
+	 * with the supplied arguments, each of which are mapped to successive constructor arguments.
 	 *
 	 * <p>The constructor will be made accessible if necessary, and any checked
 	 * exception will be {@linkplain ExceptionUtils#throwAsUncheckedException masked}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -360,7 +360,7 @@ public final class ReflectionUtils {
 
 	/**
 	 * Create a new instance of type {@code T} by invoking the supplied constructor
-	 * with the supplied arguments, each of which are mapped to successive constructor arguments.
+	 * with the supplied arguments, each of which is mapped to a successive constructor argument.
 	 *
 	 * <p>The constructor will be made accessible if necessary, and any checked
 	 * exception will be {@linkplain ExceptionUtils#throwAsUncheckedException masked}

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -160,6 +160,22 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
+	void newInstanceForArray() {
+		// @formatter:off
+		assertThat(ReflectionUtils.newInstanceForArray(D.class, new Object[]{"one", "two"})).isNotNull();
+
+		assertThrows(PreconditionViolationException.class, () ->
+				ReflectionUtils.newInstance(D.class, new Object[]{"one", null}));
+		assertThrows(PreconditionViolationException.class, () ->
+				ReflectionUtils.newInstance(D.class, ((Object[]) null)));
+
+		RuntimeException exception = assertThrows(RuntimeException.class, () ->
+				ReflectionUtils.newInstanceForArray(ArrayExploder.class, new Object[]{"one", "two"}));
+		assertThat(exception).hasMessage("bang");
+		// @formatter:on
+	}
+
+	@Test
 	void readFieldValueOfNonexistentStaticField() {
 		assertThat(readFieldValue(MyClass.class, "doesNotExist", null)).isNotPresent();
 		assertThat(readFieldValue(MySubClass.class, "staticField", null)).isNotPresent();
@@ -1006,10 +1022,23 @@ class ReflectionUtilsTests {
 
 	}
 
+	static class D {
+		D(Object[] o) {
+		}
+	}
+
 	static class Exploder {
 
 		Exploder() {
 			throw new RuntimeException("boom");
+		}
+
+	}
+
+	static class ArrayExploder {
+
+		ArrayExploder(Object[] args) {
+			throw new RuntimeException("bang");
 		}
 
 	}


### PR DESCRIPTION
## Overview

#1191 : Addition of CsvFileRowConverter to convert parameterized csv file fields into an encapsulation object. Added to CsvFileSource to provide the option of using a custom converter within a test.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
