### PR TITLE
Make TreeNode thread-safe

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreeNode.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreeNode.java
@@ -51,7 +51,7 @@ class TreeNode {
 		this.reason = reason;
 	}
 
-	TreeNode addChild(TreeNode node) {
+	synchronized TreeNode addChild(TreeNode node) {
 		if (children == Collections.EMPTY_LIST) {
 			children = new ArrayList<>();
 		}
@@ -59,7 +59,7 @@ class TreeNode {
 		return this;
 	}
 
-	TreeNode addReportEntry(ReportEntry reportEntry) {
+	synchronized TreeNode addReportEntry(ReportEntry reportEntry) {
 		if (reports == Collections.EMPTY_LIST) {
 			reports = new ArrayList<>();
 		}


### PR DESCRIPTION
Prior to this commit, both `add` methods in `TreeNode` had race
conditions when children or report entries were added concurrently
because adding to an `ArrayList` from multiple threads is documented to
be unsafe. Now, both methods are synchronized.

Fixes #1524.