### PR TITLE
Support single dynamic node as return type

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -26,6 +26,8 @@ repository on GitHub.
 * JUnit 4's `AssumptionViolatedException` is now supported in JUnit Jupiter for aborting
   a test mid-flight due to a failed assumption -- for example, via JUnit 4's
   `org.junit.Assume` utility class.
+* In addition to returning streams, `@TestFactory`-annotated methods may return a single
+  `DynamicNode`, i.e. a `DynamicTest` or a `DynamicContainer`, instance.
 
 
 [[release-notes-5.4.0-M1-junit-jupiter]]

--- a/documentation/src/test/java/example/DynamicTestsDemo.java
+++ b/documentation/src/test/java/example/DynamicTestsDemo.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -181,5 +182,23 @@ class DynamicTestsDemo {
 		// tag::user_guide[]
 	}
 
+	@TestFactory
+	DynamicTest dynamicNodeSingle() {
+		return dynamicTest("single dynamic test", () -> assertFalse(false));
+	}
+
+	@TestFactory
+	DynamicContainer dynamicNodeTree() {
+		// end::user_guide[]
+		// @formatter:off
+		// tag::user_guide[]
+		return dynamicContainer("single dynamic container", Stream.of(
+			dynamicTest("foo", () -> assertTrue(true)),
+			dynamicTest("bar", () -> assertFalse(false))
+		));
+		// end::user_guide[]
+		// @formatter:on
+		// tag::user_guide[]
+	}
 }
 // end::user_guide[]

--- a/documentation/src/test/java/example/DynamicTestsDemo.java
+++ b/documentation/src/test/java/example/DynamicTestsDemo.java
@@ -27,7 +27,6 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -183,12 +182,12 @@ class DynamicTestsDemo {
 	}
 
 	@TestFactory
-	DynamicTest dynamicNodeSingle() {
+	DynamicNode dynamicNodeSingleTest() {
 		return dynamicTest("single dynamic test", () -> assertFalse(false));
 	}
 
 	@TestFactory
-	DynamicContainer dynamicNodeTree() {
+	DynamicNode dynamicNodeSingleContainer() {
 		// end::user_guide[]
 		// @formatter:off
 		// tag::user_guide[]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -87,20 +87,30 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 				context.getExtensionRegistry());
 			TestSource defaultTestSource = getSource().orElseThrow(
 				() -> new JUnitException("Illegal state: TestSource must be present"));
+			// since 5.4: handle single node case (#1521)
+			if (testFactoryMethodResult instanceof DynamicNode) {
+				execute((DynamicNode) testFactoryMethodResult, defaultTestSource, 1, dynamicTestExecutor);
+				return;
+			}
+			// else try converting result into a stream of nodes
 			try (Stream<DynamicNode> dynamicNodeStream = toDynamicNodeStream(testFactoryMethodResult)) {
 				int index = 1;
 				Iterator<DynamicNode> iterator = dynamicNodeStream.iterator();
 				while (iterator.hasNext()) {
-					DynamicNode dynamicNode = iterator.next();
-					Optional<JupiterTestDescriptor> descriptor = createDynamicDescriptor(this, dynamicNode, index++,
-						defaultTestSource, getDynamicDescendantFilter());
-					descriptor.ifPresent(dynamicTestExecutor::execute);
+					execute(iterator.next(), defaultTestSource, index++, dynamicTestExecutor);
 				}
 			}
 			catch (ClassCastException ex) {
 				throw invalidReturnTypeException(ex);
 			}
 		});
+	}
+
+	private void execute(DynamicNode dynamicNode, TestSource defaultTestSource, int index,
+			DynamicTestExecutor dynamicTestExecutor) {
+		Optional<JupiterTestDescriptor> descriptor = createDynamicDescriptor(this, dynamicNode, index,
+			defaultTestSource, getDynamicDescendantFilter());
+		descriptor.ifPresent(dynamicTestExecutor::execute);
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
## Overview

Support single dynamic node as return type of a `@TestFactory`-annotated method.

Closes #1521 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
