### PR TITLE
[WIP] Add ArchUnit-based tests to `platform-tooling-support-tests`

### DIFF
--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle
@@ -33,6 +33,12 @@ dependencies {
 	testCompile('org.jgrapht:jgrapht-core:1.2.0') {
 		because 'building and analyzing graphs'
 	}
+	testCompile('com.tngtech.archunit:archunit-junit5-api:0.9.0') {
+		because 'checking the architecture of JUnit 5'
+	}
+	testRuntimeOnly('com.tngtech.archunit:archunit-junit5-engine:0.9.0') {
+		because 'contains the ArchUnit TestEngine implementation'
+	}
 }
 
 test {

--- a/platform-tooling-support-tests/src/main/java/platform/tooling/support/Helper.java
+++ b/platform-tooling-support-tests/src/main/java/platform/tooling/support/Helper.java
@@ -10,11 +10,14 @@
 
 package platform.tooling.support;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Properties;
+import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -77,4 +80,18 @@ public class Helper {
 		}
 	}
 
+	public static JarFile createJarFile(String module) {
+		var archive = module + '-' + version(module) + ".jar";
+		var path = Paths.get("..", module, "build", "libs", archive);
+		try {
+			return new JarFile(path.toFile());
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Creating JarFile for '" + path + "' failed.", e);
+		}
+	}
+
+	public static List<JarFile> loadJarFiles() {
+		return loadModuleDirectoryNames().stream().map(Helper::createJarFile).collect(Collectors.toList());
+	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+
+import org.junit.jupiter.api.Test;
+import platform.tooling.support.Helper;
+
+class ArchUnitTests {
+
+	@Test
+	void acyclicImportPackages() {
+		var packageNames = List.of("org.junit.platform", "org.junit.jupiter", "org.junit.vintage");
+		var classes = new ClassFileImporter().importPackages(packageNames);
+		// about 431 classes found in classpath of this project
+		acyclic(classes);
+	}
+
+	@Test
+	void acyclicImportJars() {
+		var jarFiles = Helper.loadJarFiles();
+		var classes = new ClassFileImporter().importJars(jarFiles);
+		// about 928 classes found in all jars
+		acyclic(classes);
+	}
+
+	private static void acyclic(JavaClasses classes) {
+		assertTrue(classes.iterator().hasNext()); // not empty...
+		slices().matching("org.junit.(*)..").should().beFreeOfCycles().check(classes);
+	}
+
+}


### PR DESCRIPTION
## Overview

This PR adds ArchUnit-based tests to the `platform-tooling-support-tests` project.

_At the moment it only enforces a cycle check that Degraph already applies. Caveat: both tools don't find the "bad edges" that `jdeps` is able to detect._

@codecholeric Am I using Arch-Unit as intended here? What could be improved?

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

