### PR TITLE
Do not throw NPE in assertLinesMatch() if actualLine is null

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -47,6 +47,10 @@ repository on GitHub.
   `"SunOs"`.
 * `Assertions.assertEquals()` variants that compare floating point numbers using a delta
   now support a _delta_ of zero.
+* `Assertions.assertLinesMatch()` no longer throws NullPointerException after evaluating
+  a FastForward match if there are more expected lines after the FastForward match then
+  remain in the actual results. This only manifested itself if the expected list size
+  was equal to or larger than the actual list size.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -167,7 +167,7 @@ class AssertLinesMatch {
 			return true;
 		}
 		try {
-			return actualLine.matches(expectedLine);
+			return (actualLine != null) && actualLine.matches(expectedLine);
 		}
 		catch (PatternSyntaxException ignore) {
 			return false;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
@@ -178,6 +178,23 @@ class AssertLinesMatchAssertionsTests {
 	}
 
 	@Test
+	void assertLinesMatchUsingFastForwardMarkerWithExtraExpectLineFails() {
+		List<String> expected = Arrays.asList("first line", ">> fails, because final line is missing >>", "last line",
+			"not present");
+		List<String> actual = Arrays.asList("first line", "first skipped", "second skipped", "last line");
+		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
+		List<String> expectedErrorMessageLines = Arrays.asList( //
+			"expected line #4:`not present` doesn't match ==> expected: <first line", //
+			">> fails, because final line is missing >>", //
+			"last line", //
+			"not present> but was: <first line", //
+			"first skipped", //
+			"second skipped", //
+			"last line>");
+		assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
+	}
+
+	@Test
 	void assertLinesMatchIsFastForwardLine() {
 		assertAll("valid fast-forward lines", //
 			() -> assertTrue(isFastForwardLine(">>>>")), () -> assertTrue(isFastForwardLine(">> >>")),


### PR DESCRIPTION
## Overview

Modified AssertLInesMatch to not throw a NullPointerException when expected has more results than actual after the fast forward matches.  Added to the unit test class to demonstrate the change is fixed.  Also updated the release notes for 5.4.0-M1.

Fixes: #1640 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
