### PR TITLE
Use 'java-compiler-script-engine' evaluating Java snippets

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -18,6 +18,7 @@ object Versions {
     val classgraph = "4.2.2"
     val commonsIo = "2.6"
     val groovy = "2.4.15"
+    val javaCompilerScriptEngine = "0.1.2"
     val log4j = "2.11.1"
     val mockito = "2.23.0"
     val slf4j = "1.7.25"

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -21,6 +21,7 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.engine.descriptor.TestInstanceLifecycleUtils;
 import org.junit.jupiter.engine.execution.ConditionEvaluator;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
+import org.junit.jupiter.engine.extension.ScriptExecutionCondition;
 import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfigurationStrategy;
 
 /**
@@ -162,7 +163,7 @@ public final class Constants {
 	 * @since 5.4
 	 */
 	@API(status = EXPERIMENTAL, since = "5.4")
-	public static final String DEFAULT_SCRIPT_ENGINE_PROPERTY_NAME = "junit.jupiter.script.engine.default";
+	public static final String DEFAULT_SCRIPT_ENGINE_PROPERTY_NAME = ScriptExecutionCondition.DEFAULT_SCRIPT_ENGINE_PROPERTY_NAME;
 
 	/**
 	 * Default script engine is {@code Nashorn}.
@@ -170,7 +171,7 @@ public final class Constants {
 	 * @since 5.4
 	 */
 	@API(status = EXPERIMENTAL, since = "5.4")
-	public static final String DEFAULT_SCRIPT_ENGINE = "Nashorn";
+	public static final String DEFAULT_SCRIPT_ENGINE = ScriptExecutionCondition.DEFAULT_SCRIPT_ENGINE;
 
 	private Constants() {
 		/* no-op */

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -156,6 +156,22 @@ public final class Constants {
 	public static final String PARALLEL_CONFIG_CUSTOM_CLASS_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
 			+ CONFIG_CUSTOM_CLASS_PROPERTY_NAME;
 
+	/**
+	 * Property name used to specify the default script engine.
+	 *
+	 * @since 5.4
+	 */
+	@API(status = EXPERIMENTAL, since = "5.4")
+	public static final String DEFAULT_SCRIPT_ENGINE_PROPERTY_NAME = "junit.jupiter.script.engine.default";
+
+	/**
+	 * Default script engine is {@code Nashorn}.
+	 *
+	 * @since 5.4
+	 */
+	@API(status = EXPERIMENTAL, since = "5.4")
+	public static final String DEFAULT_SCRIPT_ENGINE = "Nashorn";
+
 	private Constants() {
 		/* no-op */
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionCondition.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionCondition.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine.extension;
 
+import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
@@ -18,13 +19,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.apiguardian.api.API;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.engine.Constants;
 import org.junit.jupiter.engine.script.Script;
 import org.junit.platform.commons.util.BlacklistedExceptions;
 
@@ -36,7 +37,12 @@ import org.junit.platform.commons.util.BlacklistedExceptions;
  * @see EnabledIf
  * @see #evaluateExecutionCondition(ExtensionContext)
  */
-class ScriptExecutionCondition implements ExecutionCondition {
+@API(status = INTERNAL, since = "5.1")
+public class ScriptExecutionCondition implements ExecutionCondition {
+
+	public static final String DEFAULT_SCRIPT_ENGINE_PROPERTY_NAME = "junit.jupiter.script.engine.default";
+
+	public static final String DEFAULT_SCRIPT_ENGINE = "Nashorn";
 
 	private static final ConditionEvaluationResult ENABLED_NO_ELEMENT = enabled("AnnotatedElement not present");
 
@@ -113,9 +119,7 @@ class ScriptExecutionCondition implements ExecutionCondition {
 		if (!annotatedEngine.trim().isEmpty()) {
 			return annotatedEngine;
 		}
-		String key = Constants.DEFAULT_SCRIPT_ENGINE_PROPERTY_NAME;
-		String defaultValue = Constants.DEFAULT_SCRIPT_ENGINE;
-		return context.getConfigurationParameter(key).orElse(defaultValue);
+		return context.getConfigurationParameter(DEFAULT_SCRIPT_ENGINE_PROPERTY_NAME).orElse(DEFAULT_SCRIPT_ENGINE);
 	}
 
 	/**

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
 	testRuntimeOnly("org.codehaus.groovy:groovy-jsr223:${Versions.groovy}") {
 		because("Tests annotated with @EnabledIf(engine = \"groovy\", ...) need it.")
 	}
+	testRuntimeOnly("de.sormuras:java-compiler-script-engine:${Versions.javaCompilerScriptEngine}") {
+		because("Tests annotated with @EnabledIf(engine = \"java\", ...) need it.")
+	}
 
 	// --- http://openjdk.java.net/projects/code-tools/jmh/ -----------------------
 	jmh("org.openjdk.jmh:jmh-core:${Versions.jmh}") {

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/DisabledIfTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/DisabledIfTests.java
@@ -125,6 +125,12 @@ class DisabledIfTests {
 	}
 
 	@Test
+	@DisabledIf(engine = "java", value = "return 9 == 9;")
+	void java() {
+		fail("test must not be executed");
+	}
+
+	@Test
 	@DisabledIf("false")
 	@Disabled
 	void disabledIfAndDisabled() {

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfTests.java
@@ -131,6 +131,11 @@ class EnabledIfTests {
 	}
 
 	@Test
+	@EnabledIf(engine = "java", value = "return 9 == 9;")
+	void java() {
+	}
+
+	@Test
 	@EnabledIf("true")
 	@Disabled
 	void enabledAndDisabled() {


### PR DESCRIPTION
## Overview

Addresses #1481

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
