### PR TITLE
Add link to RepetitionInfoParameterResolver in User Guide

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -69,6 +69,7 @@ endif::[]
 //
 :DisabledCondition:                 {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/DisabledCondition.java[DisabledCondition]
 :TestInfoParameterResolver:         {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java[TestInfoParameterResolver]
+:RepetitionInfoParameterResolver:   {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java[RepetitionInfoParameterResolver]
 :TestReporterParameterResolver:     {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestReporterParameterResolver.java[TestReporterParameterResolver]
 :CustomAnnotationParameterResolver: {current-branch}/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/CustomAnnotationParameterResolver.java[CustomAnnotationParameterResolver]
 :CustomTypeParameterResolver:       {current-branch}/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/CustomTypeParameterResolver.java[CustomTypeParameterResolver]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -446,7 +446,7 @@ following demonstrates how to have `TestInfo` injected into a test constructor,
 include::{testDir}/example/TestInfoDemo.java[tags=user_guide]
 ----
 
-* `RepetitionInfoParameterResolver`: if a method parameter in a `@RepeatedTest`,
+* `{RepetitionInfoParameterResolver}`: if a method parameter in a `@RepeatedTest`,
   `@BeforeEach`, or `@AfterEach` method is of type `{RepetitionInfo}`, the
   `RepetitionInfoParameterResolver` will supply an instance of `RepetitionInfo`.
   `RepetitionInfo` can then be used to retrieve information about the current repetition


### PR DESCRIPTION
I added a link to `RepetitionInfoParameterResolver.java` from User Guide ("3.11. Dependency Injection for Constructors and Methods") because other two resolvers (i.e. `TestInfoParameterResolver` and `TestReporterParameterResolver`) have links to their source code.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).
