### PR TITLE
Emit helpful message when a configuration key is not unique

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -11,11 +11,12 @@
 package org.junit.platform.console.options;
 
 import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toMap;
 
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import joptsimple.OptionParser;
@@ -253,11 +254,25 @@ class AvailableOptions {
 		result.setExcludedEngines(detectedOptions.valuesOf(this.excludeEngine));
 
 		// Configuration Parameters
-		Map<String, String> configurationParametersMap = detectedOptions.valuesOf(
-			this.configurationParameters).stream().collect(toMap(pair -> pair.key, pair -> pair.value));
-		result.setConfigurationParameters(configurationParametersMap);
+		result.setConfigurationParameters(toMap(detectedOptions.valuesOf(this.configurationParameters)));
 
 		return result;
+	}
+
+	/**
+	 * Convert a list of key-value pairs to map.
+	 * @see <a href="https://github.com/junit-team/junit5/issues/1308">#1308</a>
+	 */
+	private Map<String, String> toMap(List<KeyValuePair> pairs) {
+		Map<String, String> map = new HashMap<>();
+		for (KeyValuePair pair : pairs) {
+			String key = pair.key;
+			if (map.containsKey(key)) {
+				throw new IllegalArgumentException("Duplicate key '" + key + "' in: " + pairs);
+			}
+			map.put(key, pair.value);
+		}
+		return map;
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParser.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParser.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import joptsimple.BuiltinHelpFormatter;
 import joptsimple.OptionDescriptor;
-import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 
@@ -40,7 +39,7 @@ public class JOptSimpleCommandLineOptionsParser implements CommandLineOptionsPar
 			OptionSet detectedOptions = parser.parse(arguments);
 			return availableOptions.toCommandLineOptions(detectedOptions);
 		}
-		catch (OptionException | IllegalStateException e) {
+		catch (Exception e) {
 			throw new JUnitException("Error parsing command-line arguments", e);
 		}
 	}

--- a/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/JOptSimpleCommandLineOptionsParserTests.java
@@ -497,11 +497,12 @@ class JOptSimpleCommandLineOptionsParserTests {
 	}
 
 	@Test
-	void parseInvalidConfigurationParametersSpecifiedTwice() {
+	void parseInvalidConfigurationParametersWithDuplicateKey() {
 		Exception e = assertThrows(JUnitException.class, () -> parseArgLine("--config foo=bar --config foo=baz"));
 
 		assertThat(e.getMessage()).isEqualTo("Error parsing command-line arguments");
-		assertThat(e.getCause().getMessage()).contains("Duplicate key foo", "bar", "baz");
+		assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
+		assertThat(e.getCause().getMessage()).isEqualTo("Duplicate key 'foo' in: [foo=bar, foo=baz]");
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

Prior to this commit a bug [1] in Java 8's stream toMap() collector did report the value instead of the duplicated key in the exception message.
 
Now, a custom list-to-map helper always emits a helpful error message.

[1] https://bugs.openjdk.java.net/browse/JDK-8040892

Closes #1308

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
