### PR TITLE
Introduce exception handling support for lifecycle callback methods

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestExecutionExceptionHandler.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestExecutionExceptionHandler.java
@@ -64,7 +64,7 @@ public interface TestExecutionExceptionHandler extends Extension {
 	default void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 		throw throwable;
 	}
-	
+
 	default void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 		throw throwable;
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestExecutionExceptionHandler.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestExecutionExceptionHandler.java
@@ -61,4 +61,11 @@ public interface TestExecutionExceptionHandler extends Extension {
 	 */
 	void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable;
 
+	default void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+		throw throwable;
+	}
+	
+	default void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+		throw throwable;
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestExecutionExceptionHandler.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestExecutionExceptionHandler.java
@@ -61,11 +61,19 @@ public interface TestExecutionExceptionHandler extends Extension {
 	 */
 	void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable;
 
+	default void handleExceptionInBeforeAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+		throw throwable;
+	}
+
 	default void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 		throw throwable;
 	}
 
 	default void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+		throw throwable;
+	}
+
+	default void handleExceptionInAfterAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 		throw throwable;
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -50,8 +50,8 @@ import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.execution.TestInstanceProvider;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.JUnitException;
-import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.StringUtils;
@@ -408,7 +408,7 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 			BiFunction<Throwable, TestExecutionExceptionHandler, Executable> generator) {
 
 		invokeTestExecutionExceptionHandlers(ex, registry.getReversedExtensions(TestExecutionExceptionHandler.class),
-				generator);
+			generator);
 	}
 
 	private void invokeTestExecutionExceptionHandlers(Throwable ex, List<TestExecutionExceptionHandler> handlers,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -362,7 +362,7 @@ public class ClassTestDescriptor extends JupiterTestDescriptor {
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 		Object testInstance = extensionContext.getTestInstance().orElse(null);
 
-		for (Method method: this.beforeAllMethods) {
+		for (Method method : this.beforeAllMethods) {
 			throwableCollector.execute(() -> {
 				try {
 					executableInvoker.invoke(method, testInstance, extensionContext, registry);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -138,7 +138,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 					adapter.invokeBeforeEachMethod(extensionContext, registry);
 				}
 				catch (Throwable throwable) {
-					invokeTestExecutionExceptionHandlers(context.getExtensionRegistry(), throwable,
+					invokeTestExecutionExceptionHandlers(throwable, registry,
 						((ex, handler) -> () -> handler.handleExceptionInBeforeEachMethod(extensionContext, ex)));
 				}
 			}),
@@ -179,13 +179,13 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 				executableInvoker.invoke(testMethod, instance, extensionContext, context.getExtensionRegistry());
 			}
 			catch (Throwable throwable) {
-				invokeTestExecutionExceptionHandlers(context.getExtensionRegistry(), throwable,
+				invokeTestExecutionExceptionHandlers(throwable, context.getExtensionRegistry(),
 					((ex, handler) -> () -> handler.handleTestExecutionException(extensionContext, ex)));
 			}
 		});
 	}
 
-	private void invokeTestExecutionExceptionHandlers(ExtensionRegistry registry, Throwable ex,
+	private void invokeTestExecutionExceptionHandlers(Throwable ex, ExtensionRegistry registry,
 			BiFunction<Throwable, TestExecutionExceptionHandler, Executable> generator) {
 
 		invokeTestExecutionExceptionHandlers(ex, registry.getReversedExtensions(TestExecutionExceptionHandler.class),
@@ -224,7 +224,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 					adapter.invokeAfterEachMethod(extensionContext, registry);
 				}
 				catch (Throwable throwable) {
-					invokeTestExecutionExceptionHandlers(context.getExtensionRegistry(), throwable,
+					invokeTestExecutionExceptionHandlers(throwable, registry,
 						((ex, handler) -> () -> handler.handleExceptionInAfterEachMethod(extensionContext, ex)));
 				}
 			}),

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -140,8 +140,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 				invokeTestExecutionExceptionHandlers(throwable, registry,
 					((ex, handler) -> () -> handler.handleExceptionInBeforeEachMethod(extensionContext, ex)));
 			}
-		}),
-		BeforeEachMethodAdapter.class);
+		}), BeforeEachMethodAdapter.class);
 	}
 
 	private void invokeBeforeTestExecutionCallbacks(JupiterEngineExecutionContext context) {
@@ -225,8 +224,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 				invokeTestExecutionExceptionHandlers(throwable, registry,
 					((ex, handler) -> () -> handler.handleExceptionInAfterEachMethod(extensionContext, ex)));
 			}
