### PR TITLE
Introduce 'empty or null' source annotations for parameterized tests

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyAndNullLists.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyAndNullLists.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code EmptyListSource} is an {@link ArgumentsSource} which provides the
+ * following values :
+ *
+ * <ul>
+ * 	<li>The null list</li>
+ * 	<li>The empty list</li>
+ * </ul>
+ *
+ * <p>The supplied values will be provided as arguments to the annotated
+ * {@code @ParameterizedTest} method.
+ *
+ * <p>It is often useful to have the same test operate on both of these values.
+ *
+ * @since 5.0
+ * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see org.junit.jupiter.params.ParameterizedTest
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = EXPERIMENTAL, since = "5.4")
+@ArgumentsSource(EmptyAndNullListsProvider.class)
+public @interface EmptyAndNullLists {
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyAndNullListsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyAndNullListsProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+class EmptyAndNullListsProvider implements ArgumentsProvider, AnnotationConsumer<EmptyAndNullLists> {
+
+	@Override
+	public void accept(EmptyAndNullLists t) {
+	}
+
+	@Override
+	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+		List<?> nullList = null;
+		List<?> emptyList = new ArrayList<>();
+
+		return Stream.of(emptyList, nullList).map(Arguments::of);
+	}
+
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyAndNullStrings.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyAndNullStrings.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code EmptyStringSource} is an {@link ArgumentsSource} which provides the
+ * following values :
+ *
+ * <ul>
+ * 	<li>The null string</li>
+ * 	<li>The empty string</li>
+ * 	<li>The blank string</li>
+ * </ul>
+ *
+ * <p>Additional blank strings of larger size can be provided via the
+{@link #blankMaxSize} attribute.
+ *
+ * <p>The supplied values will be provided as arguments to the annotated
+ * {@code @ParameterizedTest} method.
+ *
+ * <p>It is often useful to have the same test operate on all of these values.
+ *
+ * @since 5.0
+ * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see org.junit.jupiter.params.ParameterizedTest
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = EXPERIMENTAL, since = "5.4")
+@ArgumentsSource(EmptyAndNullStringsProvider.class)
+public @interface EmptyAndNullStrings {
+
+	String[] blankValues() default " ";
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyAndNullStringsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyAndNullStringsProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import static java.util.stream.Stream.of;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+class EmptyAndNullStringsProvider implements ArgumentsProvider, AnnotationConsumer<EmptyAndNullStrings> {
+
+	private static final String EMPTY = "";
+
+	private String[] blankValues;
+
+	@Override
+	public void accept(EmptyAndNullStrings annotation) {
+		this.blankValues = annotation.blankValues();
+	}
+
+	@Override
+	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+		return Stream.concat(of(null, EMPTY), of(blankValues)).map(Arguments::of);
+	}
+}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/EmptyAndNullListsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/EmptyAndNullListsProviderTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class EmptyAndNullListsProviderTests {
+
+	@Test
+	public void testContainNullEmpty() {
+		Stream<Object[]> stream = provideArguments();
+		assertThat(stream).isNotNull();
+
+		List<Object[]> argumentObjectList = stream.collect(toList());
+
+		argumentObjectList.forEach(argumentObject -> {
+			assertThat(argumentObject).isNotNull();
+			assertThat(argumentObject.length).isEqualTo(1);
+		});
+
+		List<Object> arguments = argumentObjectList.stream().map(array -> array[0]).collect(toList());
+
+		assertSoftly(softly -> {
+			softly.assertThat(arguments).contains((Object) null);
+			softly.assertThat(arguments).anySatisfy(object -> {
+				assertThat(object).isInstanceOf(List.class);
+				List<?> list = (List<?>) object;
+				assertThat(list).isEmpty();
+			});
+		});
+	}
+
+	private Stream<Object[]> provideArguments() {
+		EmptyAndNullListsProvider provider = new EmptyAndNullListsProvider();
+		return provider.provideArguments(null).map(Arguments::get);
+	}
+}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/EmptyAndNullStringsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/EmptyAndNullStringsProviderTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class EmptyAndNullStringsProviderTests {
+
+	@Test
+	public void testContainNullAndEmpty() {
+		testContainNullAndEmptyAndBlankValues();
+	}
+
+	@Test
+	public void testContainNullAndEmptyAndBlank1() {
+		testContainNullAndEmptyAndBlankValues(" ");
+	}
+
+	@Test
+	public void testContainNullAndEmptyAndBlank2() {
+		testContainNullAndEmptyAndBlankValues(" ", "  ");
+	}
+
+	private void testContainNullAndEmptyAndBlankValues(String... blankValues) {
+		Stream<Object[]> stream = provideArguments(blankValues);
+		assertThat(stream).isNotNull();
+
+		List<Object[]> list = stream.collect(toList());
+
+		list.forEach(o -> {
+			assertThat(o).isNotNull();
+			assertThat(o.length).isEqualTo(1);
+		});
+
+		List<Object> strings = list.stream().map(array -> array[0]).collect(toList());
+
+		assertSoftly(softly -> {
+			softly.assertThat(strings).contains((Object) null);
+			softly.assertThat(strings).contains("");
+
+			for (String blankValue : blankValues) {
+				softly.assertThat(strings).contains(blankValue);
+			}
+		});
+	}
+
+	private Stream<Object[]> provideArguments(String... blankValues) {
+		EmptyAndNullStrings annotation = mock(EmptyAndNullStrings.class);
+		when(annotation.blankValues()).thenReturn(blankValues);
+
+		EmptyAndNullStringsProvider provider = new EmptyAndNullStringsProvider();
+		provider.accept(annotation);
+		return provider.provideArguments(null).map(Arguments::get);
+	}
+}


### PR DESCRIPTION
## Overview

I would like to propose two new annotations :

- `@EmptyStringSource`: provides a parameterized test with the following values : the `null` String, the empty String, and the blank String
- `@EmptyListSource`: provides a parameterized test with the following values : the `null` List and the empty List

### Reasoning

- Given a method having a String input, I often have preconditions throwing an error on the null/empty/blank values
- I have then to cover all those use cases in unit tests
- Same for the null/empty list
- I can't pass `null` to `@ValueSource` or any other annotation

I ended up developing those annotations to avoid redundant code. And following that, I ended up copy/pasting them in several projects.

So I thought maybe it could be baseline in `junit-jupiter-params`.

What do you think?

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/meta/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
