### PR TITLE
issue/1338: implemented prototype of early dynamic test discovery in …

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -194,6 +194,11 @@ public interface Node<C extends EngineExecutionContext> {
 	 * @see HierarchicalTestExecutor
 	 */
 	interface DynamicTestExecutor {
+		/**
+		 * Dynamically add a found node to test plan while execution phase
+		 * @param testDescriptor the test descriptor to be added
+		 */
+		void dynamicRegister(TestDescriptor testDescriptor);
 
 		/**
 		 * Submit a dynamic test descriptor for immediate execution.
@@ -201,7 +206,5 @@ public interface Node<C extends EngineExecutionContext> {
 		 * @param testDescriptor the test descriptor to be executed
 		 */
 		void execute(TestDescriptor testDescriptor);
-
 	}
-
 }


### PR DESCRIPTION
…execution phase

## Overview

When starting execution phase for dynamic tests all dynamic tests are discovered and dynamically registered as first action.

TODO: For now when there are more tests than just one @testFactoy method, tests are discovered when execution for this @testfactory method starts

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
