### PR TITLE
Meta-annotate @Enabled*/@Disabled* with @Test

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 
 /**
  * {@code @DisabledIf} is used to determine whether the annotated test class or
@@ -129,6 +130,7 @@ import org.apiguardian.api.API;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(status = EXPERIMENTAL, since = "5.1")
+@Test
 public @interface DisabledIf {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -66,6 +67,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(DisabledIfEnvironmentVariableCondition.class)
 @API(status = STABLE, since = "5.1")
+@Test
 public @interface DisabledIfEnvironmentVariable {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -66,6 +67,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(DisabledIfSystemPropertyCondition.class)
 @API(status = STABLE, since = "5.1")
+@Test
 public @interface DisabledIfSystemProperty {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(DisabledOnJreCondition.class)
 @API(status = STABLE, since = "5.1")
+@Test
 public @interface DisabledOnJre {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOs.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOs.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(DisabledOnOsCondition.class)
 @API(status = STABLE, since = "5.1")
+@Test
 public @interface DisabledOnOs {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 
 /**
  * {@code @EnabledIf} is used to determine whether the annotated test class or
@@ -129,6 +130,7 @@ import org.apiguardian.api.API;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(status = EXPERIMENTAL, since = "5.1")
+@Test
 public @interface EnabledIf {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -65,6 +66,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(EnabledIfEnvironmentVariableCondition.class)
 @API(status = STABLE, since = "5.1")
+@Test
 public @interface EnabledIfEnvironmentVariable {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -65,6 +66,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(EnabledIfSystemPropertyCondition.class)
 @API(status = STABLE, since = "5.1")
+@Test
 public @interface EnabledIfSystemProperty {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(EnabledOnJreCondition.class)
 @API(status = STABLE, since = "5.1")
+@Test
 public @interface EnabledOnJre {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOs.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOs.java
@@ -19,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(EnabledOnOsCondition.class)
 @API(status = STABLE, since = "5.1")
+@Test
 public @interface EnabledOnOs {
 
 	/**

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/DisabledIfTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/DisabledIfTests.java
@@ -39,6 +39,11 @@ class DisabledIfTests {
 		fail("test must not be executed");
 	}
 
+	@DisabledIf("true")
+	void annotationOnlyTrue() {
+		fail("test must not be executed");
+	}
+
 	@Test
 	@DisabledIf("java.lang.Boolean.TRUE")
 	void booleanWrapperTrue() {
@@ -54,6 +59,10 @@ class DisabledIfTests {
 	@Test
 	@DisabledIf("false")
 	void booleanFalse() {
+	}
+
+	@DisabledIf("false")
+	void annotationOnlyFalse() {
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfTests.java
@@ -40,6 +40,10 @@ class EnabledIfTests {
 	void booleanTrue() {
 	}
 
+	@EnabledIf("true")
+	void annotationOnlyTrue() {
+	}
+
 	@Test
 	@EnabledIf("java.lang.Boolean.TRUE")
 	void booleanWrapperTrue() {
@@ -53,6 +57,11 @@ class EnabledIfTests {
 	@Test
 	@EnabledIf("false")
 	void booleanFalse() {
+		fail("test must not be executed");
+	}
+
+	@EnabledIf("false")
+	void annotationOnlyFalse() {
 		fail("test must not be executed");
 	}
 

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfVariantsTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfVariantsTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.extensions;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.condition.JRE.JAVA_9;
+import static org.junit.jupiter.api.condition.OS.MAC;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+
+/**
+ * Negative case tests for {@link org.junit.jupiter.api.condition.EnabledIf} variants.
+ */
+public class EnabledIfVariantsTests {
+
+	private static final String KEY = "EnabledIfVariantsTests.key";
+
+	private static final String ENIGMA = "EnabledIfVariantsTests.enigma";
+
+	private static final String BOGUS = "EnabledIfVariantsTests.bogus";
+
+	@BeforeAll
+	static void setSystemProperty() {
+		System.setProperty(KEY, ENIGMA);
+	}
+
+	@AfterAll
+	static void clearSystemProperty() {
+		System.clearProperty(KEY);
+	}
+
+	@EnabledIfEnvironmentVariable(named = KEY, matches = BOGUS)
+	void enabledIfEnvironmentVariable() {
+		fail("should NOT be enabled since this class doesn't set environment variables");
+	}
+
+	@EnabledIfSystemProperty(named = KEY, matches = BOGUS)
+	void enabledIfSystemPropertyWithDisabledCondition() {
+		fail("should NOT be enabled");
+	}
+
+	@EnabledOnOs(MAC)
+	void enabledOnOs() {
+		if (!MAC.isCurrentOs()) {
+			fail("should be disabled on MAC");
+		}
+	}
+
+	@EnabledOnJre(JAVA_9)
+	void enabledOnJre() {
+		if (!JAVA_9.isCurrentVersion()) {
+			fail("should be disabled on JAVA_9");
+		}
+	}
+
+}


### PR DESCRIPTION
## Overview

Since all of `@Enabled*`/`@Disabled*` are used on `@Test` methods, meta-annotate them with `@Test` prevents forgetting `@Test` annotation on target test methods.

Also, added tests for `@Enabled*` without `@Test` annotation.
Couldn't come up with good test for `@Disabled*`...

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
