### PR TITLE
Introduce variant of Assertions.fail() without arguments

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.2.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.2.0-M1.adoc
@@ -52,7 +52,8 @@ on GitHub.
   referenced by _fully qualified method name_.
 * Support for aggregation of multiple `@ParameterizedTest` arguments into a single
   object.
-
+* New `fail()` method in `Assertions` makes it possible to fail a test without an
+  explicit failure message.
 
 [[release-notes-5.2.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -32,6 +32,10 @@ class AssertionUtils {
 	}
 	///CLOVER:ON
 
+	static void fail() {
+		throw new AssertionFailedError();
+	}
+
 	static void fail(String message) {
 		throw new AssertionFailedError(message);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -53,6 +53,20 @@ public final class Assertions {
 	// --- fail ----------------------------------------------------------------
 
 	/**
+	 * <em>Fails</em> a test <em>without</em> a failure message.
+	 *
+	 * <p>While failing <em>with</em> a failure message is recommended
+	 * this method may be useful when maintaining legacy code.
+	 *
+	 * <p>See Javadoc for {@link #fail(String, Throwable)} for an explanation of
+	 * this method's generic return type {@code V}.
+	 */
+	public static <V> V fail() {
+		AssertionUtils.fail();
+		return null; // appeasing the compiler: this line will never be executed.
+	}
+
+	/**
 	 * <em>Fails</em> a test with the given failure {@code message}.
 	 *
 	 * <p>See Javadoc for {@link #fail(String, Throwable)} for an explanation of

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -55,7 +55,7 @@ public final class Assertions {
 	/**
 	 * <em>Fails</em> a test <em>without</em> a failure message.
 	 *
-	 * <p>While failing <em>with</em> a failure message is recommended
+	 * <p>Although failing <em>with</em> an explicit failure message is recommended,
 	 * this method may be useful when maintaining legacy code.
 	 *
 	 * <p>See Javadoc for {@link #fail(String, Throwable)} for an explanation of

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionTestUtils.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionTestUtils.java
@@ -28,6 +28,12 @@ class AssertionTestUtils {
 		throw new AssertionError("Should have thrown an " + AssertionFailedError.class.getName());
 	}
 
+	static void assertEmptyMessage(Throwable ex) throws AssertionError {
+		if (!ex.getMessage().isEmpty()) {
+			throw new AssertionError("Exception message should be an empty String, but was [" + ex.getMessage() + "].");
+		}
+	}
+
 	static void assertMessageEquals(Throwable ex, String msg) throws AssertionError {
 		if (!msg.equals(ex.getMessage())) {
 			throw new AssertionError("Exception message should be [" + msg + "], but was [" + ex.getMessage() + "].");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/FailAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/FailAssertionsTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertionTestUtils.assertEmptyMessage;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
@@ -27,6 +28,17 @@ import org.opentest4j.AssertionFailedError;
  * @since 5.0
  */
 class FailAssertionsTests {
+
+	@Test
+	void failWithoutArgument() {
+		try {
+			fail();
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertEmptyMessage(ex);
+		}
+	}
 
 	@Test
 	void failWithString() {


### PR DESCRIPTION
Issue: #1333

## Overview

Implemented as discussed to achieve a reasonable behaviour with both, the current and the upcoming versions of `opentest4j`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
