### PR TITLE
Emit warning when TestEngine ID starts with "junit-"

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -27,9 +27,13 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.engine.TrackLogRecords;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.commons.util.PreconditionViolationException;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -56,6 +60,7 @@ import org.mockito.InOrder;
 /**
  * @since 1.0
  */
+@TrackLogRecords
 class DefaultLauncherTests {
 
 	private static final String FOO = DefaultLauncherTests.class.getSimpleName() + ".foo";
@@ -491,4 +496,31 @@ class DefaultLauncherTests {
 		inOrder.verify(listener).testPlanExecutionFinished(same(testPlan));
 	}
 
+	@Test
+	void usingReservedEngineIdPrefixEmitsWarning(LogRecordListener listener) {
+		String id = "junit-using-reserved-prefix";
+		createLauncher(new TestEngineStub(id));
+		assertThat(listener.stream(DefaultLauncher.class, Level.WARNING).map(LogRecord::getMessage)) //
+				.containsExactly(
+					"Third-party TestEngine implementations are forbidden to use the reserved 'junit-' prefix for their ID: '"
+							+ id + "'");
+	}
+
+	@Test
+	void impostBeingJupiterWithoutBeingJupiterFails() {
+		String id = "junit-jupiter";
+		TestEngine impostor = new TestEngineStub(id);
+		Exception exception = assertThrows(JUnitException.class, () -> createLauncher(impostor));
+		assertThat(exception).hasMessage("Third-party TestEngine '" + impostor.getClass().getName()
+				+ "' is forbidden to use the reserved '" + id + "' TestEngine ID.");
+	}
+
+	@Test
+	void impostBeingVintageWithoutBeingVintageFails() {
+		String id = "junit-vintage";
+		TestEngine impostor = new TestEngineStub("junit-vintage");
+		Exception exception = assertThrows(JUnitException.class, () -> createLauncher(impostor));
+		assertThat(exception).hasMessage("Third-party TestEngine '" + impostor.getClass().getName()
+				+ "' is forbidden to use the reserved '" + id + "' TestEngine ID.");
+	}
 }


### PR DESCRIPTION
## Overview

The `junit-` prefix is owned by the JUnit Team. It's akin to using **"org.junit"** as a base package. No other entity in the world should do that. Only two engines should use the prefix at the moment:

 - `junit-jupiter`
 - `junit-vintage`

This commit enforces these rules.

Closes #1557

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
