### PR TITLE
Set context class loader parallel execution mode

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -48,6 +48,10 @@ repository on GitHub.
   evaluating a fast-forward match if there are more expected lines after the fast-forward
   match than remain in the actual results. This bug only manifested itself if the
   expected list size was equal to or greater than the actual list size.
+* Threads created for running tests in parallel now use the same thread context
+  class loader (_TCCL_) that was set when creating the underlying executor service.
+  This resolves `ClassNotFoundException` issues that only occur in parallel execution
+  mode and a custom thread context class loader is in place.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -11,7 +11,6 @@
 package org.junit.platform.engine.support.hierarchical;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.ForkJoinPool.defaultForkJoinWorkerThreadFactory;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.CONCURRENT;
 
@@ -23,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.Future;
 import java.util.concurrent.RecursiveAction;
 import java.util.concurrent.TimeUnit;
@@ -64,18 +64,19 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 		ParallelExecutionConfigurationStrategy strategy = DefaultParallelExecutionConfigurationStrategy.getStrategy(
 			configurationParameters);
 		ParallelExecutionConfiguration configuration = strategy.createConfiguration(configurationParameters);
+		ForkJoinWorkerThreadFactory threadFactory = new WorkerThreadFactory();
 		try {
 			// Try to use constructor available in Java >= 9
 			Constructor<ForkJoinPool> constructor = ForkJoinPool.class.getDeclaredConstructor(Integer.TYPE,
 				ForkJoinWorkerThreadFactory.class, UncaughtExceptionHandler.class, Boolean.TYPE, Integer.TYPE,
 				Integer.TYPE, Integer.TYPE, Predicate.class, Long.TYPE, TimeUnit.class);
-			return constructor.newInstance(configuration.getParallelism(), defaultForkJoinWorkerThreadFactory, null,
-				false, configuration.getCorePoolSize(), configuration.getMaxPoolSize(),
-				configuration.getMinimumRunnable(), null, configuration.getKeepAliveSeconds(), TimeUnit.SECONDS);
+			return constructor.newInstance(configuration.getParallelism(), threadFactory, null, false,
+				configuration.getCorePoolSize(), configuration.getMaxPoolSize(), configuration.getMinimumRunnable(),
+				null, configuration.getKeepAliveSeconds(), TimeUnit.SECONDS);
 		}
 		catch (Exception e) {
 			// Fallback for Java 8
-			return new ForkJoinPool(configuration.getParallelism());
+			return new ForkJoinPool(configuration.getParallelism(), threadFactory, null, false);
 		}
 	}
 
@@ -173,6 +174,24 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 			}
 		}
 
