### PR TITLE
Introduce TestWatcher extension API for processing test execution results

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -88,6 +88,7 @@ endif::[]
 :TestTemplate:                           {javadoc-root}/org/junit/jupiter/api/TestTemplate.html[@TestTemplate]
 :TestTemplateInvocationContext:          {javadoc-root}/org/junit/jupiter/api/extension/TestTemplateInvocationContext.html[TestTemplateInvocationContext]
 :TestTemplateInvocationContextProvider:  {javadoc-root}/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.html[TestTemplateInvocationContextProvider]
+:TestWatcher:                            {javadoc-root}/org/junit/jupiter/api/extension/TestWatcher.html[TestWatcher]
 //
 :DisabledCondition:                      {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/DisabledCondition.java[DisabledCondition]
 :RepetitionInfoParameterResolver:        {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java[RepetitionInfoParameterResolver]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -89,6 +89,8 @@ repository on GitHub.
   methods via the `junit-jupiter-migrationsupport` module.
   - See the <<../user-guide/index.adoc#migrating-from-junit4-ignore-annotation-support,
     User Guide>> for details.
+* New TestWatcher extension API allows extensions to process test results by defining
+result based callbacks invoked after text execution.
 
 
 [[release-notes-5.4.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -330,6 +330,26 @@ those provided in `java.lang.reflect.Parameter` in order to avoid this bug in th
 * `List<A> findRepeatableAnnotations(Class<A> annotationType)`
 ====
 
+[[extensions-test-result-processing]]
+=== Test result processing
+
+`{TestWatcher}` defines the API for extensions that wish to process test results.
+
+Test methods extended with any number of TestWatcher extensions will
+have their results reported to each of them, by invoking the interface method
+corresponding to the test result. Methods are injected with the current ExtensionContext
+and the cause of a failed/aborted/skipped execution, where applicable.
+
+Extensions implementing this interface can also be registered at the class level,
+and will be invoked for any contained tests including nested classes.
+
+[WARNING]
+====
+Any instances of `ExtensionContext.Store.CloseableResource` stored in the provided
+`{ExtensionContext}` will be closed (see <<extensions-keeping-state>>). You can use the
+parent context's store to operate with such resources.
+====
+
 [[extensions-lifecycle-callbacks]]
 === Test Lifecycle Callbacks
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestWatcher.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestWatcher.java
@@ -10,11 +10,11 @@
 
 package org.junit.jupiter.api.extension;
 
-import org.apiguardian.api.API;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Optional;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import org.apiguardian.api.API;
 
 /**
  * The {@code TestWatcher} interface defines an extension API for processing test results.
@@ -38,8 +38,7 @@ public interface TestWatcher extends Extension {
 	 *
 	 * @param context the current extension context; never {@code null}
 	 */
-	default void testSuccessful(ExtensionContext context) {
-	}
+	void testSuccessful(ExtensionContext context);
 
 	/**
 	 * Invoked after a test was aborted.
@@ -47,8 +46,7 @@ public interface TestWatcher extends Extension {
 	 * @param context the current extension context; never {@code null}
 	 * @param cause the throwable responsible for the test being aborted; may be {@code null}
 	 */
-	default void testAborted(ExtensionContext context, Throwable cause) {
-	}
+	void testAborted(ExtensionContext context, Throwable cause);
 
 	/**
 	 * Invoked after a test has failed.
@@ -56,8 +54,7 @@ public interface TestWatcher extends Extension {
 	 * @param context the current extension context; never {@code null}
 	 * @param cause the throwable that caused test failure; may be {@code null}
 	 */
-	default void testFailed(ExtensionContext context, Throwable cause) {
-	}
+	void testFailed(ExtensionContext context, Throwable cause);
 
 	/**
 	 * Invoked after skipping a disabled test.
@@ -65,6 +62,5 @@ public interface TestWatcher extends Extension {
 	 * @param context the current extension context; never {@code null}
 	 * @param reason the reason for skipping the test; never {@code null}
 	 */
-	default void testDisabled(ExtensionContext context, Optional<String> reason) {
-	}
+	void testDisabled(ExtensionContext context, Optional<String> reason);
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestWatcher.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestWatcher.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import java.util.Optional;
+
+public interface TestWatcher extends Extension {
+
+	default void testSuccessful(String identifier, ExtensionContext context) {
+	}
+
+	default void testAborted(String identifier, Throwable cause, ExtensionContext context) {
+	}
+
+	default void testFailed(String identifier, Throwable cause, ExtensionContext context) {
+	}
+
+	default void testSkipped(String identifier, Optional<String> Reason, ExtensionContext context) {
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestWatcher.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestWatcher.java
@@ -10,19 +10,61 @@
 
 package org.junit.jupiter.api.extension;
 
+import org.apiguardian.api.API;
+
 import java.util.Optional;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+/**
+ * The {@code TestWatcher} interface defines an extension API for processing test results.
+ *
+ * <p> Interface methods are called after a test has been processed. Currently,
+ * only method based tests will be reported.
+ *
+ * <p>Extensions implementing this API can be registered at any level, reporting subsequent
+ * tests down the chain.
+ *
+ * <p>Any {@code ClosableResource} objects stored in the injected {@link ExtensionContext}
+ * have already been <strong>closed</strong> at invocation time.
+ *
+ * @since 5.4
+ */
+@API(status = EXPERIMENTAL, since = "5.4")
 public interface TestWatcher extends Extension {
 
+	/**
+	 * Invoked after a test has completed successfully.
+	 *
+	 * @param context the current extension context; never {@code null}
+	 */
 	default void testSuccessful(ExtensionContext context) {
 	}
 
+	/**
+	 * Invoked after a test was aborted.
+	 *
+	 * @param context the current extension context; never {@code null}
+	 * @param cause the throwable responsible for the test being aborted; may be {@code null}
+	 */
 	default void testAborted(ExtensionContext context, Throwable cause) {
 	}
 
+	/**
+	 * Invoked after a test has failed.
+	 *
+	 * @param context the current extension context; never {@code null}
+	 * @param cause the throwable that caused test failure; may be {@code null}
+	 */
 	default void testFailed(ExtensionContext context, Throwable cause) {
 	}
 
+	/**
+	 * Invoked after skipping a disabled test.
+	 *
+	 * @param context the current extension context; never {@code null}
+	 * @param reason the reason for skipping the test; never {@code null}
+	 */
 	default void testDisabled(ExtensionContext context, Optional<String> reason) {
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestWatcher.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestWatcher.java
@@ -14,15 +14,15 @@ import java.util.Optional;
 
 public interface TestWatcher extends Extension {
 
-	default void testSuccessful(String identifier, ExtensionContext context) {
+	default void testSuccessful(ExtensionContext context) {
 	}
 
-	default void testAborted(String identifier, Throwable cause, ExtensionContext context) {
+	default void testAborted(ExtensionContext context, Throwable cause) {
 	}
 
-	default void testFailed(String identifier, Throwable cause, ExtensionContext context) {
+	default void testFailed(ExtensionContext context, Throwable cause) {
 	}
 
-	default void testSkipped(String identifier, Optional<String> Reason, ExtensionContext context) {
+	default void testDisabled(ExtensionContext context, Optional<String> reason) {
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -237,30 +237,34 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 
 	@Override
 	public void nodeSkipped(JupiterEngineExecutionContext context, TestDescriptor descriptor, SkipResult result) {
-		invokeTestWatchers(context, t -> {
-			t.testSkipped(createTestIdentifier(), result.getReason(), context.getExtensionContext());
-		});
+		if (context != null) {
+			invokeTestWatchers(context, t -> {
+				t.testSkipped(createTestIdentifier(), result.getReason(), context.getExtensionContext());
+			});
+		}
 	}
 
 	@Override
 	public void nodeFinished(JupiterEngineExecutionContext context, TestDescriptor descriptor,
 			TestExecutionResult result) {
-		invokeTestWatchers(context, t -> {
-			ExtensionContext extensionContext = context.getExtensionContext();
-			Status status = result.getStatus();
-			String identifier = createTestIdentifier();
-			switch (status) {
-				case SUCCESSFUL:
-					t.testSuccessful(identifier, extensionContext);
-					break;
-				case FAILED:
-					t.testFailed(identifier, result.getThrowable().get(), extensionContext);
-					break;
-				case ABORTED:
-					t.testAborted(identifier, result.getThrowable().get(), extensionContext);
-					break;
-			}
-		});
+		if (context != null) {
+			invokeTestWatchers(context, t -> {
+				ExtensionContext extensionContext = context.getExtensionContext();
+				TestExecutionResult.Status status = result.getStatus();
+				String identifier = createTestIdentifier();
+				switch (status) {
+					case SUCCESSFUL:
+						t.testSuccessful(identifier, extensionContext);
+						break;
+					case FAILED:
+						t.testFailed(identifier, result.getThrowable().get(), extensionContext);
+						break;
+					case ABORTED:
+						t.testAborted(identifier, result.getThrowable().get(), extensionContext);
+						break;
+				}
+			});
+		}
 	}
 
 	private void invokeTestWatchers(JupiterEngineExecutionContext context, Consumer<TestWatcher> callback) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -13,7 +13,6 @@ package org.junit.jupiter.engine.descriptor;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.ExtensionUtils.populateNewExtensionRegistryFromExtendWithAnnotation;
 import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.createThrowableCollector;
-import static org.junit.platform.engine.TestExecutionResult.Status;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -37,6 +36,7 @@ import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
@@ -278,11 +278,10 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 			try {
 				callback.accept(watcher);
 			}
-			catch (Exception e) {
-				logger.warn(() -> {
-					return String.format("Error invoking TestWatcher %s for test %s : %s", watcher.getClass().getName(),
-						e);
-				});
+			catch (Throwable throwable) {
+				BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+				logger.warn(throwable, () -> String.format("Failed to invoke TestWatcher %s for test %s",
+					watcher.getClass().getName(), context.getExtensionContext().getUniqueId()));
 			}
 		});
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -38,6 +38,7 @@ import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
@@ -279,9 +280,13 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 				callback.accept(watcher);
 			}
 			catch (Throwable throwable) {
+				ExtensionContext extensionContext = context.getExtensionContext();
 				BlacklistedExceptions.rethrowIfBlacklisted(throwable);
-				logger.warn(throwable, () -> String.format("Failed to invoke TestWatcher %s for test %s",
-					watcher.getClass().getName(), context.getExtensionContext().getUniqueId()));
+				logger.warn(throwable,
+					() -> String.format("Failed to invoke TestWatcher %s for test %s", watcher.getClass().getName(),
+						ReflectionUtils.getFullyQualifiedMethodName(extensionContext.getRequiredTestClass(),
+							extensionContext.getRequiredTestMethod().getName(),
+							extensionContext.getRequiredTestMethod().getParameterTypes())));
 			}
 		});
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+
+@Disabled
+public class TestWatcherTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void testWatcherValidityIncludingNestedTest() {
+		ExecutionEventRecorder recorder = executeTestsForClass(nestedTestWatcherTestCase.class);
+		assertEquals(0, recorder.getContainerFailedCount());
+	}
+
+	@ExtendWith(TestResultAggregator.class)
+	static class nestedTestWatcherTestCase {
+
+		@Test
+		public void successfulTest() {
+			//no-op
+		}
+
+		@Test
+		public void failedTest() {
+			fail("Must fail");
+		}
+
+		@Test
+		public void abortedTest() {
+			Assumptions.assumeTrue(false);
+		}
+
+		@Test
+		@Disabled
+		public void skippedTest() {
+			//no-op
+		}
+
+		@Nested
+		class secondLevelTestWatcherTestCase {
+			@Test
+			public void successfulTest() {
+				//no-op
+			}
+
+			@Test
+			public void failedTest() {
+				fail("Must fail");
+			}
+
+			@Test
+			public void abortedTest() {
+				Assumptions.assumeTrue(false);
+			}
+
+			@Test
+			@Disabled
+			public void skippedTest() {
+				//no-op
+			}
+		}
+
+	}
+
+	public static class TestResultAggregator implements TestWatcher, AfterAllCallback {
+
+		private Map<String, List<String>> results = new HashMap<>();
+
+		@Override
+		public void testSuccessful(String descriptor, ExtensionContext context) {
+			storeResult("SUCCESSFUL", descriptor);
+		}
+
+		@Override
+		public void testAborted(String descriptor, Throwable cause, ExtensionContext context) {
+			storeResult("ABORTED", descriptor);
+		}
+
+		@Override
+		public void testFailed(String descriptor, Throwable cause, ExtensionContext context) {
+			storeResult("FAILED", descriptor);
+		}
+
+		@Override
+		public void testSkipped(String descriptor, Optional<String> Reason, ExtensionContext context) {
+			storeResult("SKIPPED", descriptor);
+		}
+
+		private void storeResult(String status, String method) {
+			List<String> l = results.get(status);
+			if (l == null) {
+				l = new ArrayList<>();
+			}
+			l.add(method);
+			results.put(status, l);
+		}
+
+		@Override
+		public void afterAll(ExtensionContext context) throws Exception {
+			this.results.entrySet().stream().forEach(resultType -> assertEquals(2, resultType.getValue().size()));
+		}
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
@@ -10,14 +10,18 @@
 
 package org.junit.jupiter.engine.extension;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
@@ -28,18 +32,46 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.logging.LogRecordListener;
+import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 
 class TestWatcherTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void testWatcherValidityIncludingNestedTest() {
-		ExecutionEventRecorder recorder = executeTestsForClass(NestedTestWatcherTestCase.class);
+		ExecutionEventRecorder recorder = executeTestsForClass(TestWatcherValidityTestCase.class);
 		assertEquals(0, recorder.getContainerFailedCount());
 	}
 
-	@ExtendWith(TestResultAggregator.class)
-	static class NestedTestWatcherTestCase {
+	@Test
+	void testWatcherExceptionsAreLoggedAndSwallowedTest() {
+
+		List<String> testWatcherMethodNames = getTestWatcherMethodNames();
+
+		LogRecordListener listener = new LogRecordListener();
+		LoggerFactory.addListener(listener);
+		ExecutionEventRecorder recorder = executeTestsForClass(TestWatcherSimpleExceptionHandlingTestCase.class);
+		LoggerFactory.removeListener(listener);
+
+		assertAll(
+			() -> assertEquals(8,
+				listener.stream().filter(l -> l.getSourceClassName().equals(TestMethodTestDescriptor.class.getName())
+						&& l.getSourceMethodName().contains("invokeTestWatchers")
+						&& l.getThrown() instanceof JUnitException
+						&& testWatcherMethodNames.contains(l.getThrown().getStackTrace()[0].getMethodName())).count(),
+				"Thrown exceptions were not logged properly."),
+			() -> assertEquals(2, recorder.getTestFailedCount(), "Thrown exceptions were not successfully caught."));
+	}
+
+	static List<String> getTestWatcherMethodNames() {
+		Method[] methods = TestWatcher.class.getDeclaredMethods();
+		return Arrays.stream(methods).map(Method::getName).collect(Collectors.toList());
+	}
+
+	static class BaseTestWatcherNestedTestCase {
 
 		@Test
 		public void successfulTest() {
@@ -85,12 +117,19 @@ class TestWatcherTests extends AbstractJupiterTestEngineTests {
 				//no-op
 			}
 		}
-
 	}
 
-	public static class TestResultAggregator implements TestWatcher, AfterAllCallback {
+	@ExtendWith(TestWatcherValidityCheckingWatcher.class)
+	static class TestWatcherValidityTestCase extends BaseTestWatcherNestedTestCase {
+	}
 
-		private Map<String, List<String>> results = new HashMap<>();
+	@ExtendWith(ExceptionThrowingTestWatcher.class)
+	static class TestWatcherSimpleExceptionHandlingTestCase extends BaseTestWatcherNestedTestCase {
+	}
+
+	static class TestResultAggregator implements TestWatcher {
+
+		protected Map<String, List<String>> results = new HashMap<>();
 
 		@Override
 		public void testSuccessful(ExtensionContext context) {
@@ -112,15 +151,39 @@ class TestWatcherTests extends AbstractJupiterTestEngineTests {
 			storeResult("SKIPPED", context.getUniqueId());
 		}
 
-		private void storeResult(String status, String method) {
-			List<String> l = results.computeIfAbsent(status, k -> new ArrayList<String>());
+		protected void storeResult(String status, String method) {
+			List<String> l = results.computeIfAbsent(status, k -> new ArrayList<>());
 			l.add(method);
 			results.put(status, l);
 		}
+	}
+
+	static class TestWatcherValidityCheckingWatcher extends TestResultAggregator implements AfterAllCallback {
+		@Override
+		public void afterAll(ExtensionContext context) {
+			this.results.values().forEach(idList -> assertEquals(2, idList.size()));
+		}
+	}
+
+	static class ExceptionThrowingTestWatcher implements TestWatcher {
+		@Override
+		public void testSuccessful(ExtensionContext context) {
+			throw new JUnitException("Exception in testSuccessful ");
+		}
 
 		@Override
-		public void afterAll(ExtensionContext context) throws Exception {
-			this.results.values().forEach(idList -> assertEquals(2, idList.size()));
+		public void testDisabled(ExtensionContext context, Optional<String> reason) {
+			throw new JUnitException("Exception in testDisabled");
+		}
+
+		@Override
+		public void testAborted(ExtensionContext context, Throwable cause) {
+			throw new JUnitException("Exception in testAborted");
+		}
+
+		@Override
+		public void testFailed(ExtensionContext context, Throwable cause) {
+			throw new JUnitException("Exception in testFailed");
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
@@ -36,14 +36,14 @@ import org.junit.jupiter.engine.TrackLogRecords;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.LogRecordListener;
-import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
 
 class TestWatcherTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void testWatcherValidityIncludingNestedTest() {
-		ExecutionEventRecorder recorder = executeTestsForClass(TestWatcherValidityTestCase.class);
-		assertEquals(0, recorder.getContainerFailedCount());
+		EngineExecutionResults engineExecutionResults = executeTestsForClass(TestWatcherValidityTestCase.class);
+		assertEquals(0, engineExecutionResults.containers().failed().count());
 	}
 
 	@Test
@@ -51,7 +51,8 @@ class TestWatcherTests extends AbstractJupiterTestEngineTests {
 	void testWatcherExceptionsAreLoggedAndSwallowedTest(LogRecordListener logRecordListener) {
 
 		List<String> testWatcherMethodNames = getTestWatcherMethodNames();
-		ExecutionEventRecorder recorder = executeTestsForClass(TestWatcherSimpleExceptionHandlingTestCase.class);
+		EngineExecutionResults engineExecutionResults = executeTestsForClass(
+			TestWatcherSimpleExceptionHandlingTestCase.class);
 
 		assertAll(
 			() -> assertEquals(8,
@@ -61,7 +62,8 @@ class TestWatcherTests extends AbstractJupiterTestEngineTests {
 							&& testWatcherMethodNames.contains(
 								listener.getThrown().getStackTrace()[0].getMethodName())).count(),
 				"Thrown exceptions were not logged properly."),
-			() -> assertEquals(2, recorder.getTestFailedCount(), "Thrown exceptions were not successfully caught."));
+			() -> assertEquals(2, engineExecutionResults.tests().failed().count(),
+				"Thrown exceptions were not successfully caught."));
 	}
 
 	static List<String> getTestWatcherMethodNames() {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 
-@Disabled
 public class TestWatcherTests extends AbstractJupiterTestEngineTests {
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
@@ -30,16 +30,16 @@ import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 
-public class TestWatcherTests extends AbstractJupiterTestEngineTests {
+class TestWatcherTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void testWatcherValidityIncludingNestedTest() {
-		ExecutionEventRecorder recorder = executeTestsForClass(nestedTestWatcherTestCase.class);
+		ExecutionEventRecorder recorder = executeTestsForClass(NestedTestWatcherTestCase.class);
 		assertEquals(0, recorder.getContainerFailedCount());
 	}
 
 	@ExtendWith(TestResultAggregator.class)
-	static class nestedTestWatcherTestCase {
+	static class NestedTestWatcherTestCase {
 
 		@Test
 		public void successfulTest() {
@@ -63,7 +63,7 @@ public class TestWatcherTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Nested
-		class secondLevelTestWatcherTestCase {
+		class SecondLevelTestWatcherTestCase {
 			@Test
 			public void successfulTest() {
 				//no-op
@@ -93,37 +93,34 @@ public class TestWatcherTests extends AbstractJupiterTestEngineTests {
 		private Map<String, List<String>> results = new HashMap<>();
 
 		@Override
-		public void testSuccessful(String descriptor, ExtensionContext context) {
-			storeResult("SUCCESSFUL", descriptor);
+		public void testSuccessful(ExtensionContext context) {
+			storeResult("SUCCESSFUL", context.getUniqueId());
 		}
 
 		@Override
-		public void testAborted(String descriptor, Throwable cause, ExtensionContext context) {
-			storeResult("ABORTED", descriptor);
+		public void testAborted(ExtensionContext context, Throwable cause) {
+			storeResult("ABORTED", context.getUniqueId());
 		}
 
 		@Override
-		public void testFailed(String descriptor, Throwable cause, ExtensionContext context) {
-			storeResult("FAILED", descriptor);
+		public void testFailed(ExtensionContext context, Throwable cause) {
+			storeResult("FAILED", context.getUniqueId());
 		}
 
 		@Override
-		public void testSkipped(String descriptor, Optional<String> Reason, ExtensionContext context) {
-			storeResult("SKIPPED", descriptor);
+		public void testDisabled(ExtensionContext context, Optional<String> reason) {
+			storeResult("SKIPPED", context.getUniqueId());
 		}
 
 		private void storeResult(String status, String method) {
-			List<String> l = results.get(status);
-			if (l == null) {
-				l = new ArrayList<>();
-			}
+			List<String> l = results.computeIfAbsent(status, k -> new ArrayList<String>());
 			l.add(method);
 			results.put(status, l);
 		}
 
 		@Override
 		public void afterAll(ExtensionContext context) throws Exception {
-			this.results.entrySet().stream().forEach(resultType -> assertEquals(2, resultType.getValue().size()));
+			this.results.values().forEach(idList -> assertEquals(2, idList.size()));
 		}
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -127,8 +127,9 @@ public interface Node<C extends EngineExecutionContext> {
 	 *  @param context the execution context
 	 *  @param descriptor  the skipped test {@link TestDescriptor}
 	 *  @param result the cause of skipped execution
-	 * @since 5.4
+	 * @since 1.4
 	 */
+	@API(status = MAINTAINED, since = "1.4", consumers = "org.junit.platform.engine.support.hierarchical")
 	default void nodeSkipped(C context, TestDescriptor descriptor, SkipResult result) {
 	}
 
@@ -138,8 +139,9 @@ public interface Node<C extends EngineExecutionContext> {
 	 * @param context the execution context
 	 * @param descriptor the skipped test's {@link TestDescriptor}
 	 * @param result the {@link TestExecutionResult} resulting from the execution of {@code descriptor}
-	 * @since 5.4
+	 * @since 1.4
 	 */
+	@API(status = MAINTAINED, since = "1.4", consumers = "org.junit.platform.engine.support.hierarchical")
 	default void nodeFinished(C context, TestDescriptor descriptor, TestExecutionResult result) {
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.ToStringBuilder;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
 
 /**
  * A <em>node</em> within the execution hierarchy.
@@ -120,6 +121,11 @@ public interface Node<C extends EngineExecutionContext> {
 	default void after(C context) throws Exception {
 	}
 
+	default void nodeSkipped(C context, TestDescriptor descriptor, SkipResult result) {
+	}
+
+	default void nodeFinished(C context, TestDescriptor descriptor, TestExecutionResult result) {
+	}
 	/**
 	 * Get the set of {@linkplain ExclusiveResource exclusive resources}
 	 * required to execute this node.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -126,6 +126,7 @@ public interface Node<C extends EngineExecutionContext> {
 
 	default void nodeFinished(C context, TestDescriptor descriptor, TestExecutionResult result) {
 	}
+
 	/**
 	 * Get the set of {@linkplain ExclusiveResource exclusive resources}
 	 * required to execute this node.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -121,9 +121,25 @@ public interface Node<C extends EngineExecutionContext> {
 	default void after(C context) throws Exception {
 	}
 
+	/**
+	 * Action triggered when the execution of this Node is skipped.
+	 *
+	 *  @param context the execution context
+	 *  @param descriptor  the skipped test {@link TestDescriptor}
+	 *  @param result the cause of skipped execution
+	 * @since 5.4
+	 */
 	default void nodeSkipped(C context, TestDescriptor descriptor, SkipResult result) {
 	}
 
+	/**
+	 * Action triggered when the execution of this Node has finished.
+	 *
+	 * @param context the execution context
+	 * @param descriptor the skipped test's {@link TestDescriptor}
+	 * @param result the {@link TestExecutionResult} resulting from the execution of {@code descriptor}
+	 * @since 5.4
+	 */
 	default void nodeFinished(C context, TestDescriptor descriptor, TestExecutionResult result) {
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -82,6 +82,10 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 			cleanUp();
 		}
 		reportCompletion();
+
+		// Clear reference to context to allow it to be garbage collected.
+		// See https://github.com/junit-team/junit5/issues/1578
+		context = null;
 	}
 
 	private void prepare() {
@@ -125,10 +129,6 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 
 	private void cleanUp() {
 		throwableCollector.execute(() -> node.cleanUp(context));
-
-		// Clear reference to context to allow it to be garbage collected.
-		// See https://github.com/junit-team/junit5/issues/1578
-		context = null;
 	}
 
 	private void reportCompletion() {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -131,7 +131,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
             try {
                 node.nodeSkipped(context, testDescriptor, skipResult);
             }
-            finally {
+            catch(Throwable t) {
                 //swallow
             }
 			taskContext.getListener().executionSkipped(testDescriptor, skipResult.getReason().orElse("<unknown>"));
@@ -144,7 +144,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
         try {
             node.nodeFinished(context, testDescriptor, throwableCollector.toTestExecutionResult());
         }
-        finally {
+        catch(Throwable t) {
             //swallow
         }
 		taskContext.getListener().executionFinished(testDescriptor, throwableCollector.toTestExecutionResult());

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -128,6 +128,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 
 	private void reportCompletion() {
 		if (throwableCollector.isEmpty() && skipResult.isSkipped()) {
+            node.nodeSkipped(context, testDescriptor, skipResult);
 			taskContext.getListener().executionSkipped(testDescriptor, skipResult.getReason().orElse("<unknown>"));
 			return;
 		}
@@ -135,6 +136,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 			// Call executionStarted first to comply with the contract of EngineExecutionListener.
 			taskContext.getListener().executionStarted(testDescriptor);
 		}
+        node.nodeFinished(context, testDescriptor, throwableCollector.toTestExecutionResult());
 		taskContext.getListener().executionFinished(testDescriptor, throwableCollector.toTestExecutionResult());
 		throwableCollector = null;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -128,7 +128,12 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 
 	private void reportCompletion() {
 		if (throwableCollector.isEmpty() && skipResult.isSkipped()) {
-            node.nodeSkipped(context, testDescriptor, skipResult);
+            try {
+                node.nodeSkipped(context, testDescriptor, skipResult);
+            }
+            finally {
+                //swallow
+            }
 			taskContext.getListener().executionSkipped(testDescriptor, skipResult.getReason().orElse("<unknown>"));
 			return;
 		}
@@ -136,7 +141,12 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 			// Call executionStarted first to comply with the contract of EngineExecutionListener.
 			taskContext.getListener().executionStarted(testDescriptor);
 		}
-        node.nodeFinished(context, testDescriptor, throwableCollector.toTestExecutionResult());
+        try {
+            node.nodeFinished(context, testDescriptor, throwableCollector.toTestExecutionResult());
+        }
+        finally {
+            //swallow
+        }
 		taskContext.getListener().executionFinished(testDescriptor, throwableCollector.toTestExecutionResult());
 		throwableCollector = null;
 	}


### PR DESCRIPTION
## Overview

Draft implementation of a `TestWatcher`-like extension point for discussion, with a sample extension and a test case. Only supports `@Test` methods so far.

Issue: #542

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
