### PR TITLE
Issues/1338 discover dynamic tests early

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -58,7 +58,7 @@ class DynamicContainerTestDescriptor extends DynamicNodeTestDescriptor {
 					.map(child -> toDynamicDescriptor(index.getAndIncrement(), child))
 					.filter(Optional::isPresent)
 					.map(Optional::get)
-					.forEachOrdered(dynamicTestExecutor::execute);
+					.forEachOrdered(td -> dynamicTestExecutor.execute(td, true));
 			// @formatter:on
 		}
 		return context;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -34,13 +34,26 @@ class DynamicContainerTestDescriptor extends DynamicNodeTestDescriptor {
 	private final DynamicContainer dynamicContainer;
 	private final TestSource testSource;
 	private final DynamicDescendantFilter dynamicDescendantFilter;
+	private final boolean isEarlyDiscovery;
 
 	DynamicContainerTestDescriptor(UniqueId uniqueId, int index, DynamicContainer dynamicContainer,
-			TestSource testSource, DynamicDescendantFilter dynamicDescendantFilter) {
+			TestSource testSource, DynamicDescendantFilter dynamicDescendantFilter, boolean isEarlyDiscovery) {
 		super(uniqueId, index, dynamicContainer, testSource);
 		this.dynamicContainer = dynamicContainer;
 		this.testSource = testSource;
 		this.dynamicDescendantFilter = dynamicDescendantFilter;
+		this.isEarlyDiscovery = isEarlyDiscovery;
+		
+		if (isEarlyDiscovery) {
+			discoverEarly();
+		}
+	}
+	
+	private void discoverEarly() {
+		AtomicInteger index = new AtomicInteger(1);
+		try (Stream<? extends DynamicNode> children = dynamicContainer.getChildren()) {
+			children.forEach(child -> toDynamicDescriptor(index.getAndIncrement(), child, !isEarlyDiscovery));
+		}
 	}
 
 	@Override
@@ -51,20 +64,25 @@ class DynamicContainerTestDescriptor extends DynamicNodeTestDescriptor {
 	@Override
 	public JupiterEngineExecutionContext execute(JupiterEngineExecutionContext context,
 			DynamicTestExecutor dynamicTestExecutor) throws Exception {
-		AtomicInteger index = new AtomicInteger(1);
-		try (Stream<? extends DynamicNode> children = dynamicContainer.getChildren()) {
-			// @formatter:off
-			children.peek(child -> Preconditions.notNull(child, "individual dynamic node must not be null"))
-					.map(child -> toDynamicDescriptor(index.getAndIncrement(), child))
-					.filter(Optional::isPresent)
-					.map(Optional::get)
-					.forEachOrdered(td -> dynamicTestExecutor.execute(td, true));
-			// @formatter:on
+		if (isEarlyDiscovery) {
+			children.forEach(td -> dynamicTestExecutor.execute(td, false));
+		} else {
+			AtomicInteger index = new AtomicInteger(1);
+			try (Stream<? extends DynamicNode> children = dynamicContainer.getChildren()) {
+				// @formatter:off
+				children.peek(child -> Preconditions.notNull(child, "individual dynamic node must not be null"))
+						.map(child -> toDynamicDescriptor(index.getAndIncrement(), child, false))
+						.filter(Optional::isPresent)
+						.map(Optional::get)
+						.forEachOrdered(td -> dynamicTestExecutor.execute(td, true));
+				// @formatter:on
+			}
+
 		}
 		return context;
 	}
 
-	private Optional<JupiterTestDescriptor> toDynamicDescriptor(int index, DynamicNode childNode) {
-		return createDynamicDescriptor(this, childNode, index, testSource, dynamicDescendantFilter);
+	private Optional<JupiterTestDescriptor> toDynamicDescriptor(int index, DynamicNode childNode, boolean isEarlyDiscovery) {
+		return createDynamicDescriptor(this, childNode, index, testSource, dynamicDescendantFilter, isEarlyDiscovery);
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -12,7 +12,9 @@ package org.junit.jupiter.engine.descriptor;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -28,6 +30,7 @@ import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.CollectionUtils;
 import org.junit.platform.commons.util.PreconditionViolationException;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
 
@@ -49,7 +52,42 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 
 	public TestFactoryTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod) {
 		super(uniqueId, testClass, testMethod);
+		discoverTestsEarly(testMethod);
 	}
+	
+	private void discoverTestsEarly(Method testMethod) {
+		try {
+			if (Modifier.isStatic(testMethod.getModifiers())) {
+				discoverTests(testMethod.invoke(null));
+			}
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new IllegalStateException("could not invoke TestFactory method", e);
+		}
+	}
+	
+	private void discoverTests(Object testFactoryMethodResult) {
+		TestSource source = getSource().orElseThrow(
+				() -> new JUnitException("Illegal state: TestSource must be present"));
+
+		try (Stream<DynamicNode> dynamicNodeStream = toDynamicNodeStream(testFactoryMethodResult)) {
+			int index = 1;
+			Iterator<DynamicNode> iterator = dynamicNodeStream.iterator();
+			while (iterator.hasNext()) {
+				DynamicNode dynamicNode = iterator.next();
+				Optional<JupiterTestDescriptor> descriptor = createDynamicDescriptor(this, dynamicNode, index++,
+					source, getDynamicDescendantFilter());
+				descriptor.ifPresent(d -> children.add(d));
+			}
+		}
+		catch (ClassCastException ex) {
+			throw invalidReturnTypeException(ex);
+		}
+	}
+	
+	private boolean testAlreadyDiscovered() {
+		return !children.isEmpty();
+	}
+	
 
 	// --- Filterable ----------------------------------------------------------
 
@@ -78,22 +116,16 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 
 		context.getThrowableCollector().execute(() -> {
 			Object instance = extensionContext.getRequiredTestInstance();
-			Object testFactoryMethodResult = executableInvoker.invoke(getTestMethod(), instance, extensionContext,
-				context.getExtensionRegistry());
-			TestSource source = getSource().orElseThrow(
-				() -> new JUnitException("Illegal state: TestSource must be present"));
-			try (Stream<DynamicNode> dynamicNodeStream = toDynamicNodeStream(testFactoryMethodResult)) {
-				int index = 1;
-				Iterator<DynamicNode> iterator = dynamicNodeStream.iterator();
-				while (iterator.hasNext()) {
-					DynamicNode dynamicNode = iterator.next();
-					Optional<JupiterTestDescriptor> descriptor = createDynamicDescriptor(this, dynamicNode, index++,
-						source, getDynamicDescendantFilter());
-					descriptor.ifPresent(dynamicTestExecutor::execute);
-				}
+			
+			boolean testsEarlyDiscovered = testAlreadyDiscovered();
+			if (!testsEarlyDiscovered) {
+				Object testFactoryMethodResult = executableInvoker.invoke(getTestMethod(), instance, extensionContext,
+						context.getExtensionRegistry());
+				discoverTests(testFactoryMethodResult);
 			}
-			catch (ClassCastException ex) {
-				throw invalidReturnTypeException(ex);
+			
+			for (TestDescriptor td : children) {
+				dynamicTestExecutor.execute(td, !testsEarlyDiscovered);
 			}
 		});
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -130,7 +130,7 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 
 	private void execute(DynamicTestExecutor dynamicTestExecutor, TestDescriptor testDescriptor) {
 		addChild(testDescriptor);
-		dynamicTestExecutor.execute(testDescriptor);
+		dynamicTestExecutor.execute(testDescriptor, true);
 	}
 
 	private void validateWasAtLeastInvokedOnce(int invocationIndex) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.TestFactory;
 public class IsTestFactoryMethod extends IsTestableMethod {
 
 	public IsTestFactoryMethod() {
-		super(TestFactory.class, false);
+		super(TestFactory.class, false, true);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -27,16 +27,22 @@ abstract class IsTestableMethod implements Predicate<Method> {
 
 	private final Class<? extends Annotation> annotationType;
 	private final boolean mustReturnVoid;
+	private final boolean mayBeStatic;
 
-	IsTestableMethod(Class<? extends Annotation> annotationType, boolean mustReturnVoid) {
+	IsTestableMethod(Class<? extends Annotation> annotationType, boolean mustReturnVoid, boolean mayBeStatic) {
 		this.annotationType = annotationType;
 		this.mustReturnVoid = mustReturnVoid;
+		this.mayBeStatic = mayBeStatic;
 	}
 
+	IsTestableMethod(Class<? extends Annotation> annotationType, boolean mustReturnVoid) {
+		this(annotationType, mustReturnVoid, false);
+	}
+	
 	@Override
 	public boolean test(Method candidate) {
 		// Please do not collapse the following into a single statement.
-		if (isStatic(candidate)) {
+		if (!mayBeStatic && isStatic(candidate)) {
 			return false;
 		}
 		if (isPrivate(candidate)) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutor.java
@@ -110,8 +110,10 @@ class HierarchicalTestExecutor<C extends EngineExecutionContext> {
 				try {
 					context = node.before(context);
 
-					context = node.execute(context, dynamicTestDescriptor -> {
-						listener.dynamicTestRegistered(dynamicTestDescriptor);
+					context = node.execute(context, (dynamicTestDescriptor, registrationRequired) -> {
+						if (registrationRequired) {
+							listener.dynamicTestRegistered(dynamicTestDescriptor);
+						}
 						new NodeExecutor(dynamicTestDescriptor).execute(context, tracker);
 					});
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -200,7 +200,7 @@ public interface Node<C extends EngineExecutionContext> {
 		 *
 		 * @param testDescriptor the test descriptor to be executed
 		 */
-		void execute(TestDescriptor testDescriptor);
+		void execute(TestDescriptor testDescriptor, boolean withRegistration);
 
 	}
 


### PR DESCRIPTION
## Overview

Implemented test discovery for dynamic tests in discovery phase in case @testfactroy method is static

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
