### PR TITLE
Build should respect JAVA_HOME when running executables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.gradle.internal.jvm.Jvm
-
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
@@ -562,11 +560,11 @@ subprojects { subproj ->
 			dependsOn = [versionedProject.classes]
 			doLast {
 				project.exec {
-					executable "${Jvm.current().javaHome}/bin/jar"
+					executable "${System.properties['java.home']}/bin/jar"
 					args = ['--version']
 				}
 				project.exec {
-					executable "${Jvm.current().javaHome}/bin/jar"
+					executable "${System.properties['java.home']}/bin/jar"
 					args = ['--update','--file', archivePath,
 							'--release', version,
 							'-C', versionedProject.compileJava.destinationDir,

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.jvm.Jvm
+
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
@@ -560,11 +562,11 @@ subprojects { subproj ->
 			dependsOn = [versionedProject.classes]
 			doLast {
 				project.exec {
-					executable 'jar'
+					executable "${Jvm.current().javaHome}/bin/jar"
 					args = ['--version']
 				}
 				project.exec {
-					executable 'jar'
+					executable "${Jvm.current().javaHome}/bin/jar"
 					args = ['--update','--file', archivePath,
 							'--release', version,
 							'-C', versionedProject.compileJava.destinationDir,

--- a/junit-platform-commons-java-9/junit-platform-commons-java-9.gradle
+++ b/junit-platform-commons-java-9/junit-platform-commons-java-9.gradle
@@ -1,5 +1,3 @@
-import org.gradle.internal.jvm.Jvm
-
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 dependencies {
@@ -50,7 +48,7 @@ task generateDependenciesDirectory(type: Copy) {
 
 // Execute console launcher on the module-path.
 task execScanModulepath(type: Exec, dependsOn: [generateDependenciesDirectory, generateIntegrationTestsJar]) {
-	executable = "${Jvm.current().javaHome}/bin/java"
+	executable = "${System.properties['java.home']}/bin/java"
 	standardOutput = new ByteArrayOutputStream()
 	errorOutput = new ByteArrayOutputStream()
 	args = [
@@ -101,7 +99,7 @@ task execNoJavaScripting(type: Exec, dependsOn: [generateDependenciesDirectory, 
 	ignoreExitValue = true
 	standardOutput = new ByteArrayOutputStream()
 	errorOutput = new ByteArrayOutputStream()
-	executable = "${Jvm.current().javaHome}/bin/java"
+	executable = "${System.properties['java.home']}/bin/java"
 	args = [
 			'--show-module-resolution',
 			'--module-path', files(generateDependenciesDirectory.destinationDir, generateIntegrationTestsJar.archivePath).asPath,

--- a/junit-platform-commons-java-9/junit-platform-commons-java-9.gradle
+++ b/junit-platform-commons-java-9/junit-platform-commons-java-9.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.jvm.Jvm
+
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 dependencies {
@@ -48,7 +50,7 @@ task generateDependenciesDirectory(type: Copy) {
 
 // Execute console launcher on the module-path.
 task execScanModulepath(type: Exec, dependsOn: [generateDependenciesDirectory, generateIntegrationTestsJar]) {
-	executable = 'java'
+	executable = "${Jvm.current().javaHome}/bin/java"
 	standardOutput = new ByteArrayOutputStream()
 	errorOutput = new ByteArrayOutputStream()
 	args = [
@@ -99,7 +101,7 @@ task execNoJavaScripting(type: Exec, dependsOn: [generateDependenciesDirectory, 
 	ignoreExitValue = true
 	standardOutput = new ByteArrayOutputStream()
 	errorOutput = new ByteArrayOutputStream()
-	executable = 'java'
+	executable = "${Jvm.current().javaHome}/bin/java"
 	args = [
 			'--show-module-resolution',
 			'--module-path', files(generateDependenciesDirectory.destinationDir, generateIntegrationTestsJar.archivePath).asPath,


### PR DESCRIPTION
Currently when java is not on the path or the java/jar executable is on path, but the version is not 9+, junit5 cannot be build.

It would be nice if project can be build using command something like 

```
JAVA_HOME=/usr/lib/jvm/java-9-jdk ./gradlew  clean build
```

The proposed change uses gradle's internal api which is probably not ok, but couldn't find better solution.