### PR TITLE
Add implicit argument converter for String to Class

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.3.0.adoc
@@ -45,6 +45,8 @@ on GitHub.
 * The dynamic test API has been promoted from _experimental_ to _maintained_ status. This
   affects the `@TestFactory` annotation as well as the `DynamicTest`, `DynamicContainer`,
   and `DynamicNode` types in the `org.junit.jupiter.api` package.
+* Implicit argument conversion for parameterized tests can now convert strings like
+  `java.lang.Integer` to `Class` instances.
 
 
 [[release-notes-5.3.0-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1037,6 +1037,8 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=implicit_conversion_e
 | `double`/`Double`          | `"1.0"`                                  -> `1.0d`
 | `Enum` subclass            | `"SECONDS"`                              -> `TimeUnit.SECONDS`
 | `java.io.File`             | `"/path/to/file"`                        -> `new File("/path/to/file")`
+| `java.lang.Class`          | `"java.lang.Integer"`                    -> `Class.forName("java.lang.Integer")` +
+(remember to use `$` for nested classes, e.g. `"java.lang.Thread$State"`)
 | `java.math.BigDecimal`     | `"123.456e789"`                          -> `new BigDecimal("123.456e789")`
 | `java.math.BigInteger`     | `"1234567890123456789"`                  -> `new BigInteger("1234567890123456789")`
 | `java.net.URI`             | `"http://junit.org/"`                    -> `URI.create("http://junit.org/")`

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -218,6 +218,8 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 		static {
 			Map<Class<?>, Function<String, ?>> converters = new HashMap<>();
 
+			// java.lang
+			converters.put(Class.class, StringToCommonJavaTypesConverter::toClass);
 			// java.io and java.nio
 			converters.put(File.class, File::new);
 			converters.put(Charset.class, Charset::forName);
@@ -244,6 +246,15 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 		@Override
 		public Object convert(String source, Class<?> targetType) throws Exception {
 			return CONVERTERS.get(targetType).apply(source);
+		}
+
+		private static Class<?> toClass(String type) {
+			//@formatter:off
+			return ReflectionUtils
+					.loadClass(type)
+					.orElseThrow(() -> new ArgumentConversionException(
+							"Failed to convert String \"" + type + "\" to type " + Class.class.getName()));
+			//@formatter:on
 		}
 
 		private static URL toURL(String url) {

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.params.converter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.lang.Thread.State;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
@@ -110,6 +111,14 @@ class DefaultArgumentConverterTests {
 		assertConverts("path", Path.class, Paths.get("path"));
 		assertConverts("/path", Path.class, Paths.get("/path"));
 		assertConverts("/some/path", Path.class, Paths.get("/some/path"));
+	}
+
+	// --- java.lang -----------------------------------------------------------
+
+	@Test
+	void convertsStringToClass() {
+		assertConverts("java.lang.Integer", Class.class, Integer.class);
+		assertConverts("java.lang.Thread$State", Class.class, State.class);
 	}
 
 	// --- java.math -----------------------------------------------------------


### PR DESCRIPTION
## Overview

Arguments like "java.lang.Integer" should be converted to `Class` by calling `Class.forName(String)`. Automatic string-to-object conversion with `FallbackStringToObjectConverter` doesn't handle that case because `Class` has a second applicable static factory method (`getPrimitiveClass(String)`).

It is thus necessary to explicitly implement the call to `forName`.

Closes #1562

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] (_not applicable_) Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] (_not applicable_) Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
