### PR TITLE
Use correct class for method-based test descriptors

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -42,7 +42,7 @@ abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod) {
-		super(uniqueId, displayName, MethodSource.from(Preconditions.notNull(testMethod, "Method must not be null")));
+		super(uniqueId, displayName, MethodSource.from(testClass, testMethod));
 
 		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
 		this.testMethod = testMethod;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -31,8 +32,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.JupiterTestDescriptorTests.StaticTestCase.StaticTestCaseLevel2;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.MethodSource;
 
 /**
  * Unit tests for {@link ClassTestDescriptor}, {@link NestedClassTestDescriptor},
@@ -173,6 +176,21 @@ class JupiterTestDescriptorTests {
 	}
 
 	@Test
+	void constructFromInheritedMethod() throws Exception {
+		Method testMethod = ConcreteTest.class.getMethod("theTest");
+		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, ConcreteTest.class, testMethod);
+
+		assertEquals(testMethod, descriptor.getTestMethod());
+
+		Optional<TestSource> sourceOptional = descriptor.getSource();
+		assertThat(sourceOptional).containsInstanceOf(MethodSource.class);
+
+		MethodSource methodSource = (MethodSource) sourceOptional.get();
+		assertEquals(ConcreteTest.class.getName(), methodSource.getClassName());
+		assertEquals("theTest", methodSource.getMethodName());
+	}
+
+	@Test
 	void defaultDisplayNamesForTestClasses() {
 		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, getClass());
 		assertEquals(getClass().getSimpleName(), descriptor.getDisplayName());
@@ -301,6 +319,16 @@ class JupiterTestDescriptorTests {
 
 		static class StaticTestCaseLevel2 {
 		}
+	}
+
+	private abstract static class AbstractTestBase {
+
+		@Test
+		public void theTest() {
+		}
+	}
+
+	private static class ConcreteTest extends AbstractTestBase {
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
@@ -69,6 +69,17 @@ public class MethodSource implements TestSource {
 		return new MethodSource(method);
 	}
 
+	/**
+	 * Create a new {@code MethodSource} using the supplied
+	 * {@link Class class} and {@link Method method}.
+	 *
+	 * @param testClass the Java class; must not be {@code null}
+	 * @param method the Java method; must not be {@code null}
+	 */
+	public static MethodSource from(Class<?> testClass, Method method) {
+		return new MethodSource(testClass, method);
+	}
+
 	private final String className;
 	private final String methodName;
 	private final String methodParameterTypes;
@@ -86,10 +97,15 @@ public class MethodSource implements TestSource {
 	}
 
 	private MethodSource(Method method) {
-		Preconditions.notNull(method, "method must not be null");
-		this.className = method.getDeclaringClass().getName();
-		this.methodName = method.getName();
-		this.methodParameterTypes = nullSafeToString(method.getParameterTypes());
+		this(Preconditions.notNull(method, "Method must not be null").getDeclaringClass(), method);
+	}
+
+	private MethodSource(Class<?> testClass, Method testMethod) {
+		Preconditions.notNull(testClass, "Class must not be null");
+		Preconditions.notNull(testMethod, "Method must not be null");
+		this.className = testClass.getName();
+		this.methodName = testMethod.getName();
+		this.methodParameterTypes = nullSafeToString(testMethod.getParameterTypes());
 	}
 
 	/**

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -152,7 +152,7 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 		}
 		else {
 			List<Method> methods = findMethods(testClass, where(Method::getName, isEqual(methodName)));
-			return (methods.size() == 1) ? MethodSource.from(getOnlyElement(methods)) : null;
+			return (methods.size() == 1) ? MethodSource.from(testClass, getOnlyElement(methods)) : null;
 		}
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
@@ -352,7 +352,7 @@ class VintageTestEngineDiscoveryTests {
 
 		TestDescriptor testDescriptor = getOnlyElement(runnerDescriptor.getChildren());
 		assertEquals("failingTest", testDescriptor.getDisplayName());
-		assertMethodSource(superclass.getMethod("failingTest"), testDescriptor);
+		assertMethodSource(testClass, superclass.getMethod("failingTest"), testDescriptor);
 	}
 
 	@Test
@@ -764,9 +764,14 @@ class VintageTestEngineDiscoveryTests {
 	}
 
 	private static void assertMethodSource(Method expectedMethod, TestDescriptor testDescriptor) {
+		assertMethodSource(expectedMethod.getDeclaringClass(), expectedMethod, testDescriptor);
+	}
+
+	private static void assertMethodSource(Class<?> expectedClass, Method expectedMethod,
+			TestDescriptor testDescriptor) {
 		assertThat(testDescriptor.getSource()).containsInstanceOf(MethodSource.class);
 		MethodSource methodSource = (MethodSource) testDescriptor.getSource().get();
-		assertThat(methodSource.getClassName()).isEqualTo(expectedMethod.getDeclaringClass().getName());
+		assertThat(methodSource.getClassName()).isEqualTo(expectedClass.getName());
 		assertThat(methodSource.getMethodName()).isEqualTo(expectedMethod.getName());
 		assertThat(methodSource.getMethodParameterTypes()).isEqualTo(
 			ClassUtils.nullSafeToString(expectedMethod.getParameterTypes()));

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/descriptor/VintageTestDescriptorTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/descriptor/VintageTestDescriptorTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.descriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.runner.Description;
+
+class VintageTestDescriptorTests {
+
+	private static final UniqueId uniqueId = UniqueId.forEngine("vintage");
+
+	@Test
+	void constructFromInheritedMethod() throws Exception {
+		Description description = Description.createTestDescription(ConcreteTest.class, "theTest");
+		VintageTestDescriptor descriptor = new VintageTestDescriptor(uniqueId, description);
+
+		Optional<TestSource> sourceOptional = descriptor.getSource();
+		assertThat(sourceOptional).containsInstanceOf(MethodSource.class);
+
+		MethodSource methodSource = (MethodSource) sourceOptional.get();
+		assertEquals(ConcreteTest.class.getName(), methodSource.getClassName());
+		assertEquals("theTest", methodSource.getMethodName());
+	}
+
+	private abstract static class AbstractTestBase {
+
+		@Test
+		public void theTest() {
+		}
+	}
+
+	private static class ConcreteTest extends AbstractTestBase {
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
@@ -50,6 +50,22 @@ class MethodSourceTests {
 	}
 
 	@Test
+	void instantiationWithNullClassOrMethodShouldThrowPreconditionViolationException() {
+		assertThrows(PreconditionViolationException.class,
+			() -> MethodSource.from(null, String.class.getDeclaredMethod("getBytes")));
+		assertThrows(PreconditionViolationException.class, () -> MethodSource.from(String.class, null));
+	}
+
+	@Test
+	void instantiationWithClassAndMethodShouldResultInACorrectObject() throws Exception {
+		MethodSource source = MethodSource.from(String.class,
+			String.class.getDeclaredMethod("lastIndexOf", String.class, int.class));
+		assertEquals(String.class.getName(), source.getClassName());
+		assertEquals("lastIndexOf", source.getMethodName());
+		assertEquals("java.lang.String, int", source.getMethodParameterTypes());
+	}
+
+	@Test
 	void twoEqualMethodsShouldHaveEqualMethodSourceObjects() {
 		assertEquals(MethodSource.from("TestClass1", "testMethod1"), MethodSource.from("TestClass1", "testMethod1"));
 	}


### PR DESCRIPTION
## Overview

`MethodBasedTestDescriptor` and `VintageTestDescriptor` did not preserve original class of the discovered method and instead obtained it from the `java.lang.reflect.Method`. This happened to be problematic for inherited test methods. They appeared to come from the abstract class instead of the concrete class. Surefire provider failed to match such methods when executing tests matching a mask (via `-Dtest=*MaskTest`).

This PR fixes the problem by making the underlying `MethodSource` preserve the original concrete class.

Fixes: #1406

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
