### PR TITLE
Fix mixed content warning issued from documentation page

### DIFF
--- a/documentation/src/docs/asciidoc/docinfos/index-docinfo.html
+++ b/documentation/src/docs/asciidoc/docinfos/index-docinfo.html
@@ -1,1 +1,1 @@
-<link rel="icon" type="image/png" href="http://junit.org/junit5/assets/img/junit5-logo.png" />
+<link rel="icon" type="image/png" href="https://junit.org/junit5/assets/img/junit5-logo.png" />


### PR DESCRIPTION
## Overview

When visiting the documentation page modern browsers will issue a mixed content warning, because the documentation is served from https://junit.org/ but it references the junit5-logo.png from via http://junit.org.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

_does not apply_

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
