### PR TITLE
Introduce IndicativeSentences display name generator

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -126,4 +126,51 @@ public interface DisplayNameGenerator {
 		}
 	}
 
+	/**
+	 * Create a descriptive string composed from the class and
+	 * method names within the current test container.
+	 *
+	 * <p>
+	 * The {@code IndicativeSentences} generator prepends the enclosing class
+	 * display name to every nested class and method name in order to create a
+	 * contextual human readable test names.
+	 */
+	class IndicativeSentences extends ReplaceUnderscores {
+
+		@Override
+		public String generateDisplayNameForClass(Class<?> testClass) {
+			return generateName(testClass) + "...";
+		}
+
+		@Override
+		public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+			return generateName(nestedClass) + "...";
+		}
+
+		@Override
+		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+			return generateName(testClass) + ' ' + super.generateDisplayNameForMethod(testClass, testMethod);
+		}
+
+		private String generateName(Class<?> testClass) {
+			DisplayName explicitDisplayName = testClass.getAnnotation(DisplayName.class);
+			if (explicitDisplayName != null) {
+				return explicitDisplayName.value();
+			}
+			if (testClass.getEnclosingClass() == null) {
+				return super.generateDisplayNameForClass(testClass);
+			}
+			DisplayNameGeneration annotation = testClass.getAnnotation(DisplayNameGeneration.class);
+			if (annotation != null && annotation.value() == IndicativeSentences.class) {
+				return super.generateDisplayNameForNestedClass(testClass);
+			}
+			String name = super.generateDisplayNameForNestedClass(testClass);
+			name = name.trim();
+			if (name.length() > 1) {
+				name = Character.toLowerCase(name.charAt(0)) + name.substring(1);
+			}
+			return generateName(testClass.getEnclosingClass()) + ' ' + name;
+		}
+	}
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -149,7 +149,8 @@ public interface DisplayNameGenerator {
 
 		@Override
 		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
-			return generateName(testClass) + ' ' + super.generateDisplayNameForMethod(testClass, testMethod);
+			String methodName = super.generateDisplayNameForMethod(testClass, testMethod);
+			return generateName(testClass) + ' ' + methodName.replaceAll("\\(\\)$", ".");
 		}
 
 		private String generateName(Class<?> testClass) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.DisplayNameGenerator.IndicativeSentences;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.DisplayNameGenerator.Standard;
 import org.junit.platform.commons.logging.Logger;
