### PR TITLE
Support methods from external classes in @MethodSource #1088

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.2.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.2.0-M1.adoc
@@ -39,7 +39,8 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* `@MethodSource` now supports `static` factory methods declared in external classes
+  referenced by _fully qualified method name_.
 
 
 [[release-notes-5.2.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -841,10 +841,11 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_regex_exam
 [[writing-tests-parameterized-tests-sources-MethodSource]]
 ===== @MethodSource
 
-`@MethodSource` allows you to refer to one or more _factory_ methods of the test class.
-Such methods must return a `Stream`, `Iterable`, `Iterator`, or array of arguments. In
-addition, such methods must not accept any arguments. By default such methods must be
-`static` unless the test class is annotated with `@TestInstance(Lifecycle.PER_CLASS)`.
+`@MethodSource` allows you to refer to one or more _factory_ methods of the test class or
+external classes. Such methods must return a `Stream`, `Iterable`, `Iterator`, or array
+of arguments. In addition, such methods must not accept any arguments. Test class methods
+must be `static` unless the test class is annotated with
+`@TestInstance(Lifecycle.PER_CLASS)`. External classes methods must always be `static`.
 
 If you only need a single parameter, you can return a `Stream` of instances of the
 parameter type as demonstrated by the following example.
@@ -878,6 +879,16 @@ factory method defined in the `Arguments` interface.
 [source,java,indent=0]
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=multi_arg_MethodSource_example]
+----
+
+An external, `static` _factory_ method can be referenced by providing its _fully
+qualified method name_ as demonstrated in the following example.
+
+[source,java,indent=0]
+----
+package example;
+
+include::{testDir}/example/ExternalMethodSourceDemo.java[tags=external_MethodSource_example]
 ----
 
 [[writing-tests-parameterized-tests-sources-CsvSource]]

--- a/documentation/src/test/java/example/ExternalMethodSourceDemo.java
+++ b/documentation/src/test/java/example/ExternalMethodSourceDemo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example;
+
+// tag::external_MethodSource_example[]
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ExternalMethodSourceDemo {
+
+	@ParameterizedTest
+	@MethodSource("example.StringsProviders#blankStrings")
+	void testWithExternalMethodSource(String blankString) {
+		// test with blank string
+	}
+}
+
+class StringsProviders {
+
+	static Stream<String> blankStrings() {
+		return Stream.of("", " ", " \n ");
+	}
+}
+// end::external_MethodSource_example[]

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -12,13 +12,14 @@ package org.junit.jupiter.params.provider;
 
 import static java.lang.String.format;
 
-import java.util.Arrays;
+import java.lang.reflect.Method;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.CollectionUtils;
+import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.StringUtils;
 
@@ -36,18 +37,48 @@ class MethodArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<M
 
 	@Override
 	public Stream<Arguments> provideArguments(ExtensionContext context) {
-		Class<?> testClass = context.getRequiredTestClass();
 		Object testInstance = context.getTestInstance().orElse(null);
 		// @formatter:off
-		return Arrays.stream(this.methodNames)
-				.map(methodName -> StringUtils.isNotBlank(methodName) ? methodName : context.getRequiredTestMethod().getName())
-				.map(methodName -> ReflectionUtils.findMethod(testClass, methodName)
-					.orElseThrow(() -> new JUnitException(
-						format("Could not find factory method [%s] in class [%s]", methodName, testClass.getName()))))
+		return Stream.of(this.methodNames)
+				.map(argumentsMethodName -> getMethod(context, argumentsMethodName))
 				.map(method -> ReflectionUtils.invokeMethod(method, testInstance))
 				.flatMap(CollectionUtils::toStream)
 				.map(MethodArgumentsProvider::toArguments);
 		// @formatter:on
+	}
+
+	private Method getMethod(ExtensionContext context, String argumentsMethodName) {
+		if (StringUtils.isNotBlank(argumentsMethodName)) {
+			if (argumentsMethodName.contains("#")) {
+				return getMethodByFullyQualifiedName(argumentsMethodName);
+			}
+			else {
+				return getMethod(context.getRequiredTestClass(), argumentsMethodName);
+			}
+		}
+		return getMethod(context.getRequiredTestClass(), context.getRequiredTestMethod().getName());
+	}
+
+	private Method getMethodByFullyQualifiedName(String fullyQualifiedMethodName) {
+		String[] methodParts = ReflectionUtils.parseFullyQualifiedMethodName(fullyQualifiedMethodName);
+		String className = methodParts[0];
+		String methodName = methodParts[1];
+		String methodParameters = methodParts[2];
+
+		Preconditions.condition(StringUtils.isBlank(methodParameters),
+			() -> format("factory method [%s] cannot take parameters", fullyQualifiedMethodName));
+
+		return getMethod(loadRequiredClass(className), methodName);
+	}
+
+	private Class<?> loadRequiredClass(String className) {
+		return ReflectionUtils.loadClass(className).orElseThrow(
+			() -> new JUnitException(format("Could not load class [%s]", className)));
+	}
+
+	private Method getMethod(Class<?> clazz, String methodName) {
+		return ReflectionUtils.findMethod(clazz, methodName).orElseThrow(() -> new JUnitException(
+			format("Could not find factory method [%s] in class [%s]", methodName, clazz.getName())));
 	}
 
 	private static Arguments toArguments(Object item) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -26,7 +26,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 /**
  * {@code @MethodSource} is an {@link ArgumentsSource} which provides access
  * to values returned by {@linkplain #value() factory methods} of the class in
- * which this annotation is declared.
+ * which this annotation is declared or external class referenced by fully
+ * qualified method name.
  *
  * <p>Each factory method must return a {@link Stream}, {@link Iterable},
  * {@link Iterator}, or array of arguments. The returned values will be provided
@@ -56,8 +57,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 public @interface MethodSource {
 
 	/**
-	 * The names of the test class methods to use as sources for arguments;
-	 * leave empty if the source method has the same name as the test method.
+	 * The names of the test or external class methods to use as sources for arguments.
+	 * External class have to be referenced by fully qualified method name, eg.
+	 * {@code com.example.StringsProviders#blanksStrings}.
+	 * Leave empty if the source method has the same name as the test method.
 	 */
 	String[] value() default "";
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -538,6 +538,48 @@ public final class ReflectionUtils {
 	}
 
 	/**
+	 * Parses given <em>fully qualified method name</em> and returns 3-elements array where
+	 * element at index:
+	 * <ul>
+	 *     <li>{@code 0} is fully qualified class name</li>
+	 *     <li>{@code 1} is name of the method</li>
+	 *     <li>{@code 2} is comma-separated parameters list or blank string if method
+	 *     doesn't take any parameters</li>
+	 * </ul>
+	 * @param fullyQualifiedMethodName <em>fully qualified method name</em>
+	 * @return method parts array
+	 */
+	public static String[] parseFullyQualifiedMethodName(String fullyQualifiedMethodName) {
+		Preconditions.notBlank(fullyQualifiedMethodName, "fullyQualifiedMethodName must not be null or blank");
+
+		int indexOfFirstHashtag = fullyQualifiedMethodName.indexOf('#');
+		boolean validSyntax = (indexOfFirstHashtag > 0)
+				&& (indexOfFirstHashtag < fullyQualifiedMethodName.length() - 1);
+
+		Preconditions.condition(validSyntax,
+			() -> "[" + fullyQualifiedMethodName + "] is not a valid fully qualified method name: "
+					+ "it must start with a fully qualified class name followed by a '#' "
+					+ "and then the method name, optionally followed by a parameter list enclosed in parentheses.");
+
+		String className = fullyQualifiedMethodName.substring(0, indexOfFirstHashtag);
+		String methodPart = fullyQualifiedMethodName.substring(indexOfFirstHashtag + 1);
+		String methodName = methodPart;
+		String methodParameters = "";
+
+		if (methodPart.endsWith("()")) {
+			methodName = methodPart.substring(0, methodPart.length() - 2);
+		}
+		else if (methodPart.endsWith(")")) {
+			int indexOfLastOpeningParenthesis = methodPart.lastIndexOf('(');
+			if ((indexOfLastOpeningParenthesis > 0) && (indexOfLastOpeningParenthesis < methodPart.length() - 1)) {
+				methodName = methodPart.substring(0, indexOfLastOpeningParenthesis);
+				methodParameters = methodPart.substring(indexOfLastOpeningParenthesis + 1, methodPart.length() - 1);
+			}
+		}
+		return new String[] { className, methodName, methodParameters };
+	}
+
+	/**
 	 * Get the outermost instance of the required type, searching recursively
 	 * through enclosing instances.
 	 *

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.PreconditionViolationException;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.UniqueId;
 
@@ -355,34 +356,8 @@ public final class DiscoverySelectors {
 	 * @see MethodSelector
 	 */
 	public static MethodSelector selectMethod(String fullyQualifiedMethodName) throws PreconditionViolationException {
-		Preconditions.notBlank(fullyQualifiedMethodName, "fullyQualifiedMethodName must not be null or blank");
-
-		int indexOfFirstHashtag = fullyQualifiedMethodName.indexOf('#');
-		boolean validSyntax = (indexOfFirstHashtag > 0)
-				&& (indexOfFirstHashtag < fullyQualifiedMethodName.length() - 1);
-
-		Preconditions.condition(validSyntax,
-			() -> "[" + fullyQualifiedMethodName + "] is not a valid fully qualified method name: "
-					+ "it must start with a fully qualified class name followed by a '#' "
-					+ "and then the method name, optionally followed by a parameter list enclosed in parentheses.");
-
-		String className = fullyQualifiedMethodName.substring(0, indexOfFirstHashtag);
-		String methodPart = fullyQualifiedMethodName.substring(indexOfFirstHashtag + 1);
-		String methodName = methodPart;
-		String methodParameters = "";
-
-		if (methodPart.endsWith("()")) {
-			methodName = methodPart.substring(0, methodPart.length() - 2);
-		}
-		else if (methodPart.endsWith(")")) {
-			int indexOfLastOpeningParenthesis = methodPart.lastIndexOf('(');
-			if ((indexOfLastOpeningParenthesis > 0) && (indexOfLastOpeningParenthesis < methodPart.length() - 1)) {
-				methodName = methodPart.substring(0, indexOfLastOpeningParenthesis);
-				methodParameters = methodPart.substring(indexOfLastOpeningParenthesis + 1, methodPart.length() - 1);
-			}
-		}
-
-		return selectMethod(className, methodName, methodParameters);
+		String[] methodParts = ReflectionUtils.parseFullyQualifiedMethodName(fullyQualifiedMethodName);
+		return selectMethod(methodParts[0], methodParts[1], methodParts[2]);
 	}
 
 	/**

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -366,6 +366,75 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
+	void getFullyQualifiedMethodNamePreconditions() {
+		// @formatter:off
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.getFullyQualifiedMethodName(null, null));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.getFullyQualifiedMethodName(null, "testMethod"));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.getFullyQualifiedMethodName(Object.class, null));
+		// @formatter:on
+	}
+
+	@Test
+	void getFullyQualifiedMethodNameForMethodWithoutParameters() {
+		assertThat(ReflectionUtils.getFullyQualifiedMethodName(Object.class, "toString"))//
+				.isEqualTo("java.lang.Object#toString()");
+	}
+
+	@Test
+	void getFullyQualifiedMethodNameForMethodWithNullParameters() {
+		assertThat(ReflectionUtils.getFullyQualifiedMethodName(Object.class, "toString", null))//
+				.isEqualTo("java.lang.Object#toString()");
+	}
+
+	@Test
+	void getFullyQualifiedMethodNameForMethodWithSingleParameter() {
+		assertThat(ReflectionUtils.getFullyQualifiedMethodName(Object.class, "equals", Object.class))//
+				.isEqualTo("java.lang.Object#equals(java.lang.Object)");
+	}
+
+	@Test
+	void getFullyQualifiedMethodNameForMethodWithMultipleParameters() {
+		// @formatter:off
+		assertThat(ReflectionUtils.getFullyQualifiedMethodName(Object.class, "testMethod", int.class, Object.class))//
+				.isEqualTo("java.lang.Object#testMethod(int, java.lang.Object)");
+		// @formatter:on
+	}
+
+	@Test
+	void parseFullyQualifiedMethodNamePreconditions() {
+		// @formatter:off
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName(null));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName(""));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName("   "));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName("java.lang.Object#"));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName("#equals"));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName("#"));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName("java.lang.Object"));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName("equals"));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName("()"));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.parseFullyQualifiedMethodName("(int, java.lang.Object)"));
+		// @formatter:on
+	}
+
+	@Test
+	void parseFullyQualifiedMethodNameForMethodWithoutParameters() {
+		assertThat(ReflectionUtils.parseFullyQualifiedMethodName("com.example.Test#method()"))//
+				.containsExactly("com.example.Test", "method", "");
+	}
+
+	@Test
+	void parseFullyQualifiedMethodNameForMethodWithSingleParameter() {
+		assertThat(ReflectionUtils.parseFullyQualifiedMethodName("com.example.Test#method(java.lang.Object)"))//
+				.containsExactly("com.example.Test", "method", "java.lang.Object");
+	}
+
+	@Test
+	void parseFullyQualifiedMethodNameForMethodWithMultipleParameters() {
+		assertThat(ReflectionUtils.parseFullyQualifiedMethodName("com.example.Test#method(int, java.lang.Object)"))//
+				.containsExactly("com.example.Test", "method", "int, java.lang.Object");
+	}
+
+	@Test
 	void getOutermostInstancePreconditions() {
 		// @formatter:off
 		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.getOutermostInstance(null, null));


### PR DESCRIPTION
I cleaned by the way unused `throws` clauses in `ReflectionUtilsTests`.
FQMN parsing result is just a String array, I think it's simple enough and creating something like `MethodInfo` data class would be too much.
Please carefully review added test cases - I didn't have too much time for it and could miss some important ones.