### PR TITLE
Allow 0 as a delta in assertEquals methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -40,6 +40,7 @@ repository on GitHub.
 
 * `Assertions.assertAll()` is now thread-safe, i.e. it can be used with _parallel_ `Streams`.
 * `OS.SOLARIS` is now also detected for when `os.name` reports `SunOs`.
+* `Assertions.assertEquals()` that takes floating points number is now working with delta equals to zero.
 
 ==== Deprecations and Breaking Changes
 

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -40,7 +40,8 @@ repository on GitHub.
 
 * `Assertions.assertAll()` is now thread-safe, i.e. it can be used with _parallel_ `Streams`.
 * `OS.SOLARIS` is now also detected for when `os.name` reports `SunOs`.
-* `Assertions.assertEquals()` that takes floating points number is now working with delta equals to zero.
+* `Assertions.assertEquals()` variants that compare floating point numbers using a delta
+  now allow passing a delta of zero.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -142,13 +142,13 @@ class AssertionUtils {
 	}
 
 	static void assertValidDelta(float delta) {
-		if (Float.isNaN(delta) || delta <= 0.0) {
+		if (Float.isNaN(delta) || delta < 0.0) {
 			failIllegalDelta(String.valueOf(delta));
 		}
 	}
 
 	static void assertValidDelta(double delta) {
-		if (Double.isNaN(delta) || delta <= 0.0) {
+		if (Double.isNaN(delta) || delta < 0.0) {
 			failIllegalDelta(String.valueOf(delta));
 		}
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -415,30 +415,27 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertEquals(float expected, float actual, float delta) {
 		AssertEquals.assertEquals(expected, actual, delta);
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertEquals(float expected, float actual, float delta, String message) {
 		AssertEquals.assertEquals(expected, actual, delta, message);
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertEquals(float expected, float actual, float delta, Supplier<String> messageSupplier) {
@@ -474,30 +471,27 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertEquals(double expected, double actual, double delta) {
 		AssertEquals.assertEquals(expected, actual, delta);
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertEquals(double expected, double actual, double delta, String message) {
 		AssertEquals.assertEquals(expected, actual, delta, message);
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertEquals(double expected, double actual, double delta, Supplier<String> messageSupplier) {
@@ -724,20 +718,18 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertArrayEquals(float[] expected, float[] actual, float delta) {
 		AssertArrayEquals.assertArrayEquals(expected, actual, delta);
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>Fails with the supplied failure {@code message}.
 	 */
 	public static void assertArrayEquals(float[] expected, float[] actual, float delta, String message) {
@@ -745,10 +737,9 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertArrayEquals(float[] expected, float[] actual, float delta,
@@ -786,20 +777,18 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertArrayEquals(double[] expected, double[] actual, double delta) {
 		AssertArrayEquals.assertArrayEquals(expected, actual, delta);
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>Fails with the supplied failure {@code message}.
 	 */
 	public static void assertArrayEquals(double[] expected, double[] actual, double delta, String message) {
@@ -807,10 +796,9 @@ public class Assertions {
 	}
 
 	/**
-	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
+	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given non-negative {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
-	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertArrayEquals(double[] expected, double[] actual, double delta,

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -474,6 +474,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertEquals(double expected, double actual, double delta) {
 		AssertEquals.assertEquals(expected, actual, delta);
@@ -483,6 +484,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertEquals(double expected, double actual, double delta, String message) {
 		AssertEquals.assertEquals(expected, actual, delta, message);
@@ -492,6 +494,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertEquals(double expected, double actual, double delta, Supplier<String> messageSupplier) {
@@ -721,6 +724,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertArrayEquals(float[] expected, float[] actual, float delta) {
 		AssertArrayEquals.assertArrayEquals(expected, actual, delta);
@@ -730,6 +734,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>Fails with the supplied failure {@code message}.
 	 */
 	public static void assertArrayEquals(float[] expected, float[] actual, float delta, String message) {
@@ -740,6 +745,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} float arrays are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertArrayEquals(float[] expected, float[] actual, float delta,

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -418,6 +418,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertEquals(float expected, float actual, float delta) {
 		AssertEquals.assertEquals(expected, actual, delta);
@@ -427,6 +428,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertEquals(float expected, float actual, float delta, String message) {
 		AssertEquals.assertEquals(expected, actual, delta, message);
@@ -436,6 +438,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Float#equals(Object)} and
 	 * {@link Float#compare(float, float)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertEquals(float expected, float actual, float delta, Supplier<String> messageSupplier) {
@@ -786,6 +789,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 */
 	public static void assertArrayEquals(double[] expected, double[] actual, double delta) {
 		AssertArrayEquals.assertArrayEquals(expected, actual, delta);
@@ -795,6 +799,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>Fails with the supplied failure {@code message}.
 	 */
 	public static void assertArrayEquals(double[] expected, double[] actual, double delta, String message) {
@@ -805,6 +810,7 @@ public class Assertions {
 	 * <em>Asserts</em> that {@code expected} and {@code actual} double arrays are equal within the given {@code delta}.
 	 * <p>Equality imposed by this method is consistent with {@link Double#equals(Object)} and
 	 * {@link Double#compare(double, double)}.</p>
+	 * {@code delta} have to be greater or equals <em>0</em>
 	 * <p>If necessary, the failure message will be retrieved lazily from the supplied {@code messageSupplier}.
 	 */
 	public static void assertArrayEquals(double[] expected, double[] actual, double delta,

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
@@ -329,6 +329,7 @@ class AssertEqualsAssertionsTests {
 		assertEquals(0.56f, 0.6f, 0.05f);
 		assertEquals(0.01f, 0.011f, 0.002f);
 		assertEquals(Float.NaN, Float.NaN, 0.5f);
+		assertEquals(0.1f, 0.1f, 0.0f);
 	}
 
 	@Test
@@ -442,6 +443,7 @@ class AssertEqualsAssertionsTests {
 		assertEquals(0.42d, 0.24d, 0.19d);
 		assertEquals(0.02d, 0.011d, 0.01d);
 		assertEquals(Double.NaN, Double.NaN, 0.2d);
+		assertEquals(0.001d, 0.001d, 0.0d);
 	}
 
 	@Test


### PR DESCRIPTION
Issues: #1606 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