@@ -49,6 +50,8 @@ final class DisplayNameUtils {
 	 * Pre-defined display name generator instance replacing underscores.
 	 */
 	private static final DisplayNameGenerator replaceUnderscoresGenerator = new ReplaceUnderscores();
+
+	private static final DisplayNameGenerator indicativeSentencesGenerator = new IndicativeSentences();
 
 	static String determineDisplayName(AnnotatedElement element, Supplier<String> displayNameSupplier) {
 		Preconditions.notNull(element, "Annotated element must not be null");
@@ -98,6 +101,9 @@ final class DisplayNameUtils {
 		}
 		if (displayNameGeneratorClass == ReplaceUnderscores.class) {
 			return replaceUnderscoresGenerator;
+		}
+		if (displayNameGeneratorClass == IndicativeSentences.class) {
+			return indicativeSentencesGenerator;
 		}
 		// else: create an instance of the supplied generator implementation class and return it
 		return ReflectionUtils.newInstance(displayNameGeneratorClass);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -81,6 +81,34 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	void indicativeSentencesGenerator() {
+		check(IndicativeSentencesStyleTestCase.class, List.of( //
+			"CONTAINER: IndicativeSentencesStyleTestCase...", //
+			"TEST: @DisplayName prevails", //
+			"TEST: IndicativeSentencesStyleTestCase test with underscores()", //
+			"TEST: IndicativeSentencesStyleTestCase test()", //
+			"TEST: IndicativeSentencesStyleTestCase test(TestInfo)", //
+			"TEST: IndicativeSentencesStyleTestCase testUsingCamelCase and also UnderScores keepingParameterTypeNamesIntact(TestInfo)", //
+			"TEST: IndicativeSentencesStyleTestCase testUsingCamelCase and also UnderScores()", //
+			"TEST: IndicativeSentencesStyleTestCase testUsingCamelCaseStyle()" //
+		));
+	}
+
+	@Test
+	void indicativeSentencesGeneratorInheritedFromSuperClass() {
+		check(IndicativeSentencesInheritedFromSuperClassTestCase.class, List.of( //
+			"CONTAINER: IndicativeSentencesInheritedFromSuperClassTestCase...", //
+			"TEST: @DisplayName prevails", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase test with underscores()", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase test()", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase test(TestInfo)", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase testUsingCamelCase and also UnderScores keepingParameterTypeNamesIntact(TestInfo)", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase testUsingCamelCase and also UnderScores()", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase testUsingCamelCaseStyle()" //
+		));
+	}
+
+	@Test
 	void checkDisplayNameGeneratedForTestingAStackDemo() {
 		check(StackTestCase.class, List.of( //
 			"CONTAINER: A new stack", //
@@ -93,6 +121,26 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 			"TEST: the stack is no longer empty()", //
 			"TEST: throws an EmptyStackException when peeked()", //
 			"TEST: throws an EmptyStackException when popped()" //
+		));
+	}
+
+	@Test
+	void checkIndicativeSentencesDisplayNameGeneratedForTestingAStackDemo() {
+		check(IndicativeSentencesStackTestCase.class, List.of( //
+			"CONTAINER: A new stack after pushing an element to it...", //
+			"CONTAINER: A new stack...", //
+			"CONTAINER: A stack", //
+			"CONTAINER: A stack when new...", //
+
+			"TEST: A new stack after pushing an element to it peek returns that element without removing it from the stack()", //
+			"TEST: A new stack after pushing an element to it pop returns that element and leaves an empty stack()", //
+			"TEST: A new stack after pushing an element to it the stack is no longer empty()", //
+			"TEST: A new stack has no components.", //
+			"TEST: A new stack is empty()", //
+			"TEST: A new stack throws an EmptyStackException when peeked()", //
+			"TEST: A new stack throws an EmptyStackException when popped()", //
+			"TEST: A stack is instantiated using its noarg constructor()", //
+			"TEST: A stack when new is empty()" //
 		));
 	}
 
@@ -177,6 +225,14 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	static class UnderscoreStyleInheritedFromSuperClassTestCase extends UnderscoreStyleTestCase {
 	}
 
+	@DisplayNameGeneration(DisplayNameGenerator.IndicativeSentences.class)
+	static class IndicativeSentencesStyleTestCase extends UnderscoreStyleTestCase {
+	}
+
+	// No annotation here! @DisplayNameGeneration is inherited from super class
+	static class IndicativeSentencesInheritedFromSuperClassTestCase extends IndicativeSentencesStyleTestCase {
+	}
+
 	// -------------------------------------------------------------------
 
 	@DisplayName("A stack")
@@ -242,4 +298,92 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 			}
 		}
 	}
