### PR TITLE
Ensure failures in lifecycle methods take precedence over earlier TestAbortedExceptions

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassExtensionContext.java
@@ -19,9 +19,9 @@ import java.util.Optional;
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.engine.execution.ThrowableCollector;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * @since 5.0

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodExtensionContext.java
@@ -19,9 +19,9 @@ import java.util.Optional;
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.engine.execution.ThrowableCollector;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * @since 5.0

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -26,16 +26,16 @@ import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.engine.execution.AfterEachMethodAdapter;
 import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
 import org.junit.jupiter.engine.execution.ExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
-import org.junit.jupiter.engine.execution.ThrowableCollector;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector.Executable;
 
 /**
  * {@link TestDescriptor} for tests based on Java methods.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.OpenTest4JAwareThrowableCollector;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector.Executable;
 
@@ -80,7 +81,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 		ExtensionRegistry registry = populateNewExtensionRegistry(context);
 		Object testInstance = context.getTestInstanceProvider().getTestInstance(Optional.of(registry));
 
-		ThrowableCollector throwableCollector = new ThrowableCollector();
+		ThrowableCollector throwableCollector = new OpenTest4JAwareThrowableCollector();
 		ExtensionContext extensionContext = new MethodExtensionContext(context.getExtensionContext(),
 			context.getExecutionListener(), this, context.getConfigurationParameters(), testInstance,
 			throwableCollector);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionValuesStore.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionValuesStore.java
@@ -26,6 +26,7 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContextException;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * {@code ExtensionValuesStore} is used inside implementations of

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionValuesStore.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionValuesStore.java
@@ -26,6 +26,7 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContextException;
+import org.junit.platform.engine.support.hierarchical.OpenTest4JAwareThrowableCollector;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
@@ -51,7 +52,7 @@ public class ExtensionValuesStore {
 	 * does not close values in parent stores.
 	 */
 	public void closeAllStoredCloseableValues() {
-		ThrowableCollector throwableCollector = new ThrowableCollector();
+		ThrowableCollector throwableCollector = new OpenTest4JAwareThrowableCollector();
 		for (Supplier<Object> supplier : storedValues.values()) {
 			Object value = supplier.get();
 			if (value instanceof ExtensionContext.Store.CloseableResource) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContext.java
@@ -21,6 +21,7 @@ import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * @since 5.0

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ThrowableCollector.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ThrowableCollector.java
@@ -16,6 +16,7 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.Preconditions;
+import org.opentest4j.TestAbortedException;
 
 /**
  * Simple component that can be used to collect one or more instances of
@@ -55,6 +56,10 @@ public class ThrowableCollector {
 		Preconditions.notNull(t, "Throwable must not be null");
 
 		if (this.throwable == null) {
+			this.throwable = t;
+		}
+		else if (this.throwable instanceof TestAbortedException && !(t instanceof TestAbortedException)) {
+			t.addSuppressed(this.throwable);
 			this.throwable = t;
 		}
 		else {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/ExceptionHandlingTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/ExceptionHandlingTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine;
 
 import static org.assertj.core.api.Assertions.allOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.opentest4j.AssertionFailedError;
+import org.opentest4j.TestAbortedException;
 
 /**
  * Integration tests that verify correct exception handling in the {@link JupiterTestEngine}.
@@ -143,6 +145,28 @@ class ExceptionHandlingTests extends AbstractJupiterTestEngineTests {
 					message("unchecked"), //
 					suppressed(0, allOf(isA(IOException.class), message("checked")))))), //
 			event(container(testClass), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void exceptionInAfterEachTakesPrecedenceOverFailedAssumptionInTest() throws NoSuchMethodException {
+		Method method = FailureTestCase.class.getDeclaredMethod("abortedTest");
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(FailureTestCase.class, method)).build();
+
+		FailureTestCase.exceptionToThrowInAfterEach = Optional.of(new IOException("checked"));
+
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(FailureTestCase.class), started()), //
+			event(test("abortedTest"), started()), //
+			event(test("abortedTest"), //
+				finishedWithFailure(allOf( //
+					isA(IOException.class), //
+					message("checked"), //
+					suppressed(0, allOf(isA(TestAbortedException.class)))))), //
+			event(container(FailureTestCase.class), finishedSuccessfully()), //
 			event(engine(), finishedSuccessfully()));
 	}
 
@@ -281,6 +305,11 @@ class ExceptionHandlingTests extends AbstractJupiterTestEngineTests {
 		@Test
 		void testWithCheckedException() throws IOException {
 			throw new IOException("checked");
+		}
+
+		@Test
+		void abortedTest() {
+			assumeFalse(true, "abortedTest");
 		}
 
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptorTests.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
-import org.junit.jupiter.engine.execution.ThrowableCollector;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
@@ -37,6 +36,7 @@ import org.junit.platform.engine.support.descriptor.FilePosition;
 import org.junit.platform.engine.support.descriptor.FileSource;
 import org.junit.platform.engine.support.descriptor.UriSource;
 import org.junit.platform.engine.support.hierarchical.Node;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * Unit tests for {@link TestFactoryTestDescriptor}.

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptorTests.java
@@ -36,7 +36,7 @@ import org.junit.platform.engine.support.descriptor.FilePosition;
 import org.junit.platform.engine.support.descriptor.FileSource;
 import org.junit.platform.engine.support.descriptor.UriSource;
 import org.junit.platform.engine.support.hierarchical.Node;
-import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
+import org.junit.platform.engine.support.hierarchical.OpenTest4JAwareThrowableCollector;
 
 /**
  * Unit tests for {@link TestFactoryTestDescriptor}.
@@ -121,7 +121,7 @@ class TestFactoryTestDescriptorTests {
 			isClosed = false;
 
 			context = new JupiterEngineExecutionContext(null, null).extend().withThrowableCollector(
-				new ThrowableCollector()).withExtensionContext(extensionContext).build();
+				new OpenTest4JAwareThrowableCollector()).withExtensionContext(extensionContext).build();
 
 			Method testMethod = CustomStreamTestCase.class.getDeclaredMethod("customStream");
 			descriptor = new TestFactoryTestDescriptor(UniqueId.forEngine("engine"), CustomStreamTestCase.class,

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
@@ -43,6 +43,7 @@ import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
@@ -43,7 +43,7 @@ import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
-import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
+import org.junit.platform.engine.support.hierarchical.OpenTest4JAwareThrowableCollector;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -131,7 +131,7 @@ class ExtensionContextTests {
 		assertThat(nestedExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 
 		MethodExtensionContext methodExtensionContext = new MethodExtensionContext(outerExtensionContext, null,
-			methodTestDescriptor, configParams, new OuterClass(), new ThrowableCollector());
+			methodTestDescriptor, configParams, new OuterClass(), new OpenTest4JAwareThrowableCollector());
 		assertThat(methodExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "method-tag");
 		assertThat(methodExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 	}
@@ -152,7 +152,7 @@ class ExtensionContextTests {
 		ClassExtensionContext classExtensionContext = new ClassExtensionContext(engineExtensionContext, null,
 			classTestDescriptor, configParams, null);
 		MethodExtensionContext methodExtensionContext = new MethodExtensionContext(classExtensionContext, null,
-			methodTestDescriptor, configParams, testInstance, new ThrowableCollector());
+			methodTestDescriptor, configParams, testInstance, new OpenTest4JAwareThrowableCollector());
 
 		// @formatter:off
 		assertAll("methodContext",
@@ -205,7 +205,7 @@ class ExtensionContextTests {
 		ClassTestDescriptor classTestDescriptor = outerClassDescriptor(methodTestDescriptor);
 		ExtensionContext parentContext = new ClassExtensionContext(null, null, classTestDescriptor, configParams, null);
 		MethodExtensionContext childContext = new MethodExtensionContext(parentContext, null, methodTestDescriptor,
-			configParams, new OuterClass(), new ThrowableCollector());
+			configParams, new OuterClass(), new OpenTest4JAwareThrowableCollector());
 
 		ExtensionContext.Store childStore = childContext.getStore(Namespace.GLOBAL);
 		ExtensionContext.Store parentStore = parentContext.getStore(Namespace.GLOBAL);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
@@ -36,11 +36,14 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 	private final ExecutionRequest request;
 	private final C rootContext;
 	private final HierarchicalTestExecutorService executorService;
+	private final ThrowableCollector.Factory throwableCollectorFactory;
 
-	HierarchicalTestExecutor(ExecutionRequest request, C rootContext, HierarchicalTestExecutorService executorService) {
+	HierarchicalTestExecutor(ExecutionRequest request, C rootContext, HierarchicalTestExecutorService executorService,
+			ThrowableCollector.Factory throwableCollectorFactory) {
 		this.request = request;
 		this.rootContext = rootContext;
 		this.executorService = executorService;
+		this.throwableCollectorFactory = throwableCollectorFactory;
 	}
 
 	Future<Void> execute() {
@@ -52,7 +55,8 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 	NodeTestTask<C> prepareNodeTestTaskTree() {
 		TestDescriptor rootTestDescriptor = this.request.getRootTestDescriptor();
 		EngineExecutionListener executionListener = this.request.getEngineExecutionListener();
-		NodeTestTask<C> rootTestTask = new NodeTestTask<>(rootTestDescriptor, executionListener, this.executorService);
+		NodeTestTask<C> rootTestTask = new NodeTestTask<>(rootTestDescriptor, executionListener, this.executorService,
+			this.throwableCollectorFactory);
 		new NodeTestTaskWalker().walk(rootTestTask);
 		return rootTestTask;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/OpenTest4JAwareThrowableCollector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/OpenTest4JAwareThrowableCollector.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.hierarchical;
+
+import static org.apiguardian.api.API.Status.MAINTAINED;
+
+import org.apiguardian.api.API;
+import org.opentest4j.TestAbortedException;
+
+/**
+ * Specialization of {@link ThrowableCollector} that treats instances of
+ * {@link TestAbortedException} as <em>aborting</em>.
+ *
+ * @see ThrowableCollector
+ * @since 5.3
+ */
+@API(status = MAINTAINED, since = "5.3")
+public class OpenTest4JAwareThrowableCollector extends ThrowableCollector {
+
+	public OpenTest4JAwareThrowableCollector() {
+		super(TestAbortedException.class::isInstance);
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleTestExecutor.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static org.apiguardian.api.API.Status.MAINTAINED;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.junit.platform.commons.util.BlacklistedExceptions.rethrowIfBlacklisted;
 import static org.junit.platform.engine.TestExecutionResult.aborted;
 import static org.junit.platform.engine.TestExecutionResult.failed;
@@ -26,8 +26,11 @@ import org.opentest4j.TestAbortedException;
  *
  * @since 1.0
  * @see #executeSafely(Executable)
+ * @deprecated Please use {@link ThrowableCollector#execute} and
+ * {@link ThrowableCollector#toTestExecutionResult} instead.
  */
-@API(status = MAINTAINED, since = "1.0")
+@Deprecated
+@API(status = DEPRECATED, since = "1.2")
 public class SingleTestExecutor {
 
 	/**

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -575,6 +575,30 @@ class HierarchicalTestExecutorTests {
 			"Dynamic test descriptors must not declare exclusive resources");
 	}
 
+	@Test
+	void exceptionInAfterIsReportedInsteadOfEarlierTestAbortedException() throws Exception {
+
+		MyLeaf child = spy(new MyLeaf(UniqueId.root("leaf", "leaf")));
+		Exception exceptionInExecute = new TestAbortedException("execute");
+		Exception exceptionInAfter = new RuntimeException("after");
+		doThrow(exceptionInExecute).when(child).execute(eq(rootContext), any());
+		doThrow(exceptionInAfter).when(child).after(eq(rootContext));
+		root.addChild(child);
+
+		InOrder inOrder = inOrder(listener, child);
+
+		executor.execute();
+
+		ArgumentCaptor<TestExecutionResult> childExecutionResult = ArgumentCaptor.forClass(TestExecutionResult.class);
+		inOrder.verify(child).execute(eq(rootContext), any());
+		inOrder.verify(child).after(eq(rootContext));
+		inOrder.verify(listener).executionFinished(eq(child), childExecutionResult.capture());
+
+		assertThat(childExecutionResult.getValue().getStatus()).isEqualTo(FAILED);
+		assertThat(childExecutionResult.getValue().getThrowable().get()).isSameAs(
+			exceptionInAfter).hasSuppressedException(exceptionInExecute);
+	}
+
 	// -------------------------------------------------------------------
 
 	private static class MyEngineExecutionContext implements EngineExecutionContext {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -650,7 +650,8 @@ class HierarchicalTestExecutorTests {
 	private static class MyExecutor extends HierarchicalTestExecutor<MyEngineExecutionContext> {
 
 		MyExecutor(ExecutionRequest request, MyEngineExecutionContext rootContext) {
-			super(request, rootContext, new SameThreadHierarchicalTestExecutorService());
+			super(request, rootContext, new SameThreadHierarchicalTestExecutorService(),
+				OpenTest4JAwareThrowableCollector::new);
 		}
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/NodeTestTaskWalkerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/NodeTestTaskWalkerIntegrationTests.java
@@ -73,7 +73,8 @@ class NodeTestTaskWalkerIntegrationTests {
 		TestDescriptor testDescriptor = new JupiterTestEngine().discover(discoveryRequest,
 			UniqueId.forEngine("junit-jupiter"));
 		ExecutionRequest executionRequest = new ExecutionRequest(testDescriptor, null, null);
-		HierarchicalTestExecutor<?> executor = new HierarchicalTestExecutor<>(executionRequest, null, null);
+		HierarchicalTestExecutor<?> executor = new HierarchicalTestExecutor<>(executionRequest, null, null,
+			() -> new ThrowableCollector(t -> false));
 		return executor.prepareNodeTestTaskTree();
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/SingleTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/SingleTestExecutorTests.java
@@ -25,6 +25,7 @@ import org.opentest4j.TestAbortedException;
 /**
  * @since 1.0
  */
+@SuppressWarnings("deprecation")
 class SingleTestExecutorTests {
 
 	@Test


### PR DESCRIPTION
Fixes #1313.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [X] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
