### PR TITLE
Migrate to ClassGraph (formerly FastClasspathScanner) 4.0

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -51,7 +51,7 @@ dependencies {
 	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 
 	// for ApiReportGenerator
-	testImplementation('io.github.lukehutch:fast-classpath-scanner:3.1.13')
+	testImplementation('io.github.classgraph:classgraph:4.0.2')
 }
 
 asciidoctorj {


### PR DESCRIPTION
Not ready to merge (final 4.0.0 release not yet available).

Followed migration guide at: https://github.com/classgraph/classgraph/wiki/Porting-FastClasspathScanner-code-to-ClassGraph

Just to provide some feedback for classgraph/classgraph#215.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---