-		}),
-		AfterEachMethodAdapter.class);
+		}), AfterEachMethodAdapter.class);
 	}
 
 	private void invokeAfterEachCallbacks(JupiterEngineExecutionContext context) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -132,17 +132,16 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 
 	private void invokeBeforeEachMethods(JupiterEngineExecutionContext context) {
 		ExtensionRegistry registry = context.getExtensionRegistry();
-		invokeBeforeMethodsOrCallbacksUntilExceptionOccurs(context,
-			((extensionContext, adapter) -> () -> {
-				try {
-					adapter.invokeBeforeEachMethod(extensionContext, registry);
-				}
-				catch (Throwable throwable) {
-					invokeTestExecutionExceptionHandlers(throwable, registry,
-						((ex, handler) -> () -> handler.handleExceptionInBeforeEachMethod(extensionContext, ex)));
-				}
-			}),
-			BeforeEachMethodAdapter.class);
+		invokeBeforeMethodsOrCallbacksUntilExceptionOccurs(context, ((extensionContext, adapter) -> () -> {
+			try {
+				adapter.invokeBeforeEachMethod(extensionContext, registry);
+			}
+			catch (Throwable throwable) {
+				invokeTestExecutionExceptionHandlers(throwable, registry,
+					((ex, handler) -> () -> handler.handleExceptionInBeforeEachMethod(extensionContext, ex)));
+			}
+		}),
+		BeforeEachMethodAdapter.class);
 	}
 
 	private void invokeBeforeTestExecutionCallbacks(JupiterEngineExecutionContext context) {
@@ -189,7 +188,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 			BiFunction<Throwable, TestExecutionExceptionHandler, Executable> generator) {
 
 		invokeTestExecutionExceptionHandlers(ex, registry.getReversedExtensions(TestExecutionExceptionHandler.class),
-				generator);
+			generator);
 	}
 
 	private void invokeTestExecutionExceptionHandlers(Throwable ex, List<TestExecutionExceptionHandler> handlers,
@@ -218,17 +217,16 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 
 	private void invokeAfterEachMethods(JupiterEngineExecutionContext context) {
 		ExtensionRegistry registry = context.getExtensionRegistry();
-		invokeAllAfterMethodsOrCallbacks(context,
-			((extensionContext, adapter) -> () -> {
-				try {
-					adapter.invokeAfterEachMethod(extensionContext, registry);
-				}
-				catch (Throwable throwable) {
-					invokeTestExecutionExceptionHandlers(throwable, registry,
-						((ex, handler) -> () -> handler.handleExceptionInAfterEachMethod(extensionContext, ex)));
-				}
-			}),
-			AfterEachMethodAdapter.class);
+		invokeAllAfterMethodsOrCallbacks(context, ((extensionContext, adapter) -> () -> {
+			try {
+				adapter.invokeAfterEachMethod(extensionContext, registry);
+			}
+			catch (Throwable throwable) {
+				invokeTestExecutionExceptionHandlers(throwable, registry,
+					((ex, handler) -> () -> handler.handleExceptionInAfterEachMethod(extensionContext, ex)));
+			}
+		}),
+		AfterEachMethodAdapter.class);
 	}
 
 	private void invokeAfterEachCallbacks(JupiterEngineExecutionContext context) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -136,7 +136,8 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 			((extensionContext, adapter) -> () -> {
 				try {
 					adapter.invokeBeforeEachMethod(extensionContext, registry);
-				} catch (Throwable throwable) {
+				}
+				catch (Throwable throwable) {
 					invokeTestExecutionExceptionHandlers(context.getExtensionRegistry(), throwable,
 						((ex, handler) -> () -> handler.handleExceptionInBeforeEachMethod(extensionContext, ex)));
 				}
@@ -176,7 +177,8 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 				Method testMethod = getTestMethod();
 				Object instance = extensionContext.getRequiredTestInstance();
 				executableInvoker.invoke(testMethod, instance, extensionContext, context.getExtensionRegistry());
-			} catch (Throwable throwable) {
+			}
+			catch (Throwable throwable) {
 				invokeTestExecutionExceptionHandlers(context.getExtensionRegistry(), throwable,
 					((ex, handler) -> () -> handler.handleTestExecutionException(extensionContext, ex)));
 			}
@@ -202,7 +204,8 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 			// Invoke next available handler
 			Executable executable = generator.apply(ex, handlers.remove(0));
 			executable.execute();
-		} catch (Throwable t) {
+		}
+		catch (Throwable t) {
 			invokeTestExecutionExceptionHandlers(t, handlers, generator);
 		}
 	}
@@ -219,7 +222,8 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 			((extensionContext, adapter) -> () -> {
 				try {
 					adapter.invokeAfterEachMethod(extensionContext, registry);
-				} catch (Throwable throwable) {
+				}
+				catch (Throwable throwable) {
 					invokeTestExecutionExceptionHandlers(context.getExtensionRegistry(), throwable,
 						((ex, handler) -> () -> handler.handleExceptionInAfterEachMethod(extensionContext, ex)));
 				}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -182,7 +182,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 			}
 		});
 	}
