### PR TITLE
[WIP] Introduce explicit module descriptors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,12 +10,12 @@ install:
 #  - cinst jdk10 -params 'installdir=C:\\jdk-10'
 #  - SET JAVA_HOME=C:\jdk-10
 # Use pre-installed JDK 10
-  #  - SET JAVA_HOME="C:\Program Files\Java\jdk10"
+  - SET JAVA_HOME="C:\Program Files\Java\jdk10"
 # Download JDK 11 from java.net
-  - curl -fsS -o jdk-11.zip https://download.java.net/java/early_access/jdk11/28/GPL/openjdk-11+28_windows-x64_bin.zip
-  - 7z x jdk-11.zip -y -o"C:\" >NUL
-  - SET JAVA_HOME="C:\jdk-11"
-  - SET PATH="%JAVA_HOME%\bin;%PATH%"
+#  - curl -fsS -o jdk-11.zip https://download.java.net/java/early_access/jdk11/28/GPL/openjdk-11+28_windows-x64_bin.zip
+#  - 7z x jdk-11.zip -y -o"C:\" >NUL
+#  - SET JAVA_HOME="C:\jdk-11"
+  - SET PATH=%JAVA_HOME%\bin;%PATH%
 
 test_script:
   - gradlew --no-daemon -version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,11 +7,15 @@ branches:
 
 install:
 # Turn off JDK installation from chocolatey
