### PR TITLE
Introduce ReflectiveFieldArguments for parameterized tests

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ReflectiveFieldArguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ReflectiveFieldArguments.java
@@ -1,0 +1,21 @@
+package org.junit.jupiter.params.provider;
+
+import java.util.Arrays;
+
+/**
+ * helper class that can produce arguments based on the object field order. 
+ */
+public abstract class ReflectiveFieldArguments implements Arguments {
+
+	@Override
+	public Object[] get() {
+		return Arrays.stream(this.getClass().getDeclaredFields()).filter(f -> !f.isSynthetic()).map(f -> {
+			f.setAccessible(true);
+			try {
+				return f.get(this);
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException("Error while getting value for field '" + f.getName() + "' in " + this, e);
+			}
+		}).toArray(Object[]::new);
+	}
+}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ReflectiveFieldSourceTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ReflectiveFieldSourceTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @since 5.0
+ */
+class ReflectiveFieldSourceTests {
+
+	public class TestReflectiveFieldSource extends ReflectiveFieldArguments {
+
+		private final int i;
+		private final String s;
+		private final double v;
+
+		public TestReflectiveFieldSource(int i, String s, double v) {
+			this.i = i;
+			this.s = s;
+			this.v = v;
+		}
+	}
+
+	@Test
+	void providesOrder() {
+		Arguments arguments = new TestReflectiveFieldSource(1, "2", 3.0);
+
+		assertArrayEquals(new Object[] { 1, "2", 3.0 }, arguments.get());
+	}
+
+}


### PR DESCRIPTION
Hi there,

Maybe this pull request is considered useful as I'm probably going to use this quite often with Lombok's `@AllArgsConstructor` in our code base.

The basic idea is just to have a class with a field definition that automatically produces arguments that can be then used e.g via `@MethodSource`.

Any comments or feedback is greatly appreciated.

If you think if that is useful, I will clean up the code and complete the documentation.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
