### PR TITLE
[WIP] Allow static modifier on dynamic test factory methods

### DIFF
--- a/documentation/src/test/java/example/DynamicTestsDemo.java
+++ b/documentation/src/test/java/example/DynamicTestsDemo.java
@@ -199,5 +199,10 @@ class DynamicTestsDemo {
 		// @formatter:on
 		// tag::user_guide[]
 	}
+
+	@TestFactory
+	static DynamicNode dynamicNodeFromStaticMethod() {
+		return dynamicTest("static factory", () -> assertFalse(false));
+	}
 }
 // end::user_guide[]

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.TestFactory;
 public class IsTestFactoryMethod extends IsTestableMethod {
 
 	public IsTestFactoryMethod() {
-		super(TestFactory.class, false);
+		super(TestFactory.class, false, false);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -27,16 +27,22 @@ abstract class IsTestableMethod implements Predicate<Method> {
 
 	private final Class<? extends Annotation> annotationType;
 	private final boolean mustReturnVoid;
+	private final boolean mustBeNonStatic;
 
 	IsTestableMethod(Class<? extends Annotation> annotationType, boolean mustReturnVoid) {
+		this(annotationType, mustReturnVoid, true);
+	}
+
+	IsTestableMethod(Class<? extends Annotation> annotationType, boolean mustReturnVoid, boolean mustBeNonStatic) {
 		this.annotationType = annotationType;
 		this.mustReturnVoid = mustReturnVoid;
+		this.mustBeNonStatic = mustBeNonStatic;
 	}
 
 	@Override
 	public boolean test(Method candidate) {
 		// Please do not collapse the following into a single statement.
-		if (isStatic(candidate)) {
+		if (this.mustBeNonStatic && isStatic(candidate)) {
 			return false;
 		}
 		if (isPrivate(candidate)) {


### PR DESCRIPTION
## Overview

Issue: #1654

Why does this work?

Why doesn't `Object instance = extensionContext.getRequiredTestInstance();` fail here?

https://github.com/junit-team/junit5/blob/dff15fb145efd34629582e469f657ad64490e22b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java#L85-L87

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
