### PR TITLE
Introduce JUnit BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,8 +292,6 @@ subprojects { subproj ->
 
 	if (subproj.name in mavenizedProjects) {
 
-		apply from: "$rootDir/gradle/maven.gradle"
-
 		subproj.ext.baseline = null
 
 		if (subproj.name in jupiterProjects) {
@@ -310,6 +308,9 @@ subprojects { subproj ->
 			subproj.version = vintageVersion
 			subproj.baseline = vintageBaseline
 		}
+
+		// apply after `project.group`, etc. have been set
+		apply from: "$rootDir/gradle/maven.gradle"
 
 		configurations {
 			base

--- a/build.gradle
+++ b/build.gradle
@@ -292,6 +292,8 @@ subprojects { subproj ->
 
 	if (subproj.name in mavenizedProjects) {
 
+		apply from: "$rootDir/gradle/maven.gradle"
+
 		subproj.ext.baseline = null
 
 		if (subproj.name in jupiterProjects) {
@@ -308,9 +310,6 @@ subprojects { subproj ->
 			subproj.version = vintageVersion
 			subproj.baseline = vintageBaseline
 		}
-
-		// apply after `project.group`, etc. have been set
-		apply from: "$rootDir/gradle/maven.gradle"
 
 		configurations {
 			base

--- a/build.gradle
+++ b/build.gradle
@@ -291,10 +291,16 @@ subprojects { subproj ->
 	}
 
 	if (subproj.name in mavenizedProjects) {
-		apply plugin: 'maven'
-		apply plugin: 'signing'
 
-		if (subproj.name in platformProjects) {
+		apply from: "$rootDir/gradle/maven.gradle"
+
+		subproj.ext.baseline = null
+
+		if (subproj.name in jupiterProjects) {
+			subproj.group = jupiterGroup
+			subproj.baseline = jupiterBaseline
+		}
+		else if (subproj.name in platformProjects) {
 			subproj.group = platformGroup
 			subproj.version = platformVersion
 			subproj.baseline = platformBaseline
@@ -371,102 +377,7 @@ subprojects { subproj ->
 			}
 		}
 
-		def isSnapshot = project.version.contains('SNAPSHOT')
-		def isContinuousIntegrationEnvironment = Boolean.parseBoolean(System.getenv('CI'))
-		def isJitPackEnvironment = Boolean.parseBoolean(System.getenv('JITPACK'))
-		def signArtifacts = !(isSnapshot || isContinuousIntegrationEnvironment || isJitPackEnvironment)
 
-		afterEvaluate {
-			if (signArtifacts && uploadArchives.enabled) {
-				signing {
-					sign configurations.archives
-				}
-			}
-		}
-
-		uploadArchives {
-
-			dependsOn check
-
-			repositories {
-				mavenDeployer {
-
-					if (signArtifacts) {
-						beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-					}
-
-					def ossrhUsername = rootProject.hasProperty('ossrhUsername') ? rootProject.ossrhUsername : ''
-					def ossrhPassword = rootProject.hasProperty('ossrhPassword') ? rootProject.ossrhPassword : ''
-
-					repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-						authentication(userName: ossrhUsername, password: ossrhPassword)
-					}
-
-					snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-						authentication(userName: ossrhUsername, password: ossrhPassword)
-					}
-
-					def projectLicense = licenseOf(project)
-
-					pom.project {
-						name "${project.group}:${project.name}"
-						packaging 'jar'
-						description "Module \"${project.name}\" of JUnit 5."
-						url 'http://junit.org/junit5/'
-
-						scm {
-							connection 'scm:git:git://github.com/junit-team/junit5.git'
-							developerConnection 'scm:git:git://github.com/junit-team/junit5.git'
-							url 'https://github.com/junit-team/junit5'
-						}
-
-						licenses {
-							license {
-								name projectLicense['name']
-								url projectLicense['url']
-							}
-						}
-
-						developers {
-							developer {
-								id 'bechte'
-								name 'Stefan Bechtold'
-								email 'stefan.bechtold@me.com'
-							}
-							developer {
-								id 'jlink'
-								name 'Johannes Link'
-								email 'business@johanneslink.net'
-							}
-							developer {
-								id 'marcphilipp'
-								name 'Marc Philipp'
-								email 'mail@marcphilipp.de'
-							}
-							developer {
-								id 'mmerdes'
-								name 'Matthias Merdes'
-								email 'Matthias.Merdes@heidelberg-mobil.com'
-							}
-							developer {
-								id 'sbrannen'
-								name 'Sam Brannen'
-								email 'sam@sambrannen.com'
-							}
-							developer {
-								id 'sormuras'
-								name 'Christian Stein'
-								email 'sormuras@gmail.com'
-							}
-						}
-					}
-
-					pom.whenConfigured { p ->
-						p.dependencies = p.dependencies.findAll { dep -> dep.scope != 'test' }
-					}
-				}
-			}
-		}
 	} else {
 		jar.enabled = false
 		javadoc.enabled = false

--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -105,6 +105,7 @@ asciidoctor {
 	attributes	'jupiter-version': project.property('version'),
 				'platform-version': project.property('platformVersion'),
 				'vintage-version': project.property('vintageVersion'),
+				'bom-version': project.property('version'),
 				'junit4-version': project.property('junit4Version'),
 				'apiguardian-version': project.property('apiGuardianVersion'),
 				'ota4j-version': project.property('ota4jVersion'),

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.2.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.2.0-M1.adoc
@@ -10,6 +10,16 @@ link:{junit5-repo}+/milestone/22?closed=1+[5.2 M1] milestone page in the JUnit r
 on GitHub.
 
 
+[[release-notes-5.2.0-M1-overall-improvements]]
+=== Overall Improvements
+
+* JUnit BOM: To ease dependency management using
+https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies[Maven]
+or https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:bom_import[Gradle],
+a Bill of Materials POM is now provided under the `org.junit:junit-bom:5.2.0-M1` Maven
+coordinates.
+
+
 [[release-notes-5.2.0-M1-junit-platform]]
 === JUnit Platform
 

--- a/documentation/src/docs/asciidoc/user-guide/overview.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/overview.adoc
@@ -122,6 +122,18 @@ Snapshot artifacts are deployed to Sonatype's {snapshot-repo}[snapshots reposito
     JUnit Vintage test engine implementation that allows to run vintage JUnit tests, i.e. tests
     written in the JUnit 3 or JUnit 4 style, on the new JUnit Platform.
 
+[[dependency-metadata-junit-bom]]
+==== Bill of Materials (BOM)
+
+The Bill of Materials POM provided under the following Maven coordinates can be used to
+ease dependency management when referencing multiple of the above artifacts using
+https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies[Maven]
+or https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:bom_import[Gradle].
+
+* *Group ID*: `org.junit`
+* *Artifact ID*: `junit-bom`
+* *Version*: `{bom-version}`
+
 [[dependency-metadata-dependencies]]
 ==== Dependencies
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
-group               = org.junit.jupiter
+group               = org.junit
 version             = 5.2.0-SNAPSHOT
-baseline            = 5.1.0
+
+jupiterGroup        = org.junit.jupiter
+jupiterBaseline     = 5.1.0
 
 platformGroup       = org.junit.platform
 platformVersion     = 1.2.0-SNAPSHOT

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -45,7 +45,6 @@ def mavenDeployer = uploadArchives.repositories.mavenDeployer
 
 [mavenInstaller, mavenDeployer]*.pom {
 	project {
-		name "${project.group}:${project.name}"
 		packaging 'jar'
 		description "Module \"${project.name}\" of JUnit 5."
 		url 'http://junit.org/junit5/'
@@ -97,6 +96,8 @@ def mavenDeployer = uploadArchives.repositories.mavenDeployer
 		}
 	}
 	whenConfigured {
+		// set name lazily to get access to description from subprojects
+		name = project.description ?: "${project.group}:${project.name}"
 		dependencies = dependencies.findAll { dep -> dep.scope != 'test' }
 	}
 }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -35,65 +35,68 @@ uploadArchives {
 			snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
 				authentication(userName: ossrhUsername, password: ossrhPassword)
 			}
+		}
+	}
+}
 
-			def projectLicense = licenseOf(project)
+def projectLicense = licenseOf(project)
+def mavenInstaller = install.repositories.mavenInstaller
+def mavenDeployer = uploadArchives.repositories.mavenDeployer
 
-			pom.project {
-				name "${project.group}:${project.name}"
-				packaging 'jar'
-				description "Module \"${project.name}\" of JUnit 5."
-				url 'http://junit.org/junit5/'
+[mavenInstaller, mavenDeployer]*.pom {
+	project {
+		name "${project.group}:${project.name}"
+		packaging 'jar'
+		description "Module \"${project.name}\" of JUnit 5."
+		url 'http://junit.org/junit5/'
 
-				scm {
-					connection 'scm:git:git://github.com/junit-team/junit5.git'
-					developerConnection 'scm:git:git://github.com/junit-team/junit5.git'
-					url 'https://github.com/junit-team/junit5'
-				}
+		scm {
+			connection 'scm:git:git://github.com/junit-team/junit5.git'
+			developerConnection 'scm:git:git://github.com/junit-team/junit5.git'
+			url 'https://github.com/junit-team/junit5'
+		}
 
-				licenses {
-					license {
-						name projectLicense['name']
-						url projectLicense['url']
-					}
-				}
-
-				developers {
-					developer {
-						id 'bechte'
-						name 'Stefan Bechtold'
-						email 'stefan.bechtold@me.com'
-					}
-					developer {
-						id 'jlink'
-						name 'Johannes Link'
-						email 'business@johanneslink.net'
-					}
-					developer {
-						id 'marcphilipp'
-						name 'Marc Philipp'
-						email 'mail@marcphilipp.de'
-					}
-					developer {
-						id 'mmerdes'
-						name 'Matthias Merdes'
-						email 'Matthias.Merdes@heidelberg-mobil.com'
-					}
-					developer {
-						id 'sbrannen'
-						name 'Sam Brannen'
-						email 'sam@sambrannen.com'
-					}
-					developer {
-						id 'sormuras'
-						name 'Christian Stein'
-						email 'sormuras@gmail.com'
-					}
-				}
-			}
-
-			pom.whenConfigured {
-				dependencies = dependencies.findAll { dep -> dep.scope != 'test' }
+		licenses {
+			license {
+				name projectLicense['name']
+				url projectLicense['url']
 			}
 		}
+
+		developers {
+			developer {
+				id 'bechte'
+				name 'Stefan Bechtold'
+				email 'stefan.bechtold@me.com'
+			}
+			developer {
+				id 'jlink'
+				name 'Johannes Link'
+				email 'business@johanneslink.net'
+			}
+			developer {
+				id 'marcphilipp'
+				name 'Marc Philipp'
+				email 'mail@marcphilipp.de'
+			}
+			developer {
+				id 'mmerdes'
+				name 'Matthias Merdes'
+				email 'Matthias.Merdes@heidelberg-mobil.com'
+			}
+			developer {
+				id 'sbrannen'
+				name 'Sam Brannen'
+				email 'sam@sambrannen.com'
+			}
+			developer {
+				id 'sormuras'
+				name 'Christian Stein'
+				email 'sormuras@gmail.com'
+			}
+		}
+	}
+	whenConfigured {
+		dependencies = dependencies.findAll { dep -> dep.scope != 'test' }
 	}
 }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,0 +1,99 @@
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+def isSnapshot = project.version.contains('SNAPSHOT')
+def isContinuousIntegrationEnvironment = Boolean.parseBoolean(System.getenv('CI'))
+def isJitPackEnvironment = Boolean.parseBoolean(System.getenv('JITPACK'))
+def signArtifacts = !(isSnapshot || isContinuousIntegrationEnvironment || isJitPackEnvironment)
+
+afterEvaluate {
+	if (signArtifacts && uploadArchives.enabled) {
+		signing {
+			sign configurations.archives
+		}
+	}
+}
+
+uploadArchives {
+
+	dependsOn check
+
+	repositories {
+		mavenDeployer {
+
+			if (signArtifacts) {
+				beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+			}
+
+			def ossrhUsername = rootProject.hasProperty('ossrhUsername') ? rootProject.ossrhUsername : ''
+			def ossrhPassword = rootProject.hasProperty('ossrhPassword') ? rootProject.ossrhPassword : ''
+
+			repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+				authentication(userName: ossrhUsername, password: ossrhPassword)
+			}
+
+			snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+				authentication(userName: ossrhUsername, password: ossrhPassword)
+			}
+
+			def projectLicense = licenseOf(project)
+
+			pom.project {
+				name "${project.group}:${project.name}"
+				packaging 'jar'
+				description "Module \"${project.name}\" of JUnit 5."
+				url 'http://junit.org/junit5/'
+
+				scm {
+					connection 'scm:git:git://github.com/junit-team/junit5.git'
+					developerConnection 'scm:git:git://github.com/junit-team/junit5.git'
+					url 'https://github.com/junit-team/junit5'
+				}
+
+				licenses {
+					license {
+						name projectLicense['name']
+						url projectLicense['url']
+					}
+				}
+
+				developers {
+					developer {
+						id 'bechte'
+						name 'Stefan Bechtold'
+						email 'stefan.bechtold@me.com'
+					}
+					developer {
+						id 'jlink'
+						name 'Johannes Link'
+						email 'business@johanneslink.net'
+					}
+					developer {
+						id 'marcphilipp'
+						name 'Marc Philipp'
+						email 'mail@marcphilipp.de'
+					}
+					developer {
+						id 'mmerdes'
+						name 'Matthias Merdes'
+						email 'Matthias.Merdes@heidelberg-mobil.com'
+					}
+					developer {
+						id 'sbrannen'
+						name 'Sam Brannen'
+						email 'sam@sambrannen.com'
+					}
+					developer {
+						id 'sormuras'
+						name 'Christian Stein'
+						email 'sormuras@gmail.com'
+					}
+				}
+			}
+
+			pom.whenConfigured {
+				dependencies = dependencies.findAll { dep -> dep.scope != 'test' }
+			}
+		}
+	}
+}

--- a/junit-bom/README.md
+++ b/junit-bom/README.md
@@ -1,0 +1,9 @@
+# Module junit-bom
+
+This module provides a Bill of Materials POM to ease dependency management
+using Maven [1] or Gradle [2]. Please refer to the JUnit 5 User Guide [3] for
+details.
+
+[1] https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies
+[2] https://docs.gradle.org/4.6-rc-1/userguide/managing_transitive_dependencies.html#sec:bom_import
+[3] https://junit.org/junit5/docs/current/user-guide/#dependency-metadata-junit-bom

--- a/junit-bom/README.md
+++ b/junit-bom/README.md
@@ -5,5 +5,5 @@ using Maven [1] or Gradle [2]. Please refer to the JUnit 5 User Guide [3] for
 details.
 
 [1] https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies
-[2] https://docs.gradle.org/4.6-rc-1/userguide/managing_transitive_dependencies.html#sec:bom_import
+[2] https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:bom_import
 [3] https://junit.org/junit5/docs/current/user-guide/#dependency-metadata-junit-bom

--- a/junit-bom/junit-bom.gradle
+++ b/junit-bom/junit-bom.gradle
@@ -1,0 +1,41 @@
+description = rootProject.description + " (Bill of Materials)"
+
+configurations.archives.artifacts.clear()
+artifacts {
+	archives file("README.md") // work around GRADLE-2406 by attaching text artifact
+}
+
+apply from: "$rootDir/gradle/maven.gradle"
+
+uploadArchives {
+	enabled = true
+	repositories.mavenDeployer.pom {
+		project {
+			artifactId = project.name
+			name = project.description
+			description = project.description
+		}
+		whenConfigured {
+			packaging = "pom"
+			dependencies = []
+			withXml {
+				asNode().children().last() + {
+					delegate.dependencyManagement {
+						delegate.dependencies {
+							parent.mavenizedProjects.sort()
+								.findAll { name -> project.name != name }
+								.collect { name -> rootProject.project(name) }
+								.each { project ->
+									delegate.dependency {
+										delegate.groupId(project.group)
+										delegate.artifactId(project.name)
+										delegate.version(project.version)
+									}
+								}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/junit-bom/junit-bom.gradle
+++ b/junit-bom/junit-bom.gradle
@@ -15,7 +15,6 @@ def mavenDeployer = uploadArchives.repositories.mavenDeployer
 [mavenInstaller, mavenDeployer]*.pom {
 	project {
 		artifactId = project.name
-		name = project.description
 		description = project.description
 	}
 	whenConfigured {

--- a/junit-bom/junit-bom.gradle
+++ b/junit-bom/junit-bom.gradle
@@ -7,32 +7,34 @@ artifacts {
 
 apply from: "$rootDir/gradle/maven.gradle"
 
-uploadArchives {
-	enabled = true
-	repositories.mavenDeployer.pom {
-		project {
-			artifactId = project.name
-			name = project.description
-			description = project.description
-		}
-		whenConfigured {
-			packaging = "pom"
-			dependencies = []
-			withXml {
-				asNode().children().last() + {
-					delegate.dependencyManagement {
-						delegate.dependencies {
-							parent.mavenizedProjects.sort()
-								.findAll { name -> project.name != name }
-								.collect { name -> rootProject.project(name) }
-								.each { project ->
-									delegate.dependency {
-										delegate.groupId(project.group)
-										delegate.artifactId(project.name)
-										delegate.version(project.version)
-									}
+uploadArchives.enabled = true
+
+def mavenInstaller = install.repositories.mavenInstaller
+def mavenDeployer = uploadArchives.repositories.mavenDeployer
+
+[mavenInstaller, mavenDeployer]*.pom {
+	project {
+		artifactId = project.name
+		name = project.description
+		description = project.description
+	}
+	whenConfigured {
+		packaging = 'pom'
+		dependencies = []
+		withXml {
+			asNode().children().last() + {
+				delegate.dependencyManagement {
+					delegate.dependencies {
+						parent.mavenizedProjects.sort()
+							.findAll { name -> name != 'junit-platform-console-standalone' }
+							.collect { name -> rootProject.project(name) }
+							.each { project ->
+								delegate.dependency {
+									delegate.groupId(project.group)
+									delegate.artifactId(project.name)
+									delegate.version(project.version)
 								}
-						}
+							}
 					}
 				}
 			}

--- a/junit-jupiter-api/junit-jupiter-api.gradle
+++ b/junit-jupiter-api/junit-jupiter-api.gradle
@@ -1,3 +1,5 @@
+description = 'JUnit Jupiter API'
+
 dependencies {
 	api("org.opentest4j:opentest4j:${ota4jVersion}")
 	api(project(":junit-platform-commons"))

--- a/junit-jupiter-engine/junit-jupiter-engine.gradle
+++ b/junit-jupiter-engine/junit-jupiter-engine.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
+description = 'JUnit Jupiter Engine'
+
 junitPlatform {
 	filters {
 		engines {

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
+description = 'JUnit Jupiter Migration Support'
+
 junitPlatform {
 	filters {
 		engines {

--- a/junit-jupiter-params/junit-jupiter-params.gradle
+++ b/junit-jupiter-params/junit-jupiter-params.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'com.github.johnrengelman.shadow'
 
+description = 'JUnit Jupiter Params'
+
 buildscript {
 	repositories {
 		jcenter()

--- a/junit-platform-commons/junit-platform-commons.gradle
+++ b/junit-platform-commons/junit-platform-commons.gradle
@@ -1,3 +1,5 @@
+description = 'JUnit Platform Commons'
+
 jar {
 	manifest {
 		attributes(

--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'java-library'
 apply plugin: 'com.github.johnrengelman.shadow'
 
+description = 'JUnit Platform Console Standalone'
+
 buildscript {
 	repositories {
 		jcenter()

--- a/junit-platform-console/junit-platform-console.gradle
+++ b/junit-platform-console/junit-platform-console.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.github.johnrengelman.shadow'
 
+description = 'JUnit Platform Console'
+
 buildscript {
 	repositories {
 		jcenter()

--- a/junit-platform-engine/junit-platform-engine.gradle
+++ b/junit-platform-engine/junit-platform-engine.gradle
@@ -1,3 +1,5 @@
+description = 'JUnit Platform Engine API'
+
 configurations {
 	testArtifacts.extendsFrom testRuntime
 }

--- a/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
+++ b/junit-platform-gradle-plugin/junit-platform-gradle-plugin.gradle
@@ -5,6 +5,8 @@ plugins {
 
 apply from: 'gradle/functional-test.gradle'
 
+description = 'JUnit Platform Gradle Plugin (deprecated)'
+
 generateJacocoTestKitProperties {
 	destinationFile = file("$buildDir/jacoco/testkit.exec")
 	onlyIf { project.hasProperty('enableJaCoCo') }

--- a/junit-platform-launcher/junit-platform-launcher.gradle
+++ b/junit-platform-launcher/junit-platform-launcher.gradle
@@ -1,3 +1,5 @@
+description = 'JUnit Platform Launcher'
+
 dependencies {
 	api(project(':junit-platform-engine'))
 }

--- a/junit-platform-runner/junit-platform-runner.gradle
+++ b/junit-platform-runner/junit-platform-runner.gradle
@@ -1,3 +1,5 @@
+description = 'JUnit Platform Runner'
+
 dependencies {
 	api(project(':junit-platform-launcher'))
 	api(project(':junit-platform-suite-api'))

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle
@@ -1,3 +1,5 @@
+description = 'JUnit Platform Suite API'
+
 dependencies {
 	api(project(':junit-platform-commons'))
 }

--- a/junit-platform-surefire-provider/junit-platform-surefire-provider.gradle
+++ b/junit-platform-surefire-provider/junit-platform-surefire-provider.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
+description = "JUnit Platform Surefire Provider"
+
 junitPlatform {
 	filters {
 		engines {

--- a/junit-vintage-engine/junit-vintage-engine.gradle
+++ b/junit-vintage-engine/junit-vintage-engine.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'org.junit.platform.gradle.plugin'
 
+description = 'JUnit Vintage Engine'
+
 junitPlatform {
 	filters {
 		engines {

--- a/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
+++ b/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
@@ -68,6 +68,7 @@ class AutomaticModuleNameTests {
 				.filter(line -> line.startsWith(startOfModuleLine))
 				.map(line -> line.substring(startOfModuleLine.length(), line.length() - 1))
 				.filter(name -> !name.equals("junit-platform-console-standalone"))
+				.filter(name -> !name.equals("junit-bom"))
 				.filter(name -> !name.endsWith("-java-9"))
 				.filter(name -> name.startsWith("junit-"))) {
 			return stream.collect(Collectors.toList());

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ include 'junit-platform-suite-api'
 include 'junit-platform-surefire-provider'
 include 'junit-vintage-engine'
 include 'platform-tests'
+include 'junit-bom'
 
 // check that every subproject has a custom build file
 // based on the project name


### PR DESCRIPTION
This pull request introduces the `junit-bom` subproject. In order to reuse build logic it was moved to `gradle/maven.gradle`. In addition, `gradle install` and `gradle uploadArchives` now use the same POM configuration.

Resolves #316.