### PR TITLE
Use simple class name as display name in JUnit Vintage

### DIFF
--- a/junit-platform-commons-java-9/junit-platform-commons-java-9.gradle
+++ b/junit-platform-commons-java-9/junit-platform-commons-java-9.gradle
@@ -61,7 +61,7 @@ task testScanModulepath(dependsOn: execScanModulepath) {
 		String text = execScanModulepath.errorOutput.toString() + execScanModulepath.standardOutput.toString()
 		// tree node names
 		assert text.contains("JUnit Vintage")
-		assert text.contains("integration.VintageIntegrationTest")
+		assert text.contains("VintageIntegrationTest")
 		assert text.contains("successfulTest")
 		assert text.contains("JUnit Jupiter")
 		assert text.contains("JupiterIntegrationTests")

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -41,7 +41,7 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 	private boolean wasFiltered;
 
 	public RunnerTestDescriptor(UniqueId uniqueId, Class<?> testClass, Runner runner) {
-		super(uniqueId, runner.getDescription(), testClass.getName(), ClassSource.from(testClass));
+		super(uniqueId, runner.getDescription(), testClass.getSimpleName(), ClassSource.from(testClass));
 		this.runner = runner;
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageLauncherIntegrationTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageLauncherIntegrationTests.java
@@ -67,7 +67,7 @@ class VintageLauncherIntegrationTests {
 
 		Map<TestIdentifier, TestExecutionResult> results = execute(request);
 		assertThat(results.keySet().stream().map(TestIdentifier::getDisplayName)) //
-				.containsExactlyInAnyOrder("JUnit Vintage", testClass.getName(), "failingTest");
+				.containsExactlyInAnyOrder("JUnit Vintage", testClass.getSimpleName(), "failingTest");
 	}
 
 	@Test
@@ -83,7 +83,7 @@ class VintageLauncherIntegrationTests {
 
 		Map<TestIdentifier, TestExecutionResult> results = execute(request);
 		assertThat(results.keySet().stream().map(TestIdentifier::getDisplayName)) //
-				.containsExactlyInAnyOrder("JUnit Vintage", testClass.getName(), nestedTestClass.getName(),
+				.containsExactlyInAnyOrder("JUnit Vintage", testClass.getSimpleName(), nestedTestClass.getName(),
 					"failingTest");
 	}
 
@@ -100,7 +100,7 @@ class VintageLauncherIntegrationTests {
 
 		Map<TestIdentifier, TestExecutionResult> results = execute(request);
 		assertThat(results.keySet().stream().map(TestIdentifier::getDisplayName)) //
-				.containsExactlyInAnyOrder("JUnit Vintage", testClass.getName(), nestedTestClass.getName(),
+				.containsExactlyInAnyOrder("JUnit Vintage", testClass.getSimpleName(), nestedTestClass.getName(),
 					"successfulTest");
 	}
 
@@ -163,7 +163,7 @@ class VintageLauncherIntegrationTests {
 
 		Map<TestIdentifier, TestExecutionResult> results = execute(request);
 		assertThat(results.keySet().stream().map(TestIdentifier::getDisplayName)) //
-				.containsExactlyInAnyOrder("JUnit Vintage", testClass.getName(), "Test #0", "Test #1");
+				.containsExactlyInAnyOrder("JUnit Vintage", testClass.getSimpleName(), "Test #0", "Test #1");
 		assertThat(logRecordListener.stream(RunnerTestDescriptor.class, Level.WARNING).map(LogRecord::getMessage)) //
 				.containsExactly(
 					"Runner " + NotFilterableRunner.class.getName() + " (used on class " + testClass.getName() + ")" //
@@ -185,7 +185,7 @@ class VintageLauncherIntegrationTests {
 
 		Map<TestIdentifier, TestExecutionResult> results = execute(request);
 		assertThat(results.keySet().stream().map(TestIdentifier::getDisplayName)) //
-				.containsExactlyInAnyOrder("JUnit Vintage", suiteClass.getName(), testClass.getName(), "Test #0",
+				.containsExactlyInAnyOrder("JUnit Vintage", suiteClass.getSimpleName(), testClass.getName(), "Test #0",
 					"Test #1");
 		assertThat(logRecordListener.stream(RunnerTestDescriptor.class, Level.WARNING).map(LogRecord::getMessage)) //
 				.containsExactly("Runner " + Suite.class.getName() + " (used on class " + suiteClass.getName() + ")" //
@@ -205,7 +205,7 @@ class VintageLauncherIntegrationTests {
 
 		Map<TestIdentifier, TestExecutionResult> results = execute(request);
 		assertThat(results.keySet().stream().map(TestIdentifier::getDisplayName)) //
-				.containsExactlyInAnyOrder("JUnit Vintage", suiteClass.getName(), testClass.getName(),
+				.containsExactlyInAnyOrder("JUnit Vintage", suiteClass.getSimpleName(), testClass.getName(),
 					"successfulTest");
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
@@ -122,7 +122,7 @@ class VintageTestEngineDiscoveryTests {
 		TestDescriptor runnerDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		assertFalse(runnerDescriptor.isContainer());
 		assertTrue(runnerDescriptor.isTest());
-		assertEquals(testClass.getName(), runnerDescriptor.getDisplayName());
+		assertEquals(testClass.getSimpleName(), runnerDescriptor.getDisplayName());
 		assertEquals(VintageUniqueIdBuilder.uniqueIdForClass(testClass), runnerDescriptor.getUniqueId());
 		assertThat(runnerDescriptor.getChildren()).isEmpty();
 	}
@@ -240,9 +240,9 @@ class VintageTestEngineDiscoveryTests {
 		// @formatter:off
 		assertThat(engineDescriptor.getChildren())
 			.extracting(TestDescriptor::getDisplayName)
-			.contains(PlainJUnit4TestCaseWithSingleTestWhichFails.class.getName())
-			.contains(PlainJUnit3TestCaseWithSingleTestWhichFails.class.getName())
-			.doesNotContain(PlainOldJavaClassWithoutAnyTestsTestCase.class.getName());
+			.contains(PlainJUnit4TestCaseWithSingleTestWhichFails.class.getSimpleName())
+			.contains(PlainJUnit3TestCaseWithSingleTestWhichFails.class.getSimpleName())
+			.doesNotContain(PlainOldJavaClassWithoutAnyTestsTestCase.class.getSimpleName());
 		// @formatter:on
 	}
 
@@ -262,7 +262,7 @@ class VintageTestEngineDiscoveryTests {
 			// @formatter:off
 			assertThat(engineDescriptor.getChildren())
 					.extracting(TestDescriptor::getDisplayName)
-					.containsExactly("com.example.project.JUnit4Test");
+					.containsExactly("JUnit4Test");
 			// @formatter:on
 		}
 		finally {
@@ -282,9 +282,9 @@ class VintageTestEngineDiscoveryTests {
 		// @formatter:off
 		assertThat(engineDescriptor.getChildren())
 			.extracting(TestDescriptor::getDisplayName)
-			.contains(PlainJUnit4TestCaseWithSingleTestWhichFails.class.getName())
-			.doesNotContain(JUnit4TestCaseWithOverloadedMethod.class.getName())
-			.doesNotContain(PlainJUnit3TestCaseWithSingleTestWhichFails.class.getName());
+			.contains(PlainJUnit4TestCaseWithSingleTestWhichFails.class.getSimpleName())
+			.doesNotContain(JUnit4TestCaseWithOverloadedMethod.class.getSimpleName())
+			.doesNotContain(PlainJUnit3TestCaseWithSingleTestWhichFails.class.getSimpleName());
 		// @formatter:on
 	}
 
@@ -300,7 +300,7 @@ class VintageTestEngineDiscoveryTests {
 		// @formatter:off
 		assertThat(engineDescriptor.getChildren())
 				.extracting(TestDescriptor::getDisplayName)
-				.contains(PlainJUnit4TestCaseWithSingleTestWhichFails.class.getName());
+				.contains(PlainJUnit4TestCaseWithSingleTestWhichFails.class.getSimpleName());
 		// @formatter:on
 	}
 
@@ -316,8 +316,8 @@ class VintageTestEngineDiscoveryTests {
 		// @formatter:off
 		assertThat(engineDescriptor.getChildren())
 			.extracting(TestDescriptor::getDisplayName)
-			.contains(testClass.getName())
-			.doesNotContain(PlainJUnit3TestCaseWithSingleTestWhichFails.class.getName());
+			.contains(testClass.getSimpleName())
+			.doesNotContain(PlainJUnit3TestCaseWithSingleTestWhichFails.class.getSimpleName());
 		// @formatter:on
 	}
 
@@ -333,8 +333,8 @@ class VintageTestEngineDiscoveryTests {
 		// @formatter:off
 		assertThat(engineDescriptor.getChildren())
 			.extracting(TestDescriptor::getDisplayName)
-			.contains(testClass.getName())
-			.doesNotContain(PlainJUnit4TestCaseWithSingleTestWhichFails.class.getName());
+			.contains(testClass.getSimpleName())
+			.doesNotContain(PlainJUnit4TestCaseWithSingleTestWhichFails.class.getSimpleName());
 		// @formatter:on
 	}
 
@@ -347,7 +347,7 @@ class VintageTestEngineDiscoveryTests {
 		TestDescriptor engineDescriptor = discoverTests(discoveryRequest);
 
 		TestDescriptor runnerDescriptor = getOnlyElement(engineDescriptor.getChildren());
-		assertEquals(testClass.getName(), runnerDescriptor.getDisplayName());
+		assertEquals(testClass.getSimpleName(), runnerDescriptor.getDisplayName());
 		assertClassSource(testClass, runnerDescriptor);
 
 		TestDescriptor testDescriptor = getOnlyElement(runnerDescriptor.getChildren());
@@ -637,7 +637,7 @@ class VintageTestEngineDiscoveryTests {
 		TestDescriptor engineDescriptor = discoverTests(request);
 
 		TestDescriptor runnerDescriptor = getOnlyElement(engineDescriptor.getChildren());
-		assertEquals(testClass.getName(), runnerDescriptor.getDisplayName());
+		assertEquals(testClass.getSimpleName(), runnerDescriptor.getDisplayName());
 		assertEquals(VintageUniqueIdBuilder.uniqueIdForClass(testClass), runnerDescriptor.getUniqueId());
 		assertThat(runnerDescriptor.getChildren()).isNotEmpty();
 	}
@@ -720,7 +720,7 @@ class VintageTestEngineDiscoveryTests {
 	private static void assertRunnerTestDescriptor(TestDescriptor runnerDescriptor, Class<?> testClass) {
 		assertTrue(runnerDescriptor.isContainer());
 		assertFalse(runnerDescriptor.isTest());
-		assertEquals(testClass.getName(), runnerDescriptor.getDisplayName());
+		assertEquals(testClass.getSimpleName(), runnerDescriptor.getDisplayName());
 		assertEquals(VintageUniqueIdBuilder.uniqueIdForClass(testClass), runnerDescriptor.getUniqueId());
 		assertClassSource(testClass, runnerDescriptor);
 	}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
@@ -378,7 +378,7 @@ class VintageTestEngineExecutionTests {
 		// @formatter:off
 		assertThat(PlainJUnit4TestCaseWithLifecycleMethods.EVENTS).containsExactly(
 			"executionStarted:JUnit Vintage",
-				"executionStarted:" + testClass.getName(),
+				"executionStarted:" + testClass.getSimpleName(),
 					"beforeClass",
 						"executionStarted:failingTest",
 							"before",
@@ -392,7 +392,7 @@ class VintageTestEngineExecutionTests {
 							"after",
 						"executionFinished:succeedingTest",
 					"afterClass",
-				"executionFinished:" + testClass.getName(),
+				"executionFinished:" + testClass.getSimpleName(),
 			"executionFinished:JUnit Vintage"
 		);
 		// @formatter:on


### PR DESCRIPTION
Resolves Issue: #970

## Overview

The changes involve the default display name of JUnit Vintage test classes. It was different from the Jupiter tests because it was the FQCN. This pull request makes the display names the same, and it fixes the tests that failed upon change.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).
