### PR TITLE
Add TestInstanceFactory to ExtendWith doc

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
@@ -36,6 +36,7 @@ import org.apiguardian.api.API;
  * <li>{@link AfterEachCallback}</li>
  * <li>{@link BeforeTestExecutionCallback}</li>
  * <li>{@link AfterTestExecutionCallback}</li>
+ * <li>{@link TestInstanceFactory} (EXPERIMENTAL)</li>
  * <li>{@link TestInstancePostProcessor}</li>
  * <li>{@link ParameterResolver}</li>
  * <li>{@link TestExecutionExceptionHandler}</li>

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
@@ -36,7 +36,7 @@ import org.apiguardian.api.API;
  * <li>{@link AfterEachCallback}</li>
  * <li>{@link BeforeTestExecutionCallback}</li>
  * <li>{@link AfterTestExecutionCallback}</li>
- * <li>{@link TestInstanceFactory} (EXPERIMENTAL)</li>
+ * <li>{@link TestInstanceFactory}</li>
  * <li>{@link TestInstancePostProcessor}</li>
  * <li>{@link ParameterResolver}</li>
  * <li>{@link TestExecutionExceptionHandler}</li>


### PR DESCRIPTION
Adds `TestInstanceFactory` to `@ExtendWith` javadoc.

I've put (EXPERIMENTAL) after TestInstanceFactory in the doc. Not sure if that's needed or desired.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
