### PR TITLE
Upgrade AssertJ to 3.9.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ vintageBaseline     = 5.1.0
 javacRelease = 8
 
 apiGuardianVersion  = 1.0.0
-assertJVersion      = 3.9.0
+assertJVersion      = 3.9.1
 degraphVersion      = 0.1.4
 jmhVersion          = 1.20
 junit4Version       = 4.12


### PR DESCRIPTION
Main feature: Cglib was replaced with Byte-Buddy.

See http://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.9.1 for details.

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).