### PR TITLE
WIP of #1309: Add support for a description of Arguments.

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -72,6 +72,8 @@ public @interface ParameterizedTest {
 	 * <ul>
 	 * <li><code>{index}</code>: the current invocation index (1-based)</li>
 	 * <li><code>{arguments}</code>: the complete, comma-separated arguments list</li>
+	 * // todo: link Arguments.getDescription?
+	 * <li><code>{arguments.description}</code>: a description of the arguments</li>
 	 * <li><code>{0}</code>, <code>{1}</code>, etc.: an individual argument</li>
 	 * </ul>
 	 *

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -73,7 +73,6 @@ public @interface ParameterizedTest {
 	 * <ul>
 	 * <li><code>{index}</code>: the current invocation index (1-based)</li>
 	 * <li><code>{arguments}</code>: the complete, comma-separated arguments list</li>
-	 * // todo: link Arguments.getDescription?
 	 * <li><code>{arguments.description}</code>: a description of the arguments</li>
 	 * <li><code>{0}</code>, <code>{1}</code>, etc.: an individual argument</li>
 	 * </ul>
@@ -83,6 +82,7 @@ public @interface ParameterizedTest {
 	 *
 	 * @see java.text.MessageFormat
 	 */
+	// todo: link Arguments.getDescription to {arguments.description}?
 	//todo: consider either changing the default name or its interpretation:
 	// arguments = all arguments + arguments.description
 	String name() default "[{index}] {arguments}";

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -17,7 +17,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +80,8 @@ public @interface ParameterizedTest {
 	 *
 	 * @see java.text.MessageFormat
 	 */
+	//todo: consider either changing the default name or its interpretation:
+	// arguments = all arguments + arguments.description
 	String name() default "[{index}] {arguments}";
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -17,6 +17,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -85,17 +85,24 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 
 	private Arguments consumedArguments(Arguments arguments, Method templateMethod) {
 		int parametersCount = templateMethod.getParameterCount();
-		Object[] providedArguments = arguments.get();
-		if (providedArguments.length > parametersCount) {
-			Arguments consumed = Arguments.of(Arrays.copyOf(providedArguments, parametersCount));
-			// todo: can be simplified? Maybe allow setting empty descriptions?
-			if (arguments.description().isEmpty()) {
-				return consumed;
-			} else {
-				return consumed.description(arguments.description());
-			}
+		if (parametersCount < arguments.size()) {
+			// Strip the redundant arguments.
+			return argumentsOfSize(arguments, parametersCount);
 		}
 		return arguments;
+	}
+
+	private static Arguments argumentsOfSize(Arguments arguments,
+																					 int newSize) {
+		Object[] providedArguments = arguments.get();
+		Arguments consumed = Arguments.of(Arrays.copyOf(providedArguments, newSize));
+		// todo: can be simplified? Maybe allow setting empty descriptions? Or a factory method?
+		// Arguments.from(Optional<>desc, Object… arguments))
+		if (arguments.description().isEmpty()) {
+      return consumed;
+    } else {
+      return consumed.description(arguments.description());
+    }
 	}
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -98,11 +98,11 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 		Arguments consumed = Arguments.of(Arrays.copyOf(providedArguments, newSize));
 		// todo: can be simplified? Maybe allow setting empty descriptions? Or a factory method?
 		// Arguments.from(Optional<>desc, Object… arguments))
-		if (arguments.description().isEmpty()) {
-      return consumed;
-    } else {
-      return consumed.description(arguments.description());
-    }
+		if (arguments.description().isPresent()) {
+			return consumed.description(arguments.description().get());
+		} else {
+			return consumed;
+		}
 	}
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
@@ -92,15 +93,15 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 		return arguments;
 	}
 
-	private static Arguments argumentsOfSize(Arguments arguments,
-																					 int newSize) {
+	private static Arguments argumentsOfSize(Arguments arguments, int newSize) {
 		Object[] providedArguments = arguments.get();
 		Arguments consumed = Arguments.of(Arrays.copyOf(providedArguments, newSize));
 		// todo: can be simplified? Maybe allow setting empty descriptions? Or a factory method?
 		// Arguments.from(Optional<>desc, Object… arguments))
 		if (arguments.getDescription().isPresent()) {
 			return consumed.describedAs(arguments.getDescription().get());
-		} else {
+		}
+		else {
 			return consumed;
 		}
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -98,8 +98,8 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 		Arguments consumed = Arguments.of(Arrays.copyOf(providedArguments, newSize));
 		// todo: can be simplified? Maybe allow setting empty descriptions? Or a factory method?
 		// Arguments.from(Optional<>desc, Object… arguments))
-		if (arguments.description().isPresent()) {
-			return consumed.description(arguments.description().get());
+		if (arguments.getDescription().isPresent()) {
+			return consumed.describedAs(arguments.getDescription().get());
 		} else {
 			return consumed;
 		}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.params;
 import static java.util.Collections.singletonList;
 
 import java.util.List;
+
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -25,8 +26,7 @@ class ParameterizedTestInvocationContext implements TestTemplateInvocationContex
 	private final ParameterizedTestNameFormatter formatter;
 	private final Arguments arguments;
 
-	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter,
-																		 Arguments arguments) {
+	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter, Arguments arguments) {
 		this.formatter = formatter;
 		this.arguments = arguments;
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
@@ -13,9 +13,9 @@ package org.junit.jupiter.params;
 import static java.util.Collections.singletonList;
 
 import java.util.List;
-
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.params.provider.Arguments;
 
 /**
  * @since 5.0
@@ -23,9 +23,10 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 class ParameterizedTestInvocationContext implements TestTemplateInvocationContext {
 
 	private final ParameterizedTestNameFormatter formatter;
-	private final Object[] arguments;
+	private final Arguments arguments;
 
-	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter, Object[] arguments) {
+	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter,
+																		 Arguments arguments) {
 		this.formatter = formatter;
 		this.arguments = arguments;
 	}
@@ -37,6 +38,6 @@ class ParameterizedTestInvocationContext implements TestTemplateInvocationContex
 
 	@Override
 	public List<Extension> getAdditionalExtensions() {
-		return singletonList(new ParameterizedTestParameterResolver(arguments));
+		return singletonList(new ParameterizedTestParameterResolver(arguments.get()));
 	}
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -42,7 +42,7 @@ class ParameterizedTestNameFormatter {
 		result = result.replace("{arguments.description}", arguments.description());
 		if (result.contains("{arguments}")) {
 			// @formatter:off
-			String replacement = IntStream.range(0, arguments.get().length)
+			String replacement = IntStream.range(0, arguments.size())
 					.mapToObj(index -> "{" + index + "}")
 					.collect(joining(", "));
 			// @formatter:on

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -15,6 +15,7 @@ import static java.util.stream.Collectors.joining;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.stream.IntStream;
+
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.StringUtils;
@@ -55,10 +56,12 @@ class ParameterizedTestNameFormatter {
 	private Object[] makeReadable(Arguments arguments) {
 		// Note: humanReadableArguments must be an Object[] in order to
 		// avoid varargs issues with non-Eclipse compilers.
+		// @formatter:off
 		Object[] humanReadableArguments = //
 			Arrays.stream(arguments.get())
 					.map(StringUtils::nullSafeToString)
 					.toArray(String[]::new);
+		// @formatter:on
 		return humanReadableArguments;
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -39,7 +39,7 @@ class ParameterizedTestNameFormatter {
 	private String prepareMessageFormatPattern(int invocationIndex, Arguments arguments) {
 		// todo: shall it be split into three methods for clarity?
 		String result = namePattern.replace("{index}", String.valueOf(invocationIndex));
-		result = result.replace("{arguments.description}", arguments.description().orElse(""));
+		result = result.replace("{arguments.description}", arguments.getDescription().orElse(""));
 		if (result.contains("{arguments}")) {
 			// @formatter:off
 			String replacement = IntStream.range(0, arguments.size())

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -39,7 +39,7 @@ class ParameterizedTestNameFormatter {
 	private String prepareMessageFormatPattern(int invocationIndex, Arguments arguments) {
 		// todo: shall it be split into three methods for clarity?
 		String result = namePattern.replace("{index}", String.valueOf(invocationIndex));
-		result = result.replace("{arguments.description}", arguments.description());
+		result = result.replace("{arguments.description}", arguments.description().orElse(""));
 		if (result.contains("{arguments}")) {
 			// @formatter:off
 			String replacement = IntStream.range(0, arguments.size())

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -53,7 +53,8 @@ public interface Arguments {
 	// todo: @MustCheckReturnValue
 	default Arguments description(String testCaseDescription) {
 		Preconditions.notBlank(testCaseDescription,
-				() -> "Test case description must not be blank: '" + testCaseDescription + "'!");
+				() -> "Test case description must not be blank: '" + testCaseDescription + "'! " +
+						"Simply do not set it: it’s optional.");
 
 		Object[] arguments = get();
 		String trimmedDesc = testCaseDescription.trim();

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -19,6 +19,8 @@ import org.junit.platform.commons.util.Preconditions;
 /**
  * {@code Arguments} is an abstraction that provides access to an array of
  * objects to be used for invoking a {@code @ParameterizedTest} method.
+ * An optional description may be provided and included in the
+ * {@linkplain org.junit.jupiter.params.ParameterizedTest#name() name of the parameterized test}.
  *
  * <p>A {@link java.util.stream.Stream} of such {@code Arguments} will
  * typically be provided by an {@link ArgumentsProvider}.
@@ -39,18 +41,36 @@ public interface Arguments {
 	 */
 	Object[] get();
 
-	/** Returns the number of arguments. Non-negative. */
+	/**
+	 * Returns the number of arguments. Non-negative.
+	 *
+	 * @since 5.2
+	 */
 	default int size() {
 		return get().length;
 	}
 
-	// todo: document properly this and below.
-	default Optional<String> description() {
+	/**
+	 * Returns a description of these arguments. If present, not blank.
+	 *
+	 * @since 5.2
+	 * @see #describedAs(String)
+	 */
+	default Optional<String> getDescription() {
 		return Optional.empty();
 	}
 
-	// todo: @MustCheckReturnValue
-	default Arguments description(String testCaseDescription) {
+	/**
+	 * Creates a new instance of Arguments with the given description. It will have the same
+	 * set of arguments and a non-blank description.
+	 *
+	 * @param testCaseDescription a description of this set of arguments. Must not be blank.
+	 * @return a new instance of Arguments with the given description
+	 * @throws org.junit.platform.commons.util.PreconditionViolationException if the description
+	 *     is blank
+	 * @since 5.2
+	 */
+	default Arguments describedAs(String testCaseDescription) {
 		Preconditions.notBlank(testCaseDescription,
 				() -> "Test case description must not be blank: '" + testCaseDescription + "'! " +
 						"Simply do not set it: it’s optional.");
@@ -65,7 +85,7 @@ public interface Arguments {
 			}
 
 			@Override
-			public Optional<String> description() {
+			public Optional<String> getDescription() {
 				return trimmedDesc;
 			}
 		};
@@ -75,10 +95,12 @@ public interface Arguments {
 	 * Factory method for creating an instance of {@code Arguments} based on
 	 * the supplied {@code arguments}.
 	 *
+	 * <p>The produced instance of {@code Arguments} will have empty description.
+	 * Use {@link #describedAs(String)} to set a description of these arguments.
+	 *
 	 * @param arguments the arguments to be used for an invocation of the test
 	 * method; must not be {@code null}
 	 * @return an instance of {@code Arguments}; never {@code null}
-	 * // todo: document default empty description and how to set it.
 	 */
 	static Arguments of(Object... arguments) {
 		Preconditions.notNull(arguments, "argument array must not be null");

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -38,6 +38,11 @@ public interface Arguments {
 	 */
 	Object[] get();
 
+	/** Returns the number of arguments. Non-negative. */
+	default int size() {
+		return get().length;
+	}
+
 	// todo: document properly this and below.
 	// todo: The fact there used to be `hasDescription` indicates we might be better of with Optional<String>
 	default String description() {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.params.provider;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Optional;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
 
@@ -71,9 +72,8 @@ public interface Arguments {
 	 * @since 5.2
 	 */
 	default Arguments describedAs(String testCaseDescription) {
-		Preconditions.notBlank(testCaseDescription,
-				() -> "Test case description must not be blank: '" + testCaseDescription + "'! " +
-						"Simply do not set it: it’s optional.");
+		Preconditions.notBlank(testCaseDescription, () -> "Test case description must not be blank: '"
+				+ testCaseDescription + "'! Simply do not set it: it’s optional.");
 
 		Object[] arguments = get();
 		Optional<String> trimmedDesc = Optional.of(testCaseDescription.trim());

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.params.provider;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.util.Optional;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
 
@@ -44,16 +45,9 @@ public interface Arguments {
 	}
 
 	// todo: document properly this and below.
-	// todo: The fact there used to be `hasDescription` indicates we might be better of with Optional<String>
-	default String description() {
-		return "";
+	default Optional<String> description() {
+		return Optional.empty();
 	}
-
-// todo: do we need this?
-//	/** Returns true if these arguments have a non-empty description. **/
-//	default boolean hasDescription() {
-//		return !description().isEmpty();
-//	}
 
 	// todo: @MustCheckReturnValue
 	default Arguments description(String testCaseDescription) {
@@ -62,7 +56,7 @@ public interface Arguments {
 						"Simply do not set it: it’s optional.");
 
 		Object[] arguments = get();
-		String trimmedDesc = testCaseDescription.trim();
+		Optional<String> trimmedDesc = Optional.of(testCaseDescription.trim());
 
 		return new Arguments() {
 			@Override
@@ -71,7 +65,7 @@ public interface Arguments {
 			}
 
 			@Override
-			public String description() {
+			public Optional<String> description() {
 				return trimmedDesc;
 			}
 		};

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -38,7 +38,8 @@ public interface Arguments {
 	 */
 	Object[] get();
 
-	// todo: document properly this and below
+	// todo: document properly this and below.
+	// todo: The fact there used to be `hasDescription` indicates we might be better of with Optional<String>
 	default String description() {
 		return "";
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -38,6 +38,38 @@ public interface Arguments {
 	 */
 	Object[] get();
 
+	// todo: document properly this and below
+	default String description() {
+		return "";
+	}
+
+// todo: do we need this?
+//	/** Returns true if these arguments have a non-empty description. **/
+//	default boolean hasDescription() {
+//		return !description().isEmpty();
+//	}
+
+	// todo: @MustCheckReturnValue
+	default Arguments description(String testCaseDescription) {
+		Preconditions.notBlank(testCaseDescription,
+				() -> "Test case description must not be blank: '" + testCaseDescription + "'!");
+
+		Object[] arguments = get();
+		String trimmedDesc = testCaseDescription.trim();
+
+		return new Arguments() {
+			@Override
+			public Object[] get() {
+				return arguments;
+			}
+
+			@Override
+			public String description() {
+				return trimmedDesc;
+			}
+		};
+	}
+
 	/**
 	 * Factory method for creating an instance of {@code Arguments} based on
 	 * the supplied {@code arguments}.
@@ -45,6 +77,7 @@ public interface Arguments {
 	 * @param arguments the arguments to be used for an invocation of the test
 	 * method; must not be {@code null}
 	 * @return an instance of {@code Arguments}; never {@code null}
+	 * // todo: document default empty description and how to set it.
 	 */
 	static Arguments of(Object... arguments) {
 		Preconditions.notNull(arguments, "argument array must not be null");

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -86,19 +87,19 @@ class ParameterizedTestIntegrationTests {
 	@Test
 	void executesWithDefaultEmptyArgumentsDescriptions() {
 		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(TestCase.class, "testWithDefaultEmptyDescriptions", String.class.getName()));
+			selectMethod(TestCase.class, "testWithDefaultEmptyDescriptions", String.class.getName()));
 		assertThat(executionEvents) //
-				.haveExactly(1, event(test(), displayName("[1] Parameter #1 "),
-						finishedWithFailure(message("Parameter #1")))); //
+				.haveExactly(1,
+					event(test(), displayName("[1] Parameter #1 "), finishedWithFailure(message("Parameter #1")))); //
 	}
 
 	@Test
 	void executesWithExplicitArgumentsDescriptions() {
 		List<ExecutionEvent> executionEvents = execute(
-				selectMethod(TestCase.class, "testWithNonEmptyDescriptions", String.class.getName()));
+			selectMethod(TestCase.class, "testWithNonEmptyDescriptions", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), displayName("[1] test case description"),
-						finishedWithFailure(message("test with a description parameter")))); //
+					finishedWithFailure(message("test with a description parameter")))); //
 	}
 
 	@Test
@@ -277,7 +278,7 @@ class ParameterizedTestIntegrationTests {
 			fail(argument);
 		}
 
-		@SuppressWarnings("unused")  // discovered automatically by the test above
+		@SuppressWarnings("unused") // discovered automatically by the test above
 		static Stream<Arguments> testWithEmptyMethodSource() {
 			return Stream.of(Arguments.of("empty method source"));
 		}
@@ -288,11 +289,9 @@ class ParameterizedTestIntegrationTests {
 			fail(argument);
 		}
 
-		@SuppressWarnings("unused")  // discovered automatically by the test above
+		@SuppressWarnings("unused") // discovered automatically by the test above
 		static Stream<Arguments> testWithNonEmptyDescriptions() {
-			return Stream.of(
-					Arguments.of("test with a description parameter").describedAs("test case description")
-			);
+			return Stream.of(Arguments.of("test with a description parameter").describedAs("test case description"));
 		}
 
 		@ParameterizedTest(name = "[{index}] {arguments} {arguments.description}")
@@ -301,11 +300,9 @@ class ParameterizedTestIntegrationTests {
 			fail(argument);
 		}
 
-		@SuppressWarnings("unused")  // discovered automatically by the test above
+		@SuppressWarnings("unused") // discovered automatically by the test above
 		static Stream<Arguments> testWithDefaultEmptyDescriptions() {
-			return Stream.of(
-					Arguments.of("Parameter #1")
-			);
+			return Stream.of(Arguments.of("Parameter #1"));
 		}
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -28,7 +28,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,6 +81,24 @@ class ParameterizedTestIntegrationTests {
 			selectMethod(TestCase.class, "testWithEmptyMethodSource", String.class.getName()));
 		assertThat(executionEvents) //
 				.haveExactly(1, event(test(), finishedWithFailure(message("empty method source")))); //
+	}
+
+	@Test
+	void executesWithDefaultEmptyArgumentsDescriptions() {
+		List<ExecutionEvent> executionEvents = execute(
+				selectMethod(TestCase.class, "testWithDefaultEmptyDescriptions", String.class.getName()));
+		assertThat(executionEvents) //
+				.haveExactly(1, event(test(), displayName("[1] Parameter #1 "),
+						finishedWithFailure(message("Parameter #1")))); //
+	}
+
+	@Test
+	void executesWithExplicitArgumentsDescriptions() {
+		List<ExecutionEvent> executionEvents = execute(
+				selectMethod(TestCase.class, "testWithNonEmptyDescriptions", String.class.getName()));
+		assertThat(executionEvents) //
+				.haveExactly(1, event(test(), displayName("[1] test case description"),
+						finishedWithFailure(message("test with a description parameter")))); //
 	}
 
 	@Test
@@ -260,8 +277,35 @@ class ParameterizedTestIntegrationTests {
 			fail(argument);
 		}
 
+		@SuppressWarnings("unused")  // discovered automatically by the test above
 		static Stream<Arguments> testWithEmptyMethodSource() {
 			return Stream.of(Arguments.of("empty method source"));
+		}
+
+		@ParameterizedTest(name = "[{index}] {arguments.description}")
+		@MethodSource
+		void testWithNonEmptyDescriptions(String argument) {
+			fail(argument);
+		}
+
+		@SuppressWarnings("unused")  // discovered automatically by the test above
+		static Stream<Arguments> testWithNonEmptyDescriptions() {
+			return Stream.of(
+					Arguments.of("test with a description parameter").description("test case description")
+			);
+		}
+
+		@ParameterizedTest(name = "[{index}] {arguments} {arguments.description}")
+		@MethodSource
+		void testWithDefaultEmptyDescriptions(String argument) {
+			fail(argument);
+		}
+
+		@SuppressWarnings("unused")  // discovered automatically by the test above
+		static Stream<Arguments> testWithDefaultEmptyDescriptions() {
+			return Stream.of(
+					Arguments.of("Parameter #1")
+			);
 		}
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -291,7 +291,7 @@ class ParameterizedTestIntegrationTests {
 		@SuppressWarnings("unused")  // discovered automatically by the test above
 		static Stream<Arguments> testWithNonEmptyDescriptions() {
 			return Stream.of(
-					Arguments.of("test with a description parameter").description("test case description")
+					Arguments.of("test with a description parameter").describedAs("test case description")
 			);
 		}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -68,7 +68,7 @@ class ParameterizedTestNameFormatterTests {
 		);
 
 		assertEquals("test case description",
-				formatter.format(1, Arguments.of().description("test case description"))
+				formatter.format(1, Arguments.of().describedAs("test case description"))
 		);
 	}
 
@@ -80,7 +80,7 @@ class ParameterizedTestNameFormatterTests {
 
 		int invocationIndex = 1;
 		Arguments arguments = Arguments.of(2, 4)
-				.description("squared(2) = 4");
+				.describedAs("squared(2) = 4");
 
 		assertEquals("[1] 2, 4: squared(2) = 4",
 				formatter.format(invocationIndex, arguments)

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -63,28 +64,23 @@ class ParameterizedTestNameFormatterTests {
 
 	@Test
 	void formatsArgumentsDescription() {
-		ParameterizedTestNameFormatter formatter = new ParameterizedTestNameFormatter(
-				"{arguments.description}"
-		);
+		ParameterizedTestNameFormatter formatter = new ParameterizedTestNameFormatter("{arguments.description}");
 
-		assertEquals("test case description",
-				formatter.format(1, Arguments.of().describedAs("test case description"))
-		);
+		Arguments arguments = Arguments.of().describedAs("test case description");
+		String formatted = formatter.format(1, arguments);
+
+		assertEquals("test case description", formatted);
 	}
 
 	@Test
 	void formatsArgumentsAndTheirDescription() {
 		ParameterizedTestNameFormatter formatter = new ParameterizedTestNameFormatter(
-				"[{index}] {arguments}: {arguments.description}"
-		);
+			"[{index}] {arguments}: {arguments.description}");
 
 		int invocationIndex = 1;
-		Arguments arguments = Arguments.of(2, 4)
-				.describedAs("squared(2) = 4");
+		Arguments arguments = Arguments.of(2, 4).describedAs("squared(2) = 4");
 
-		assertEquals("[1] 2, 4: squared(2) = 4",
-				formatter.format(invocationIndex, arguments)
-		);
+		assertEquals("[1] 2, 4: squared(2) = 4", formatter.format(invocationIndex, arguments));
 	}
 
 	// todo: default pattern is likely to be changed? Or its interpretation:
@@ -94,13 +90,10 @@ class ParameterizedTestNameFormatterTests {
 		ParameterizedTestNameFormatter formatter = new ParameterizedTestNameFormatter("[{index}] {arguments}");
 
 		// Explicit test for https://github.com/junit-team/junit5/issues/814
-		assertEquals("[1] [foo, bar]",
-				formatter.format(1, arguments((Object) new String[] { "foo", "bar" }))
-		);
+		assertEquals("[1] [foo, bar]", formatter.format(1, arguments((Object) new String[] { "foo", "bar" })));
 
 		assertEquals("[1] [foo, bar], 42, true",
-				formatter.format(1, arguments(new String[] { "foo", "bar" }, 42, true))
-		);
+			formatter.format(1, arguments(new String[] { "foo", "bar" }, 42, true)));
 	}
 
 	@Test
@@ -113,17 +106,11 @@ class ParameterizedTestNameFormatterTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-			"{}",
-			"{index",
-			"{-1}"
-	})
+	@ValueSource(strings = { "{}", "{index", "{-1}" })
 	void throwsReadableExceptionForInvalidPatterns(String invalidPattern) {
 		ParameterizedTestNameFormatter formatter = new ParameterizedTestNameFormatter(invalidPattern);
 
-		JUnitException exception = assertThrows(JUnitException.class,
-				() -> formatter.format(1, EMPTY_ARGUMENTS)
-		);
+		JUnitException exception = assertThrows(JUnitException.class, () -> formatter.format(1, EMPTY_ARGUMENTS));
 		assertNotNull(exception.getCause());
 		assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.JUnitException;
 
 /**
@@ -113,7 +113,7 @@ class ParameterizedTestNameFormatterTests {
 	}
 
 	@ParameterizedTest
-	@CsvSource({
+	@ValueSource(strings = {
 			"{}",
 			"{index",
 			"{-1}"

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
@@ -41,6 +41,15 @@ class ArgumentsTests {
 	}
 
 	@Test
+	void sizeEqualToTheArrayLength() {
+		Object[] input = {1, "2", 3.0};
+
+		Arguments arguments = of(input);
+
+		assertThat(arguments.size()).isEqualTo(input.length);
+	}
+
+	@Test
 	void hasEmptyDescriptionByDefault() {
 		Arguments arguments = of(1);
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
@@ -62,7 +62,7 @@ class ArgumentsTests {
 
 		Arguments arguments = of(1).description(description);
 
-		assertThat(arguments.description()).isEqualTo(description);
+		assertThat(arguments.description()).hasValue(description);
 	}
 
 	@Test
@@ -71,7 +71,7 @@ class ArgumentsTests {
 
 		Arguments arguments = of(1).description(description);
 
-		assertThat(arguments.description()).isEqualTo("test case #1");
+		assertThat(arguments.description()).hasValue("test case #1");
 	}
 
 	@Test
@@ -93,7 +93,7 @@ class ArgumentsTests {
 		String second = "A better description!";
 		arguments = arguments.description(second);
 
-		assertThat(arguments.description()).isEqualTo(second);
+		assertThat(arguments.description()).hasValue(second);
 	}
 
 	@Test

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
@@ -12,9 +12,12 @@ package org.junit.jupiter.params.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.platform.commons.util.PreconditionViolationException;
 
 /**
  * @since 5.0
@@ -37,4 +40,80 @@ class ArgumentsTests {
 		assertThat(arguments.get()).isSameAs(input);
 	}
 
+	@Test
+	void hasEmptyDescriptionByDefault() {
+		Arguments arguments = of(1);
+
+		assertThat(arguments.description()).isEmpty();
+	}
+
+	@Test
+	void setDescriptionValidString() {
+		String description = "test case #1";
+
+		Arguments arguments = of(1).description(description);
+
+		assertThat(arguments.description()).isEqualTo(description);
+	}
+
+	@Test
+	void setDescriptionTrimsWhitespaces() {
+		String description = " \ttest case #1\n";
+
+		Arguments arguments = of(1).description(description);
+
+		assertThat(arguments.description()).isEqualTo("test case #1");
+	}
+
+	@Test
+	void setDescriptionCreatesNewObject() {
+		String validDescription = "test case #1";
+
+		Arguments argumentsNoDesc = of(1);
+		Arguments argumentsWithDesc = argumentsNoDesc.description(validDescription);
+
+		assertThat(argumentsNoDesc.description()).isEmpty();
+		assertThat(argumentsWithDesc).isNotEqualTo(argumentsNoDesc);
+	}
+
+	@Test
+	void replaceDescription() {
+		String first = "Test case #1";
+		Arguments arguments = of(1).description(first);
+
+		String second = "A better description!";
+		arguments = arguments.description(second);
+
+		assertThat(arguments.description()).isEqualTo(second);
+	}
+
+	@Test
+	void setDescriptionRejectsNull() {
+		Arguments arguments = of(1);
+
+		assertThrows(PreconditionViolationException.class,
+				() -> arguments.description(null)
+		);
+
+		// Description must remain empty.
+		assertThat(arguments.description()).isEmpty();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"",
+			" ",
+			"  ",
+			"\n\t"
+	})
+	void setDescriptionRejectsBlankStrings(String illegalDescription) {
+		Arguments arguments = of(1);
+
+		assertThrows(PreconditionViolationException.class,
+				() -> arguments.description(illegalDescription)
+		);
+
+		// Description must remain empty.
+		assertThat(arguments.description()).isEmpty();
+	}
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
@@ -42,7 +42,7 @@ class ArgumentsTests {
 
 	@Test
 	void sizeEqualToTheArrayLength() {
-		Object[] input = {1, "2", 3.0};
+		Object[] input = { 1, "2", 3.0 };
 
 		Arguments arguments = of(input);
 
@@ -100,27 +100,18 @@ class ArgumentsTests {
 	void setDescriptionRejectsNull() {
 		Arguments arguments = of(1);
 
-		assertThrows(PreconditionViolationException.class,
-				() -> arguments.describedAs(null)
-		);
+		assertThrows(PreconditionViolationException.class, () -> arguments.describedAs(null));
 
 		// Description must remain empty.
 		assertThat(arguments.getDescription()).isEmpty();
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-			"",
-			" ",
-			"  ",
-			"\n\t"
-	})
+	@ValueSource(strings = { "", " ", "  ", "\n\t" })
 	void setDescriptionRejectsBlankStrings(String illegalDescription) {
 		Arguments arguments = of(1);
 
-		assertThrows(PreconditionViolationException.class,
-				() -> arguments.describedAs(illegalDescription)
-		);
+		assertThrows(PreconditionViolationException.class, () -> arguments.describedAs(illegalDescription));
 
 		// Description must remain empty.
 		assertThat(arguments.getDescription()).isEmpty();

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ArgumentsTests.java
@@ -53,25 +53,25 @@ class ArgumentsTests {
 	void hasEmptyDescriptionByDefault() {
 		Arguments arguments = of(1);
 
-		assertThat(arguments.description()).isEmpty();
+		assertThat(arguments.getDescription()).isEmpty();
 	}
 
 	@Test
 	void setDescriptionValidString() {
 		String description = "test case #1";
 
-		Arguments arguments = of(1).description(description);
+		Arguments arguments = of(1).describedAs(description);
 
-		assertThat(arguments.description()).hasValue(description);
+		assertThat(arguments.getDescription()).hasValue(description);
 	}
 
 	@Test
 	void setDescriptionTrimsWhitespaces() {
 		String description = " \ttest case #1\n";
 
-		Arguments arguments = of(1).description(description);
+		Arguments arguments = of(1).describedAs(description);
 
-		assertThat(arguments.description()).hasValue("test case #1");
+		assertThat(arguments.getDescription()).hasValue("test case #1");
 	}
 
 	@Test
@@ -79,21 +79,21 @@ class ArgumentsTests {
 		String validDescription = "test case #1";
 
 		Arguments argumentsNoDesc = of(1);
-		Arguments argumentsWithDesc = argumentsNoDesc.description(validDescription);
+		Arguments argumentsWithDesc = argumentsNoDesc.describedAs(validDescription);
 
-		assertThat(argumentsNoDesc.description()).isEmpty();
+		assertThat(argumentsNoDesc.getDescription()).isEmpty();
 		assertThat(argumentsWithDesc).isNotEqualTo(argumentsNoDesc);
 	}
 
 	@Test
 	void replaceDescription() {
 		String first = "Test case #1";
-		Arguments arguments = of(1).description(first);
+		Arguments arguments = of(1).describedAs(first);
 
 		String second = "A better description!";
-		arguments = arguments.description(second);
+		arguments = arguments.describedAs(second);
 
-		assertThat(arguments.description()).hasValue(second);
+		assertThat(arguments.getDescription()).hasValue(second);
 	}
 
 	@Test
@@ -101,11 +101,11 @@ class ArgumentsTests {
 		Arguments arguments = of(1);
 
 		assertThrows(PreconditionViolationException.class,
-				() -> arguments.description(null)
+				() -> arguments.describedAs(null)
 		);
 
 		// Description must remain empty.
-		assertThat(arguments.description()).isEmpty();
+		assertThat(arguments.getDescription()).isEmpty();
 	}
 
 	@ParameterizedTest
@@ -119,10 +119,10 @@ class ArgumentsTests {
 		Arguments arguments = of(1);
 
 		assertThrows(PreconditionViolationException.class,
-				() -> arguments.description(illegalDescription)
+				() -> arguments.describedAs(illegalDescription)
 		);
 
 		// Description must remain empty.
-		assertThat(arguments.description()).isEmpty();
+		assertThat(arguments.getDescription()).isEmpty();
 	}
 }


### PR DESCRIPTION
## Overview

This is a WIP PR for #1309. Some documentation is _deliberately_ missed, because we haven't yet agreed on the approach to go with, and on some implementation details.

Feedback is welcome! Perhaps some of TODOs are better to be discussed in the [issue](https://github.com/junit-team/junit5/issues/1309), not in the PR.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---
### TODO
- [ ] CsvSource & CsvFileSource (need to agree on requirements, see the issue).
- [ ] Consider lazy `Arguments#get` (a decorator) and more factory methods (depends on ^, see the [thread](https://github.com/junit-team/junit5/pull/1310#discussion_r170445795))
- [ ] Test description is preserved when arguments are stripped.
- [ ] Default `ParameterizedTest#name` and how it is expanded (need to agree on requirements, see the issue).

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
