### PR TITLE
Expose selected modifier related methods from ReflectionUtils

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -16,6 +16,7 @@ endif::[]
 //
 :AnnotationSupport:                      {javadoc-root}/org/junit/platform/commons/support/AnnotationSupport.html[AnnotationSupport]
 :ClassSupport:                           {javadoc-root}/org/junit/platform/commons/support/ClassSupport.html[ClassSupport]
+:ModifierSupport:                        {javadoc-root}/org/junit/platform/commons/support/ModifierSupport.html[ModifierSupport]
 :ReflectionSupport:                      {javadoc-root}/org/junit/platform/commons/support/ReflectionSupport.html[ReflectionSupport]
 //
 :ConsoleLauncher:                        {javadoc-root}/org/junit/platform/console/ConsoleLauncher.html[ConsoleLauncher]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -33,7 +33,8 @@ repository on GitHub.
   single `DynamicNode` -- for example, a `DynamicTest` or a `DynamicContainer`.
 * New `DisplayNameGenerator` interface and `@DisplayNameGeneration` annotation that allow
   declarative configuration of a pre-defined or custom display name generator.
-
+* New `ModifierSupport` class providing an API for extension authors to inspect modifiers
+  of classes and members.
 
 [[release-notes-5.4.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -33,8 +33,8 @@ repository on GitHub.
   single `DynamicNode` -- for example, a `DynamicTest` or a `DynamicContainer`.
 * New `DisplayNameGenerator` interface and `@DisplayNameGeneration` annotation that allow
   declarative configuration of a pre-defined or custom display name generator.
-* New `ModifierSupport` class providing an API for extension authors to inspect modifiers
-  of classes and members.
+* New `ModifierSupport` class providing an API for extension and test engine authors to
+  inspect modifiers of classes and members.
 
 [[release-notes-5.4.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -495,6 +495,14 @@ class, and to find and invoke methods. Some of these methods traverse class hier
 to locate matching methods. Consult the Javadoc for `{ReflectionSupport}` for further
 details.
 
+[[extensions-supported-utilities-modifier]]
+==== Modifier Support
+
+`ModifierSupport` provides static utility methods for working with member and class
+modifiers (i.e., is a member declared `public` or `private`?). Consult the Javadoc for
+`{ModifierSupport}` for further details.
+
+
 [[extensions-execution-order]]
 === Relative Execution Order of User Code and Extensions
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
@@ -33,10 +33,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given class is declared {@code public}, {@code false} otherwise.
+	 * Determine if the supplied class is {@code public}.
 	 *
 	 * @param clazz the class to check; never {@code null}
-	 * @return true if the class is public, false otherwise
+	 * @return {@code true} if the class is {@code public}
 	 * @see java.lang.reflect.Modifier#isPublic(int)
 	 */
 	public static boolean isPublic(Class<?> clazz) {
@@ -45,10 +45,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given member is declared {@code public}, {@code false} otherwise.
+	 * Determine if the supplied member is {@code public}.
 	 *
 	 * @param member the member to check; never {@code null}
-	 * @return true if the class is public, false otherwise
+	 * @return {@code true} if the member is {@code public}
 	 * @see java.lang.reflect.Modifier#isPublic(int)
 	 */
 	public static boolean isPublic(Member member) {
@@ -57,10 +57,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given class is declared {@code private}, {@code false} otherwise.
+	 * Determine if the supplied class is {@code private}.
 	 *
 	 * @param clazz the class to check; never {@code null}
-	 * @return true if the class is private, false otherwise
+	 * @return {@code true} if the class is {@code private}
 	 * @see java.lang.reflect.Modifier#isPrivate(int)
 	 */
 	public static boolean isPrivate(Class<?> clazz) {
@@ -69,10 +69,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given member is declared {@code private}, {@code false} otherwise.
+	 * Determine if the supplied member is {@code private}.
 	 *
 	 * @param member the member to check; never {@code null}
-	 * @return true if the class is private, false otherwise
+	 * @return {@code true} if the member is {@code private}
 	 * @see java.lang.reflect.Modifier#isPrivate(int)
 	 */
 	public static boolean isPrivate(Member member) {
@@ -81,13 +81,13 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given member is not declared {@code private}, {@code false} otherwise.
+	 * Determine if the supplied member is not {@code private}.
 	 *
-	 * <p>In other words this method will return true for members declared public, protected or package private and
-	 * false for members declared private.</p>
+	 * <p>In other words this method will return true for members declared {@code public}, {@code protected} or
+	 * {@code package private} and {@code false} for members declared {@code private}.</p>
 	 *
 	 * @param member the member to check; never {@code null}
-	 * @return true if the member is not private, false otherwise
+	 * @return {@code true} if the member is not {@code private}
 	 * @see java.lang.reflect.Modifier#isPublic(int)
 	 * @see java.lang.reflect.Modifier#isProtected(int)
 	 * @see java.lang.reflect.Modifier#isPrivate(int)
@@ -98,10 +98,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given class is declared {@code abstract}, {@code false} otherwise.
+	 * Determine if the supplied class is {@code abstract}.
 	 *
 	 * @param clazz the class to check; never {@code null}
-	 * @return true if the class is abstract, false otherwise
+	 * @return {@code true} if the class is {@code abstract}
 	 * @see java.lang.reflect.Modifier#isAbstract(int)
 	 */
 	public static boolean isAbstract(Class<?> clazz) {
@@ -110,10 +110,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given member is declared {@code abstract}, {@code false} otherwise.
+	 * Determine if the supplied member is {@code abstract}.
 	 *
 	 * @param member the class to check; never {@code null}
-	 * @return true if the member is abstract, false otherwise
+	 * @return {@code true} if the member is {@code abstract}
 	 * @see java.lang.reflect.Modifier#isAbstract(int)
 	 */
 	public static boolean isAbstract(Member member) {
@@ -122,10 +122,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given class is declared {@code static}, {@code false} otherwise.
+	 * Determine if the supplied class is {@code static}.
 	 *
 	 * @param clazz the class to check; never {@code null}
-	 * @return true if the class is static, false otherwise
+	 * @return {@code true} if the class is {@code static}
 	 * @see java.lang.reflect.Modifier#isStatic(int)
 	 */
 	public static boolean isStatic(Class<?> clazz) {
@@ -134,10 +134,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given member is declared {@code static}, {@code false} otherwise.
+	 * Determine if the supplied member is {@code static}.
 	 *
 	 * @param member the member to check; never {@code null}
-	 * @return true if the member is static, false otherwise
+	 * @return {@code true} if the member is {@code static}
 	 * @see java.lang.reflect.Modifier#isStatic(int)
 	 */
 	public static boolean isStatic(Member member) {
@@ -146,10 +146,10 @@ public final class ModifierSupport {
 	}
 
 	/**
-	 * Returns {@code true} if the given member is not declared {@code static}, {@code false} otherwise.
+	 * Determine if the supplied member is not {@code static}.
 	 *
 	 * @param member the member to check; never {@code null}
-	 * @return true if the member is not static, false otherwise
+	 * @return {@code true} if the member is not {@code static}
 	 * @see java.lang.reflect.Modifier#isStatic(int)
 	 */
 	public static boolean isNotStatic(Member member) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
@@ -28,6 +28,10 @@ import org.junit.platform.commons.util.ReflectionUtils;
 @API(status = MAINTAINED, since = "1.4")
 public final class ModifierSupport {
 
+	private ModifierSupport() {
+		/* no-op */
+	}
+
 	/**
 	 * Returns {@code true} if the given class is declared {@code public}, {@code false} otherwise.
 	 *

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
@@ -19,12 +19,13 @@ import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
- * Common modifier support.
+ * This class provides static utility methods for working with member and class
+ * modifiers (i.e., is a member declared {@code public} or {@code private}?).
  *
  * @since 1.4
  * @see java.lang.reflect.Modifier
  */
-@API(status = MAINTAINED, since = "1.4.0")
+@API(status = MAINTAINED, since = "1.4")
 public final class ModifierSupport {
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support;
+
+import static org.apiguardian.api.API.Status.MAINTAINED;
+
+import java.lang.reflect.Member;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+/**
+ * Common modifier support.
+ *
+ * @since 1.4
+ * @see java.lang.reflect.Modifier
+ */
+@API(status = MAINTAINED, since = "1.4.0")
+public final class ModifierSupport {
+
+	/**
+	 * Returns {@code true} if the given class is declared {@code public}, {@code false} otherwise.
+	 *
+	 * @param clazz the class to check; never {@code null}
+	 * @return true if the class is public, false otherwise
+	 * @see java.lang.reflect.Modifier#isPublic(int)
+	 */
+	public static boolean isPublic(Class<?> clazz) {
+		Preconditions.notNull(clazz, "Class must not be null");
+		return ReflectionUtils.isPublic(clazz);
+	}
+
+	/**
+	 * Returns {@code true} if the given member is declared {@code public}, {@code false} otherwise.
+	 *
+	 * @param member the member to check; never {@code null}
+	 * @return true if the class is public, false otherwise
+	 * @see java.lang.reflect.Modifier#isPublic(int)
+	 */
+	public static boolean isPublic(Member member) {
+		Preconditions.notNull(member, "Member must not be null");
+		return ReflectionUtils.isPublic(member);
+	}
+
+	/**
+	 * Returns {@code true} if the given class is declared {@code private}, {@code false} otherwise.
+	 *
+	 * @param clazz the class to check; never {@code null}
+	 * @return true if the class is private, false otherwise
+	 * @see java.lang.reflect.Modifier#isPrivate(int)
+	 */
+	public static boolean isPrivate(Class<?> clazz) {
+		Preconditions.notNull(clazz, "Class must not be null");
+		return ReflectionUtils.isPrivate(clazz);
+	}
+
+	/**
+	 * Returns {@code true} if the given member is declared {@code private}, {@code false} otherwise.
+	 *
+	 * @param member the member to check; never {@code null}
+	 * @return true if the class is private, false otherwise
+	 * @see java.lang.reflect.Modifier#isPrivate(int)
+	 */
+	public static boolean isPrivate(Member member) {
+		Preconditions.notNull(member, "Member must not be null");
+		return ReflectionUtils.isPrivate(member);
+	}
+
+	/**
+	 * Returns {@code true} if the given member is not declared {@code private}, {@code false} otherwise.
+	 *
+	 * <p>In other words this method will return true for members declared public, protected or package private and
+	 * false for members declared private.</p>
+	 *
+	 * @param member the member to check; never {@code null}
+	 * @return true if the member is not private, false otherwise
+	 * @see java.lang.reflect.Modifier#isPublic(int)
+	 * @see java.lang.reflect.Modifier#isProtected(int)
+	 * @see java.lang.reflect.Modifier#isPrivate(int)
+	 */
+	public static boolean isNotPrivate(Member member) {
+		Preconditions.notNull(member, "Member must not be null");
+		return ReflectionUtils.isNotPrivate(member);
+	}
+
+	/**
+	 * Returns {@code true} if the given class is declared {@code abstract}, {@code false} otherwise.
+	 *
+	 * @param clazz the class to check; never {@code null}
+	 * @return true if the class is abstract, false otherwise
+	 * @see java.lang.reflect.Modifier#isAbstract(int)
+	 */
+	public static boolean isAbstract(Class<?> clazz) {
+		Preconditions.notNull(clazz, "Class must not be null");
+		return ReflectionUtils.isAbstract(clazz);
+	}
+
+	/**
+	 * Returns {@code true} if the given member is declared {@code abstract}, {@code false} otherwise.
+	 *
+	 * @param member the class to check; never {@code null}
+	 * @return true if the member is abstract, false otherwise
+	 * @see java.lang.reflect.Modifier#isAbstract(int)
+	 */
+	public static boolean isAbstract(Member member) {
+		Preconditions.notNull(member, "Member must not be null");
+		return ReflectionUtils.isAbstract(member);
+	}
+
+	/**
+	 * Returns {@code true} if the given class is declared {@code static}, {@code false} otherwise.
+	 *
+	 * @param clazz the class to check; never {@code null}
+	 * @return true if the class is static, false otherwise
+	 * @see java.lang.reflect.Modifier#isStatic(int)
+	 */
+	public static boolean isStatic(Class<?> clazz) {
+		Preconditions.notNull(clazz, "Class must not be null");
+		return ReflectionUtils.isStatic(clazz);
+	}
+
+	/**
+	 * Returns {@code true} if the given member is declared {@code static}, {@code false} otherwise.
+	 *
+	 * @param member the member to check; never {@code null}
+	 * @return true if the member is static, false otherwise
+	 * @see java.lang.reflect.Modifier#isStatic(int)
+	 */
+	public static boolean isStatic(Member member) {
+		Preconditions.notNull(member, "Member must not be null");
+		return ReflectionUtils.isStatic(member);
+	}
+
+	/**
+	 * Returns {@code true} if the given member is not declared {@code static}, {@code false} otherwise.
+	 *
+	 * @param member the member to check; never {@code null}
+	 * @return true if the member is not static, false otherwise
+	 * @see java.lang.reflect.Modifier#isStatic(int)
+	 */
+	public static boolean isNotStatic(Member member) {
+		Preconditions.notNull(member, "Member must not be null");
+		return ReflectionUtils.isNotStatic(member);
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ModifierSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ModifierSupportTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Member;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.PreconditionViolationException;
+
+/**
+ * Unit tests for {@link ModifierSupport}.
+ *
+ * @since 1.4
+ */
+class ModifierSupportTests {
+
+	@Test
+	void isPublic() throws Exception {
+		assertTrue(ModifierSupport.isPublic(PublicClass.class));
+		assertTrue(ModifierSupport.isPublic(PublicClass.class.getMethod("publicMethod")));
+
+		assertFalse(ModifierSupport.isPublic(PrivateClass.class));
+		assertFalse(ModifierSupport.isPublic(PrivateClass.class.getDeclaredMethod("privateMethod")));
+		assertFalse(ModifierSupport.isPublic(ProtectedClass.class));
+		assertFalse(ModifierSupport.isPublic(ProtectedClass.class.getDeclaredMethod("protectedMethod")));
+		assertFalse(ModifierSupport.isPublic(PackageVisibleClass.class));
+		assertFalse(ModifierSupport.isPublic(PackageVisibleClass.class.getDeclaredMethod("packageVisibleMethod")));
+
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isPublic((Class<?>) null));
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isPublic((Member) null));
+	}
+
+	@Test
+	void isPrivate() throws Exception {
+		assertTrue(ModifierSupport.isPrivate(PrivateClass.class));
+		assertTrue(ModifierSupport.isPrivate(PrivateClass.class.getDeclaredMethod("privateMethod")));
+
+		assertFalse(ModifierSupport.isPrivate(PublicClass.class));
+		assertFalse(ModifierSupport.isPrivate(PublicClass.class.getMethod("publicMethod")));
+		assertFalse(ModifierSupport.isPrivate(ProtectedClass.class));
+		assertFalse(ModifierSupport.isPrivate(ProtectedClass.class.getDeclaredMethod("protectedMethod")));
+		assertFalse(ModifierSupport.isPrivate(PackageVisibleClass.class));
+		assertFalse(ModifierSupport.isPrivate(PackageVisibleClass.class.getDeclaredMethod("packageVisibleMethod")));
+
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isPrivate((Class<?>) null));
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isPrivate((Member) null));
+	}
+
+	@Test
+	void isNotPrivate() throws Exception {
+		assertTrue(ModifierSupport.isNotPrivate(PublicClass.class.getDeclaredMethod("publicMethod")));
+		assertTrue(ModifierSupport.isNotPrivate(ProtectedClass.class.getDeclaredMethod("protectedMethod")));
+		assertTrue(ModifierSupport.isNotPrivate(PackageVisibleClass.class.getDeclaredMethod("packageVisibleMethod")));
+
+		assertFalse(ModifierSupport.isNotPrivate(PrivateClass.class.getDeclaredMethod("privateMethod")));
+
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isNotPrivate(null));
+	}
+
+	@Test
+	void isAbstract() throws Exception {
+		assertTrue(ModifierSupport.isAbstract(AbstractClass.class));
+		assertTrue(ModifierSupport.isAbstract(AbstractClass.class.getDeclaredMethod("abstractMethod")));
+
+		assertFalse(ModifierSupport.isAbstract(PublicClass.class));
+		assertFalse(ModifierSupport.isAbstract(PublicClass.class.getDeclaredMethod("publicMethod")));
+
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isAbstract((Class<?>) null));
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isAbstract((Member) null));
+	}
+
+	@Test
+	void isStatic() throws Exception {
+		assertTrue(ModifierSupport.isStatic(StaticClass.class));
+		assertTrue(ModifierSupport.isStatic(StaticClass.class.getDeclaredMethod("staticMethod")));
+
+		assertFalse(ModifierSupport.isStatic(PublicClass.class));
+		assertFalse(ModifierSupport.isStatic(PublicClass.class.getDeclaredMethod("publicMethod")));
+
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isStatic((Class<?>) null));
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isStatic((Member) null));
+	}
+
+	@Test
+	void isNotStatic() throws Exception {
+		assertTrue(ModifierSupport.isNotStatic(PublicClass.class.getDeclaredMethod("publicMethod")));
+
+		assertFalse(ModifierSupport.isNotStatic(StaticClass.class.getDeclaredMethod("staticMethod")));
+
+		assertThrows(PreconditionViolationException.class, () -> ModifierSupport.isNotStatic(null));
+	}
+
+	// -------------------------------------------------------------------------
+
+	// Intentionally non-static
+	public class PublicClass {
+
+		public void publicMethod() {
+		}
+	}
+
+	private class PrivateClass {
+
+		@SuppressWarnings("unused")
+		private void privateMethod() {
+		}
+	}
+
+	protected class ProtectedClass {
+
+		@SuppressWarnings("unused")
+		protected void protectedMethod() {
+		}
+	}
+
+	class PackageVisibleClass {
+
+		@SuppressWarnings("unused")
+		void packageVisibleMethod() {
+		}
+	}
+
+	abstract static class AbstractClass {
+
+		abstract void abstractMethod();
+	}
+
+	static class StaticClass {
+
+		static void staticMethod() {
+		}
+	}
+
+}


### PR DESCRIPTION
## Overview

For the [Testcontainers extension](https://github.com/testcontainers/testcontainers-java/pull/887) I needed to use some APIs from `ReflectionUtils` to find out whether annotated fields are declared `static` or not.

Since `ReflectionUtils` is considered a private API it would be nice to have an official API for this. I decided to create a dedicated class to work with modifiers of classes and fields: `ModifierSupport`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
