### PR TITLE
Lifecycle.PER_CLASS ⇒ ExecutionMode.SAME_THREAD

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0-RC1.adoc
@@ -93,6 +93,8 @@ on GitHub.
   class name and system hash code, separated by an `@` symbol.
 * New `getAs<Class>(index)` Kotlin extension method to make `ArgumentsAccessor` friendlier
   to use from Kotlin.
+* Tests in classes that use `Lifecycle.PER_CLASS` are now executed in the same thread by
+  default when parallel execution is enabled.
 
 
 [[release-notes-5.3.0-RC1-junit-vintage]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
@@ -10,8 +10,6 @@
 
 package org.junit.jupiter.engine.descriptor;
 
-import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.CONCURRENT;
-
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.platform.engine.TestDescriptor;
@@ -30,11 +28,6 @@ abstract class DynamicNodeTestDescriptor extends JupiterTestDescriptor {
 	DynamicNodeTestDescriptor(UniqueId uniqueId, int index, DynamicNode dynamicNode, TestSource testSource) {
 		super(uniqueId, dynamicNode.getDisplayName(), testSource);
 		this.index = index;
-	}
-
-	@Override
-	public ExecutionMode getExecutionMode() {
-		return getParent().map(parent -> ((JupiterTestDescriptor) parent).getExecutionMode()).orElse(CONCURRENT);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.descriptor;
 
 import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.platform.commons.util.ClassUtils;
@@ -59,12 +60,11 @@ abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
 
 	@Override
 	public Set<ExclusiveResource> getExclusiveResources() {
-		return getExclusiveResources(getTestMethod());
+		return getExclusiveResourcesFromAnnotation(getTestMethod());
 	}
 
-	@Override
-	public ExecutionMode getExecutionMode() {
-		return getExecutionMode(getTestMethod());
+	protected Optional<ExecutionMode> getExplicitExecutionMode() {
+		return getExecutionModeFromAnnotation(getTestMethod());
 	}
 
 	public final Class<?> getTestClass() {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -20,6 +20,7 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
@@ -42,8 +43,9 @@ public class NestedClassTestDescriptor extends ClassTestDescriptor {
 	 */
 	private final Set<TestTag> tags;
 
-	public NestedClassTestDescriptor(UniqueId uniqueId, Class<?> testClass) {
-		super(uniqueId, Class::getSimpleName, testClass);
+	public NestedClassTestDescriptor(UniqueId uniqueId, Class<?> testClass,
+			ConfigurationParameters configurationParameters) {
+		super(uniqueId, Class::getSimpleName, testClass, configurationParameters);
 
 		this.tags = getTags(testClass);
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import org.apiguardian.api.API;
 import org.junit.jupiter.engine.discovery.predicates.IsTestClassWithTests;
 import org.junit.platform.commons.util.ClassFilter;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.discovery.ClassSelector;
@@ -51,7 +52,8 @@ public class DiscoverySelectorResolver {
 	}
 
 	private void resolve(EngineDiscoveryRequest request, TestDescriptor engineDescriptor, ClassFilter classFilter) {
-		JavaElementsResolver javaElementsResolver = createJavaElementsResolver(engineDescriptor, classFilter);
+		JavaElementsResolver javaElementsResolver = createJavaElementsResolver(request.getConfigurationParameters(),
+			engineDescriptor, classFilter);
 
 		request.getSelectorsByType(ClasspathRootSelector.class).forEach(javaElementsResolver::resolveClasspathRoot);
 		request.getSelectorsByType(ModuleSelector.class).forEach(javaElementsResolver::resolveModule);
@@ -69,10 +71,11 @@ public class DiscoverySelectorResolver {
 		rootDescriptor.accept(TestDescriptor::prune);
 	}
 
-	private JavaElementsResolver createJavaElementsResolver(TestDescriptor engineDescriptor, ClassFilter classFilter) {
+	private JavaElementsResolver createJavaElementsResolver(ConfigurationParameters configurationParameters,
+			TestDescriptor engineDescriptor, ClassFilter classFilter) {
 		Set<ElementResolver> resolvers = new LinkedHashSet<>();
-		resolvers.add(new TestContainerResolver());
-		resolvers.add(new NestedTestsResolver());
+		resolvers.add(new TestContainerResolver(configurationParameters));
+		resolvers.add(new NestedTestsResolver(configurationParameters));
 		resolvers.add(new TestMethodResolver());
 		resolvers.add(new TestFactoryMethodResolver());
 		resolvers.add(new TestTemplateMethodResolver());

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/NestedTestsResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/NestedTestsResolver.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.discovery;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsNestedTestClass;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 
@@ -24,6 +25,10 @@ class NestedTestsResolver extends TestContainerResolver {
 	private static final IsNestedTestClass isNestedTestClass = new IsNestedTestClass();
 
 	static final String SEGMENT_TYPE = "nested-class";
+
+	public NestedTestsResolver(ConfigurationParameters configurationParameters) {
+		super(configurationParameters);
+	}
 
 	@Override
 	protected Class<? extends TestDescriptor> requiredParentType() {
@@ -52,7 +57,7 @@ class NestedTestsResolver extends TestContainerResolver {
 
 	@Override
 	protected TestDescriptor resolveClass(Class<?> testClass, UniqueId uniqueId) {
-		return new NestedClassTestDescriptor(uniqueId, testClass);
+		return new NestedClassTestDescriptor(uniqueId, testClass, this.configurationParameters);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestContainerResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestContainerResolver.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.discovery.predicates.IsPotentialTestContainer;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 
@@ -29,6 +30,12 @@ class TestContainerResolver implements ElementResolver {
 	private static final IsPotentialTestContainer isPotentialTestContainer = new IsPotentialTestContainer();
 
 	static final String SEGMENT_TYPE = "class";
+
+	protected final ConfigurationParameters configurationParameters;
+
+	public TestContainerResolver(ConfigurationParameters configurationParameters) {
+		this.configurationParameters = configurationParameters;
+	}
 
 	@Override
 	public Set<TestDescriptor> resolveElement(AnnotatedElement element, TestDescriptor parent) {
@@ -97,7 +104,7 @@ class TestContainerResolver implements ElementResolver {
 	}
 
 	protected TestDescriptor resolveClass(Class<?> testClass, UniqueId uniqueId) {
-		return new ClassTestDescriptor(uniqueId, testClass);
+		return new ClassTestDescriptor(uniqueId, testClass, this.configurationParameters);
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleExecutionModeTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleExecutionModeTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.CONCURRENT;
+import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.SAME_THREAD;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.support.hierarchical.Node;
+
+class TestInstanceLifecycleExecutionModeTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void methodsInTestClassesWithInstancePerClassHaveExecutionModeSameThread() {
+		var engineDescriptor = discoverTests(selectClass(SimpleTestCase.class));
+		var classDescriptor = (Node<?> & TestDescriptor) getOnlyElement(engineDescriptor.getChildren());
+		var testDescriptor = (Node<?> & TestDescriptor) getOnlyElement(classDescriptor.getChildren());
+
+		assertExecutionMode(classDescriptor, CONCURRENT);
+		assertExecutionMode(testDescriptor, SAME_THREAD);
+	}
+
+	@Test
+	void methodsInNestedTestClassesWithInstancePerClassInHierarchyHaveExecutionModeSameThread() {
+		var engineDescriptor = discoverTests(selectClass(OuterTestCase.class));
+		var outerTestCaseClassDescriptor = firstChild(engineDescriptor, ClassTestDescriptor.class);
+		var outerTestMethodDescriptor = firstChild(outerTestCaseClassDescriptor, TestMethodTestDescriptor.class);
+		var level1NestedClassDescriptor = firstChild(outerTestCaseClassDescriptor, NestedClassTestDescriptor.class);
+		var level1TestMethodDescriptor = firstChild(level1NestedClassDescriptor, TestMethodTestDescriptor.class);
+		var level2NestedClassDescriptor = firstChild(level1NestedClassDescriptor, NestedClassTestDescriptor.class);
+		var level2TestMethodDescriptor = firstChild(level2NestedClassDescriptor, TestMethodTestDescriptor.class);
+		var level3NestedClassDescriptor = firstChild(level2NestedClassDescriptor, NestedClassTestDescriptor.class);
+		var level3TestMethodDescriptor = firstChild(level3NestedClassDescriptor, TestMethodTestDescriptor.class);
+
+		assertExecutionMode(outerTestCaseClassDescriptor, CONCURRENT);
+		assertExecutionMode(outerTestMethodDescriptor, CONCURRENT);
+		assertExecutionMode(level1NestedClassDescriptor, CONCURRENT);
+		assertExecutionMode(level1TestMethodDescriptor, CONCURRENT);
+		assertExecutionMode(level2NestedClassDescriptor, CONCURRENT);
+		assertExecutionMode(level2TestMethodDescriptor, SAME_THREAD);
+		assertExecutionMode(level3NestedClassDescriptor, SAME_THREAD);
+		assertExecutionMode(level3TestMethodDescriptor, SAME_THREAD);
+	}
+
+	private static <T extends Node<?> & TestDescriptor> void assertExecutionMode(T testDescriptor,
+			Node.ExecutionMode expectedExecutionMode) {
+		assertThat(testDescriptor.getExecutionMode()) //
+				.describedAs("ExecutionMode for %s", testDescriptor) //
+				.isEqualTo(expectedExecutionMode);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T extends Node<?> & TestDescriptor> T firstChild(TestDescriptor engineDescriptor,
+			Class<T> testDescriptorClass) {
+		return (T) engineDescriptor.getChildren().stream() //
+				.filter(testDescriptorClass::isInstance) //
+				.findFirst() //
+				.orElseGet(() -> fail("No child of type " + testDescriptorClass + " found"));
+	}
+
+	@TestInstance(PER_CLASS)
+	static class SimpleTestCase {
+
+		@Test
+		void test() {
+		}
+
+	}
+
+	static class OuterTestCase {
+		@Nested
+		class LevelOne {
+			@Nested
+			@TestInstance(PER_CLASS)
+			class LevelTwo {
+				@Nested
+				class LevelThree {
+					@Test
+					void test() {
+					}
+				}
+
+				@Test
+				void test() {
+				}
+			}
+
+			@Test
+			void test() {
+			}
+		}
+
+		@Test
+		void test() {
+		}
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.descriptor;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.JupiterTestDescriptorTests.StaticTestCase.StaticTestCaseLevel2;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
@@ -49,9 +51,11 @@ class JupiterTestDescriptorTests {
 
 	private static final UniqueId uniqueId = UniqueId.root("enigma", "foo");
 
+	private final ConfigurationParameters configParams = mock(ConfigurationParameters.class);
+
 	@Test
 	void constructFromClass() {
-		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCase.class);
+		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCase.class, configParams);
 
 		assertEquals(TestCase.class, descriptor.getTestClass());
 		assertThat(descriptor.getTags()).containsExactly(TestTag.create("inherited-class-level-tag"),
@@ -62,7 +66,8 @@ class JupiterTestDescriptorTests {
 	void constructFromClassWithInvalidBeforeAllDeclaration() {
 		// Note: if we can instantiate the descriptor, then the invalid configuration
 		// will not be reported during the test engine discovery phase.
-		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCaseWithInvalidBeforeAllMethod.class);
+		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCaseWithInvalidBeforeAllMethod.class,
+			configParams);
 
 		assertEquals(TestCaseWithInvalidBeforeAllMethod.class, descriptor.getTestClass());
 	}
@@ -71,7 +76,8 @@ class JupiterTestDescriptorTests {
 	void constructFromClassWithInvalidAfterAllDeclaration() {
 		// Note: if we can instantiate the descriptor, then the invalid configuration
 		// will not be reported during the test engine discovery phase.
-		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCaseWithInvalidAfterAllMethod.class);
+		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCaseWithInvalidAfterAllMethod.class,
+			configParams);
 
 		assertEquals(TestCaseWithInvalidAfterAllMethod.class, descriptor.getTestClass());
 	}
@@ -80,7 +86,8 @@ class JupiterTestDescriptorTests {
 	void constructFromClassWithInvalidBeforeEachDeclaration() {
 		// Note: if we can instantiate the descriptor, then the invalid configuration
 		// will not be reported during the test engine discovery phase.
-		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCaseWithInvalidBeforeEachMethod.class);
+		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCaseWithInvalidBeforeEachMethod.class,
+			configParams);
 
 		assertEquals(TestCaseWithInvalidBeforeEachMethod.class, descriptor.getTestClass());
 	}
@@ -89,7 +96,8 @@ class JupiterTestDescriptorTests {
 	void constructFromClassWithInvalidAfterEachDeclaration() {
 		// Note: if we can instantiate the descriptor, then the invalid configuration
 		// will not be reported during the test engine discovery phase.
-		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCaseWithInvalidAfterEachMethod.class);
+		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, TestCaseWithInvalidAfterEachMethod.class,
+			configParams);
 
 		assertEquals(TestCaseWithInvalidAfterEachMethod.class, descriptor.getTestClass());
 	}
@@ -107,7 +115,7 @@ class JupiterTestDescriptorTests {
 
 	@Test
 	void constructFromMethodWithAnnotations() throws Exception {
-		JupiterTestDescriptor classDescriptor = new ClassTestDescriptor(uniqueId, TestCase.class);
+		JupiterTestDescriptor classDescriptor = new ClassTestDescriptor(uniqueId, TestCase.class, configParams);
 		Method testMethod = TestCase.class.getDeclaredMethod("foo");
 		TestMethodTestDescriptor methodDescriptor = new TestMethodTestDescriptor(uniqueId, TestCase.class, testMethod);
 		classDescriptor.addChild(methodDescriptor);
@@ -192,17 +200,17 @@ class JupiterTestDescriptorTests {
 
 	@Test
 	void defaultDisplayNamesForTestClasses() {
-		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, getClass());
+		ClassTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, getClass(), configParams);
 		assertEquals(getClass().getSimpleName(), descriptor.getDisplayName());
 
-		descriptor = new NestedClassTestDescriptor(uniqueId, NestedTestCase.class);
+		descriptor = new NestedClassTestDescriptor(uniqueId, NestedTestCase.class, configParams);
 		assertEquals(NestedTestCase.class.getSimpleName(), descriptor.getDisplayName());
 
-		descriptor = new ClassTestDescriptor(uniqueId, StaticTestCase.class);
+		descriptor = new ClassTestDescriptor(uniqueId, StaticTestCase.class, configParams);
 		String staticDisplayName = getClass().getSimpleName() + "$" + StaticTestCase.class.getSimpleName();
 		assertEquals(staticDisplayName, descriptor.getDisplayName());
 
-		descriptor = new ClassTestDescriptor(uniqueId, StaticTestCaseLevel2.class);
+		descriptor = new ClassTestDescriptor(uniqueId, StaticTestCaseLevel2.class, configParams);
 		staticDisplayName += "$" + StaticTestCaseLevel2.class.getSimpleName();
 		assertEquals(staticDisplayName, descriptor.getDisplayName());
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestDescriptorBuilder.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestDescriptorBuilder.java
@@ -10,10 +10,13 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import static org.mockito.Mockito.mock;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 
@@ -22,6 +25,7 @@ import org.junit.platform.engine.UniqueId;
  */
 public abstract class TestDescriptorBuilder<T extends TestDescriptor> {
 
+	private static final ConfigurationParameters configParams = mock(ConfigurationParameters.class);
 	final List<TestDescriptorBuilder<?>> children = new ArrayList<>();
 
 	public static JupiterEngineDescriptorBuilder engineDescriptor() {
@@ -69,7 +73,7 @@ public abstract class TestDescriptorBuilder<T extends TestDescriptor> {
 
 		@Override
 		ClassTestDescriptor buildDescriptor() {
-			return new ClassTestDescriptor(UniqueId.root("class", uniqueId), testClass);
+			return new ClassTestDescriptor(UniqueId.root("class", uniqueId), testClass, configParams);
 		}
 	}
 
@@ -81,7 +85,7 @@ public abstract class TestDescriptorBuilder<T extends TestDescriptor> {
 
 		@Override
 		NestedClassTestDescriptor buildDescriptor() {
-			return new NestedClassTestDescriptor(UniqueId.root("nested-class", uniqueId), testClass);
+			return new NestedClassTestDescriptor(UniqueId.root("nested-class", uniqueId), testClass, configParams);
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextTests.java
@@ -250,7 +250,7 @@ class ExtensionContextTests {
 		JupiterEngineDescriptor engineDescriptor = new JupiterEngineDescriptor(engineUniqueId);
 
 		UniqueId classUniqueId = UniqueId.parse("[engine:junit-jupiter]/[class:MyClass]");
-		ClassTestDescriptor classTestDescriptor = new ClassTestDescriptor(classUniqueId, getClass());
+		ClassTestDescriptor classTestDescriptor = new ClassTestDescriptor(classUniqueId, getClass(), configParams);
 
 		Method method = getClass().getDeclaredMethod("configurationParameter");
 		UniqueId methodUniqueId = UniqueId.parse("[engine:junit-jupiter]/[class:MyClass]/[method:myMethod]");
@@ -266,13 +266,13 @@ class ExtensionContextTests {
 	}
 
 	private ClassTestDescriptor nestedClassDescriptor() {
-		return new NestedClassTestDescriptor(UniqueId.root("nested-class", "NestedClass"),
-			OuterClass.NestedClass.class);
+		return new NestedClassTestDescriptor(UniqueId.root("nested-class", "NestedClass"), OuterClass.NestedClass.class,
+			configParams);
 	}
 
 	private ClassTestDescriptor outerClassDescriptor(TestDescriptor child) {
 		ClassTestDescriptor classTestDescriptor = new ClassTestDescriptor(UniqueId.root("class", "OuterClass"),
-			OuterClass.class);
+			OuterClass.class, configParams);
 		if (child != null) {
 			classTestDescriptor.addChild(child);
 		}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContextTests.java
@@ -45,7 +45,7 @@ class JupiterEngineExecutionContextTests {
 	@Test
 	void extendWithAllAttributes() {
 		UniqueId uniqueId = UniqueId.parse("[engine:junit-jupiter]/[class:MyClass]");
-		ClassTestDescriptor classTestDescriptor = new ClassTestDescriptor(uniqueId, getClass());
+		ClassTestDescriptor classTestDescriptor = new ClassTestDescriptor(uniqueId, getClass(), configParams);
 		ClassExtensionContext extensionContext = new ClassExtensionContext(null, null, classTestDescriptor,
 			configParams, null);
 		ExtensionRegistry extensionRegistry = ExtensionRegistry.createRegistryWithDefaultExtensions(configParams);
@@ -64,7 +64,7 @@ class JupiterEngineExecutionContextTests {
 	@Test
 	void canOverrideAttributeWhenContextIsExtended() {
 		UniqueId uniqueId = UniqueId.parse("[engine:junit-jupiter]/[class:MyClass]");
-		ClassTestDescriptor classTestDescriptor = new ClassTestDescriptor(uniqueId, getClass());
+		ClassTestDescriptor classTestDescriptor = new ClassTestDescriptor(uniqueId, getClass(), configParams);
 		ClassExtensionContext extensionContext = new ClassExtensionContext(null, null, classTestDescriptor,
 			configParams, null);
 		ExtensionRegistry extensionRegistry = ExtensionRegistry.createRegistryWithDefaultExtensions(configParams);

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/RunListenerAdapterTests.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestDescriptor.Type;
 import org.junit.platform.engine.TestExecutionResult;
@@ -62,6 +63,8 @@ import org.mockito.InOrder;
  * @since 1.0
  */
 class RunListenerAdapterTests {
+
+	private static final ConfigurationParameters configParams = mock(ConfigurationParameters.class);
 
 	private RunListener listener;
 	private RunListenerAdapter adapter;
@@ -393,7 +396,8 @@ class RunListenerAdapterTests {
 	}
 
 	private static TestDescriptor newClassDescriptor() {
-		return new ClassTestDescriptor(UniqueId.root("class", MyTestClass.class.getName()), MyTestClass.class);
+		return new ClassTestDescriptor(UniqueId.root("class", MyTestClass.class.getName()), MyTestClass.class,
+			configParams);
 	}
 
 	private static TestIdentifier newSourcelessChildIdentifierWithParent(TestPlan testPlan, String parentDisplay,

--- a/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/TestMethodFilterTests.java
+++ b/junit-platform-surefire-provider/src/test/java/org/junit/platform/surefire/provider/TestMethodFilterTests.java
@@ -28,6 +28,7 @@ import org.apache.maven.surefire.testset.TestListResolver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.UniqueId;
 
@@ -38,6 +39,7 @@ import org.junit.platform.engine.UniqueId;
  */
 class TestMethodFilterTests {
 
+	private static final ConfigurationParameters configParams = mock(ConfigurationParameters.class);
 	private final TestListResolver resolver = mock(TestListResolver.class);
 
 	private final TestMethodFilter filter = new TestMethodFilter(this.resolver);
@@ -79,7 +81,7 @@ class TestMethodFilterTests {
 
 	private static ClassTestDescriptor newClassTestDescriptor() throws Exception {
 		UniqueId uniqueId = UniqueId.forEngine("class");
-		return new ClassTestDescriptor(uniqueId, TestClass.class);
+		return new ClassTestDescriptor(uniqueId, TestClass.class, configParams);
 	}
 
 	public static class TestClass {


### PR DESCRIPTION
Tests in classes that use `Lifecycle.PER_CLASS` now use `ExecutionMode.SAME_THREAD` by default when parallel execution is enabled. In the case of nested classes, as soon as one enclosing class uses `Lifecycle.PER_CLASS` all contained nested classes and tests use `ExecutionMode.SAME_THREAD`.

Fixes #1511.