### PR TITLE
Introduce Try type to preserve failure cause

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -30,6 +30,9 @@ repository on GitHub.
   inspect modifiers of classes and members.
   - See the <<../user-guide/index.adoc#extensions-supported-utilities-modifier, User
     Guide>> for details.
+* Exceptions reported due to failed reflective operations such as loading a class, reading
+  a field's value, or looking up a method by name now include the original exception as
+  their cause to make it easier to debug underlying issues.
 
 
 [[release-notes-5.4.0-M1-junit-jupiter]]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -15,7 +15,7 @@ import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedField
 import static org.junit.platform.commons.util.AnnotationUtils.findRepeatableAnnotations;
 import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
 import static org.junit.platform.commons.util.ReflectionUtils.isStatic;
-import static org.junit.platform.commons.util.ReflectionUtils.readFieldValue;
+import static org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
@@ -90,7 +90,7 @@ final class ExtensionUtils {
 		Predicate<Field> predicate = (instance == null) ? isStaticExtension : isNonStaticExtension;
 
 		findAnnotatedFields(clazz, RegisterExtension.class, predicate).forEach(field -> {
-			readFieldValue(field, instance).ifPresent(value -> {
+			tryToReadFieldValue(field, instance).ifSuccess(value -> {
 				Extension extension = (Extension) value;
 				registry.registerExtension(extension, field);
 			});

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestContainerResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/TestContainerResolver.java
@@ -65,7 +65,7 @@ class TestContainerResolver implements ElementResolver {
 
 		String className = getClassName(parent, segment.getValue());
 
-		Optional<Class<?>> optionalContainerClass = ReflectionUtils.loadClass(className);
+		Optional<Class<?>> optionalContainerClass = ReflectionUtils.tryToLoadClass(className).toOptional();
 		if (!optionalContainerClass.isPresent()) {
 			return Optional.empty();
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/OpenTest4JAndJUnit4AwareThrowableCollector.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/OpenTest4JAndJUnit4AwareThrowableCollector.java
@@ -37,7 +37,8 @@ class OpenTest4JAndJUnit4AwareThrowableCollector extends ThrowableCollector {
 		Predicate<Throwable> otaPredicate = TestAbortedException.class::isInstance;
 
 		// Additionally support JUnit 4's AssumptionViolatedException?
-		Class<?> clazz = ReflectionUtils.loadClass("org.junit.internal.AssumptionViolatedException").orElse(null);
+		Class<?> clazz = ReflectionUtils.tryToLoadClass(
+			"org.junit.internal.AssumptionViolatedException").toOptional().orElse(null);
 		if (clazz != null) {
 			return otaPredicate.or(clazz::isInstance);
 		}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -431,7 +431,7 @@ class DiscoverySelectorResolverTests {
 	}
 
 	@Test
-	void packageResolutionUsingDefaultPackage() {
+	void packageResolutionUsingDefaultPackage() throws Exception {
 		resolver.resolveSelectors(request().selectors(selectPackage("")).build(), engineDescriptor);
 
 		// 150 is completely arbitrary. The actual number is likely much higher.
@@ -442,7 +442,7 @@ class DiscoverySelectorResolverTests {
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertThat(uniqueIds)//
 				.describedAs("Failed to pick up DefaultPackageTestCase via classpath scanning")//
-				.contains(uniqueIdForClass(ReflectionUtils.loadClass("DefaultPackageTestCase").get()));
+				.contains(uniqueIdForClass(ReflectionUtils.tryToLoadClass("DefaultPackageTestCase").get()));
 		assertThat(uniqueIds).contains(uniqueIdForClass(Class1WithTestCases.class));
 		assertThat(uniqueIds).contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()"));
 		assertThat(uniqueIds).contains(uniqueIdForClass(Class2WithTestCases.class));
@@ -466,7 +466,7 @@ class DiscoverySelectorResolverTests {
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertThat(uniqueIds)//
 				.describedAs("Failed to pick up DefaultPackageTestCase via classpath scanning")//
-				.contains(uniqueIdForClass(ReflectionUtils.loadClass("DefaultPackageTestCase").get()));
+				.contains(uniqueIdForClass(ReflectionUtils.tryToLoadClass("DefaultPackageTestCase").get()));
 		assertThat(uniqueIds).contains(uniqueIdForClass(Class1WithTestCases.class));
 		assertThat(uniqueIds).contains(uniqueIdForMethod(Class1WithTestCases.class, "test1()"));
 		assertThat(uniqueIds).contains(uniqueIdForClass(Class2WithTestCases.class));

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -251,9 +251,9 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 		private static Class<?> toClass(String type) {
 			//@formatter:off
 			return ReflectionUtils
-					.loadClass(type)
-					.orElseThrow(() -> new ArgumentConversionException(
-							"Failed to convert String \"" + type + "\" to type " + Class.class.getName()));
+					.tryToLoadClass(type)
+					.getOrThrow(cause -> new ArgumentConversionException(
+							"Failed to convert String \"" + type + "\" to type " + Class.class.getName(), cause));
 			//@formatter:on
 		}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -74,8 +74,8 @@ class MethodArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<M
 	}
 
 	private Class<?> loadRequiredClass(String className) {
-		return ReflectionUtils.loadClass(className).orElseThrow(
-			() -> new JUnitException(format("Could not load class [%s]", className)));
+		return ReflectionUtils.tryToLoadClass(className).getOrThrow(
+			cause -> new JUnitException(format("Could not load class [%s]", className), cause));
 	}
 
 	private Method getMethod(Class<?> clazz, String methodName) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/function/Try.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/function/Try.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.function;
+
+import static org.apiguardian.api.API.Status.MAINTAINED;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.JUnitException;
+
+/**
+ * A container object which may either contain a nullable value in case of
+ * <em>success</em> or an exception in case of <em>failure</em>.
+ *
+ * <p>Instances of this class should be returned by methods instead of
+ * {@link Optional} when callers might want to report the exception via logging
+ * or by wrapping it in another exception at a later point in time, e.g. via
+ * {@link #getOrThrow(Function)}.
+ *
+ * <p>Moreover, it makes it particularly convenient to attach follow-up actions
+ * should the {@code Try} have been successful (cf. {@link #andThen} and
+ * {@link #andThenTry}) or fallback actions should it not have been (cf.
+ * {@link #orElse} and {@link #orElseTry}).
+ *
+ * @since 1.4
+ */
+@API(status = MAINTAINED, since = "1.4")
+public abstract class Try<V> {
+
+	/**
+	 * Call the supplied {@link Callable} and return a successful {@code Try}
+	 * that contains the returned value or, in case an exception was thrown, a
+	 * failed {@code Try} that contains the exception.
+	 *
+	 * @param action the action to try; must not be {@code null}
+	 * @return a succeeded or failed {@code Try} depending on the outcome of the
+	 * supplied action; never {@code null}
+	 * @see #success(Object)
+	 * @see #failure(Exception)
+	 */
+	public static <V> Try<V> call(Callable<V> action) {
+		checkNotNull(action, "action");
+		return Try.of(() -> success(action.call()));
+	}
+
+	/**
+	 * Convert the supplied value into a succeeded {@code Try}.
+	 *
+	 * @param value the value to wrap; potentially {@code null}
+	 * @return a succeeded {@code Try} that contains the supplied value; never
+	 * {@code null}
+	 */
+	public static <V> Try<V> success(V value) {
+		return new Success<>(value);
+	}
+
+	/**
+	 * Convert the supplied exception into a failed {@code Try}.
+	 *
+	 * @param cause the exception to wrap; must not be {@code null}
+	 * @return a failed {@code Try} that contains the supplied value; never
+	 * {@code null}
+	 */
+	public static <V> Try<V> failure(Exception cause) {
+		return new Failure<>(checkNotNull(cause, "cause"));
+	}
+
+	// Cannot use Preconditions due to package cycle
+	private static <T> T checkNotNull(T input, String title) {
+		if (input == null) {
+			// Cannot use PreconditionViolationException due to package cycle
+			throw new JUnitException(title + " must not be null");
+		}
+		return input;
+	}
+
+	private static <V> Try<V> of(Callable<Try<V>> action) {
+		try {
+			return action.call();
+		}
+		catch (Exception e) {
+			return failure(e);
+		}
+	}
+
+	private Try() {
+		/* no-op */
+	}
+
+	/**
+	 * If this {@code Try} is a success, apply the supplied transformer to its
+	 * value and return a new successful or failed {@code Try} depending on the
+	 * action's outcome; if it's a failure, do nothing.
+	 *
+	 * @param action the action to try; must not be {@code null}
+	 * @return a succeeded or failed {@code Try}; never {@code null}
+	 */
+	public abstract <U> Try<U> andThenTry(Transformer<V, U> action);
+
+	/**
+	 * If this {@code Try} is a success, apply the supplied action to its value
+	 * and return a new successful or failed {@code Try} depending on the
+	 * action's outcome; if it's a failure, do nothing.
+	 *
+	 * @param action the action to apply; must not be {@code null}
+	 * @return a succeeded or failed {@code Try}; never {@code null}
+	 */
+	public abstract <U> Try<U> andThen(Function<V, Try<U>> action);
+
+	/**
+	 * If this {@code Try} is a failure, call the supplied action and return a
+	 * new successful or failed {@code Try} depending on the action's outcome;
+	 * if it's a success, do nothing.
+	 *
+	 * @param action the action to try; must not be {@code null}
+	 * @return a succeeded or failed {@code Try}; never {@code null}
+	 */
+	public abstract Try<V> orElseTry(Callable<V> action);
+
+	/**
+	 * If this {@code Try} is a failure, call the supplied action and return a
+	 * new successful or failed {@code Try} depending on the action's outcome;
+	 * if it's a success, do nothing.
+	 *
+	 * @param action the action to apply; must not be {@code null}
+	 * @return a succeeded or failed {@code Try}; never {@code null}
+	 */
+	public abstract Try<V> orElse(Supplier<Try<V>> action);
+
+	/**
+	 * If this {@code Try} is a success, get the contained value; if it's a
+	 * failure, throw the contained exception.
+	 *
+	 * @return the contained value, if available; potentially {@code null}
+	 */
+	public abstract V get() throws Exception;
+
+	/**
+	 * If this {@code Try} is a success, get the contained value; if it's a
+	 * failure, call the supplied {@link Function} with the contained exception
+	 * and throw the resulting {@link Exception}.
+	 *
+	 * @param exceptionTransformer the transformer to be called with the
+	 * contained exception, if available; must not be {@code null}
+	 * @return the contained value, if available
+	 */
+	public abstract <E extends Exception> V getOrThrow(Function<? super Exception, E> exceptionTransformer) throws E;
+
+	/**
+	 * If this {@code Try} is a success, call the supplied {@link Consumer} with
+	 * the contained value; otherwise, do nothing.
+	 *
+	 * @param valueConsumer the consumer to be called with the contained value,
+	 * if available; must not be {@code null}
+	 * @return the same {@code Try} for method chaining
+	 */
+	public abstract Try<V> ifSuccess(Consumer<V> valueConsumer);
+
+	/**
+	 * If this {@code Try} is a failure, call the supplied {@link Consumer} with
+	 * the contained exception; otherwise, do nothing.
+	 *
+	 * @param causeConsumer the consumer to be called with the contained
+	 * exception, if available; must not be {@code null}
+	 * @return the same {@code Try} for method chaining
+	 */
+	public abstract Try<V> ifFailure(Consumer<Exception> causeConsumer);
+
+	/**
+	 * If this {@code Try} is a failure, return an empty {@link Optional}; if
+	 * it's a success, wrap the contained value using
+	 * {@link Optional#ofNullable(Object)}.
+	 *
+	 * @return an empty or present {@link Optional}; never {@code null}
+	 */
+	public abstract Optional<V> toOptional();
+
+	/**
+	 * A transformer for values of type {@code S} to type {@code T}.
+	 */
+	@FunctionalInterface
+	public interface Transformer<S, T> {
+
+		/**
+		 * Apply this transformer to the supplied value.
+		 */
+		T apply(S value) throws Exception;
+
+	}
+
+	private static class Success<V> extends Try<V> {
+
+		private final V value;
+
+		Success(V value) {
+			this.value = value;
+		}
+
+		@Override
+		public <U> Try<U> andThenTry(Transformer<V, U> transformer) {
+			Try.checkNotNull(transformer, "transformer");
+			return Try.call(() -> transformer.apply(this.value));
+		}
+
+		@Override
+		public <U> Try<U> andThen(Function<V, Try<U>> action) {
+			Try.checkNotNull(action, "action");
+			return Try.of(() -> action.apply(this.value));
+		}
+
+		@Override
+		public Try<V> orElseTry(Callable<V> action) {
+			return this;
+		}
+
+		@Override
+		public Try<V> orElse(Supplier<Try<V>> action) {
+			return this;
+		}
+
+		@Override
+		public V get() {
+			return this.value;
+		}
+
+		@Override
+		public <E extends Exception> V getOrThrow(Function<? super Exception, E> exceptionTransformer) {
+			return this.value;
+		}
+
+		@Override
+		public Try<V> ifSuccess(Consumer<V> valueConsumer) {
+			Try.checkNotNull(valueConsumer, "valueConsumer");
+			valueConsumer.accept(this.value);
+			return this;
+		}
+
+		@Override
+		public Try<V> ifFailure(Consumer<Exception> causeConsumer) {
+			return this;
+		}
+
+		@Override
+		public Optional<V> toOptional() {
+			return Optional.ofNullable(this.value);
+		}
+
+		@Override
+		public boolean equals(Object that) {
+			if (this == that) {
+				return true;
+			}
+			if (that == null || this.getClass() != that.getClass()) {
+				return false;
+			}
+			return Objects.equals(this.value, ((Success<?>) that).value);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(value);
+		}
+	}
+
+	private static class Failure<V> extends Try<V> {
+
+		private final Exception cause;
+
+		Failure(Exception cause) {
+			this.cause = cause;
+		}
+
+		@Override
+		public <U> Try<U> andThenTry(Transformer<V, U> transformer) {
+			return uncheckedCast();
+		}
+
+		@Override
+		public <U> Try<U> andThen(Function<V, Try<U>> action) {
+			return uncheckedCast();
+		}
+
+		@SuppressWarnings("unchecked")
+		private <U> Try<U> uncheckedCast() {
+			return (Try<U>) this;
+		}
+
+		@Override
+		public Try<V> orElseTry(Callable<V> action) {
+			Try.checkNotNull(action, "action");
+			return Try.call(action);
+		}
+
+		@Override
+		public Try<V> orElse(Supplier<Try<V>> action) {
+			Try.checkNotNull(action, "action");
+			return Try.of(action::get);
+		}
+
+		@Override
+		public V get() throws Exception {
+			throw this.cause;
+		}
+
+		@Override
+		public <E extends Exception> V getOrThrow(Function<? super Exception, E> exceptionTransformer) throws E {
+			Try.checkNotNull(exceptionTransformer, "exceptionTransformer");
+			throw exceptionTransformer.apply(this.cause);
+		}
+
+		@Override
+		public Try<V> ifSuccess(Consumer<V> valueConsumer) {
+			return this;
+		}
+
+		@Override
+		public Try<V> ifFailure(Consumer<Exception> causeConsumer) {
+			Try.checkNotNull(causeConsumer, "causeConsumer");
+			causeConsumer.accept(this.cause);
+			return this;
+		}
+
+		@Override
+		public Optional<V> toOptional() {
+			return Optional.empty();
+		}
+
+		@Override
+		public boolean equals(Object that) {
+			if (this == that) {
+				return true;
+			}
+			if (that == null || this.getClass() != that.getClass()) {
+				return false;
+			}
+			return Objects.equals(this.cause, ((Failure<?>) that).cause);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(cause);
+		}
+
+	}
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/function/package-info.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/function/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Maintained functional interfaces and support classes.
+ */
+
+package org.junit.platform.commons.function;

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.commons.support;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.lang.reflect.Method;
@@ -19,6 +20,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.function.Try;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 
@@ -56,9 +58,33 @@ public final class ReflectionSupport {
 	 * @param name the name of the class to load; never {@code null} or blank
 	 * @return an {@code Optional} containing the loaded class; never {@code null}
 	 * but potentially empty if no such class could be loaded
+	 * @deprecated Please use {@link #tryToLoadClass(String)} instead.
 	 */
+	@API(status = DEPRECATED, since = "1.4")
+	@Deprecated
 	public static Optional<Class<?>> loadClass(String name) {
 		return ReflectionUtils.loadClass(name);
+	}
+
+	/**
+	 * Try to load a class by its <em>primitive name</em> or <em>fully qualified name</em>,
+	 * using the default {@link ClassLoader}.
+	 *
+	 * <p>Class names for arrays may be specified using either the JVM's internal
+	 * String representation (e.g., {@code [[I} for {@code int[][]},
+	 * {@code [Lava.lang.String;} for {@code java.lang.String[]}, etc.) or
+	 * <em>source code syntax</em> (e.g., {@code int[][]}, {@code java.lang.String[]},
+	 * etc.).
+	 *
+	 * @param name the name of the class to load; never {@code null} or blank
+	 * @return a successful {@code Try} containing the loaded class or a failed
+	 * {@code Try} containing the exception if no such class could be loaded;
+	 * never {@code null}
+	 * @since 1.4
+	 */
+	@API(status = MAINTAINED, since = "1.4")
+	public static Try<Class<?>> tryToLoadClass(String name) {
+		return ReflectionUtils.tryToLoadClass(name);
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -249,10 +249,10 @@ public final class AnnotationUtils {
 					// Note: it's not a legitimate containing annotation type if it doesn't declare
 					// a 'value' attribute that returns an array of the contained annotation type.
 					// See https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.6.3
-					Method method = ReflectionUtils.getMethod(containerType, "value").orElseThrow(
-						() -> new JUnitException(String.format(
+					Method method = ReflectionUtils.tryToGetMethod(containerType, "value").getOrThrow(
+						cause -> new JUnitException(String.format(
 							"Container annotation type '%s' must declare a 'value' attribute of type %s[].",
-							containerType, annotationType)));
+							containerType, annotationType), cause));
 
 					Annotation[] containedAnnotations = (Annotation[]) ReflectionUtils.invokeMethod(method, candidate);
 					found.addAll((Collection<? extends A>) asList(containedAnnotations));

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
@@ -26,12 +26,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.junit.platform.commons.function.Try;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 
@@ -59,10 +59,10 @@ class ClasspathScanner {
 
 	private final Supplier<ClassLoader> classLoaderSupplier;
 
-	private final BiFunction<String, ClassLoader, Optional<Class<?>>> loadClass;
+	private final BiFunction<String, ClassLoader, Try<Class<?>>> loadClass;
 
 	ClasspathScanner(Supplier<ClassLoader> classLoaderSupplier,
-			BiFunction<String, ClassLoader, Optional<Class<?>>> loadClass) {
+			BiFunction<String, ClassLoader, Try<Class<?>>> loadClass) {
 
 		this.classLoaderSupplier = classLoaderSupplier;
 		this.loadClass = loadClass;
@@ -132,6 +132,7 @@ class ClasspathScanner {
 				try {
 					// @formatter:off
 					loadClass.apply(fullyQualifiedClassName, getClassLoader())
+							.toOptional()
 							.filter(classFilter) // Always use ".filter(classFilter)" to include future predicates.
 							.ifPresent(classConsumer);
 					// @formatter:on

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -520,7 +520,7 @@ public final class ReflectionUtils {
 	 * @param field the field to read; never {@code null}
 	 * @see #readFieldValue(Field, Object)
 	 * @see #readFieldValue(Class, String, Object)
-	 * @since 1.3
+	 * @since 1.4
 	 */
 	@API(status = INTERNAL, since = "1.4")
 	public static Try<Object> tryToReadFieldValue(Field field) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -559,7 +559,7 @@ public final class ReflectionUtils {
 	 * be {@code null} for a static field
 	 * @see #readFieldValue(Field)
 	 * @see #readFieldValue(Class, String, Object)
-	 * @since 1.3
+	 * @since 1.4
 	 */
 	@API(status = INTERNAL, since = "1.4")
 	public static Try<Object> tryToReadFieldValue(Field field, Object instance) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassSelector.java
@@ -71,8 +71,9 @@ public class ClassSelector implements DiscoverySelector {
 	 */
 	public Class<?> getJavaClass() {
 		if (this.javaClass == null) {
-			this.javaClass = ReflectionUtils.loadClass(this.className).orElseThrow(
-				() -> new PreconditionViolationException("Could not load class with name: " + this.className));
+			this.javaClass = ReflectionUtils.tryToLoadClass(this.className).getOrThrow(
+				cause -> new PreconditionViolationException("Could not load class with name: " + this.className,
+					cause));
 		}
 		return this.javaClass;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
@@ -152,8 +152,10 @@ public class MethodSelector implements DiscoverySelector {
 
 	private void lazyLoadJavaClass() {
 		if (this.javaClass == null) {
-			this.javaClass = ReflectionUtils.loadClass(this.className).orElseThrow(
-				() -> new PreconditionViolationException("Could not load class with name: " + this.className));
+			// @formatter:off
+			this.javaClass = ReflectionUtils.tryToLoadClass(this.className).getOrThrow(
+				cause -> new PreconditionViolationException("Could not load class with name: " + this.className, cause));
+			// @formatter:on
 		}
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -129,8 +129,9 @@ public class ClassSource implements TestSource {
 	 */
 	public final Class<?> getJavaClass() {
 		if (this.javaClass == null) {
-			this.javaClass = ReflectionUtils.loadClass(this.className).orElseThrow(
-				() -> new PreconditionViolationException("Could not load class with name: " + this.className));
+			this.javaClass = ReflectionUtils.tryToLoadClass(this.className).getOrThrow(
+				cause -> new PreconditionViolationException("Could not load class with name: " + this.className,
+					cause));
 		}
 		return this.javaClass;
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdSelectorResolver.java
@@ -71,11 +71,12 @@ class UniqueIdSelectorResolver implements DiscoverySelectorResolver {
 	}
 
 	private Optional<Class<?>> loadTestClass(String className, UniqueId uniqueId) {
-		Optional<Class<?>> testClass = ReflectionUtils.loadClass(className);
-		if (!testClass.isPresent()) {
-			logger.warn(() -> format("Unresolvable Unique ID (%s): Unknown class %s", uniqueId, className));
-		}
-		return testClass;
+		// @formatter:off
+		return ReflectionUtils.tryToLoadClass(className)
+				.ifFailure(cause -> logger.warn(cause, () ->
+						format("Unresolvable Unique ID (%s): Unknown class %s", uniqueId, className)))
+				.toOptional();
+		// @formatter:on
 	}
 
 	private Optional<String> determineTestClassName(UniqueId uniqueId) {

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/support/UniqueIdReaderTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/support/UniqueIdReaderTests.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.runner.Description.createTestDescription;
 
 import java.io.Serializable;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -50,14 +51,11 @@ class UniqueIdReaderTests {
 
 		assertEquals(description.getDisplayName(), uniqueId);
 
-		// @formatter:off
-		assertThat(listener.stream(UniqueIdReader.class, Level.WARNING)
-			.map(LogRecord::getMessage)
-			.filter(m -> m.equals("Could not read unique ID for Description; using display name instead: "
-					+ description.getDisplayName()))
-			.count()
-		).isEqualTo(1);
-		// @formatter:on
+		Optional<LogRecord> logRecord = listener.stream(UniqueIdReader.class, Level.WARNING).findFirst();
+		assertThat(logRecord).isPresent();
+		assertThat(logRecord.get().getMessage()).isEqualTo(
+			"Could not read unique ID for Description; using display name instead: " + description.getDisplayName());
+		assertThat(logRecord.get().getThrown()).isInstanceOf(NoSuchFieldException.class);
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/function/TryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/function/TryTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.JUnitException;
+
+public class TryTests {
+
+	@Test
+	void successfulTriesCanBeTransformed() throws Exception {
+		Try<String> t = Try.success("foo");
+
+		assertThat(t.get()).isEqualTo("foo");
+		assertThat(t.getOrThrow(RuntimeException::new)).isEqualTo("foo");
+		assertThat(t.toOptional()).contains("foo");
+
+		assertThat(t.andThen(v -> {
+			assertThat(v).isEqualTo("foo");
+			return Try.success("bar");
+		}).get()).isEqualTo("bar");
+		assertThat(t.andThenTry(v -> {
+			assertThat(v).isEqualTo("foo");
+			return "bar";
+		}).get()).isEqualTo("bar");
+
+		assertThat(t.orElse(() -> fail("should not be called"))).isSameAs(t);
+		assertThat(t.orElseTry(() -> fail("should not be called"))).isSameAs(t);
+
+		AtomicReference<String> value = new AtomicReference<>();
+		assertThat(t.ifSuccess(value::set)).isSameAs(t);
+		assertThat(value.get()).isEqualTo("foo");
+		assertThat(t.ifFailure(cause -> fail("should not be called"))).isSameAs(t);
+	}
+
+	@Test
+	void failedTriesCanBeTransformed() throws Exception {
+		JUnitException cause = new JUnitException("foo");
+		Try<String> t = Try.failure(cause);
+
+		assertThat(assertThrows(JUnitException.class, t::get)).isSameAs(cause);
+		assertThat(assertThrows(RuntimeException.class, () -> t.getOrThrow(RuntimeException::new))).isInstanceOf(
+			RuntimeException.class).hasCause(cause);
+		assertThat(t.toOptional()).isEmpty();
+
+		assertThat(t.andThen(v -> fail("should not be called"))).isSameAs(t);
+		assertThat(t.andThenTry(v -> fail("should not be called"))).isSameAs(t);
+
+		assertThat(t.orElse(() -> Try.success("bar")).get()).isEqualTo("bar");
+		assertThat(t.orElseTry(() -> "bar").get()).isEqualTo("bar");
+
+		assertThat(t.ifSuccess(v -> fail("should not be called"))).isSameAs(t);
+		AtomicReference<Exception> exception = new AtomicReference<>();
+		assertThat(t.ifFailure(exception::set)).isSameAs(t);
+		assertThat(exception.get()).isSameAs(cause);
+	}
+
+	@Test
+	void successfulTriesCanStoreNull() throws Exception {
+		Try<String> t = Try.success(null);
+		assertThat(t.get()).isNull();
+		assertThat(t.getOrThrow(RuntimeException::new)).isNull();
+		assertThat(t.toOptional()).isEmpty();
+	}
+
+	@Test
+	void triesWithSameContentAreEqual() {
+		Exception cause = new Exception();
+		Callable<Object> failingCallable = () -> {
+			throw cause;
+		};
+
+		Try<String> success = Try.call(() -> "foo");
+		assertThat(success).isEqualTo(success).hasSameHashCodeAs(success);
+		assertThat(success).isEqualTo(Try.success("foo"));
+		assertThat(success).isNotEqualTo(Try.failure(cause));
+
+		Try<Object> failure = Try.call(failingCallable);
+		assertThat(failure).isEqualTo(failure).hasSameHashCodeAs(failure);
+		assertThat(failure).isNotEqualTo(Try.success("foo"));
+		assertThat(failure).isEqualTo(Try.failure(cause));
+	}
+
+	@Test
+	void methodPreconditionsAreChecked() {
+		assertThrows(JUnitException.class, () -> Try.call(null));
+
+		Try<String> success = Try.success("foo");
+		assertThrows(JUnitException.class, () -> success.andThen(null));
+		assertThrows(JUnitException.class, () -> success.andThenTry(null));
+		assertThrows(JUnitException.class, () -> success.ifSuccess(null));
+
+		Try<String> failure = Try.failure(new Exception());
+		assertThrows(JUnitException.class, () -> failure.orElse(null));
+		assertThrows(JUnitException.class, () -> failure.orElseTry(null));
+		assertThrows(JUnitException.class, () -> failure.ifFailure(null));
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
@@ -37,11 +37,21 @@ class ReflectionSupportTests {
 	private final Predicate<String> allNames = name -> true;
 	private final Predicate<Method> allMethods = name -> true;
 
+	@SuppressWarnings("deprecation")
 	@Test
 	void loadClassDelegates() {
 		assertEquals(ReflectionUtils.loadClass("-"), ReflectionSupport.loadClass("-"));
 		assertEquals(ReflectionUtils.loadClass("A"), ReflectionSupport.loadClass("A"));
 		assertEquals(ReflectionUtils.loadClass("java.io.Bits"), ReflectionSupport.loadClass("java.io.Bits"));
+	}
+
+	@Test
+	void tryToLoadClassDelegates() {
+		assertEquals(ReflectionUtils.tryToLoadClass("-").toOptional(),
+			ReflectionSupport.tryToLoadClass("-").toOptional());
+		assertEquals(ReflectionUtils.tryToLoadClass("A").toOptional(),
+			ReflectionSupport.tryToLoadClass("A").toOptional());
+		assertEquals(ReflectionUtils.tryToLoadClass("java.io.Bits"), ReflectionSupport.tryToLoadClass("java.io.Bits"));
 	}
 
 	@TestFactory

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/PackageUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/PackageUtilsTests.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import java.util.Arrays;
@@ -78,9 +77,8 @@ class PackageUtilsTests {
 	}
 
 	@Test
-	void getAttributeFromDefaultPackageMemberIsEmpty() {
-		Class<?> classInDefaultPackage = ReflectionUtils.loadClass("DefaultPackageTestCase").orElseGet(
-			() -> fail("Could not load class from default package"));
+	void getAttributeFromDefaultPackageMemberIsEmpty() throws Exception {
+		Class<?> classInDefaultPackage = ReflectionUtils.tryToLoadClass("DefaultPackageTestCase").get();
 		assertFalse(PackageUtils.getAttribute(classInDefaultPackage, Package::getSpecificationTitle).isPresent());
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -18,12 +18,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.commons.function.Try.success;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.BOTTOM_UP;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethod;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethods;
 import static org.junit.platform.commons.util.ReflectionUtils.invokeMethod;
 import static org.junit.platform.commons.util.ReflectionUtils.readFieldValue;
+import static org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue;
 
 import java.io.File;
 import java.io.IOException;
@@ -176,6 +178,7 @@ class ReflectionUtilsTests {
 		// @formatter:on
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	void readFieldValueOfNonexistentStaticField() {
 		assertThat(readFieldValue(MyClass.class, "doesNotExist", null)).isNotPresent();
@@ -183,11 +186,28 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
+	void tryToReadFieldValueOfNonexistentStaticField() {
+		assertThrows(NoSuchFieldException.class, () -> tryToReadFieldValue(MyClass.class, "doesNotExist", null).get());
+		assertThrows(NoSuchFieldException.class,
+			() -> tryToReadFieldValue(MySubClass.class, "staticField", null).get());
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
 	void readFieldValueOfNonexistentInstanceField() {
 		assertThat(readFieldValue(MyClass.class, "doesNotExist", new MyClass(42))).isNotPresent();
 		assertThat(readFieldValue(MyClass.class, "doesNotExist", new MySubClass(42))).isNotPresent();
 	}
 
+	@Test
+	void tryToReadFieldValueOfNonexistentInstanceField() {
+		assertThrows(NoSuchFieldException.class,
+			() -> tryToReadFieldValue(MyClass.class, "doesNotExist", new MyClass(42)).get());
+		assertThrows(NoSuchFieldException.class,
+			() -> tryToReadFieldValue(MyClass.class, "doesNotExist", new MySubClass(42)).get());
+	}
+
+	@SuppressWarnings("deprecation")
 	@Test
 	void readFieldValueOfExistingStaticField() throws Exception {
 		assertThat(readFieldValue(MyClass.class, "staticField", null)).contains(42);
@@ -198,6 +218,16 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
+	void tryToReadFieldValueOfExistingStaticField() throws Exception {
+		assertThat(tryToReadFieldValue(MyClass.class, "staticField", null).get()).isEqualTo(42);
+
+		Field field = MyClass.class.getDeclaredField("staticField");
+		assertThat(tryToReadFieldValue(field).get()).isEqualTo(42);
+		assertThat(tryToReadFieldValue(field, null).get()).isEqualTo(42);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
 	void readFieldValueOfExistingInstanceField() throws Exception {
 		MyClass instance = new MyClass(42);
 		assertThat(readFieldValue(MyClass.class, "instanceField", instance)).contains(42);
@@ -205,6 +235,16 @@ class ReflectionUtilsTests {
 		Field field = MyClass.class.getDeclaredField("instanceField");
 		assertThat(readFieldValue(field, instance)).contains(42);
 		assertThat(readFieldValue(field, null)).isNotPresent();
+	}
+
+	@Test
+	void tryToReadFieldValueOfExistingInstanceField() throws Exception {
+		MyClass instance = new MyClass(42);
+		assertThat(tryToReadFieldValue(MyClass.class, "instanceField", instance).get()).isEqualTo(42);
+
+		Field field = MyClass.class.getDeclaredField("instanceField");
+		assertThat(tryToReadFieldValue(field, instance).get()).isEqualTo(42);
+		assertThrows(NullPointerException.class, () -> tryToReadFieldValue(field, null).get());
 	}
 
 	@Test
@@ -368,20 +408,29 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
-	void loadClassPreconditions() {
-		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.loadClass(null));
-		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.loadClass(""));
-		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.loadClass("   "));
+	void tryToLoadClassPreconditions() {
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToLoadClass(null));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToLoadClass(""));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToLoadClass("   "));
 
-		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.loadClass(null, null));
-		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.loadClass(getClass().getName(), null));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToLoadClass(null, null));
+		assertThrows(PreconditionViolationException.class,
+			() -> ReflectionUtils.tryToLoadClass(getClass().getName(), null));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	void loadClassWhenClassNotFoundException() {
 		assertThat(ReflectionUtils.loadClass("foo.bar.EnigmaClassThatDoesNotExist")).isEmpty();
 	}
 
+	@Test
+	void tryToLoadClassWhenClassNotFoundException() {
+		assertThrows(ClassNotFoundException.class,
+			() -> ReflectionUtils.tryToLoadClass("foo.bar.EnigmaClassThatDoesNotExist").get());
+	}
+
+	@SuppressWarnings("deprecation")
 	@Test
 	void loadClass() {
 		Optional<Class<?>> optional = ReflectionUtils.loadClass(Integer.class.getName());
@@ -389,78 +438,72 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
-	void loadClassTrimsClassName() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass("  " + Integer.class.getName() + "\t");
-		assertThat(optional).contains(Integer.class);
+	void tryToLoadClass() {
+		assertThat(ReflectionUtils.tryToLoadClass(Integer.class.getName())).isEqualTo(success(Integer.class));
 	}
 
 	@Test
-	void loadClassForPrimitive() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass(int.class.getName());
-		assertThat(optional).contains(int.class);
+	void tryToLoadClassTrimsClassName() {
+		assertThat(ReflectionUtils.tryToLoadClass("  " + Integer.class.getName() + "\t")).isEqualTo(
+			success(Integer.class));
 	}
 
 	@Test
-	void loadClassForPrimitiveArray() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass(int[].class.getName());
-		assertThat(optional).contains(int[].class);
+	void tryToLoadClassForPrimitive() {
+		assertThat(ReflectionUtils.tryToLoadClass(int.class.getName())).isEqualTo(success(int.class));
 	}
 
 	@Test
-	void loadClassForPrimitiveArrayUsingSourceCodeSyntax() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass("int[]");
-		assertThat(optional).contains(int[].class);
+	void tryToLoadClassForPrimitiveArray() {
+		assertThat(ReflectionUtils.tryToLoadClass(int[].class.getName())).isEqualTo(success(int[].class));
 	}
 
 	@Test
-	void loadClassForObjectArray() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass(String[].class.getName());
-		assertThat(optional).contains(String[].class);
+	void tryToLoadClassForPrimitiveArrayUsingSourceCodeSyntax() {
+		assertThat(ReflectionUtils.tryToLoadClass("int[]")).isEqualTo(success(int[].class));
 	}
 
 	@Test
-	void loadClassForObjectArrayUsingSourceCodeSyntax() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass("java.lang.String[]");
-		assertThat(optional).contains(String[].class);
+	void tryToLoadClassForObjectArray() {
+		assertThat(ReflectionUtils.tryToLoadClass(String[].class.getName())).isEqualTo(success(String[].class));
 	}
 
 	@Test
-	void loadClassForTwoDimensionalPrimitiveArray() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass(int[][].class.getName());
-		assertThat(optional).contains(int[][].class);
+	void tryToLoadClassForObjectArrayUsingSourceCodeSyntax() {
+		assertThat(ReflectionUtils.tryToLoadClass("java.lang.String[]")).isEqualTo(success(String[].class));
 	}
 
 	@Test
-	void loadClassForTwoDimensionaldimensionalPrimitiveArrayUsingSourceCodeSyntax() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass("int[][]");
-		assertThat(optional).contains(int[][].class);
+	void tryToLoadClassForTwoDimensionalPrimitiveArray() {
+		assertThat(ReflectionUtils.tryToLoadClass(int[][].class.getName())).isEqualTo(success(int[][].class));
 	}
 
 	@Test
-	void loadClassForMultidimensionalPrimitiveArray() {
-		String className = int[][][][][].class.getName();
-		Optional<Class<?>> optional = ReflectionUtils.loadClass(className);
-		assertThat(optional).as(className).contains(int[][][][][].class);
+	void tryToLoadClassForTwoDimensionaldimensionalPrimitiveArrayUsingSourceCodeSyntax() {
+		assertThat(ReflectionUtils.tryToLoadClass("int[][]")).isEqualTo(success(int[][].class));
 	}
 
 	@Test
-	void loadClassForMultidimensionalPrimitiveArrayUsingSourceCodeSyntax() {
-		String className = "int[][][][][]";
-		Optional<Class<?>> optional = ReflectionUtils.loadClass(className);
-		assertThat(optional).as(className).contains(int[][][][][].class);
+	void tryToLoadClassForMultidimensionalPrimitiveArray() {
+		assertThat(ReflectionUtils.tryToLoadClass(int[][][][][].class.getName())).isEqualTo(
+			success(int[][][][][].class));
 	}
 
 	@Test
-	void loadClassForMultidimensionalObjectArray() {
-		String className = String[][][][][].class.getName();
-		Optional<Class<?>> optional = ReflectionUtils.loadClass(className);
-		assertThat(optional).as(className).contains(String[][][][][].class);
+	void tryToLoadClassForMultidimensionalPrimitiveArrayUsingSourceCodeSyntax() {
+		assertThat(ReflectionUtils.tryToLoadClass("int[][][][][]")).isEqualTo(success(int[][][][][].class));
 	}
 
 	@Test
-	void loadClassForMultidimensionalObjectArrayUsingSourceCodeSyntax() {
-		Optional<Class<?>> optional = ReflectionUtils.loadClass("java.lang.String[][][][][]");
-		assertThat(optional).contains(String[][][][][].class);
+	void tryToLoadClassForMultidimensionalObjectArray() {
+		assertThat(ReflectionUtils.tryToLoadClass(String[][][][][].class.getName())).isEqualTo(
+			success(String[][][][][].class));
+	}
+
+	@Test
+	void tryToLoadClassForMultidimensionalObjectArrayUsingSourceCodeSyntax() {
+		assertThat(ReflectionUtils.tryToLoadClass("java.lang.String[][][][][]")).isEqualTo(
+			success(String[][][][][].class));
 	}
 
 	@Test
@@ -650,24 +693,26 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
-	void getMethodPreconditions() {
-		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.getMethod(null, null));
-		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.getMethod(String.class, null));
-		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.getMethod(null, "hashCode"));
+	void tryToGetMethodPreconditions() {
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToGetMethod(null, null));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToGetMethod(String.class, null));
+		assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.tryToGetMethod(null, "hashCode"));
 	}
 
 	@Test
-	void getMethod() throws Exception {
-		assertThat(ReflectionUtils.getMethod(Object.class, "hashCode")).contains(Object.class.getMethod("hashCode"));
-		assertThat(ReflectionUtils.getMethod(String.class, "charAt", int.class))//
-				.contains(String.class.getMethod("charAt", int.class));
+	void tryToGetMethod() throws Exception {
+		assertThat(ReflectionUtils.tryToGetMethod(Object.class, "hashCode").get()).isEqualTo(
+			Object.class.getMethod("hashCode"));
+		assertThat(ReflectionUtils.tryToGetMethod(String.class, "charAt", int.class).get())//
+				.isEqualTo(String.class.getMethod("charAt", int.class));
 
-		assertThat(ReflectionUtils.getMethod(Path.class, "subpath", int.class, int.class))//
-				.contains(Path.class.getMethod("subpath", int.class, int.class));
-		assertThat(ReflectionUtils.getMethod(String.class, "chars")).contains(String.class.getMethod("chars"));
+		assertThat(ReflectionUtils.tryToGetMethod(Path.class, "subpath", int.class, int.class).get())//
+				.isEqualTo(Path.class.getMethod("subpath", int.class, int.class));
+		assertThat(ReflectionUtils.tryToGetMethod(String.class, "chars").get()).isEqualTo(
+			String.class.getMethod("chars"));
 
-		assertThat(ReflectionUtils.getMethod(String.class, "noSuchMethod")).isEmpty();
-		assertThat(ReflectionUtils.getMethod(Object.class, "clone", int.class)).isEmpty();
+		assertThat(ReflectionUtils.tryToGetMethod(String.class, "noSuchMethod").toOptional()).isEmpty();
+		assertThat(ReflectionUtils.tryToGetMethod(Object.class, "clone", int.class).toOptional()).isEmpty();
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/ClassSelectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/ClassSelectorTests.java
@@ -10,8 +10,12 @@
 
 package org.junit.platform.engine.discovery;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 import org.junit.platform.AbstractEqualsAndHashCodeTests;
+import org.junit.platform.commons.util.PreconditionViolationException;
 
 /**
  * Unit tests for {@link ClassSelector}.
@@ -30,4 +34,13 @@ class ClassSelectorTests extends AbstractEqualsAndHashCodeTests {
 		assertEqualsAndHashCode(selector1, selector2, selector3);
 	}
 
+	@Test
+	void preservesOriginalExceptionWhenTryingToLoadClass() {
+		ClassSelector selector = new ClassSelector("org.example.TestClass");
+
+		PreconditionViolationException e = assertThrows(PreconditionViolationException.class, selector::getJavaClass);
+
+		assertThat(e).hasMessage("Could not load class with name: org.example.TestClass").hasCauseInstanceOf(
+			ClassNotFoundException.class);
+	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/MethodSelectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/MethodSelectorTests.java
@@ -10,8 +10,12 @@
 
 package org.junit.platform.engine.discovery;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 import org.junit.platform.AbstractEqualsAndHashCodeTests;
+import org.junit.platform.commons.util.PreconditionViolationException;
 
 /**
  * Unit tests for {@link MethodSelector}.
@@ -32,6 +36,16 @@ class MethodSelectorTests extends AbstractEqualsAndHashCodeTests {
 		assertEqualsAndHashCode(selector1, selector2, new MethodSelector("TestClass", "X"));
 		assertEqualsAndHashCode(selector1, selector2, new MethodSelector("X", "method", "int, boolean"));
 		assertEqualsAndHashCode(selector1, selector2, new MethodSelector("X", "method"));
+	}
+
+	@Test
+	void preservesOriginalExceptionWhenTryingToLoadClass() {
+		MethodSelector selector = new MethodSelector("TestClass", "method", "int, boolean");
+
+		PreconditionViolationException e = assertThrows(PreconditionViolationException.class, selector::getJavaClass);
+
+		assertThat(e).hasMessage("Could not load class with name: TestClass").hasCauseInstanceOf(
+			ClassNotFoundException.class);
 	}
 
 }

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
@@ -4,6 +4,7 @@ org.junit.platform.commons@${platformVersion} automatic
 requires java.base mandated
 contains org.junit.platform.commons
 contains org.junit.platform.commons.annotation
+contains org.junit.platform.commons.function
 contains org.junit.platform.commons.logging
 contains org.junit.platform.commons.support
 contains org.junit.platform.commons.util


### PR DESCRIPTION
Exceptions reported due to failed reflective operations such as loading
a class, reading a field's value, or looking up a method by name now
include the original exception as their cause to make it easier to debug
underlying issues.

Such operations in `ReflectionUtils` and `ReflectionSupport` no longer
return an instance of `Optional` but one of a new `Try` type which
encapsulates either a successful invocation with a (nullable) resulting
value or a failure with an exception as its cause. Depending on the
caller, the cause can then be logged or rethrown as appropriate.

Resolves #602.