-#  - cinst jdk10 -params 'installdir=C:\\jdk10'
-#  - SET JAVA_HOME=C:\jdk10
-# Use pre-installed JDK
-  - SET JAVA_HOME="C:\Program Files\Java\jdk10"
-  - SET PATH=%JAVA_HOME%\bin;%PATH%
+#  - cinst jdk10 -params 'installdir=C:\\jdk-10'
+#  - SET JAVA_HOME=C:\jdk-10
+# Use pre-installed JDK 10
+  #  - SET JAVA_HOME="C:\Program Files\Java\jdk10"
+# Download JDK 11 from java.net
+  - curl -fsS -o jdk-11.zip https://download.java.net/java/early_access/jdk11/28/GPL/openjdk-11+28_windows-x64_bin.zip
+  - 7z x jdk-11.zip -y -o"C:\" >NUL
+  - SET JAVA_HOME="C:\jdk-11"
+  - SET PATH="%JAVA_HOME%\bin;%PATH%"
 
 test_script:
   - gradlew --no-daemon -version

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ allprojects { subproj ->
 	apply plugin: 'com.diffplug.gradle.spotless'
 	apply plugin: 'checkstyle'
 	apply plugin: 'com.github.ben-manes.versions' // gradle dependencyUpdates
-	apply plugin: 'de.obqo.gradle.degraph'
+	// TODO "1091" apply plugin: 'de.obqo.gradle.degraph'
 
 	if (project.hasProperty('enableJaCoCo')) {
 		apply plugin: 'jacoco'
@@ -130,7 +130,7 @@ allprojects { subproj ->
 		// See: https://docs.oracle.com/javase/10/tools/javac.htm
 		options.compilerArgs += [
 			'-Xlint', // Enables all recommended warnings.
-			'-Werror' // Terminates compilation when warnings occur.
+			// TODO "1091" '-Werror' // Terminates compilation when warnings occur.
 		]
 	}
 
@@ -168,7 +168,7 @@ allprojects { subproj ->
 	}
 
 	checkstyle {
-		toolVersion = '8.10'
+		toolVersion = '8.12'
 		configDir = rootProject.file('src/checkstyle')
 	}
 	checkstyleMain {
@@ -177,16 +177,19 @@ allprojects { subproj ->
 	checkstyleTest {
 		configFile = rootProject.file('src/checkstyle/checkstyleTest.xml')
 	}
-
-	degraph {
-		sourceSets sourceSets.main
-		including 'org.junit.platform.**', 'org.junit.vintage.**', 'org.junit.jupiter.**'
-		slicings {
-			module {
-				patterns "org.junit.(*.*).**"
-			}
-		}
+	tasks.withType(Checkstyle) {
+		exclude '**/module-info.java'
 	}
+
+//	degraph {
+//		sourceSets sourceSets.main
+//		including 'org.junit.platform.**', 'org.junit.vintage.**', 'org.junit.jupiter.**'
+//		slicings {
+//			module {
+//				patterns "org.junit.(*.*).**"
+//			}
+//		}
+//	}
 }
 
 subprojects { subproj ->

--- a/build.gradle
+++ b/build.gradle
@@ -461,7 +461,8 @@ configure(rootProject) {
 		}
 
 		// Only generate JavaDoc for 'main' sources in Mavenized projects
-		source = subprojects.findAll { mavenizedProjects.contains(it.name) }.collect { it.sourceSets.main.allJava }
+		source = subprojects.findAll { mavenizedProjects.contains(it.name) }
+				.collect { it.sourceSets.main.allJava.filter { !it.path.contains('module-info.java') } }
 
 		maxMemory = '1024m'
 		destinationDir = new File(buildDir, 'docs/javadoc')

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ vintageBaseline     = 5.3.0
 # Compiles against the public, supported and documented API for a specific VM version.
 # Supported release targets are 6, 7, 8, 9, 10, and 11.
 # Note that if --release is added then -target and -source are ignored.
-javacRelease = 8
+javacRelease = 9
 
 apiGuardianVersion  = 1.0.0
 assertJVersion      = 3.11.1

--- a/junit-jupiter-api/junit-jupiter-api.gradle
+++ b/junit-jupiter-api/junit-jupiter-api.gradle
@@ -1,15 +1,11 @@
+plugins {
+	id 'com.zyxist.chainsaw' version '0.3.1'
+}
+
 description = 'JUnit Jupiter API'
 
 dependencies {
 	api("org.opentest4j:opentest4j:${ota4jVersion}")
 	api(project(':junit-platform-commons'))
 	compileOnly('org.jetbrains.kotlin:kotlin-stdlib')
-}
-
-jar {
-	manifest {
-		attributes(
-			'Automatic-Module-Name': 'org.junit.jupiter.api'
-		)
-	}
 }

--- a/junit-jupiter-api/src/main/java/module-info.java
+++ b/junit-jupiter-api/src/main/java/module-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+module org.junit.jupiter.api {
+	requires transitive org.apiguardian.api;
+	requires transitive org.junit.platform.commons;
+	requires org.opentest4j;
+
+	exports org.junit.jupiter.api;
+	exports org.junit.jupiter.api.condition;
+	exports org.junit.jupiter.api.extension;
+	exports org.junit.jupiter.api.function;
+	exports org.junit.jupiter.api.parallel;
+}

--- a/junit-platform-commons-java-9/src/test/java/integration/JupiterIntegrationTests.java
+++ b/junit-platform-commons-java-9/src/test/java/integration/JupiterIntegrationTests.java
@@ -13,7 +13,6 @@ package integration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
 import org.junit.jupiter.api.Test;
@@ -67,7 +66,7 @@ class JupiterIntegrationTests {
 		resolver.resolveSelectors(request().selectors(selector).build(), engine);
 
 		assertEquals(1, engine.getChildren().size()); // JupiterIntegrationTests.class
-		assertEquals(5, getOnlyElement(engine.getChildren()).getChildren().size()); // 5 test methods
+		assertEquals(5, engine.getChildren().iterator().next().getChildren().size()); // 5 test methods
 	}
 
 	@Test

--- a/junit-platform-commons/junit-platform-commons.gradle
+++ b/junit-platform-commons/junit-platform-commons.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'com.zyxist.chainsaw' version '0.3.1'
+}
+
 description = 'JUnit Platform Commons'
 
 jar {

--- a/junit-platform-commons/junit-platform-commons.gradle
+++ b/junit-platform-commons/junit-platform-commons.gradle
@@ -3,11 +3,3 @@ plugins {
 }
 
 description = 'JUnit Platform Commons'
-
-jar {
-	manifest {
-		attributes(
-			'Automatic-Module-Name': 'org.junit.platform.commons'
-		)
-	}
-}

--- a/junit-platform-commons/src/main/java/module-info.java
+++ b/junit-platform-commons/src/main/java/module-info.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+module org.junit.platform.commons {
+
+	requires static java.compiler; // usage of `javax.lang.model.SourceVersion` in `PackageUtils`
+	requires java.logging;
+	requires org.apiguardian.api;
+
+	//
+	// Public API of this module.
+	//
+	exports org.junit.platform.commons;
+	exports org.junit.platform.commons.annotation;
+	exports org.junit.platform.commons.support;
+
+	//
+	// Make internal packages only visible to other JUnit modules.
+	//
+	exports org.junit.platform.commons.logging to
+			org.junit.platform.engine,
+			org.junit.platform.console,
+			org.junit.platform.launcher,
+			org.junit.jupiter.engine,
+			org.junit.vintage.engine;
+
+	exports org.junit.platform.commons.util to
+			org.junit.platform.engine,
+			org.junit.platform.console,
+			org.junit.platform.launcher,
+			org.junit.jupiter.api,
+			org.junit.jupiter.engine,
+			org.junit.vintage.engine;
+}

--- a/junit-platform-commons/src/main/java/module-info.java
+++ b/junit-platform-commons/src/main/java/module-info.java
@@ -27,6 +27,7 @@ module org.junit.platform.commons {
 			org.junit.platform.engine,
 			org.junit.platform.console,
 			org.junit.platform.launcher,
+			org.junit.jupiter.api,
 			org.junit.jupiter.engine,
 			org.junit.vintage.engine;
 

--- a/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
+++ b/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
@@ -86,6 +86,10 @@ class AutomaticModuleNameTests {
 		String jarName = module + "-" + version(module) + ".jar";
 		Path jarPath = Paths.get("..", module).resolve("build/libs").resolve(jarName).normalize();
 		try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+			// skip explicit module
+			if (jarFile.getEntry("module-info.class") != null) {
+				return;
+			}
 			// first, check automatic module name
 			Manifest manifest = jarFile.getManifest();
 			String automaticModuleName = manifest.getMainAttributes().getValue("Automatic-Module-Name");

--- a/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
+++ b/platform-tests/src/test/java/org/junit/AutomaticModuleNameTests.java
@@ -97,6 +97,7 @@ class AutomaticModuleNameTests {
 			List<String> unexpectedNames = jarFile.stream()
 					.map(ZipEntry::getName)
 					.filter(n -> n.endsWith(".class"))
+					.filter(n -> !n.equals("module-info.class"))
 					.filter(n -> !n.startsWith(expectedStartOfPackageName))
 					.filter(n -> !(n.startsWith("META-INF/versions/") && n.contains(expectedStartOfPackageName)))
 					.collect(toList());

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-api.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-api.expected.txt
@@ -1,9 +1,10 @@
->> 1 line header: No module descriptor found. Derived automatic module. >>
-
-org.junit.jupiter.api@${jupiterVersion} automatic
+org.junit.jupiter.api jar.+module-info.class
+exports org.junit.jupiter.api
+exports org.junit.jupiter.api.condition
+exports org.junit.jupiter.api.extension
+exports org.junit.jupiter.api.function
+exports org.junit.jupiter.api.parallel
 requires java.base mandated
-contains org.junit.jupiter.api
-contains org.junit.jupiter.api.condition
-contains org.junit.jupiter.api.extension
-contains org.junit.jupiter.api.function
-contains org.junit.jupiter.api.parallel
+requires org.apiguardian.api transitive
+requires org.junit.platform.commons transitive
+requires org.opentest4j

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
@@ -6,5 +6,5 @@ requires java.base mandated
 requires java.compiler static
 requires java.logging
 requires org.apiguardian.api
-qualified exports org.junit.platform.commons.logging to org.junit.jupiter.engine org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.vintage.engine
+qualified exports org.junit.platform.commons.logging to org.junit.jupiter.api org.junit.jupiter.engine org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.vintage.engine
 qualified exports org.junit.platform.commons.util to org.junit.jupiter.api org.junit.jupiter.engine org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.vintage.engine

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
@@ -1,9 +1,10 @@
->> 1 line header: No module descriptor found. Derived automatic module. >>
-
-org.junit.platform.commons@${platformVersion} automatic
+org.junit.platform.commons jar.+module-info.class
+exports org.junit.platform.commons
+exports org.junit.platform.commons.annotation
+exports org.junit.platform.commons.support
 requires java.base mandated
-contains org.junit.platform.commons
-contains org.junit.platform.commons.annotation
-contains org.junit.platform.commons.logging
-contains org.junit.platform.commons.support
-contains org.junit.platform.commons.util
+requires java.compiler static
+requires java.logging
+requires org.apiguardian.api
+qualified exports org.junit.platform.commons.logging to org.junit.jupiter.engine org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.vintage.engine
+qualified exports org.junit.platform.commons.util to org.junit.jupiter.api org.junit.jupiter.engine org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.vintage.engine

--- a/platform-tooling-support-tests/src/main/java/platform/tooling/support/Helper.java
+++ b/platform-tooling-support-tests/src/main/java/platform/tooling/support/Helper.java
@@ -10,6 +10,7 @@
 
 package platform.tooling.support;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -80,18 +81,25 @@ public class Helper {
 		}
 	}
 
-	public static JarFile createJarFile(String module) {
+	public static File createFile(String module) {
 		var archive = module + '-' + version(module) + ".jar";
-		var path = Paths.get("..", module, "build", "libs", archive);
+		return Paths.get("..", module, "build", "libs", archive).toFile();
+	}
+
+	public static JarFile createJarFile(String module) {
 		try {
-			return new JarFile(path.toFile());
+			return new JarFile(createFile(module));
 		}
 		catch (IOException e) {
-			throw new UncheckedIOException("Creating JarFile for '" + path + "' failed.", e);
+			throw new UncheckedIOException("Creating JarFile for '" + module + "' failed.", e);
 		}
 	}
 
 	public static List<JarFile> loadJarFiles() {
 		return loadModuleDirectoryNames().stream().map(Helper::createJarFile).collect(Collectors.toList());
+	}
+
+	public static List<File> loadModulesAsFiles() {
+		return loadModuleDirectoryNames().stream().map(Helper::createFile).collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
## Overview

Introduce module descriptors as layed out in #1091.

- [x] `org.junit.platform.commons`
- [x] `org.junit.jupiter.api`
- [ ] _others_

## Caveats

- This PR also **temporarily** moves the "javac --target" option from **8 to 9** to enable `module-info.java` compilation. Who knows a way to remain binary compatible with Java 8?

- **Checkstyle** and **Degraph** are muted/turned off until they support Java 9+...

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
