### PR TITLE
Update ClassGraph and use try-with-resources

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -55,7 +55,7 @@ dependencies {
 	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
 
 	// for ApiReportGenerator
-	testImplementation('io.github.classgraph:classgraph:4.0.2')
+	testImplementation('io.github.classgraph:classgraph:4.1.3')
 }
 
 asciidoctorj {

--- a/documentation/src/test/java/org/junit/api/tools/ApiReportGenerator.java
+++ b/documentation/src/test/java/org/junit/api/tools/ApiReportGenerator.java
@@ -67,7 +67,8 @@ class ApiReportGenerator {
 		final String EOL = System.lineSeparator();
 
 		// Scan packages
-		try (ScanResult scanResult = new ClassGraph().whitelistPackages(packages).enableAnnotationInfo().scan()) {
+		try (ScanResult scanResult = new ClassGraph().whitelistPackages(
+			packages).disableNestedJarScanning().enableAnnotationInfo().scan()) {
 
 			// Collect names
 			ClassInfoList classesWithApiAnnotation = scanResult.getClassesWithAnnotation(API.class.getCanonicalName());

--- a/documentation/src/test/java/org/junit/api/tools/ApiReportGenerator.java
+++ b/documentation/src/test/java/org/junit/api/tools/ApiReportGenerator.java
@@ -67,43 +67,44 @@ class ApiReportGenerator {
 		final String EOL = System.lineSeparator();
 
 		// Scan packages
-		ScanResult scanResult = new ClassGraph().whitelistPackages(packages).enableAnnotationInfo().scan();
+		try (ScanResult scanResult = new ClassGraph().whitelistPackages(packages).enableAnnotationInfo().scan()) {
 
-		// Collect names
-		ClassInfoList classesWithApiAnnotation = scanResult.getClassesWithAnnotation(API.class.getCanonicalName());
-		List<String> names = classesWithApiAnnotation.getNames();
+			// Collect names
+			ClassInfoList classesWithApiAnnotation = scanResult.getClassesWithAnnotation(API.class.getCanonicalName());
+			List<String> names = classesWithApiAnnotation.getNames();
 
-		logger.debug(() -> {
-			StringBuilder builder = new StringBuilder(
-				names.size() + " @API declarations (including meta) found in class-path:");
-			builder.append(EOL);
-			scanResult.getClasspathURLs().forEach(e -> builder.append(e).append(EOL));
-			return builder.toString();
+			logger.debug(() -> {
+				StringBuilder builder = new StringBuilder(
+					names.size() + " @API declarations (including meta) found in class-path:");
+				builder.append(EOL);
+				scanResult.getClasspathURLs().forEach(e -> builder.append(e).append(EOL));
+				return builder.toString();
 
-		});
+			});
 
-		// Collect types
-		List<Class<?>> types = classesWithApiAnnotation.loadClasses();
-		// only retain directly annotated types
-		types.removeIf(c -> !c.isAnnotationPresent(API.class));
-		types.sort(Comparator.comparing(Class::getName));
+			// Collect types
+			List<Class<?>> types = classesWithApiAnnotation.loadClasses();
+			// only retain directly annotated types
+			types.removeIf(c -> !c.isAnnotationPresent(API.class));
+			types.sort(Comparator.comparing(Class::getName));
 
-		logger.debug(() -> {
-			StringBuilder builder = new StringBuilder("Listing of all " + types.size() + " annotated types:");
-			builder.append(EOL);
-			types.forEach(e -> builder.append(e).append(EOL));
-			return builder.toString();
-		});
+			logger.debug(() -> {
+				StringBuilder builder = new StringBuilder("Listing of all " + types.size() + " annotated types:");
+				builder.append(EOL);
+				types.forEach(e -> builder.append(e).append(EOL));
+				return builder.toString();
+			});
 
-		// Build map
-		Map<Status, List<Class<?>>> declarationsMap = new EnumMap<>(Status.class);
-		for (Status status : Status.values()) {
-			declarationsMap.put(status, new ArrayList<>());
+			// Build map
+			Map<Status, List<Class<?>>> declarationsMap = new EnumMap<>(Status.class);
+			for (Status status : Status.values()) {
+				declarationsMap.put(status, new ArrayList<>());
+			}
+			types.forEach(type -> declarationsMap.get(type.getAnnotation(API.class).status()).add(type));
+
+			// Create report
+			return new ApiReport(types, declarationsMap);
 		}
-		types.forEach(type -> declarationsMap.get(type.getAnnotation(API.class).status()).add(type));
-
-		// Create report
-		return new ApiReport(types, declarationsMap);
 	}
 
 }


### PR DESCRIPTION
Update ClassGraph and follow suggestions from the release notes: https://github.com/classgraph/classgraph/releases

This seems to be a one off command, so resource leaks are unlikely to be a problem, but otherwise @lukehutch might send you a reminder like this one: https://github.com/BrynCooke/cdi-unit/issues/141

Related: https://github.com/junit-team/junit5/pull/1512

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
