### PR TITLE
Set jmh's fork=1 and fix too long command line on Windows

### DIFF
--- a/platform-tests/platform-tests.gradle
+++ b/platform-tests/platform-tests.gradle
@@ -45,9 +45,10 @@ dependencies {
 
 jmh {
 	jmhVersion = "${jmhVersion}"
+	jvmArgs = ['-Djmh.separateClasspathJAR=true'] // Fix too long command line on Windows...
 
 	duplicateClassesStrategy = DuplicatesStrategy.WARN
-	fork = 0 // Too long command line on Windows...
+	fork = 1
 	warmupIterations = 1
 	iterations = 5
 }


### PR DESCRIPTION
## Overview

I have seen a jmh warning about ```fork=0``` and found the [too long command line on Windows has been fixed](https://github.com/melix/jmh-gradle-plugin/issues/107).

This patch set ```fork=1```.

Remark : I have not tested on Windows

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
