### PR TITLE
Describe non-goals of Arguments, so that users do not mis-use it.

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -12,7 +12,12 @@ package org.junit.jupiter.params.provider;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
 import org.apiguardian.api.API;
+import org.junit.jupiter.params.converter.ArgumentConverter;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -21,6 +26,21 @@ import org.junit.platform.commons.util.Preconditions;
  *
  * <p>A {@link java.util.stream.Stream} of such {@code Arguments} will
  * typically be provided by an {@link ArgumentsProvider}.
+ *
+ * @apiNote This interface is specifically designed as a simple holder of arguments of
+ * a parameterized test. Therefore, if you end up {@linkplain Stream#map(Function) transforming}
+ * or {@linkplain Stream#filter(Predicate) filtering} the arguments, you shall consider
+ * using one of the following in intermediate steps:
+ * <ul>
+ *   <li>The standard collections.</li>
+ *   <li>Tuples from third-party libraries, e.g.,
+ *   <a href="http://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/tuple/package-summary.html">Commons Lang</a>,
+ *   or <a href="https://www.javatuples.org">javatuples</a>.</li>
+ *   <li>Your own data class.</li>
+ * </ul>
+ *
+ * <p>You can also use {@link ArgumentConverter}s to convert some of the arguments from one type
+ * to another.
  *
  * @since 5.0
  * @see org.junit.jupiter.params.ParameterizedTest
@@ -33,6 +53,9 @@ public interface Arguments {
 	/**
 	 * Get the arguments used for an invocation of the
 	 * {@code @ParameterizedTest} method.
+	 *
+	 * @apiNote If you need a type-safe way to access some or all of the arguments,
+	 * please read the {@linkplain Arguments class-level API note}.
 	 *
 	 * @return the arguments; must not be {@code null}
 	 */


### PR DESCRIPTION
## Overview

As was discussed in #1307, it's a non-goal of `Arguments`
to be easily consumed by the user-code. Therefore,
a Javadoc is updated to explicitly specify non-goals and
to point users to alternatives.

Issue: #1311, #1307


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