-	
+
 	private void invokeTestExecutionExceptionHandlers(ExtensionRegistry registry, Throwable ex,
 			BiFunction<Throwable, TestExecutionExceptionHandler, Executable> generator) {
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -170,7 +170,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 	protected void invokeTestMethod(JupiterEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) {
 		ExtensionContext extensionContext = context.getExtensionContext();
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
-		
+
 		throwableCollector.execute(() -> {
 			try {
 				Method testMethod = getTestMethod();
@@ -185,19 +185,19 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 	
 	private void invokeTestExecutionExceptionHandlers(ExtensionRegistry registry, Throwable ex,
 			BiFunction<Throwable, TestExecutionExceptionHandler, Executable> generator) {
-		
+
 		invokeTestExecutionExceptionHandlers(ex, registry.getReversedExtensions(TestExecutionExceptionHandler.class),
 				generator);
 	}
-	
+
 	private void invokeTestExecutionExceptionHandlers(Throwable ex, List<TestExecutionExceptionHandler> handlers,
 			BiFunction<Throwable, TestExecutionExceptionHandler, Executable> generator) {
-		
+
 		// No handlers left?
 		if (handlers.isEmpty()) {
 			ExceptionUtils.throwAsUncheckedException(ex);
 		}
-		
+
 		try {
 			// Invoke next available handler
 			Executable executable = generator.apply(ex, handlers.remove(0));

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllExceptionHandlerTests.java
@@ -63,7 +63,7 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 			event(engine(), started()), //
 			event(container(RethrowTestCase.class), started()), //
 			event(container(RethrowTestCase.class),
-			      finishedWithFailure(allOf(isA(IOException.class), message("checked")))), //
+				finishedWithFailure(allOf(isA(IOException.class), message("checked")))), //
 			event(engine(), finishedSuccessfully()));
 
 		assertEquals(Arrays.asList("rethrowBeforeAll", "rethrowAfterAll", "rethrowAfterAll"), handlerCalls);
@@ -96,7 +96,7 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 			event(engine(), started()), //
 			event(container(ConvertTestCase.class), started()), //
 			event(container(ConvertTestCase.class),
-			      finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))), //
+				finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))), //
 			event(engine(), finishedSuccessfully()));
 
 		assertEquals(Arrays.asList("convertBeforeAll", "convertAfterAll", "convertAfterAll"), handlerCalls);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllExceptionHandlerTests.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.assertj.core.api.Assertions.allOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.assertRecordedExecutionEventsContainsExactly;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.engine;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.event;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.finishedSuccessfully;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.finishedWithFailure;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.started;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.test;
+import static org.junit.platform.engine.test.event.TestExecutionResultConditions.isA;
+import static org.junit.platform.engine.test.event.TestExecutionResultConditions.message;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+
+/**
+ * Integration tests that verify exception handling of {@code @BeforeAll} and {@code @AfterAll} methods in
+ * {@link TestExecutionExceptionHandler}.
+ */
+class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTests {
+
+	static List<String> handlerCalls = new ArrayList<>();
+
+	@BeforeEach
+	void resetStatics() {
+		handlerCalls.clear();
+	}
+
+	@Test
+	void exceptionHandlerRethrowsException() {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(RethrowTestCase.class, "test")).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
+				event(engine(), started()),
+				event(container(RethrowTestCase.class), started()),
+				event(container(RethrowTestCase.class), finishedWithFailure(allOf(isA(IOException.class), message("checked")))),
+				event(engine(), finishedSuccessfully()));
+
+		assertEquals(Arrays.asList("rethrowBeforeAll", "rethrowAfterAll", "rethrowAfterAll"),
+				handlerCalls);
+	}
+
+	@Test
+	void exceptionHandlerSwallowsException() {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(SwallowTestCase.class, "test")).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
+				event(engine(), started()),
+				event(container(SwallowTestCase.class), started()),
+				event(test("test"), started()),
+				event(test("test"), finishedSuccessfully()),
+				event(container(SwallowTestCase.class), finishedSuccessfully()),
+				event(engine(), finishedSuccessfully()));
+
+		assertEquals(Arrays.asList(
+				"swallowBeforeAll", "swallowBeforeAll", "swallowTest", "swallowAfterAll", "swallowAfterAll"),
+				handlerCalls);
+	}
+
+	@Test
+	void exceptionHandlerConvertsException() {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(ConvertTestCase.class, "test")).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
+				event(engine(), started()),
+				event(container(ConvertTestCase.class), started()),
+				event(container(ConvertTestCase.class), finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))),
+				event(engine(), finishedSuccessfully()));
+
+		assertEquals(Arrays.asList("convertBeforeAll", "convertAfterAll", "convertAfterAll"),
+				handlerCalls);
+	}
+
+	@Test
+	void severalHandlersAreCalledInOrder() {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(SeveralTestCase.class, "test")).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
+				event(engine(), started()),
+				event(container(SeveralTestCase.class), started()),
+				event(test("test"), started()),
+				event(test("test"), finishedSuccessfully()),
+				event(container(SeveralTestCase.class), finishedSuccessfully()),
+				event(engine(), finishedSuccessfully()));
+
+		assertEquals(Arrays.asList(
+				"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll",
+				"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll",
+				"convertTest", "rethrowTest", "swallowTest",
+				"convertAfterAll", "rethrowAfterAll", "swallowAfterAll",
+				"convertAfterAll", "rethrowAfterAll", "swallowAfterAll"),
+				handlerCalls);
+	}
+
+	// -------------------------------------------------------------------
+
+	static abstract class ATestCase {
+
+		@BeforeAll
+		static void beforeAll() throws IOException {
+			throw new IOException("checked");
+		}
+
+		@BeforeAll
+		static void beforeAll2() throws IOException {
+			throw new IOException("checked");
+		}
+
+		@Test
+		void test() throws IOException {
+			throw new IOException("checked");
+		}
+
+		@AfterAll
+		static void afterAll() throws IOException {
+			throw new IOException("checked");
+		}
+
+		@AfterAll
+		static void afterAll2() throws IOException {
+			throw new IOException("checked");
+		}
+	}
+
+	@ExtendWith(RethrowException.class)
+	static class RethrowTestCase extends ATestCase {
+	}
+
+	@ExtendWith(SwallowException.class)
+	static class SwallowTestCase extends ATestCase {
+	}
+
+	@ExtendWith(ConvertException.class)
+	static class ConvertTestCase extends ATestCase {
+	}
+
+	@ExtendWith(ShouldNotBeCalled.class)
+	@ExtendWith(SwallowException.class)
+	@ExtendWith(RethrowException.class)
+	@ExtendWith(ConvertException.class)
+	static class SeveralTestCase extends ATestCase {
+	}
+
+	static class RethrowException implements TestExecutionExceptionHandler {
+
+		@Override
+		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("rethrowTest");
+			throw throwable;
+		}
+
+		@Override
+		public void handleExceptionInBeforeAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("rethrowBeforeAll");
+			throw throwable;
+		}
+
+		@Override
+		public void handleExceptionInAfterAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("rethrowAfterAll");
+			throw throwable;
+		}
+	}
+
+	static class SwallowException implements TestExecutionExceptionHandler {
+		// swallow exception by not rethrowing it
+
+		@Override
+		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("swallowTest");
+		}
+
+		@Override
+		public void handleExceptionInBeforeAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("swallowBeforeAll");
+		}
+
+		@Override
+		public void handleExceptionInAfterAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("swallowAfterAll");
+		}
+	}
+
+	static class ConvertException implements TestExecutionExceptionHandler {
+
+		@Override
+		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("convertTest");
+			throw new RuntimeException("unchecked");
+		}
+
+		@Override
+		public void handleExceptionInBeforeAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("convertBeforeAll");
+			throw new RuntimeException("unchecked");
+		}
+
+		@Override
+		public void handleExceptionInAfterAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("convertAfterAll");
+			throw new RuntimeException("unchecked");
+		}
+	}
+
+	static class ShouldNotBeCalled implements TestExecutionExceptionHandler {
+
+		@Override
+		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("shouldNotBeCalledTest");
+		}
+
+		@Override
+		public void handleExceptionInBeforeAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("shouldNotBeCalledBeforeAll");
+		}
+
+		@Override
+		public void handleExceptionInAfterAllMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("shouldNotBeCalledAfterAll");
+		}
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllExceptionHandlerTests.java
@@ -62,7 +62,8 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			event(engine(), started()), //
 			event(container(RethrowTestCase.class), started()), //
