### PR TITLE
Add TestSource support to dynamic containers and tests

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0-M1.adoc
@@ -65,6 +65,9 @@ on GitHub.
   _alias_ for `Arguments.of()`. `arguments()` is intended to be used via `import static`.
 * New `get<Class>(index)` Kotlin extension method to make `ArgumentsAccessor` friendlier
   to use from Kotlin.
+* New support for supplying a custom test source `URI` when creating a dynamic container
+  or test. See factory methods `dynamicContainer(String, URI, ...)` in `DynamicContainer`
+  and `dynamicTest(String, URI, Executable)` in `DynamicTest` for details.
 
 
 [[release-notes-5.3.0-M1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicContainer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicContainer.java
@@ -71,13 +71,13 @@ public class DynamicContainer extends DynamicNode {
 
 	/**
 	 * Factory for creating a new {@code DynamicContainer} for the supplied display
-	 * name, the test source uri, and stream of dynamic nodes.
+	 * name, the test source {@link URI}, and stream of dynamic nodes.
 	 *
 	 * <p>The stream of dynamic nodes must not contain {@code null} elements.
 	 *
 	 * @param displayName the display name for the dynamic container; never
 	 * {@code null} or blank
-	 * @param testSourceUri the test source uri for the dynamic test; can be {@code null}
+	 * @param testSourceUri the test source URI for the dynamic test; can be {@code null}
 	 * @param dynamicNodes stream of dynamic nodes to execute;
 	 * never {@code null}
 	 * @since 5.3

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicContainer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicContainer.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.api;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.net.URI;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -49,7 +50,7 @@ public class DynamicContainer extends DynamicNode {
 	 * @see #dynamicContainer(String, Stream)
 	 */
 	public static DynamicContainer dynamicContainer(String displayName, Iterable<? extends DynamicNode> dynamicNodes) {
-		return new DynamicContainer(displayName, StreamSupport.stream(dynamicNodes.spliterator(), false));
+		return dynamicContainer(displayName, null, StreamSupport.stream(dynamicNodes.spliterator(), false));
 	}
 
 	/**
@@ -65,13 +66,32 @@ public class DynamicContainer extends DynamicNode {
 	 * @see #dynamicContainer(String, Iterable)
 	 */
 	public static DynamicContainer dynamicContainer(String displayName, Stream<? extends DynamicNode> dynamicNodes) {
-		return new DynamicContainer(displayName, dynamicNodes);
+		return dynamicContainer(displayName, null, dynamicNodes);
+	}
+
+	/**
+	 * Factory for creating a new {@code DynamicContainer} for the supplied display
+	 * name, the test source uri, and stream of dynamic nodes.
+	 *
+	 * <p>The stream of dynamic nodes must not contain {@code null} elements.
+	 *
+	 * @param displayName the display name for the dynamic container; never
+	 * {@code null} or blank
+	 * @param testSourceUri the test source uri for the dynamic test; can be {@code null}
+	 * @param dynamicNodes stream of dynamic nodes to execute;
+	 * never {@code null}
+	 * @since 5.3
+	 * @see #dynamicContainer(String, Iterable)
+	 */
+	public static DynamicContainer dynamicContainer(String displayName, URI testSourceUri,
+			Stream<? extends DynamicNode> dynamicNodes) {
+		return new DynamicContainer(displayName, testSourceUri, dynamicNodes);
 	}
 
 	private final Stream<? extends DynamicNode> children;
 
-	private DynamicContainer(String displayName, Stream<? extends DynamicNode> children) {
-		super(displayName);
+	private DynamicContainer(String displayName, URI testSourceUri, Stream<? extends DynamicNode> children) {
+		super(displayName, testSourceUri);
 		Preconditions.notNull(children, "children must not be null");
 		this.children = children;
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicNode.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicNode.java
@@ -42,16 +42,21 @@ public abstract class DynamicNode {
 
 	/**
 	 * Get the display name of this {@code DynamicNode}.
+	 *
+	 * @return the display name
 	 */
 	public String getDisplayName() {
 		return this.displayName;
 	}
 
 	/**
-	 * Get the optional test source of this {@code DynamicNode}.
+	 * Get the optional test source {@link URI} of this {@code DynamicNode}.
+	 *
+	 * @return an {@code Optional} containing the test source {@link URI};
+	 * never {@code null} but potentially empty
 	 * @since 5.3
 	 */
-	public Optional<URI> getTestSourceURI() {
+	public Optional<URI> getTestSourceUri() {
 		return Optional.ofNullable(testSourceUri);
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicNode.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicNode.java
@@ -12,6 +12,9 @@ package org.junit.jupiter.api;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.net.URI;
+import java.util.Optional;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ToStringBuilder;
@@ -29,8 +32,12 @@ public abstract class DynamicNode {
 
 	private final String displayName;
 
-	DynamicNode(String displayName) {
+	/** Custom test source {@link URI} instance associated with this node; potentially {@code null}. */
+	private final URI testSourceUri;
+
+	DynamicNode(String displayName, URI testSourceUri) {
 		this.displayName = Preconditions.notBlank(displayName, "displayName must not be null or blank");
+		this.testSourceUri = testSourceUri;
 	}
 
 	/**
@@ -40,9 +47,20 @@ public abstract class DynamicNode {
 		return this.displayName;
 	}
 
+	/**
+	 * Get the optional test source of this {@code DynamicNode}.
+	 * @since 5.3
+	 */
+	public Optional<URI> getTestSourceURI() {
+		return Optional.ofNullable(testSourceUri);
+	}
+
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).append("displayName", displayName).toString();
+		return new ToStringBuilder(this) //
+				.append("displayName", displayName) //
+				.append("testSourceUri", testSourceUri) //
+				.toString();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicTest.java
@@ -65,11 +65,11 @@ public class DynamicTest extends DynamicNode {
 
 	/**
 	 * Factory for creating a new {@code DynamicTest} for the supplied display
-	 * name, the test source uri, and executable code block.
+	 * name, the test source {@link URI}, and executable code block.
 	 *
 	 * @param displayName the display name for the dynamic test; never
 	 * {@code null} or blank
-	 * @param testSourceUri the test source uri for the dynamic test; can be {@code null}
+	 * @param testSourceUri the test source URI for the dynamic test; can be {@code null}
 	 * @param executable the executable code block for the dynamic test;
 	 * never {@code null}
 	 * @since 5.3

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DynamicTest.java
@@ -14,6 +14,7 @@ import static java.util.Spliterator.ORDERED;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.net.URI;
 import java.util.Iterator;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -59,7 +60,23 @@ public class DynamicTest extends DynamicNode {
 	 * @see #stream(Iterator, Function, ThrowingConsumer)
 	 */
 	public static DynamicTest dynamicTest(String displayName, Executable executable) {
-		return new DynamicTest(displayName, executable);
+		return new DynamicTest(displayName, null, executable);
+	}
+
+	/**
+	 * Factory for creating a new {@code DynamicTest} for the supplied display
+	 * name, the test source uri, and executable code block.
+	 *
+	 * @param displayName the display name for the dynamic test; never
+	 * {@code null} or blank
+	 * @param testSourceUri the test source uri for the dynamic test; can be {@code null}
+	 * @param executable the executable code block for the dynamic test;
+	 * never {@code null}
+	 * @since 5.3
+	 * @see #stream(Iterator, Function, ThrowingConsumer)
+	 */
+	public static DynamicTest dynamicTest(String displayName, URI testSourceUri, Executable executable) {
+		return new DynamicTest(displayName, testSourceUri, executable);
 	}
 
 	/**
@@ -101,8 +118,8 @@ public class DynamicTest extends DynamicNode {
 
 	private final Executable executable;
 
-	private DynamicTest(String displayName, Executable executable) {
-		super(displayName);
+	private DynamicTest(String displayName, URI testSourceUri, Executable executable) {
+		super(displayName, testSourceUri);
 		this.executable = Preconditions.notNull(executable, "executable must not be null");
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
@@ -12,16 +12,19 @@ package org.junit.jupiter.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.function.Executable;
 import org.junit.platform.commons.support.ReflectionSupport;
 import org.opentest4j.AssertionFailedError;
 
@@ -29,6 +32,9 @@ import org.opentest4j.AssertionFailedError;
  * @since 5.0
  */
 class DynamicTestTests {
+
+	private static final Executable nix = () -> {
+	};
 
 	private final List<String> assertedValues = new ArrayList<>();
 
@@ -77,6 +83,24 @@ class DynamicTestTests {
 		Throwable t50 = assertThrows(InvocationTargetException.class,
 			() -> dynamicTest("1 == 50", this::assert1Equals50Reflectively).getExecutable().execute());
 		assertThat(t50.getCause()).hasMessage("expected: <1> but was: <50>");
+	}
+
+	@Test
+	void testSourceUriIsNotPresentByDefault() {
+		DynamicTest test = dynamicTest("foo", nix);
+		assertThat(test.getTestSourceURI()).isNotPresent();
+		assertThat(dynamicContainer("bar", Stream.of(test)).getTestSourceURI()).isNotPresent();
+	}
+
+	@Test
+	void testSourceUriIsReturnedWhenSupplied() {
+		URI testSourceUri = URI.create("any://test");
+		DynamicTest test = dynamicTest("foo", testSourceUri, nix);
+		URI containerSourceUri = URI.create("other://container");
+		DynamicContainer container = dynamicContainer("bar", containerSourceUri, Stream.of(test));
+
+		assertThat(test.getTestSourceURI().get()).isSameAs(testSourceUri);
+		assertThat(container.getTestSourceURI().get()).isSameAs(containerSourceUri);
 	}
 
 	private void assert1Equals48Directly() {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
@@ -88,8 +88,11 @@ class DynamicTestTests {
 	@Test
 	void testSourceUriIsNotPresentByDefault() {
 		DynamicTest test = dynamicTest("foo", nix);
-		assertThat(test.getTestSourceURI()).isNotPresent();
-		assertThat(dynamicContainer("bar", Stream.of(test)).getTestSourceURI()).isNotPresent();
+		assertThat(test.getTestSourceUri()).isNotPresent();
+		assertThat(test.toString()).isEqualTo("DynamicTest [displayName = 'foo', testSourceUri = null]");
+		DynamicContainer container = dynamicContainer("bar", Stream.of(test));
+		assertThat(container.getTestSourceUri()).isNotPresent();
+		assertThat(container.toString()).isEqualTo("DynamicContainer [displayName = 'bar', testSourceUri = null]");
 	}
 
 	@Test
@@ -99,8 +102,11 @@ class DynamicTestTests {
 		URI containerSourceUri = URI.create("other://container");
 		DynamicContainer container = dynamicContainer("bar", containerSourceUri, Stream.of(test));
 
-		assertThat(test.getTestSourceURI().get()).isSameAs(testSourceUri);
-		assertThat(container.getTestSourceURI().get()).isSameAs(containerSourceUri);
+		assertThat(test.getTestSourceUri().get()).isSameAs(testSourceUri);
+		assertThat(test.toString()).isEqualTo("DynamicTest [displayName = 'foo', testSourceUri = any://test]");
+		assertThat(container.getTestSourceUri().get()).isSameAs(containerSourceUri);
+		assertThat(container.toString()).isEqualTo(
+			"DynamicContainer [displayName = 'bar', testSourceUri = other://container]");
 	}
 
 	private void assert1Equals48Directly() {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DefaultUriSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DefaultUriSource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.descriptor;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.net.URI;
+import java.util.Objects;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ToStringBuilder;
+
+/**
+ * Default uri-based test source implementation.
+ *
+ * @since 1.3
+ */
+@API(status = STABLE, since = "1.3")
+class DefaultUriSource implements UriSource {
+
+	private static final long serialVersionUID = 1L;
+
+	private final URI uri;
+
+	DefaultUriSource(URI uri) {
+		this.uri = Preconditions.notNull(uri, "uri must not be null");
+	}
+
+	@Override
+	public URI getUri() {
+		return uri;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		DefaultUriSource that = (DefaultUriSource) o;
+		return Objects.equals(this.uri, that.uri);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.uri);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).append("uri", this.uri).toString();
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DefaultUriSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DefaultUriSource.java
@@ -20,7 +20,7 @@ import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
- * Default uri-based test source implementation.
+ * Default implementation of {@link UriSource}.
  *
  * @since 1.3
  */
@@ -32,7 +32,7 @@ class DefaultUriSource implements UriSource {
 	private final URI uri;
 
 	DefaultUriSource(URI uri) {
-		this.uri = Preconditions.notNull(uri, "uri must not be null");
+		this.uri = Preconditions.notNull(uri, "URI must not be null");
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FilePosition.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FilePosition.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.StringUtils;
@@ -33,11 +34,14 @@ public class FilePosition implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
+	private static final Logger logger = LoggerFactory.getLogger(FilePosition.class);
+
 	/**
 	 * Create a new {@code FilePosition} using the supplied {@code line} number
 	 * and an undefined column number.
 	 *
 	 * @param line the line number; must be greater than zero
+	 * @return a {@link FilePosition} with the given line number
 	 */
 	public static FilePosition from(int line) {
 		return new FilePosition(line);
@@ -49,13 +53,14 @@ public class FilePosition implements Serializable {
 	 *
 	 * @param line the line number; must be greater than zero
 	 * @param column the column number; must be greater than zero
+	 * @return a {@link FilePosition} with the given line and column numbers
 	 */
 	public static FilePosition from(int line, int column) {
 		return new FilePosition(line, column);
 	}
 
 	/**
-	 * Create an optional {@code FilePosition} parsing the supplied
+	 * Create an optional {@code FilePosition} by parsing the supplied
 	 * {@code query} string.
 	 *
 	 * <p>Examples of valid {@code query} strings:
@@ -65,6 +70,8 @@ public class FilePosition implements Serializable {
 	 * </ul>
 	 *
 	 * @param query the query string; may be {@code null}
+	 * @return an {@link Optional} containing a {@link FilePosition} with
+	 * the parsed line and column numbers; potentially empty
 	 * @since 1.3
 	 */
 	public static Optional<FilePosition> fromQuery(String query) {
@@ -88,7 +95,7 @@ public class FilePosition implements Serializable {
 				}
 			}
 			catch (IllegalArgumentException e) {
-				LoggerFactory.getLogger(FilePosition.class).debug(e, () -> "parsing query failed: " + query);
+				logger.debug(e, () -> "Failed to parse 'line' and/or 'column' from query string: " + query);
 				// fall-through and continue
 			}
 			if (line != null) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
@@ -13,8 +13,14 @@ package org.junit.platform.engine.support.descriptor;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.TestSource;
 
 /**
@@ -32,5 +38,43 @@ public interface UriSource extends TestSource {
 	 * @return the source {@code URI}; never {@code null}
 	 */
 	URI getUri();
+
+	/**
+	 * Create a new {@code UriSource} using the supplied {@code uri}.
+	 * <p>
+	 * This implementation tries resolve the {@code uri} to local file
+	 * system path-based source first. If that fails for any reason, an
+	 * instance of a simple default uri source class storing the supplied
+	 * {@code uri} <em>as-is</em> is returned.
+	 *
+	 * @param uri the uri instance; must not be {@code null}
+	 * @return a uri source instance
+	 * @since 1.3
+	 * @see org.junit.platform.engine.support.descriptor.FileSource
+	 * @see org.junit.platform.engine.support.descriptor.DirectorySource
+	 */
+	static UriSource from(final URI uri) {
+		Preconditions.notNull(uri, "uri must not be null");
+		try {
+			URI pathBasedUri = uri;
+			String query = pathBasedUri.getQuery();
+			if (StringUtils.isNotBlank(query)) {
+				String s = pathBasedUri.toString();
+				pathBasedUri = URI.create(s.substring(0, s.indexOf('?')));
+			}
+			Path path = Paths.get(pathBasedUri);
+			if (Files.isRegularFile(path)) {
+				return FileSource.from(path.toFile(), FilePosition.fromQuery(query).orElse(null));
+			}
+			if (Files.isDirectory(path)) {
+				return DirectorySource.from(path.toFile());
+			}
+		}
+		catch (IllegalArgumentException e) {
+			LoggerFactory.getLogger(UriSource.class).debug(e, () -> "uri not path-based: " + uri);
+		}
+		// store uri as-is
+		return new DefaultUriSource(uri);
+	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSourceTests.java
@@ -13,6 +13,8 @@ package org.junit.platform.engine.support.descriptor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.PreconditionViolationException;
 
@@ -26,6 +28,11 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 	private static final String FOO_RESOURCE = "test/foo.xml";
 	private static final String BAR_RESOURCE = "/config/bar.json";
 
+	@Override
+	Stream<ClasspathResourceSource> createSerializableInstances() {
+		return Stream.of(ClasspathResourceSource.from(FOO_RESOURCE));
+	}
+
 	@Test
 	void preconditions() {
 		assertThrows(PreconditionViolationException.class, () -> ClasspathResourceSource.from(null));
@@ -34,7 +41,7 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 	}
 
 	@Test
-	void resourceWithoutPosition() throws Exception {
+	void resourceWithoutPosition() {
 		ClasspathResourceSource source = ClasspathResourceSource.from(FOO_RESOURCE);
 
 		assertThat(source.getClasspathResourceName()).isEqualTo(FOO_RESOURCE);
@@ -42,7 +49,7 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 	}
 
 	@Test
-	void resourceWithLeadingSlashWithoutPosition() throws Exception {
+	void resourceWithLeadingSlashWithoutPosition() {
 		ClasspathResourceSource source = ClasspathResourceSource.from("/" + FOO_RESOURCE);
 
 		assertThat(source.getClasspathResourceName()).isEqualTo(FOO_RESOURCE);
@@ -50,7 +57,7 @@ class ClasspathResourceSourceTests extends AbstractTestSourceTests {
 	}
 
 	@Test
-	void resourceWithPosition() throws Exception {
+	void resourceWithPosition() {
 		FilePosition position = FilePosition.from(42, 23);
 		ClasspathResourceSource source = ClasspathResourceSource.from(FOO_RESOURCE, position);
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/CompositeTestSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/CompositeTestSourceTests.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.PreconditionViolationException;
@@ -29,6 +30,14 @@ import org.junit.platform.engine.TestSource;
  * @since 1.0
  */
 class CompositeTestSourceTests extends AbstractTestSourceTests {
+
+	@Override
+	Stream<CompositeTestSource> createSerializableInstances() {
+		FileSource fileSource = FileSource.from(new File("sample.instance"));
+		ClassSource classSource = ClassSource.from(getClass());
+		List<TestSource> sources = new ArrayList<>(Arrays.asList(fileSource, classSource));
+		return Stream.of(CompositeTestSource.from(sources));
+	}
 
 	@Test
 	void createCompositeTestSourceFromNullList() {
@@ -60,8 +69,8 @@ class CompositeTestSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void equalsAndHashCode() {
-		List<TestSource> sources1 = Arrays.asList(ClassSource.from(Number.class));
-		List<TestSource> sources2 = Arrays.asList(ClassSource.from(String.class));
+		List<TestSource> sources1 = Collections.singletonList(ClassSource.from(Number.class));
+		List<TestSource> sources2 = Collections.singletonList(ClassSource.from(String.class));
 		assertEqualsAndHashCode(CompositeTestSource.from(sources1), CompositeTestSource.from(sources1),
 			CompositeTestSource.from(sources2));
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DefaultUriSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DefaultUriSourceTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.descriptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.PreconditionViolationException;
+
+/**
+ * Unit tests for {@link DefaultUriSource}.
+ *
+ * @since 1.3
+ */
+class DefaultUriSourceTests extends AbstractTestSourceTests {
+
+	@Override
+	Stream<UriSource> createSerializableInstances() {
+		return Stream.of(new DefaultUriSource(URI.create("sample://instance")));
+	}
+
+	@Test
+	void nullSourceUriYieldsException() {
+		assertThrows(PreconditionViolationException.class, () -> new DefaultUriSource(null));
+	}
+
+	@Test
+	void getterReturnsSameUriInstanceAsSuppliedToTheConstructor() throws Exception {
+		URI expected = new URI("foo.txt");
+		URI actual = new DefaultUriSource(expected).getUri();
+		assertSame(expected, actual);
+	}
+
+	@Test
+	void equalsAndHashCode() throws Exception {
+		URI uri1 = new URI("foo.txt");
+		URI uri2 = new URI("bar.txt");
+		assertEqualsAndHashCode(new DefaultUriSource(uri1), new DefaultUriSource(uri1), new DefaultUriSource(uri2));
+	}
+
+	@Test
+	void testToString() {
+		String actual = new DefaultUriSource(URI.create("foo.txt")).toString();
+		assertEquals("DefaultUriSource [uri = foo.txt]", actual);
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FilePositionTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FilePositionTests.java
@@ -32,6 +32,11 @@ import org.junit.platform.commons.util.PreconditionViolationException;
 @DisplayName("FilePosition unit tests")
 class FilePositionTests extends AbstractTestSourceTests {
 
+	@Override
+	Stream<FilePosition> createSerializableInstances() {
+		return Stream.of(FilePosition.from(42, 99));
+	}
+
 	@Test
 	@DisplayName("factory method preconditions")
 	void preconditions() {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FilePositionTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FilePositionTests.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine.support.descriptor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -81,13 +82,13 @@ class FilePositionTests extends AbstractTestSourceTests {
 	@SuppressWarnings("unused")
 	static Stream<Arguments> filePositionFromQuery() {
 		return Stream.of( //
-			Arguments.of(null, -1, -1), //
-			Arguments.of("?!", -1, -1), //
-			Arguments.of("line=ZZ", -1, -1), //
-			Arguments.of("line=42", 42, -1), //
-			Arguments.of("line=42&line=24", 24, -1), //
-			Arguments.of("line=42&column=99", 42, 99), //
-			Arguments.of("line=42&column=ZZ", 42, -1) //
+			arguments(null, -1, -1), //
+			arguments("?!", -1, -1), //
+			arguments("line=ZZ", -1, -1), //
+			arguments("line=42", 42, -1), //
+			arguments("line=42&line=24", 24, -1), //
+			arguments("line=42&column=99", 42, 99), //
+			arguments("line=42&column=ZZ", 42, -1) //
 		);
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FileSystemSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/FileSystemSourceTests.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.PreconditionViolationException;
@@ -24,6 +25,13 @@ import org.junit.platform.commons.util.PreconditionViolationException;
  * @since 1.0
  */
 class FileSystemSourceTests extends AbstractTestSourceTests {
+
+	@Override
+	Stream<FileSource> createSerializableInstances() {
+		return Stream.of( //
+			FileSource.from(new File("file.source")), //
+			FileSource.from(new File("file.and.position"), FilePosition.from(42, 23)));
+	}
 
 	@Test
 	void nullSourceFileOrDirectoryYieldsException() {
@@ -56,7 +64,7 @@ class FileSystemSourceTests extends AbstractTestSourceTests {
 	}
 
 	@Test
-	void fileWithPosition() throws Exception {
+	void fileWithPosition() {
 		File file = new File("test.txt");
 		FilePosition position = FilePosition.from(42, 23);
 		FileSource source = FileSource.from(file, position);

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/GenericSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/GenericSourceTests.java
@@ -13,7 +13,9 @@ package org.junit.platform.engine.support.descriptor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -26,6 +28,17 @@ import org.junit.platform.commons.util.PreconditionViolationException;
  * @since 1.0
  */
 class GenericSourceTests extends AbstractTestSourceTests {
+
+	@Override
+	Stream<Serializable> createSerializableInstances() throws Exception {
+		return Stream.of( //
+			PackageSource.from("package.source"), //
+			ClassSource.from("class.source"), //
+			ClassSource.from("class.and.position", FilePosition.from(1, 2)), //
+			MethodSource.from(getMethod("method1")), //
+			MethodSource.from(getMethod("method2")) //
+		);
+	}
 
 	@Test
 	void packageSourceFromNullPackageName() {


### PR DESCRIPTION
## Overview

Addresses #1178

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
