### PR TITLE
Briefly explain support in Ant build tool for JUnit 5 tests

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -423,6 +423,78 @@ below) or via the `junit-platform.properties` file.
 	...
 ----
 
+[[running-tests-ant]]
+=== Ant
+
+Starting version `1.10.3` of link:https://ant.apache.org/[Ant], a new
+link:https://ant.apache.org/manual/Tasks/junitlauncher.html[junitlauncher]
+task has been introduced to provide native support for launching JUnit 5 tests.
+The `junitlauncher` task is solely responsible for launching the JUnit 5 platform
+and passing it the selected collection of tests. JUnit 5 platform then does the necessary
+test identification as well as test execution.
+
+The `junitlauncher` task tries to stay as close as possible to Ant's native constructs,
+like link:https://ant.apache.org/manual/Types/resources.html#collection[resource collections],
+for allowing users to select the tests that they want executed by the test engines. This gives
+the task a consitent and natural feel when compared to many other core Ant tasks.
+
+NOTE: The version of this task shipped in Ant 1.10.3, provides basic minimal support for
+launching the tests. A lot more enhancements (including support for forking the tests in a
+separate JVM) are currently being worked upon and should be available in subsequent releases
+of Ant.
+
+==== Basic Usage
+
+The following shows an example, where a single test class called `org.myapp.test.MyFirstJUnit5Test`
+is being launched by the `junitlauncher` task:
+
+[source,xml]
+----
+	<path id="test.classpath">
+		<!-- The location where you have your compiled classes -->
+		<pathelement location="${build.classes.dir}"/>
+	</path>
+	....
+	<junitlauncher>
+		<classpath refid="test.classpath" />
+		<test name="org.myapp.test.MyFirstJUnit5Test"/>
+	</junitlauncher>
+----
+The `test` element lets you specify a single test class that you want to be selected and launched.
+The `classpath` element let's you specify the classpath to be used during the launching and
+execution of these tests. This classpath will be used to locate the test class(es) that are part
+of the execution.
+
+The following is another example of using the `junitlauncher` task. On this instance, we will launch
+multiple tests that are located under specific locations.
+
+[source,xml]
+----
+	<path id="test.classpath">
+		<!-- The location where you have your compiled classes -->
+		<pathelement location="${build.classes.dir}"/>
+	</path>
+	....
+	<junitlauncher>
+		<classpath refid="test.classpath"/>
+		<testclasses outputdir="${output.dir}">
+			<fileset dir="${build.classes.dir}">
+				<include name="org/example/**/demo/**/"/>
+			</fileset>
+			<fileset dir="${some.other.dir}">
+				<include name="org/myapp/**/"/>
+			</fileset>
+		</testclasses>
+	</junitlauncher>
+----
+
+In the above example, the `testclasses` element allows you to select multiple test classes that
+reside in different locations, to launch them for test execution.
+
+For more details on the usage of the task and its configurations, please refer to Ant's official
+documentation of the link:https://ant.apache.org/manual/Tasks/junitlauncher.html[junitlauncher task]
+
+
 [[running-tests-console-launcher]]
 === Console Launcher
 


### PR DESCRIPTION
The commit here updates the user guide and adds a section for documenting the recent support available in Ant build tool for launching JUnit 5 tests. This relates to issue https://github.com/junit-team/junit5/issues/1352