### PR TITLE
Introduce a Kotlin extension function for ArgumentsAccessor

### DIFF
--- a/junit-jupiter-params/junit-jupiter-params.gradle
+++ b/junit-jupiter-params/junit-jupiter-params.gradle
@@ -47,6 +47,9 @@ dependencies {
 	testRuntimeOnly(project(':junit-platform-console'))
 	testRuntimeOnly("org.apache.logging.log4j:log4j-core:${log4jVersion}")
 	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
+
+	compileOnly("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
+
 }
 
 jar.enabled = false

--- a/junit-jupiter-params/junit-jupiter-params.gradle
+++ b/junit-jupiter-params/junit-jupiter-params.gradle
@@ -49,7 +49,7 @@ dependencies {
 	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 
 	compileOnly("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
-
+	testCompile("org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}")
 }
 
 jar.enabled = false

--- a/junit-jupiter-params/junit-jupiter-params.gradle
+++ b/junit-jupiter-params/junit-jupiter-params.gradle
@@ -49,7 +49,7 @@ dependencies {
 	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 
 	compileOnly("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
-	testCompile("org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}")
+	testImplementation("org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}")
 }
 
 jar.enabled = false

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessor.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessor.java
@@ -34,6 +34,10 @@ import org.apiguardian.api.API;
  *
  * <p>This interface is not intended to be implemented by clients.
  *
+ * <p>Additional <a href="https://kotlinlang.org/">Kotlin</a> arguments accessors can be
+ * found as <em>extension functions</em> in the {@link org.junit.jupiter.params.aggregator.ArgumentsAccessorExtensionsKt}
+ * file.
+ *
  * @since 5.2
  * @see ArgumentsAggregator
  * @see org.junit.jupiter.params.ParameterizedTest

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessorExtensions.kt
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessorExtensions.kt
@@ -10,9 +10,9 @@
 package org.junit.jupiter.params.aggregator
 
 /**
- * <p>Extension Function for {@link ArgumentsAccessor}.
+ * Extension Function for {@link ArgumentsAccessor}.
  *
- * @since 5.2
+ * @since 5.3
  * @receiver[ArgumentsAccessor]
  * @see ArgumentsAccessor.get(Int, Class<T!>!)
  */

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessorExtensions.kt
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessorExtensions.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.aggregator
+
+/**
+ * <p>Extension Function for {@link ArgumentsAccessor}.
+ *
+ * @since 5.2
+ * @receiver[ArgumentsAccessor]
+ * @see ArgumentsAccessor.get(Int, Class<T!>!)
+ */
+inline fun <reified T: Any> ArgumentsAccessor.get(index: Int) : T =
+        this.get(index, T::class.java)

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/ArgumentsAccessorExtensionsTests.kt
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/ArgumentsAccessorExtensionsTests.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.aggregator
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [ArgumentsAccessorExtensions].
+ */
+class ArgumentsAccessorExtensionsTests {
+
+    @Test
+    fun getWithCast() {
+        assertEquals(1, DefaultArgumentsAccessor(1).get<Int>(0))
+        assertEquals('A', DefaultArgumentsAccessor('A').get<Char>(0))
+    }
+
+    @Test
+    fun getWithCastToIncompatibleType() {
+        val exception = assertThrows<ArgumentAccessException>(ArgumentAccessException::class.java
+        ) { DefaultArgumentsAccessor(Integer.valueOf(1)).get<Char>(0) }
+        assertThat(exception.message).isEqualTo(
+                "Argument at index [0] with value [1] and type [java.lang.Integer] could not be converted or cast to type [java.lang.Character].")
+    }
+
+}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/ArgumentsAccessorExtensionsTests.kt
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/ArgumentsAccessorExtensionsTests.kt
@@ -11,8 +11,8 @@ package org.junit.jupiter.params.aggregator
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * Unit tests for [ArgumentsAccessorExtensions].
@@ -27,8 +27,10 @@ class ArgumentsAccessorExtensionsTests {
 
     @Test
     fun getWithCastToIncompatibleType() {
-        val exception = assertThrows<ArgumentAccessException>(ArgumentAccessException::class.java
-        ) { DefaultArgumentsAccessor(Integer.valueOf(1)).get<Char>(0) }
+        val exception = assertThrows<ArgumentAccessException> {
+            DefaultArgumentsAccessor(Integer.valueOf(1)).get<Char>(0)
+        }
+
         assertThat(exception.message).isEqualTo(
                 "Argument at index [0] with value [1] and type [java.lang.Integer] could not be converted or cast to type [java.lang.Character].")
     }


### PR DESCRIPTION
## Overview

This PR introduces a Kotlin _extension function_ for `ArgumentsAccessor` for parameterized tests.

Issue: #1382 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
