### PR TITLE
allow to disable reporting

### DIFF
--- a/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
+++ b/junit-platform-gradle-plugin/src/main/groovy/org/junit/platform/gradle/plugin/JUnitPlatformPlugin.groovy
@@ -187,8 +187,10 @@ class JUnitPlatformPlugin implements Plugin<Project> {
 			args.addAll('--config', "${key}=${value}")
 		}
 
-		args.add('--reports-dir')
-		args.add(reportsDir.getAbsolutePath())
+		if(reportsDir != 'none') {
+		        args.add('--reports-dir')
+		        args.add(reportsDir.getAbsolutePath())
+		}
 
 		return args
 	}


### PR DESCRIPTION
## Overview

This is only a hack, but I hope it shows what the intention is. I want to be able to disable the report entirely. Currently I modify `junitPlatformTest` as follows which is even a bigger hack:

```groovy
def reportIndex = junitPlatformTestTask.args.findIndexOf { it=='--reports-dir' }
def keep = (0..(junitPlatformTestTask.args.size()-1)) - [reportIndex, reportIndex + 1]
junitPlatformTestTask.args = junitPlatformTestTask.args[keep]
```

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