+	}
+
+	static class WorkerThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory {
+
+		private final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+		@Override
+		public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+			return new WorkerThread(pool, contextClassLoader);
+		}
+	}
+
+	static class WorkerThread extends ForkJoinWorkerThread {
+
+		WorkerThread(ForkJoinPool pool, ClassLoader contextClassLoader) {
+			super(pool);
+			super.setContextClassLoader(contextClassLoader);
+		}
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -190,7 +190,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 
 		WorkerThread(ForkJoinPool pool, ClassLoader contextClassLoader) {
 			super(pool);
-			super.setContextClassLoader(contextClassLoader);
+			setContextClassLoader(contextClassLoader);
 		}
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
@@ -124,7 +124,7 @@ class ParallelExecutionIntegrationTests {
 
 			assertThat(executionEvents.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(3);
 			assertThat(ThreadReporter.getThreadNames(executionEvents)).hasSize(3);
-			assertThat(ThreadReporter.getLoaderNames(executionEvents).collect(toList())).containsExactly("(-:");
+			assertThat(ThreadReporter.getLoaderNames(executionEvents)).containsExactly("(-:");
 		}
 		finally {
 			thread.setContextClassLoader(old);

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
@@ -30,6 +30,8 @@ import static org.junit.platform.testkit.ExecutionEventConditions.started;
 import static org.junit.platform.testkit.ExecutionEventConditions.test;
 import static org.junit.platform.testkit.ExecutionEventConditions.type;
 
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -76,8 +78,8 @@ class ParallelExecutionIntegrationTests {
 
 		assertThat(startedTimestamps).hasSize(3);
 		assertThat(finishedTimestamps).hasSize(3);
-		assertThat(startedTimestamps).allMatch(startTimestamp -> finishedTimestamps.stream().allMatch(
-			finishedTimestamp -> !finishedTimestamp.isBefore(startTimestamp)));
+		assertThat(startedTimestamps).allMatch(startTimestamp -> finishedTimestamps.stream().noneMatch(
+			finishedTimestamp -> finishedTimestamp.isBefore(startTimestamp)));
 		assertThat(ThreadReporter.getThreadNames(executionEvents)).hasSize(3);
 	}
 
@@ -109,6 +111,25 @@ class ParallelExecutionIntegrationTests {
 
 		assertThat(executionEvents.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(3);
 		assertThat(ThreadReporter.getThreadNames(executionEvents)).hasSize(1);
+	}
+
+	@Test
+	void customContextClassLoader() {
+		var thread = Thread.currentThread();
+		ClassLoader old = thread.getContextClassLoader();
+		ClassLoader tccl = new URLClassLoader("(-:", new URL[0], ClassLoader.getSystemClassLoader());
+		try {
+			thread.setContextClassLoader(tccl);
+			List<ExecutionEvent> executionEvents = execute(3, SuccessfulWithMethodLockTestCase.class);
+
+			assertThat(executionEvents.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(3);
+			assertThat(ThreadReporter.getThreadNames(executionEvents)).hasSize(3);
+			assertThat(ThreadReporter.getLoaderNames(executionEvents).collect(toList())).containsExactly("(-:");
+		}
+		finally {
+			thread.setContextClassLoader(old);
+		}
+
 	}
 
 	@RepeatedTest(10)
@@ -150,17 +171,17 @@ class ParallelExecutionIntegrationTests {
 		}
 
 		@Test
-		void firstTest(TestReporter reporter) throws Exception {
+		void firstTest() throws Exception {
 			incrementAndBlock(sharedResource, countDownLatch);
 		}
 
 		@Test
-		void secondTest(TestReporter reporter) throws Exception {
+		void secondTest() throws Exception {
 			incrementAndBlock(sharedResource, countDownLatch);
 		}
 
 		@Test
-		void thirdTest(TestReporter reporter) throws Exception {
+		void thirdTest() throws Exception {
 			incrementAndBlock(sharedResource, countDownLatch);
 		}
 	}
@@ -178,17 +199,17 @@ class ParallelExecutionIntegrationTests {
 		}
 
 		@Test
-		void firstTest(TestReporter reporter) throws Exception {
+		void firstTest() throws Exception {
 			incrementBlockAndCheck(sharedResource, countDownLatch);
 		}
 
 		@Test
-		void secondTest(TestReporter reporter) throws Exception {
+		void secondTest() throws Exception {
 			incrementBlockAndCheck(sharedResource, countDownLatch);
 		}
 
 		@Test
-		void thirdTest(TestReporter reporter) throws Exception {
+		void thirdTest() throws Exception {
 			incrementBlockAndCheck(sharedResource, countDownLatch);
 		}
 	}
@@ -207,19 +228,19 @@ class ParallelExecutionIntegrationTests {
 
 		@Test
 		@ResourceLock("sharedResource")
-		void firstTest(TestReporter reporter) throws Exception {
+		void firstTest() throws Exception {
 			incrementBlockAndCheck(sharedResource, countDownLatch);
 		}
 
 		@Test
 		@ResourceLock("sharedResource")
-		void secondTest(TestReporter reporter) throws Exception {
+		void secondTest() throws Exception {
 			incrementBlockAndCheck(sharedResource, countDownLatch);
 		}
 
 		@Test
 		@ResourceLock("sharedResource")
-		void thirdTest(TestReporter reporter) throws Exception {
+		void thirdTest() throws Exception {
 			incrementBlockAndCheck(sharedResource, countDownLatch);
 		}
 	}
@@ -261,7 +282,7 @@ class ParallelExecutionIntegrationTests {
 			CountDownLatch countDownLatch = new CountDownLatch(3);
 			return IntStream.range(0, 3).mapToObj(i -> dynamicTest("test " + i, () -> {
 				incrementBlockAndCheck(sharedResource, countDownLatch);
-				testReporter.publishEntry(ThreadReporter.KEY, Thread.currentThread().getName());
+				testReporter.publishEntry("thread", Thread.currentThread().getName());
 			}));
 		}
 	}
@@ -418,16 +439,22 @@ class ParallelExecutionIntegrationTests {
 
 	static class ThreadReporter implements AfterTestExecutionCallback {
 
-		public static final String KEY = "thread";
+		private static Stream<String> getLoaderNames(List<ExecutionEvent> executionEvents) {
+			return getValues(executionEvents, "loader");
+		}
 
 		private static Stream<String> getThreadNames(List<ExecutionEvent> executionEvents) {
+			return getValues(executionEvents, "thread");
+		}
+
+		private static Stream<String> getValues(List<ExecutionEvent> executionEvents, String key) {
 			// @formatter:off
 			return executionEvents.stream()
 					.filter(type(REPORTING_ENTRY_PUBLISHED)::matches)
 					.map(event -> event.getPayload(ReportEntry.class).orElse(null))
 					.map(ReportEntry::getKeyValuePairs)
-					.filter(keyValuePairs -> keyValuePairs.containsKey(KEY))
-					.map(keyValuePairs -> keyValuePairs.get("thread"))
+					.filter(keyValuePairs -> keyValuePairs.containsKey(key))
+					.map(keyValuePairs -> keyValuePairs.get(key))
 					.distinct();
 			// @formatter:on
 		}
@@ -435,6 +462,7 @@ class ParallelExecutionIntegrationTests {
 		@Override
 		public void afterTestExecution(ExtensionContext context) {
 			context.publishReportEntry("thread", Thread.currentThread().getName());
+			context.publishReportEntry("loader", Thread.currentThread().getContextClassLoader().getName());
 		}
 	}
 


### PR DESCRIPTION
## Overview

Prior to this commit the `ForkJoinPoolHierarchicalTestExecutorService` used the default `ForkJoinWorkerThreadFactory` which in turn sets the context class loader to `ClassLoader.getSystemClassLoader()`. In runtime environments that create and use a tailored context
class loader this leads to `ClassNotFoundException` when only the `ClassLoader.getSystemClassLoader()` is available.

Now the `ForkJoinPoolHierarchicalTestExecutorService` creates `ForkJoinWorkerThread` instances that set the context class loader to the one available at creation time of the service.

Fixes #1646

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
