### PR TITLE
Switch to JDK 10

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,9 +6,9 @@ branches:
     - /^r\d.*$/
 
 install:
-  - cinst jdk9 -version 9.0.4.11 -params 'installdir=C:\\jdk9'
-  - SET JAVA_HOME=C:\jdk9
-  - SET PATH=C:\jdk9\bin;%PATH%
+  - cinst jdk10 -params 'installdir=C:\\jdk10'
+  - SET JAVA_HOME=C:\jdk10
+  - SET PATH=C:\jdk10\bin;%PATH%
 
 test_script:
   - gradlew --no-daemon -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,12 @@ before_install:
 
 matrix:
   include:
-# Java 9 "Oracle JDK" (provided by Travis CI)
-    - jdk: oraclejdk9
-      env: JDK='Oracle JDK 9' EXTRA_GRADLE_ARGS='-PenableJaCoCo'
-      install: echo "Don't let Travis CI execute './gradlew assemble' by default"
 # Java 10 "Oracle JDK" (not yet provided by Travis CI)
     - jdk: oraclejdk10
       env: JDK='Oracle JDK 10'
       install: echo "Don't let Travis CI execute './gradlew assemble' by default"
 # Java 10 "OpenJDK"
-    - env: JDK='OpenJDK 10'
+    - env: JDK='OpenJDK 10' EXTRA_GRADLE_ARGS='-PenableJaCoCo'
       install: . ./install-jdk.sh -F 10 -L GPL
 # Java 11 "Oracle JDK"
     - env: JDK='Oracle JDK 11'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ script:
 
 # Run JaCoCo report and send report to codecov.io after build success for JDK 9 build
 after_success:
-  - test "${JDK}" = "Oracle JDK 9" && ./gradlew -PenableJaCoCo jacocoRootReport || true
-  - test "${JDK}" = "Oracle JDK 9" && bash <(curl -s https://codecov.io/bash) || true
+  - test "${JDK}" = "OpenJDK 10" && ./gradlew -PenableJaCoCo jacocoRootReport || true
+  - test "${JDK}" = "OpenJDK 10" && bash <(curl -s https://codecov.io/bash) || true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent { label 'hi-speed' }
   tools {
-    jdk 'Oracle JDK 9'
+    jdk 'Oracle JDK 10'
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '10'))

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ project, click on "See console output" on the build scan page.
 
 ## Building from Source
 
-You need [JDK-9] or higher to build JUnit 5.
+You need [JDK-10] to build JUnit 5.
 All modules can be built with Gradle using the following command.
 
 ```
@@ -117,11 +117,11 @@ See also <http://repo1.maven.org/maven2/org/junit/> for releases and <https://os
 - **Artifact ID** and **Automatic-Module-Name**:
   - `junit-vintage-engine` (`org.junit.vintage.engine`)
 
-## Java 9 Module Names
+## Java Module Names
 
 All published JAR artifacts contain an [Automatic-Module-Name] manifest attribute
 whose value is used as the name of the automatic module defined by that JAR file
-when it is placed on the **Java 9** module path. The names are listed above in the
+when it is placed on the module path. The names are listed above in the
 Dependency Metadata section.
 
 This allows test module authors to require well-known JUnit module names as
@@ -145,7 +145,7 @@ as it is not intended to be used as a module.
 [Gitter]: https://gitter.im/junit-team/junit5
 [JaCoCo]: http://www.eclemma.org/jacoco/
 [Javadoc]: https://junit.org/junit5/docs/current/api/
-[JDK-9]: http://jdk.java.net/9/
+[JDK-10]: http://jdk.java.net/10/
 [Jenkins CI server]: https://junit.ci.cloudbees.com/job/JUnit5/job/master/lastSuccessfulBuild/artifact/build/reports/jacoco/jacocoRootReport/html/index.html
 [OpenClover]: http://openclover.org
 [Prototype]: https://github.com/junit-team/junit5/wiki/Prototype

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.taskdefs.condition.Os
-
 buildscript {
 	dependencies {
 		// upgrade to latest jruby version due to a bugfix needed for Windows 10.
@@ -103,12 +101,6 @@ asciidoctor {
 	}
 
 	backends 'html5'
-
-	// The PDF backend currently does not work on Linux
-	// see https://github.com/junit-team/junit5/issues/1099
-	if (Os.isFamily(Os.FAMILY_WINDOWS) || Os.isFamily(Os.FAMILY_MAC)) {
-		backends 'pdf'
-	}
 
 	attributes	'jupiter-version': project.property('version'),
 				'platform-version': project.property('platformVersion'),

--- a/platform-tests/platform-tests.gradle
+++ b/platform-tests/platform-tests.gradle
@@ -69,3 +69,15 @@ jmh {
 checkstyleJmh { // use same style rules as defined for tests
 	configFile = rootProject.file('src/checkstyle/checkstyleTest.xml')
 }
+
+eclipse {
+	classpath {
+		plusConfigurations += [ project(':junit-platform-console').configurations.shadowed ]
+	}
+}
+
+idea {
+	module {
+		scopes.PROVIDED.plus += [ project(':junit-platform-console').configurations.shadowed ]
+	}
+}


### PR DESCRIPTION
## Overview

_Drop 9, play on 10._

This PR promotes JDK 10 to our underlying build JDK. The `--release` target is still and remains Java 8.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

