### PR TITLE
Include OSGi metadata in published artifacts of mavenized projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,8 @@ ext {
 	jacocoTestProjects = cloverTestProjects << 'junit-platform-gradle-plugin'
 	jacocoCoveredProjects = mavenizedProjects - ['junit-platform-console-standalone']
 	jacocoClassesDir = "$buildDir/jacoco/classes"
+
+	osgiProjects = mavenizedProjects - ['junit-platform-console-standalone']
 }
 
 allprojects { subproj ->
@@ -288,6 +290,17 @@ subprojects { subproj ->
 
 	javadoc {
 		classpath = project.sourceSets.main.compileClasspath + configurations.shadowed
+	}
+
+	if (subproj.name in osgiProjects) {
+		apply plugin: 'osgi'
+
+		jar {
+			manifest {
+				license = licenseOf(project)
+				vendor = 'junit.org'
+			}
+		}
 	}
 
 	if (subproj.name in mavenizedProjects) {
@@ -557,7 +570,7 @@ subprojects { subproj ->
 			// We're only interested in the compiled classes. So we depend
 			// on the classes task and change (-C) to the destination
 			// directory of the version-aware project later.
-			dependsOn = [versionedProject.classes]
+			dependsOn versionedProject.classes
 			doLast {
 				project.exec {
 					executable "${System.properties['java.home']}/bin/jar"


### PR DESCRIPTION
The 'osgi' Gradle plugin analyzes source files and creates an OSGi compatible MANIFEST.MF containing "Import-Package" and "Export-Package" as well as some further "Bundle-*" attributes.
(see also https://docs.gradle.org/current/userguide/osgi_plugin.html)

Any feedback is welcome :-)

## Overview

I applied the 'osgi' Gradle plugin to all mavenized projects. I also used this 'osgi' plugin for my project (https://github.com/TNG/junit-dataprovider) and it worked fine for a huge OSGi project.
**Disclaimer**: As I have no longer access to that project, I could not test it myself. Maybe t is a good idea to test it with a real-life OSGi project.

Subproject 'junit-platform-console-standalone' is excluded as it does not contain any source code itself which is not supported by 'osgi' plugin.

For multi-release jars other dependencies of 'jar' task should not be removed, instead ':*-java-9:classes' task should only be added.

Issue: #195 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by ~~[automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)~~ manual tests on a real life OSGi project (see comment above)
  - Idea: Providing a SNAPSHOT version of this PR on Maven Central such that somebody can take it from there and test it on his/her OSGi project.
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes) 
  - Precondition: As soon as you accept the change, I will create a suggestion for the "User Guide" and "Release Notes"
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
- [ ] For issues: change is merged into master
- [ ] Issue and pull request, if applicable, are closed and assigned to the corresponding milestone, the labels _in progress_ and _team discussion_ label have been removed