-			event(container(RethrowTestCase.class), finishedWithFailure(allOf(isA(IOException.class), message("checked")))), //
+			event(container(RethrowTestCase.class),
+			      finishedWithFailure(allOf(isA(IOException.class), message("checked")))), //
 			event(engine(), finishedSuccessfully()));
 
 		assertEquals(Arrays.asList("rethrowBeforeAll", "rethrowAfterAll", "rethrowAfterAll"), handlerCalls);
@@ -81,7 +82,9 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 			event(container(SwallowTestCase.class), finishedSuccessfully()), //
 			event(engine(), finishedSuccessfully()));
 
-		assertEquals(Arrays.asList("swallowBeforeAll", "swallowBeforeAll", "swallowTest", "swallowAfterAll", "swallowAfterAll"), handlerCalls);
+		assertEquals(
+			Arrays.asList("swallowBeforeAll", "swallowBeforeAll", "swallowTest", "swallowAfterAll", "swallowAfterAll"),
+			handlerCalls);
 	}
 
 	@Test
@@ -92,7 +95,8 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
 			event(engine(), started()), //
 			event(container(ConvertTestCase.class), started()), //
-			event(container(ConvertTestCase.class), finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))), //
+			event(container(ConvertTestCase.class),
+			      finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))), //
 			event(engine(), finishedSuccessfully()));
 
 		assertEquals(Arrays.asList("convertBeforeAll", "convertAfterAll", "convertAfterAll"), handlerCalls);
@@ -112,12 +116,12 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 			event(engine(), finishedSuccessfully()));
 
 		assertEquals(Arrays.asList( //
-				"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll", //
-				"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll", //
-				"convertTest", "rethrowTest", "swallowTest", //
-				"convertAfterAll", "rethrowAfterAll", "swallowAfterAll", //
-				"convertAfterAll", "rethrowAfterAll", "swallowAfterAll"), //
-				handlerCalls);
+			"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll", //
+			"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll", //
+			"convertTest", "rethrowTest", "swallowTest", //
+			"convertAfterAll", "rethrowAfterAll", "swallowAfterAll", //
+			"convertAfterAll", "rethrowAfterAll", "swallowAfterAll"), //
+			handlerCalls);
 	}
 
 	// -------------------------------------------------------------------

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllExceptionHandlerTests.java
@@ -59,14 +59,13 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(RethrowTestCase.class, "test")).build();
 		ExecutionEventRecorder eventRecorder = executeTests(request);
 
