### PR TITLE
Wait for dynamic tests before finishing test factory

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -52,6 +52,9 @@ repository on GitHub.
   class loader (_TCCL_) that was set when creating the underlying executor service.
   This resolves `ClassNotFoundException` issues that only occur in parallel execution
   mode and a custom thread context class loader is in place.
+* When executing tests in parallel, lifecycle methods and callbacks called after a
+  `@TestFactory` method are now always executed after the dynamic tests returned by the
+  method.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -100,6 +100,7 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 			catch (ClassCastException ex) {
 				throw invalidReturnTypeException(ex);
 			}
+			dynamicTestExecutor.awaitFinished();
 		});
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -243,6 +243,17 @@ public interface Node<C extends EngineExecutionContext> {
 		 */
 		void execute(TestDescriptor testDescriptor);
 
+		/**
+		 * Block until all dynamic test descriptors submitted to this executor
+		 * are finished.
+		 *
+		 * <p>This method is useful if the node needs to perform actions in its
+		 * {@link #execute(EngineExecutionContext, DynamicTestExecutor)} method
+		 * after all its dynamic children have finished.
+		 *
+		 * @throws InterruptedException if interrupted while waiting
+		 */
+		void awaitFinished() throws InterruptedException;
 	}
 
 	/**


### PR DESCRIPTION
When executing tests in parallel, lifecycle methods and callbacks called
after a `@TestFactory` method are now always executed after the dynamic
tests returned by the method.

Fixes #1643.