### PR TITLE
Support converting integral types in hex and octal

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -47,7 +47,8 @@ repository on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* Support converting integral types in hex and octal in parameterized test
+  arguments resolvers.
 
 
 [[release-notes-5.4.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -48,7 +48,7 @@ repository on GitHub.
 ==== New Features and Improvements
 
 * Support converting integral types in hex and octal in parameterized test
-  arguments resolvers.
+  arguments resolvers (e.g. `"0xff"` into `255`).
 
 
 [[release-notes-5.4.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1061,7 +1061,8 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=implicit_conversion_e
 ----
 
 `String` instances are currently implicitly converted to the following target types.
-Integral types support decimal, hexadecimal and octal `String` literals.
+Integral types (`byte`, `short`, `int`, `long` and their boxed counterparts)
+support decimal, hexadecimal and octal `String` literals.
 
 [[writing-tests-parameterized-tests-argument-conversion-implicit-table]]
 [cols="10,90"]
@@ -1069,11 +1070,11 @@ Integral types support decimal, hexadecimal and octal `String` literals.
 | Target Type | Example
 
 | `boolean`/`Boolean`        | `"true"`                                 -> `true`
-| `byte`/`Byte`              | `"1"`                                    -> `(byte) 1`
+| `byte`/`Byte`              | `"15"`, `"0xF"` or `017`                 -> `(byte) 15`
 | `char`/`Character`         | `"o"`                                    -> `'o'`
-| `short`/`Short`            | `"0xF"`                                  -> `(short) 15`
-| `int`/`Integer`            | `"1"`                                    -> `1`
-| `long`/`Long`              | `"1"`                                    -> `1L`
+| `short`/`Short`            | `"15"`, `"0xF"` or `017`                 -> `(short) 15`
+| `int`/`Integer`            | `"15"`, `"0xF"` or `017`                 -> `15`
+| `long`/`Long`              | `"15"`, `"0xF"` or `017`                 -> `15L`
 | `float`/`Float`            | `"1.0"`                                  -> `1.0f`
 | `double`/`Double`          | `"1.0"`                                  -> `1.0d`
 | `Enum` subclass            | `"SECONDS"`                              -> `TimeUnit.SECONDS`

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1070,11 +1070,11 @@ support decimal, hexadecimal and octal `String` literals.
 | Target Type | Example
 
 | `boolean`/`Boolean`        | `"true"`                                 -> `true`
-| `byte`/`Byte`              | `"15"`, `"0xF"` or `017`                 -> `(byte) 15`
+| `byte`/`Byte`              | `"15"`, `"0xF"` or `"017"`               -> `(byte) 15`
 | `char`/`Character`         | `"o"`                                    -> `'o'`
-| `short`/`Short`            | `"15"`, `"0xF"` or `017`                 -> `(short) 15`
-| `int`/`Integer`            | `"15"`, `"0xF"` or `017`                 -> `15`
-| `long`/`Long`              | `"15"`, `"0xF"` or `017`                 -> `15L`
+| `short`/`Short`            | `"15"`, `"0xF"` or `"017"`               -> `(short) 15`
+| `int`/`Integer`            | `"15"`, `"0xF"` or `"017"`               -> `15`
+| `long`/`Long`              | `"15"`, `"0xF"` or `"017"`               -> `15L`
 | `float`/`Float`            | `"1.0"`                                  -> `1.0f`
 | `double`/`Double`          | `"1.0"`                                  -> `1.0d`
 | `Enum` subclass            | `"SECONDS"`                              -> `TimeUnit.SECONDS`

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1061,6 +1061,7 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=implicit_conversion_e
 ----
 
 `String` instances are currently implicitly converted to the following target types.
+Integral types support decimal, hexadecimal and octal `String` literals.
 
 [[writing-tests-parameterized-tests-argument-conversion-implicit-table]]
 [cols="10,90"]
@@ -1070,7 +1071,7 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=implicit_conversion_e
 | `boolean`/`Boolean`        | `"true"`                                 -> `true`
 | `byte`/`Byte`              | `"1"`                                    -> `(byte) 1`
 | `char`/`Character`         | `"o"`                                    -> `'o'`
-| `short`/`Short`            | `"1"`                                    -> `(short) 1`
+| `short`/`Short`            | `"0xF"`                                  -> `(short) 15`
 | `int`/`Integer`            | `"1"`                                    -> `1`
 | `long`/`Long`              | `"1"`                                    -> `1L`
 | `float`/`Float`            | `"1.0"`                                  -> `1.0f`

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -176,7 +176,7 @@ class ParameterizedTestDemo {
 
 	// tag::CsvSource_example[]
 	@ParameterizedTest
-	@CsvSource({ "foo, 1", "bar, 2", "'baz, qux', 3" })
+	@CsvSource({ "foo, 1", "bar, 2", "'baz, qux', 0xF1" })
 	void testWithCsvSource(String first, int second) {
 		assertNotNull(first);
 		assertNotEquals(0, second);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -145,10 +145,10 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 				Preconditions.condition(source.length() == 1, () -> "String must have length of 1: " + source);
 				return source.charAt(0);
 			});
-			converters.put(Byte.class, Byte::valueOf);
-			converters.put(Short.class, Short::valueOf);
-			converters.put(Integer.class, Integer::valueOf);
-			converters.put(Long.class, Long::valueOf);
+			converters.put(Byte.class, Byte::decode);
+			converters.put(Short.class, Short::decode);
+			converters.put(Integer.class, Integer::decode);
+			converters.put(Long.class, Long::decode);
 			converters.put(Float.class, Float::valueOf);
 			converters.put(Double.class, Double::valueOf);
 			CONVERTERS = unmodifiableMap(converters);

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -87,6 +87,26 @@ class DefaultArgumentConverterTests {
 	}
 
 	@Test
+	@SuppressWarnings("OctalInteger") // We test parsing octal integers here as well as hex.
+	void convertsEncodedStringsToIntegralTypes() {
+		assertConverts("0x10", byte.class, (byte) 0x10);
+		assertConverts("-0x10", byte.class, (byte) -0x10);
+		assertConverts("010", byte.class, (byte) 010);
+
+		assertConverts("0x1000", short.class, (short) 0x1000);
+		assertConverts("-0x1000", short.class, (short) -0x1000);
+		assertConverts("01000", short.class, (short) 01000);
+
+		assertConverts("0x10000000", int.class, 0x10000000);
+		assertConverts("-0x10000000", int.class, -0x10000000);
+		assertConverts("010000000", int.class, 010000000);
+
+		assertConverts("0x10000000000", long.class, 0x10000000000L);
+		assertConverts("-0x10000000000", long.class, -0x10000000000L);
+		assertConverts("0100000000000", long.class, 0100000000000L);
+	}
+
+	@Test
 	void convertsStringsToEnumConstants() {
 		assertConverts("DAYS", TimeUnit.class, TimeUnit.DAYS);
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -89,20 +89,20 @@ class DefaultArgumentConverterTests {
 	@Test
 	@SuppressWarnings("OctalInteger") // We test parsing octal integers here as well as hex.
 	void convertsEncodedStringsToIntegralTypes() {
-		assertConverts("0x10", byte.class, (byte) 0x10);
-		assertConverts("-0x10", byte.class, (byte) -0x10);
+		assertConverts("0x1f", byte.class, (byte) 0x1F);
+		assertConverts("-0x1F", byte.class, (byte) -0x1F);
 		assertConverts("010", byte.class, (byte) 010);
 
-		assertConverts("0x1000", short.class, (short) 0x1000);
-		assertConverts("-0x1000", short.class, (short) -0x1000);
+		assertConverts("0x1f00", short.class, (short) 0x1F00);
+		assertConverts("-0x1F00", short.class, (short) -0x1F00);
 		assertConverts("01000", short.class, (short) 01000);
 
-		assertConverts("0x10000000", int.class, 0x10000000);
-		assertConverts("-0x10000000", int.class, -0x10000000);
+		assertConverts("0x1f000000", int.class, 0x1F000000);
+		assertConverts("-0x1F000000", int.class, -0x1F000000);
 		assertConverts("010000000", int.class, 010000000);
 
-		assertConverts("0x10000000000", long.class, 0x10000000000L);
-		assertConverts("-0x10000000000", long.class, -0x10000000000L);
+		assertConverts("0x1f000000000", long.class, 0x1F000000000L);
+		assertConverts("-0x1F000000000", long.class, -0x1F000000000L);
 		assertConverts("0100000000000", long.class, 0100000000000L);
 	}
 


### PR DESCRIPTION
## Overview

Use PrimitiveType#decode to convert strings to the primitive
integral types. This allows the values to be specified in the following
format:
```
    DecodableString:
        Signopt DecimalNumeral
        Signopt 0x HexDigits
        Signopt 0X HexDigits
        Signopt # HexDigits
        Signopt 0 OctalDigits
    Sign:
        -
        +
```

Addresses #1624

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