-		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
-				event(engine(), started()),
-				event(container(RethrowTestCase.class), started()),
-				event(container(RethrowTestCase.class), finishedWithFailure(allOf(isA(IOException.class), message("checked")))),
-				event(engine(), finishedSuccessfully()));
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(RethrowTestCase.class), started()), //
+			event(container(RethrowTestCase.class), finishedWithFailure(allOf(isA(IOException.class), message("checked")))), //
+			event(engine(), finishedSuccessfully()));
 
-		assertEquals(Arrays.asList("rethrowBeforeAll", "rethrowAfterAll", "rethrowAfterAll"),
-				handlerCalls);
+		assertEquals(Arrays.asList("rethrowBeforeAll", "rethrowAfterAll", "rethrowAfterAll"), handlerCalls);
 	}
 
 	@Test
@@ -74,17 +73,15 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(SwallowTestCase.class, "test")).build();
 		ExecutionEventRecorder eventRecorder = executeTests(request);
 
-		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
-				event(engine(), started()),
-				event(container(SwallowTestCase.class), started()),
-				event(test("test"), started()),
-				event(test("test"), finishedSuccessfully()),
-				event(container(SwallowTestCase.class), finishedSuccessfully()),
-				event(engine(), finishedSuccessfully()));
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(SwallowTestCase.class), started()), //
+			event(test("test"), started()), //
+			event(test("test"), finishedSuccessfully()), //
+			event(container(SwallowTestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
 
-		assertEquals(Arrays.asList(
-				"swallowBeforeAll", "swallowBeforeAll", "swallowTest", "swallowAfterAll", "swallowAfterAll"),
-				handlerCalls);
+		assertEquals(Arrays.asList("swallowBeforeAll", "swallowBeforeAll", "swallowTest", "swallowAfterAll", "swallowAfterAll"), handlerCalls);
 	}
 
 	@Test
@@ -92,14 +89,13 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(ConvertTestCase.class, "test")).build();
 		ExecutionEventRecorder eventRecorder = executeTests(request);
 
-		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
-				event(engine(), started()),
-				event(container(ConvertTestCase.class), started()),
-				event(container(ConvertTestCase.class), finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))),
-				event(engine(), finishedSuccessfully()));
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(ConvertTestCase.class), started()), //
+			event(container(ConvertTestCase.class), finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))), //
+			event(engine(), finishedSuccessfully()));
 
-		assertEquals(Arrays.asList("convertBeforeAll", "convertAfterAll", "convertAfterAll"),
-				handlerCalls);
+		assertEquals(Arrays.asList("convertBeforeAll", "convertAfterAll", "convertAfterAll"), handlerCalls);
 	}
 
 	@Test
@@ -107,20 +103,20 @@ class BeforeAndAfterAllExceptionHandlerTests extends AbstractJupiterTestEngineTe
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(SeveralTestCase.class, "test")).build();
 		ExecutionEventRecorder eventRecorder = executeTests(request);
 
