### PR TITLE
Only instantiate Argument Converters and aggregators once per parameterized test

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
@@ -13,9 +13,12 @@ package org.junit.jupiter.params;
 import static java.util.Collections.singletonList;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregator;
+import org.junit.jupiter.params.converter.ArgumentConverter;
 
 /**
  * @since 5.0
@@ -24,10 +27,16 @@ class ParameterizedTestInvocationContext implements TestTemplateInvocationContex
 
 	private final ParameterizedTestNameFormatter formatter;
 	private final Object[] arguments;
+	private final ConcurrentHashMap<Class<? extends ArgumentsAggregator>, ArgumentsAggregator> aggregatorInstanceMap;
+	private final ConcurrentHashMap<Class<? extends ArgumentConverter>, ArgumentConverter> converterInstanceMap;
 
-	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter, Object[] arguments) {
+	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter, Object[] arguments,
+			ConcurrentHashMap<Class<? extends ArgumentsAggregator>, ArgumentsAggregator> aggregatorInstanceMap,
+			ConcurrentHashMap<Class<? extends ArgumentConverter>, ArgumentConverter> converterInstanceMap) {
 		this.formatter = formatter;
 		this.arguments = arguments;
+		this.aggregatorInstanceMap = aggregatorInstanceMap;
+		this.converterInstanceMap = converterInstanceMap;
 	}
 
 	@Override
@@ -37,7 +46,8 @@ class ParameterizedTestInvocationContext implements TestTemplateInvocationContex
 
 	@Override
 	public List<Extension> getAdditionalExtensions() {
-		return singletonList(new ParameterizedTestParameterResolver(this.arguments));
+		return singletonList(new ParameterizedTestParameterResolver(this.arguments, this.aggregatorInstanceMap,
+			this.converterInstanceMap));
 	}
 
 }


### PR DESCRIPTION
Issue: #1397

## Overview

Prior to this commit Argument Converter and Aggregator classed were
instantiated once per invocation of the @ParameterizedTest invocation.

With this commit instances will be created during the first invocation
of the @ParameterizedTest method, stored and reused on subsequent
invocations.

If the same Converter of Aggregator classes are used on other
@ParameterizedTest methods a new instance will be created on first
invocation and reused for subsequent invocations of that method.

Of the two proposed options to implement this, either eager
instantiation or reuse I chose reuse. The rationale was if the
instantiation of a Converter of Aggregator failed with an exception this
error could be caught with the existing safe mechanism and also for the
failure to be very close to the impacting test invocation.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
