### PR TITLE
Add --fail-if-no-tests command line option to ConsoleLauncher

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0-M1.adoc
@@ -29,6 +29,8 @@ on GitHub.
 
 * New overloaded variant of `isAnnotated()` in `AnnotationSupport` that accepts
   `Optional<? extends AnnotatedElement>` instead of `AnnotatedElement`.
+* Added `--fail-if-no-tests` command line option to `ConsoleLauncher`. When this option is enabled
+and no tests are found for execution the launcher will fail and exit with the non zero code `2`.
 
 [[release-notes-5.3.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0-M1.adoc
@@ -29,8 +29,9 @@ on GitHub.
 
 * New overloaded variant of `isAnnotated()` in `AnnotationSupport` that accepts
   `Optional<? extends AnnotatedElement>` instead of `AnnotatedElement`.
-* Added `--fail-if-no-tests` command line option to `ConsoleLauncher`. When this option is enabled
-and no tests are found for execution the launcher will fail and exit with the non zero code `2`.
+* Added `--fail-if-no-tests` command line option to `ConsoleLauncher`. When this option
+  is enabled and no tests are found for execution the launcher will fail and exit with
+  the non zero code `2`.
 
 [[release-notes-5.3.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -580,7 +580,8 @@ Test run finished after 64 ms
 
 .Exit Code
 NOTE: The `{ConsoleLauncher}` exits with a status code of `1` if any containers or tests
-failed. Otherwise the exit code is `0`.
+failed. Also if no tests are found and `--fail-if-no-tests` option is enabled it exits with
+status code `2`. Otherwise the exit code is `0`.
 
 [[running-tests-console-launcher-options]]
 ==== Options

--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -82,7 +82,7 @@ public class ConsoleLauncher {
 	private ConsoleLauncherExecutionResult executeTests(CommandLineOptions options, PrintWriter out) {
 		try {
 			TestExecutionSummary testExecutionSummary = new ConsoleTestExecutor(options).execute(out);
-			return ConsoleLauncherExecutionResult.forSummary(testExecutionSummary);
+			return ConsoleLauncherExecutionResult.forSummary(testExecutionSummary, options);
 		}
 		catch (Exception exception) {
 			exception.printStackTrace(errStream);

--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncherExecutionResult.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncherExecutionResult.java
@@ -15,6 +15,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.junit.platform.console.options.CommandLineOptions;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
 
 /**
@@ -34,37 +35,41 @@ public class ConsoleLauncherExecutionResult {
 	private static final int TEST_FAILED = 1;
 
 	/**
+	 * Exit code indicating no tests found
+	 */
+	private static final int NO_TESTS_FOUND = 2;
+
+	/**
 	 * Exit code indicating any failure(s)
 	 */
 	private static final int FAILED = -1;
 
-	public static int computeExitCode(TestExecutionSummary summary) {
+	public static int computeExitCode(TestExecutionSummary summary, CommandLineOptions options) {
+		if (options.isFailIfNoTests() && summary.getTestsFoundCount() == 0) {
+			return NO_TESTS_FOUND;
+		}
 		return summary.getTotalFailureCount() == 0 ? SUCCESS : TEST_FAILED;
 	}
 
 	static ConsoleLauncherExecutionResult success() {
-		return new ConsoleLauncherExecutionResult(SUCCESS);
+		return new ConsoleLauncherExecutionResult(SUCCESS, null);
 	}
 
 	static ConsoleLauncherExecutionResult failed() {
-		return new ConsoleLauncherExecutionResult(FAILED);
+		return new ConsoleLauncherExecutionResult(FAILED, null);
 	}
 
-	static ConsoleLauncherExecutionResult forSummary(TestExecutionSummary summary) {
-		return new ConsoleLauncherExecutionResult(summary);
+	static ConsoleLauncherExecutionResult forSummary(TestExecutionSummary summary, CommandLineOptions options) {
+		int exitCode = computeExitCode(summary, options);
+		return new ConsoleLauncherExecutionResult(exitCode, summary);
 	}
 
 	private final int exitCode;
 	private final TestExecutionSummary testExecutionSummary;
 
-	private ConsoleLauncherExecutionResult(int exitCode) {
-		this.exitCode = exitCode;
-		this.testExecutionSummary = null;
-	}
-
-	private ConsoleLauncherExecutionResult(TestExecutionSummary testExecutionSummary) {
+	private ConsoleLauncherExecutionResult(int exitCode, TestExecutionSummary testExecutionSummary) {
 		this.testExecutionSummary = testExecutionSummary;
-		this.exitCode = computeExitCode(testExecutionSummary);
+		this.exitCode = exitCode;
 	}
 
 	public int getExitCode() {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -42,6 +42,7 @@ class AvailableOptions {
 	private final OptionSpec<Details> details;
 	private final OptionSpec<Theme> theme;
 	private final OptionSpec<Path> additionalClasspathEntries;
+	private final OptionSpec<Void> failIfNoTests;
 
 	// Reports
 	private final OptionSpec<Path> reportsDir;
@@ -105,6 +106,9 @@ class AvailableOptions {
 				.withValuesConvertedBy(new PathConverter()) //
 				.withValuesSeparatedBy(File.pathSeparatorChar) //
 				.describedAs("path1" + File.pathSeparator + "path2" + File.pathSeparator + "...");
+
+		failIfNoTests = parser.accepts("fail-if-no-tests",
+			"Fail and return error exit code, if no tests are found to be executed.");
 
 		// --- Reports ---------------------------------------------------------
 
@@ -224,6 +228,7 @@ class AvailableOptions {
 		result.setDetails(detectedOptions.valueOf(this.details));
 		result.setTheme(detectedOptions.valueOf(this.theme));
 		result.setAdditionalClasspathEntries(detectedOptions.valuesOf(this.additionalClasspathEntries));
+		result.setFailIfNoTests(detectedOptions.has(this.failIfNoTests));
 
 		// Reports
 		result.setReportsDir(detectedOptions.valueOf(this.reportsDir));

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
@@ -67,6 +67,8 @@ public class CommandLineOptions {
 
 	private List<Path> additionalClasspathEntries = emptyList();
 
+	private boolean failIfNoTests;
+
 	private Path reportsDir;
 
 	private Map<String, String> configurationParameters = emptyMap();
@@ -276,6 +278,14 @@ public class CommandLineOptions {
 
 	public void setSelectedClasspathEntries(List<Path> selectedClasspathEntries) {
 		this.selectedClasspathEntries = selectedClasspathEntries;
+	}
+
+	public boolean isFailIfNoTests() {
+		return failIfNoTests;
+	}
+
+	public void setFailIfNoTests(boolean failIfNoTests) {
+		this.failIfNoTests = failIfNoTests;
 	}
 
 	public Map<String, String> getConfigurationParameters() {

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherExecutionResultTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherExecutionResultTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.console.options.CommandLineOptions;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+/**
+ * @since 1.3
+ */
+class ConsoleLauncherExecutionResultTests {
+
+	private final CommandLineOptions options = new CommandLineOptions();
+	private final TestExecutionSummary summary = mock(TestExecutionSummary.class);
+
+	@Test
+	void hasStatusCode0ForNoTotalFailures() {
+		when(summary.getTotalFailureCount()).thenReturn(0L);
+
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(summary, options);
+
+		assertThat(exitCode).isEqualTo(0);
+	}
+
+	@Test
+	void hasStatusCode1ForForAnyFailure() {
+		when(summary.getTotalFailureCount()).thenReturn(1L);
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(summary, options);
+
+		assertThat(exitCode).isEqualTo(1);
+	}
+
+	@Test
+	void hasStatusCode2ForNoTestsAndHasOptionFailIfNoTestsFound() {
+
+		options.setFailIfNoTests(true);
+		when(summary.getTestsFoundCount()).thenReturn(0L);
+
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(summary, options);
+
+		assertThat(exitCode).isEqualTo(2);
+	}
+
+	@Test
+	void hasStatusCode0ForTestsAndHasOptionFailIfNoTestsFound() {
+
+		options.setFailIfNoTests(true);
+		when(summary.getTestsFoundCount()).thenReturn(1L);
+		when(summary.getTotalFailureCount()).thenReturn(0L);
+
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(summary, options);
+
+		assertThat(exitCode).isEqualTo(0);
+	}
+
+	@Test
+	void hasStatusCode0ForNoTestsAndNotFailIfNoTestsFound() {
+		options.setFailIfNoTests(false);
+		when(summary.getTestsFoundCount()).thenReturn(0L);
+
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(summary, options);
+
+		assertThat(exitCode).isEqualTo(0);
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/ConsoleTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/ConsoleTestExecutorTests.java
@@ -100,7 +100,7 @@ class ConsoleTestExecutorTests {
 		dummyTestEngine.addTest("succeedingTest", SUCCEEDING_TEST);
 
 		ConsoleTestExecutor task = new ConsoleTestExecutor(options, () -> createLauncher(dummyTestEngine));
-		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(task.execute(dummyWriter()));
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(task.execute(dummyWriter()), options);
 
 		assertThat(exitCode).isEqualTo(0);
 	}
@@ -110,7 +110,7 @@ class ConsoleTestExecutorTests {
 		dummyTestEngine.addTest("failingTest", FAILING_BLOCK);
 
 		ConsoleTestExecutor task = new ConsoleTestExecutor(options, () -> createLauncher(dummyTestEngine));
-		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(task.execute(dummyWriter()));
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(task.execute(dummyWriter()), options);
 
 		assertThat(exitCode).isEqualTo(1);
 	}
@@ -120,9 +120,29 @@ class ConsoleTestExecutorTests {
 		dummyTestEngine.addContainer("failingContainer", FAILING_BLOCK);
 
 		ConsoleTestExecutor task = new ConsoleTestExecutor(options, () -> createLauncher(dummyTestEngine));
-		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(task.execute(dummyWriter()));
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(task.execute(dummyWriter()), options);
 
 		assertThat(exitCode).isEqualTo(1);
+	}
+
+	@Test
+	void hasStatusCode2ForNoTestsAndHasOptionFailIfNoTestsFound() throws Exception {
+
+		options.setFailIfNoTests(true);
+
+		ConsoleTestExecutor task = new ConsoleTestExecutor(options, () -> createLauncher(dummyTestEngine));
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(task.execute(dummyWriter()), options);
+
+		assertThat(exitCode).isEqualTo(2);
+	}
+
+	@Test
+	void hasStatusCode0ForNoTestsAndNotFailIfNoTestsFound() throws Exception {
+
+		ConsoleTestExecutor task = new ConsoleTestExecutor(options, () -> createLauncher(dummyTestEngine));
+		int exitCode = ConsoleLauncherExecutionResult.computeExitCode(task.execute(dummyWriter()), options);
+
+		assertThat(exitCode).isEqualTo(0);
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

This PR implements the `--fail-if-no-tests` command line option for the `ConsoleLauncher` as discussed in #1298.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