-		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
-				event(engine(), started()),
-				event(container(SeveralTestCase.class), started()),
-				event(test("test"), started()),
-				event(test("test"), finishedSuccessfully()),
-				event(container(SeveralTestCase.class), finishedSuccessfully()),
-				event(engine(), finishedSuccessfully()));
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(SeveralTestCase.class), started()), //
+			event(test("test"), started()), //
+			event(test("test"), finishedSuccessfully()), //
+			event(container(SeveralTestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
 
-		assertEquals(Arrays.asList(
-				"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll",
-				"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll",
-				"convertTest", "rethrowTest", "swallowTest",
-				"convertAfterAll", "rethrowAfterAll", "swallowAfterAll",
-				"convertAfterAll", "rethrowAfterAll", "swallowAfterAll"),
+		assertEquals(Arrays.asList( //
+				"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll", //
+				"convertBeforeAll", "rethrowBeforeAll", "swallowBeforeAll", //
+				"convertTest", "rethrowTest", "swallowTest", //
+				"convertAfterAll", "rethrowAfterAll", "swallowAfterAll", //
+				"convertAfterAll", "rethrowAfterAll", "swallowAfterAll"), //
 				handlerCalls);
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachExceptionHandlerTests.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.assertj.core.api.Assertions.allOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.assertRecordedExecutionEventsContainsExactly;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.container;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.engine;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.event;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.finishedSuccessfully;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.finishedWithFailure;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.started;
+import static org.junit.platform.engine.test.event.ExecutionEventConditions.test;
+import static org.junit.platform.engine.test.event.TestExecutionResultConditions.isA;
+import static org.junit.platform.engine.test.event.TestExecutionResultConditions.message;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+
+/**
+ * Integration tests that verify exception handling of {@code @BeforeEach} and {@code @AfterEach} methods in
+ * {@link TestExecutionExceptionHandler}.
+ */
+class BeforeAndAfterEachExceptionHandlerTests extends AbstractJupiterTestEngineTests {
+	static List<String> handlerCalls = new ArrayList<>();
+	@BeforeEach
+	void resetStatics() {
+		handlerCalls.clear();
+	}
+	@Test
+	void exceptionHandlerRethrowsException() {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testRethrow")).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
+				event(engine(), started()),
+				event(container(ATestCase.class), started()),
+				event(test("testRethrow"), started()),
+				event(test("testRethrow"), finishedWithFailure(allOf(isA(IOException.class), message("checked")))),
+				event(container(ATestCase.class), finishedSuccessfully()),
+				event(engine(), finishedSuccessfully()));
+		assertEquals(Arrays.asList("rethrowBeforeEach", "rethrowAfterEach", "rethrowAfterEach"),
+				handlerCalls);
+	}
+	@Test
+	void exceptionHandlerSwallowsException() {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testSwallow")).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
+				event(engine(), started()),
+				event(container(ATestCase.class), started()),
+				event(test("testSwallow"), started()),
+				event(test("testSwallow"), finishedSuccessfully()),
+				event(container(ATestCase.class), finishedSuccessfully()),
+				event(engine(), finishedSuccessfully()));
+		assertEquals(Arrays.asList("swallowBeforeEach", "swallowBeforeEach", "swallowTest", "swallowAfterEach", "swallowAfterEach"),
+				handlerCalls);
+	}
+	@Test
+	void exceptionHandlerConvertsException() {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testConvert")).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
+				event(engine(), started()),
+				event(container(ATestCase.class), started()),
+				event(test("testConvert"), started()),
+				event(test("testConvert"), finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))),
+				event(container(ATestCase.class), finishedSuccessfully()),
+				event(engine(), finishedSuccessfully()));
+		assertEquals(Arrays.asList("convertBeforeEach", "convertAfterEach", "convertAfterEach"),
+				handlerCalls);
+	}
+	@Test
+	void severalHandlersAreCalledInOrder() {
+		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testSeveral")).build();
+		ExecutionEventRecorder eventRecorder = executeTests(request);
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
+				event(engine(), started()),
+				event(container(ATestCase.class), started()),
+				event(test("testSeveral"), started()),
+				event(test("testSeveral"), finishedSuccessfully()),
+				event(container(ATestCase.class), finishedSuccessfully()),
+				event(engine(), finishedSuccessfully()));
+		assertEquals(Arrays.asList(
+				"convertBeforeEach", "rethrowBeforeEach", "swallowBeforeEach",
+				"convertBeforeEach", "rethrowBeforeEach", "swallowBeforeEach",
+				"convertTest", "rethrowTest", "swallowTest",
+				"convertAfterEach", "rethrowAfterEach", "swallowAfterEach",
+				"convertAfterEach", "rethrowAfterEach", "swallowAfterEach"),
+				handlerCalls);
+	}
+	// -------------------------------------------------------------------
+	static class ATestCase {
+		@BeforeEach
+		void beforeEach() throws IOException {
+			throw new IOException("checked");
+		}
+		@BeforeEach
+		void beforeEach2() throws IOException {
+			throw new IOException("checked");
+		}
+		@Test
+		@ExtendWith(RethrowException.class)
+		void testRethrow() throws IOException {
+			throw new IOException("checked");
+		}
+		@Test
+		@ExtendWith(SwallowException.class)
+		void testSwallow() throws IOException {
+			throw new IOException("checked");
+		}
+		@Test
+		@ExtendWith(ConvertException.class)
+		void testConvert() throws IOException {
+			throw new IOException("checked");
+		}
+		@Test
+		@ExtendWith(ShouldNotBeCalled.class)
+		@ExtendWith(SwallowException.class)
+		@ExtendWith(RethrowException.class)
+		@ExtendWith(ConvertException.class)
+		void testSeveral() throws IOException {
+			throw new IOException("checked");
+		}
+		@AfterEach
+		void afterEach() throws IOException {
+			throw new IOException("checked");
+		}
+		@AfterEach
+		void afterEach2() throws IOException {
+			throw new IOException("checked");
+		}
+	}
+	static class RethrowException implements TestExecutionExceptionHandler {
+		@Override
+		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("rethrowTest");
+			throw throwable;
+		}
+		@Override
+		public void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("rethrowBeforeEach");
+			throw throwable;
+		}
+		@Override
+		public void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("rethrowAfterEach");
+			throw throwable;
+		}
+	}
+	static class SwallowException implements TestExecutionExceptionHandler {
+		// swallow exception by not rethrowing it
+		@Override
+		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("swallowTest");
+		}
+		@Override
+		public void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("swallowBeforeEach");
+		}
+		@Override
+		public void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("swallowAfterEach");
+		}
+	}
+	static class ConvertException implements TestExecutionExceptionHandler {
+		@Override
+		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("convertTest");
+			throw new RuntimeException("unchecked");
+		}
+		@Override
+		public void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("convertBeforeEach");
+			throw new RuntimeException("unchecked");
+		}
+		@Override
+		public void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("convertAfterEach");
+			throw new RuntimeException("unchecked");
+		}
+	}
+	static class ShouldNotBeCalled implements TestExecutionExceptionHandler {
+		@Override
+		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("shouldNotBeCalledTest");
+		}
+		@Override
+		public void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("shouldNotBeCalledBeforeEach");
+		}
+		@Override
+		public void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
+			handlerCalls.add("shouldNotBeCalledAfterEach");
+		}
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachExceptionHandlerTests.java
@@ -68,6 +68,7 @@ class BeforeAndAfterEachExceptionHandlerTests extends AbstractJupiterTestEngineT
 
 		assertEquals(Arrays.asList("rethrowBeforeEach", "rethrowAfterEach", "rethrowAfterEach"), handlerCalls);
 	}