+
+	// -------------------------------------------------------------------
+
+	@DisplayName("A stack")
+	@DisplayNameGeneration(DisplayNameGenerator.IndicativeSentences.class)
+	static class IndicativeSentencesStackTestCase {
+
+		Stack<Object> stack;
+
+		@Test
+		void is_instantiated_using_its_noarg_constructor() {
+			new Stack<>();
+		}
+
+		@Nested
+		class When_new {
+			@BeforeEach
+			void createNewStack() {
+				stack = new Stack<>();
+			}
+
+			@Test
+			void is_empty() {
+				assertTrue(stack.isEmpty());
+			}
+
+			@DisplayName("A new stack has no components.")
+			@Test
+			void has_size_zero() {
+				assertTrue(stack.isEmpty());
+			}
+		}
+
+		@DisplayNameGeneration(DisplayNameGenerator.IndicativeSentences.class)
+		@Nested
+		class A_new_stack {
+
+			@BeforeEach
+			void createNewStack() {
+				stack = new Stack<>();
+			}
+
+			@Test
+			void is_empty() {
+				assertTrue(stack.isEmpty());
+			}
+
+			@Test
+			void throws_an_EmptyStackException_when_popped() {
+				assertThrows(EmptyStackException.class, () -> stack.pop());
+			}
+
+			@Test
+			void throws_an_EmptyStackException_when_peeked() {
+				assertThrows(EmptyStackException.class, () -> stack.peek());
+			}
+
+			@Nested
+			class After_pushing_an_element_to_it {
+
+				String anElement = "an element";
+
+				@BeforeEach
+				void pushAnElement() {
+					stack.push(anElement);
+				}
+
+				@Test
+				void the_stack_is_no_longer_empty() {
+					assertFalse(stack.isEmpty());
+				}
+
+				@Test
+				void pop_returns_that_element_and_leaves_an_empty_stack() {
+					assertEquals(anElement, stack.pop());
+					assertTrue(stack.isEmpty());
+				}
+
+				@Test
+				void peek_returns_that_element_without_removing_it_from_the_stack() {
+					assertEquals(anElement, stack.peek());
+					assertFalse(stack.isEmpty());
+				}
+			}
+
+		}
+	}
+
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -85,12 +85,12 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 		check(IndicativeSentencesStyleTestCase.class, List.of( //
 			"CONTAINER: IndicativeSentencesStyleTestCase...", //
 			"TEST: @DisplayName prevails", //
-			"TEST: IndicativeSentencesStyleTestCase test with underscores()", //
-			"TEST: IndicativeSentencesStyleTestCase test()", //
+			"TEST: IndicativeSentencesStyleTestCase test with underscores.", //
 			"TEST: IndicativeSentencesStyleTestCase test(TestInfo)", //
+			"TEST: IndicativeSentencesStyleTestCase test.", //
 			"TEST: IndicativeSentencesStyleTestCase testUsingCamelCase and also UnderScores keepingParameterTypeNamesIntact(TestInfo)", //
-			"TEST: IndicativeSentencesStyleTestCase testUsingCamelCase and also UnderScores()", //
-			"TEST: IndicativeSentencesStyleTestCase testUsingCamelCaseStyle()" //
+			"TEST: IndicativeSentencesStyleTestCase testUsingCamelCase and also UnderScores.", //
+			"TEST: IndicativeSentencesStyleTestCase testUsingCamelCaseStyle." //
 		));
 	}
 
@@ -99,12 +99,12 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 		check(IndicativeSentencesInheritedFromSuperClassTestCase.class, List.of( //
 			"CONTAINER: IndicativeSentencesInheritedFromSuperClassTestCase...", //
 			"TEST: @DisplayName prevails", //
-			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase test with underscores()", //
-			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase test()", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase test with underscores.", //
 			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase test(TestInfo)", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase test.", //
 			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase testUsingCamelCase and also UnderScores keepingParameterTypeNamesIntact(TestInfo)", //
-			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase testUsingCamelCase and also UnderScores()", //
-			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase testUsingCamelCaseStyle()" //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase testUsingCamelCase and also UnderScores.", //
+			"TEST: IndicativeSentencesInheritedFromSuperClassTestCase testUsingCamelCaseStyle." //
 		));
 	}
 
@@ -132,15 +132,15 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 			"CONTAINER: A stack", //
 			"CONTAINER: A stack when new...", //
 
-			"TEST: A new stack after pushing an element to it peek returns that element without removing it from the stack()", //
-			"TEST: A new stack after pushing an element to it pop returns that element and leaves an empty stack()", //
-			"TEST: A new stack after pushing an element to it the stack is no longer empty()", //
+			"TEST: A new stack after pushing an element to it peek returns that element without removing it from the stack.", //
+			"TEST: A new stack after pushing an element to it pop returns that element and leaves an empty stack.", //
+			"TEST: A new stack after pushing an element to it the stack is no longer empty.", //
 			"TEST: A new stack has no components.", //
-			"TEST: A new stack is empty()", //
-			"TEST: A new stack throws an EmptyStackException when peeked()", //
-			"TEST: A new stack throws an EmptyStackException when popped()", //
-			"TEST: A stack is instantiated using its noarg constructor()", //
-			"TEST: A stack when new is empty()" //
+			"TEST: A new stack is empty.", //
+			"TEST: A new stack throws an EmptyStackException when peeked.", //
+			"TEST: A new stack throws an EmptyStackException when popped.", //
+			"TEST: A stack is instantiated using its noarg constructor.", //
+			"TEST: A stack when new is empty." //
 		));
 	}
 


### PR DESCRIPTION
Overview
---

Issue: #1596

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass