### PR TITLE
Fix ArgumentsAccessor extension function shadowing

### DIFF
--- a/junit-jupiter-params/src/main/kotlin/org/junit/jupiter/params/aggregator/ArgumentsAccessor.kt
+++ b/junit-jupiter-params/src/main/kotlin/org/junit/jupiter/params/aggregator/ArgumentsAccessor.kt
@@ -20,6 +20,5 @@ package org.junit.jupiter.params.aggregator
  * @receiver[ArgumentsAccessor]
  * @see ArgumentsAccessor.get(Int, Class<T!>!)
  */
-@Suppress("EXTENSION_SHADOWED_BY_MEMBER") // method is in fact not shadowed due to reified type
-inline fun <reified T : Any> ArgumentsAccessor.get(index: Int): T =
+inline fun <reified T : Any> ArgumentsAccessor.getAs(index: Int): T =
         this.get(index, T::class.java)

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/aggregator/ArgumentsAccessorKotlinTests.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/aggregator/ArgumentsAccessorKotlinTests.kt
@@ -20,15 +20,15 @@ import org.junit.jupiter.api.assertThrows
 class ArgumentsAccessorKotlinTests {
 
     @Test
-    fun `get() with reified type and index`() {
-        assertEquals(1, DefaultArgumentsAccessor(1).get<Int>(0))
-        assertEquals('A', DefaultArgumentsAccessor('A').get<Char>(0))
+    fun `getAs() with reified type and index`() {
+        assertEquals(1, DefaultArgumentsAccessor(1).getAs(0))
+        assertEquals('A', DefaultArgumentsAccessor('A').getAs(0))
     }
 
     @Test
-    fun `get() with reified type and index for incompatible type`() {
+    fun `getAs() with reified type and index for incompatible type`() {
         val exception = assertThrows<ArgumentAccessException> {
-            DefaultArgumentsAccessor(Integer.valueOf(1)).get<Char>(0)
+            DefaultArgumentsAccessor(Integer.valueOf(1)).getAs<Char>(0)
         }
 
         assertThat(exception).hasMessage(


### PR DESCRIPTION
## Overview

The extension function was being shadowed by [org.junit.jupiter.params.aggregator.get](https://github.com/junit-team/junit5/blob/master/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessor.java#L55).
This commit renames the funcion so it can be used correctly.

Issue: #1490  
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [X] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