+
 	@Test
 	void exceptionHandlerSwallowsException() {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testSwallow")).build();
@@ -81,8 +82,11 @@ class BeforeAndAfterEachExceptionHandlerTests extends AbstractJupiterTestEngineT
 			event(container(ATestCase.class), finishedSuccessfully()), //
 			event(engine(), finishedSuccessfully()));
 
-		assertEquals(Arrays.asList("swallowBeforeEach", "swallowBeforeEach", "swallowTest", "swallowAfterEach", "swallowAfterEach"), handlerCalls);
+		assertEquals(Arrays.asList( //
+			"swallowBeforeEach", "swallowBeforeEach", "swallowTest", "swallowAfterEach", "swallowAfterEach"), //
+			handlerCalls);
 	}
+
 	@Test
 	void exceptionHandlerConvertsException() {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testConvert")).build();
@@ -98,6 +102,7 @@ class BeforeAndAfterEachExceptionHandlerTests extends AbstractJupiterTestEngineT
 
 		assertEquals(Arrays.asList("convertBeforeEach", "convertAfterEach", "convertAfterEach"), handlerCalls);
 	}
+
 	@Test
 	void severalHandlersAreCalledInOrder() {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testSeveral")).build();

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachExceptionHandlerTests.java
@@ -95,6 +95,7 @@ class BeforeAndAfterEachExceptionHandlerTests extends AbstractJupiterTestEngineT
 			event(test("testConvert"), finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))), //
 			event(container(ATestCase.class), finishedSuccessfully()), //
 			event(engine(), finishedSuccessfully()));
+
 		assertEquals(Arrays.asList("convertBeforeEach", "convertAfterEach", "convertAfterEach"), handlerCalls);
 	}
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachExceptionHandlerTests.java
@@ -45,97 +45,112 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
  * {@link TestExecutionExceptionHandler}.
  */
 class BeforeAndAfterEachExceptionHandlerTests extends AbstractJupiterTestEngineTests {
+
 	static List<String> handlerCalls = new ArrayList<>();
+
 	@BeforeEach
 	void resetStatics() {
 		handlerCalls.clear();
 	}
+
 	@Test
 	void exceptionHandlerRethrowsException() {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testRethrow")).build();
 		ExecutionEventRecorder eventRecorder = executeTests(request);
-		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
-				event(engine(), started()),
-				event(container(ATestCase.class), started()),
-				event(test("testRethrow"), started()),
-				event(test("testRethrow"), finishedWithFailure(allOf(isA(IOException.class), message("checked")))),
-				event(container(ATestCase.class), finishedSuccessfully()),
-				event(engine(), finishedSuccessfully()));
-		assertEquals(Arrays.asList("rethrowBeforeEach", "rethrowAfterEach", "rethrowAfterEach"),
-				handlerCalls);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(ATestCase.class), started()), //
+			event(test("testRethrow"), started()), //
+			event(test("testRethrow"), finishedWithFailure(allOf(isA(IOException.class), message("checked")))), //
+			event(container(ATestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+
+		assertEquals(Arrays.asList("rethrowBeforeEach", "rethrowAfterEach", "rethrowAfterEach"), handlerCalls);
 	}
 	@Test
 	void exceptionHandlerSwallowsException() {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testSwallow")).build();
 		ExecutionEventRecorder eventRecorder = executeTests(request);
-		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
-				event(engine(), started()),
-				event(container(ATestCase.class), started()),
-				event(test("testSwallow"), started()),
-				event(test("testSwallow"), finishedSuccessfully()),
-				event(container(ATestCase.class), finishedSuccessfully()),
-				event(engine(), finishedSuccessfully()));
-		assertEquals(Arrays.asList("swallowBeforeEach", "swallowBeforeEach", "swallowTest", "swallowAfterEach", "swallowAfterEach"),
-				handlerCalls);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(ATestCase.class), started()), //
+			event(test("testSwallow"), started()), //
+			event(test("testSwallow"), finishedSuccessfully()), //
+			event(container(ATestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+
+		assertEquals(Arrays.asList("swallowBeforeEach", "swallowBeforeEach", "swallowTest", "swallowAfterEach", "swallowAfterEach"), handlerCalls);
 	}
 	@Test
 	void exceptionHandlerConvertsException() {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testConvert")).build();
 		ExecutionEventRecorder eventRecorder = executeTests(request);
-		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
-				event(engine(), started()),
-				event(container(ATestCase.class), started()),
-				event(test("testConvert"), started()),
-				event(test("testConvert"), finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))),
-				event(container(ATestCase.class), finishedSuccessfully()),
-				event(engine(), finishedSuccessfully()));
-		assertEquals(Arrays.asList("convertBeforeEach", "convertAfterEach", "convertAfterEach"),
-				handlerCalls);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(ATestCase.class), started()), //
+			event(test("testConvert"), started()), //
+			event(test("testConvert"), finishedWithFailure(allOf(isA(RuntimeException.class), message("unchecked")))), //
+			event(container(ATestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+		assertEquals(Arrays.asList("convertBeforeEach", "convertAfterEach", "convertAfterEach"), handlerCalls);
 	}
 	@Test
 	void severalHandlersAreCalledInOrder() {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(ATestCase.class, "testSeveral")).build();
 		ExecutionEventRecorder eventRecorder = executeTests(request);
-		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(),
-				event(engine(), started()),
-				event(container(ATestCase.class), started()),
-				event(test("testSeveral"), started()),
-				event(test("testSeveral"), finishedSuccessfully()),
-				event(container(ATestCase.class), finishedSuccessfully()),
-				event(engine(), finishedSuccessfully()));
-		assertEquals(Arrays.asList(
-				"convertBeforeEach", "rethrowBeforeEach", "swallowBeforeEach",
-				"convertBeforeEach", "rethrowBeforeEach", "swallowBeforeEach",
-				"convertTest", "rethrowTest", "swallowTest",
-				"convertAfterEach", "rethrowAfterEach", "swallowAfterEach",
-				"convertAfterEach", "rethrowAfterEach", "swallowAfterEach"),
-				handlerCalls);
+
+		assertRecordedExecutionEventsContainsExactly(eventRecorder.getExecutionEvents(), //
+			event(engine(), started()), //
+			event(container(ATestCase.class), started()), //
+			event(test("testSeveral"), started()), //
+			event(test("testSeveral"), finishedSuccessfully()), //
+			event(container(ATestCase.class), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+
+		assertEquals(Arrays.asList( //
+			"convertBeforeEach", "rethrowBeforeEach", "swallowBeforeEach", //
+			"convertBeforeEach", "rethrowBeforeEach", "swallowBeforeEach", //
+			"convertTest", "rethrowTest", "swallowTest", //
+			"convertAfterEach", "rethrowAfterEach", "swallowAfterEach", //
+			"convertAfterEach", "rethrowAfterEach", "swallowAfterEach"), //
+			handlerCalls);
 	}
+
 	// -------------------------------------------------------------------
+
 	static class ATestCase {
+
 		@BeforeEach
 		void beforeEach() throws IOException {
 			throw new IOException("checked");
 		}
+
 		@BeforeEach
 		void beforeEach2() throws IOException {
 			throw new IOException("checked");
 		}
+
 		@Test
 		@ExtendWith(RethrowException.class)
 		void testRethrow() throws IOException {
 			throw new IOException("checked");
 		}
+
 		@Test
 		@ExtendWith(SwallowException.class)
 		void testSwallow() throws IOException {
 			throw new IOException("checked");
 		}
+
 		@Test
 		@ExtendWith(ConvertException.class)
 		void testConvert() throws IOException {
 			throw new IOException("checked");
 		}
+
 		@Test
 		@ExtendWith(ShouldNotBeCalled.class)
 		@ExtendWith(SwallowException.class)
@@ -144,73 +159,91 @@ class BeforeAndAfterEachExceptionHandlerTests extends AbstractJupiterTestEngineT
 		void testSeveral() throws IOException {
 			throw new IOException("checked");
 		}
+
 		@AfterEach
 		void afterEach() throws IOException {
 			throw new IOException("checked");
 		}
+
 		@AfterEach
 		void afterEach2() throws IOException {
 			throw new IOException("checked");
 		}
 	}
+
 	static class RethrowException implements TestExecutionExceptionHandler {
+
 		@Override
 		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("rethrowTest");
 			throw throwable;
 		}
+
 		@Override
 		public void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("rethrowBeforeEach");
 			throw throwable;
 		}
