### PR TITLE
Fix Solaris OS detection for @[Enabled|Disabled]OnOs

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
@@ -100,7 +100,7 @@ public enum OS {
 		if (osName.contains("mac")) {
 			return MAC;
 		}
-		if (osName.contains("solaris")) {
+		if (osName.contains("sunos") || osName.contains("solaris")) {
 			return SOLARIS;
 		}
 		if (osName.contains("win")) {


### PR DESCRIPTION
## Overview

fixes #1603 

This pr also detects `SunOS` as Solaris (e.g. used for `@DisabledOnOs`).


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
