### PR TITLE
Fix handling of trailing null elements in @CsvSource

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.1.0.adoc
@@ -31,7 +31,8 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Null elements specified in the last column after the first row via `@CsvSource` for
+  parameterized tests are now correctly converted to `null` instead of the empty `String`.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -26,6 +26,8 @@ import org.junit.platform.commons.util.Preconditions;
  */
 class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvSource> {
 
+	private static final String LINE_SEPARATOR = "\n";
+
 	private String[] lines;
 	private char delimiter;
 
@@ -39,6 +41,7 @@ class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvS
 	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
 		CsvParserSettings settings = new CsvParserSettings();
 		settings.getFormat().setDelimiter(delimiter);
+		settings.getFormat().setLineSeparator(LINE_SEPARATOR);
 		settings.getFormat().setQuote('\'');
 		settings.getFormat().setQuoteEscape('\'');
 		settings.setEmptyValue("");
@@ -48,7 +51,7 @@ class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvS
 		// @formatter:off
 		return Arrays.stream(lines)
 				.map(
-					line -> Preconditions.notNull(csvParser.parseLine(line),
+					line -> Preconditions.notNull(csvParser.parseLine(line + LINE_SEPARATOR),
 					() -> "Line at index " + index.get() + " contains invalid CSV: \"" + line + "\"")
 				)
 				.peek(values -> index.incrementAndGet())

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -89,6 +89,13 @@ class CsvArgumentsProviderTests {
 		assertThat(arguments).containsExactly(new Object[][] { { "1", "" }, { "2", "" }, { "3", "" }, { "4", "" } });
 	}
 
+	@Test
+	void convertsEmptyValuesToNullInLinesAfterFirst() {
+		Stream<Object[]> arguments = provideArguments(',', "'', ''", " , ");
+
+		assertThat(arguments).containsExactly(new Object[][] { { "", "" }, { null, null } });
+	}
+
 	private Stream<Object[]> provideArguments(char delimiter, String... value) {
 		CsvSource annotation = mock(CsvSource.class);
 		when(annotation.value()).thenReturn(value);


### PR DESCRIPTION
Fixes #1296.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