+
 		@Override
 		public void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("rethrowAfterEach");
 			throw throwable;
 		}
 	}
+
 	static class SwallowException implements TestExecutionExceptionHandler {
 		// swallow exception by not rethrowing it
+
 		@Override
 		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("swallowTest");
 		}
+
 		@Override
 		public void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("swallowBeforeEach");
 		}
+
 		@Override
 		public void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("swallowAfterEach");
 		}
 	}
+
 	static class ConvertException implements TestExecutionExceptionHandler {
+
 		@Override
 		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("convertTest");
 			throw new RuntimeException("unchecked");
 		}
+
 		@Override
 		public void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("convertBeforeEach");
 			throw new RuntimeException("unchecked");
 		}
+
 		@Override
 		public void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("convertAfterEach");
 			throw new RuntimeException("unchecked");
 		}
 	}
+
 	static class ShouldNotBeCalled implements TestExecutionExceptionHandler {
+
 		@Override
 		public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("shouldNotBeCalledTest");
 		}
+
 		@Override
 		public void handleExceptionInBeforeEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("shouldNotBeCalledBeforeEach");
 		}
+
 		@Override
 		public void handleExceptionInAfterEachMethod(ExtensionContext context, Throwable throwable) throws Throwable {
 			handlerCalls.add("shouldNotBeCalledAfterEach");


### PR DESCRIPTION
## Overview
PR for Issue #1454 
Make it possible to also handle exceptions thrown by BeforeEach/AfterEach methods via the TestExecutionExceptionHandler.
The new handler methods are default methods to make them optional and to not break the FunctionalInterface.
This PR is a proposal to solve the issue. It's not complete. The Javadoc is not adjusted and the exception handling for the BeforeAll/AfterAll methods is missing.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
