### PR TITLE
Make md and adoc formatting guidelines more visible in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ Whenever an acronym is included as part of a field name or parameter name:
 
 ### Formatting
 
+#### Code
+
 Code formatting is enforced using the [Spotless](https://github.com/diffplug/spotless)
 Gradle plugin. You can use `gradle spotlessApply` to format new code and add missing
 license headers to source files. Formatter and import order settings for Eclipse are
@@ -79,8 +81,12 @@ Eclipse settings.
 It is forbidden to use _wildcard imports_ (e.g., `import static org.junit.jupiter.api.Assertions.*;`)
 in Java code.
 
+#### Documentation
+
 Text in `*.adoc` and `*.md` files should be wrapped at 90 characters whenever technically
 possible.
+
+In multi-line bullet point entries, subsequent lines should be indented.
 
 ### Javadoc
 


### PR DESCRIPTION
## Overview

During my work on #1399 I have found myself missing the `.adoc` and `.md` formatting guidelines. With the proposed changes it would be more easy to spot and find the guidelines.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests)
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
