### PR TITLE
Break ReflectionUtils findMethod with 3 additional methods.

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -815,6 +815,21 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
+	void getSuperClassesPrecondition() {
+		RuntimeException exception = assertThrows(PreconditionViolationException.class, () -> ReflectionUtils.getSuperClasses(null));
+		assertThat(exception).hasMessage("Class must not be null");
+	}
+
+	@Test
+	void getSuperClasses() {
+		assertThat(ReflectionUtils.getSuperClasses(Object.class)).isEmpty();
+
+		assertThat(ReflectionUtils.getSuperClasses(String.class)).contains(String.class);
+		assertThat(ReflectionUtils.getSuperClasses(Integer.class)).contains(Number.class);
+		assertThat(ReflectionUtils.getSuperClasses(NullPointerException.class)).contains(RuntimeException.class, Exception.class);
+	}
+
+	@Test
 	void findMethodsPreconditions() {
 		// @formatter:off
 		assertThrows(PreconditionViolationException.class, () -> findMethods(null, null));


### PR DESCRIPTION
## Overview
Issue: #981 

Moved for loops out of the findMethod to their own methods named searchForMatchingMethod and searchForMatchingMethodInInterfaces. Added a new public method to get superclasses of a class. Overall algorithm of findMethod hasn't changed much, though.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
