### PR TITLE
[WIP] Introduce ResourceSupplier SPI

### DIFF
--- a/documentation/src/test/java/example/TempDirectoryDemo.java
+++ b/documentation/src/test/java/example/TempDirectoryDemo.java
@@ -12,6 +12,7 @@ package example;
 
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -20,16 +21,16 @@ import java.nio.file.Path;
 import example.util.ListWriter;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.support.io.TempDirectory;
-import org.junit.jupiter.api.support.io.TempDirectory.TempDir;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ResourceSupplier.New;
+import org.junit.jupiter.api.extension.ResourceSupplier.Singleton;
+import org.junit.jupiter.api.support.io.Temporary;
 
 class TempDirectoryDemo {
 
 	// tag::user_guide_parameter_injection[]
 	@Test
-	@ExtendWith(TempDirectory.class)
-	void writeItemsToFile(@TempDir Path tempDir) throws IOException {
+	void writeItemsToFile(@Temporary.Directory Path tempDir) throws IOException {
 		Path file = tempDir.resolve("test.txt");
 
 		new ListWriter(file).write("a", "b", "c");
@@ -38,15 +39,31 @@ class TempDirectoryDemo {
 	}
 	// end::user_guide_parameter_injection[]
 
-	// tag::user_guide_field_injection[]
-	@ExtendWith(TempDirectory.class)
-	// end::user_guide_field_injection[]
-	static
-	// tag::user_guide_field_injection[]
-	class SharedTempDirectoryDemo {
+	static class GloballySharedSingletonTempDirectoryDemo {
+		@Test
+		void text1(@Singleton(Temporary.class) Path temp) throws IOException {
+			Path file = temp.resolve("test1.txt");
 
-		@TempDir
-		static Path sharedTempDir;
+			new ListWriter(file).write("a", "b", "c");
+
+			assertEquals(singletonList("a,b,c"), Files.readAllLines(file));
+		}
+
+		@Test
+		void text2(@Singleton(Temporary.class) Path temp) {
+			// use same temporary directory
+		}
+	}
+
+	// tag::user_guide_field_injection[]
+	@TestInstance(PER_CLASS)
+	static class SharedTempDirectoryDemo {
+
+		private final Path sharedTempDir;
+
+		SharedTempDirectoryDemo(@New(Temporary.class) Path sharedTempDir) {
+			this.sharedTempDir = sharedTempDir;
+		}
 
 		@Test
 		void writeItemsToFile() throws IOException {
@@ -60,6 +77,11 @@ class TempDirectoryDemo {
 		@Test
 		void anotherTestThatUsesTheSameTempDir() {
 			// use sharedTempDir
+		}
+
+		@Test
+		void text3(@Singleton(Temporary.class) Path temp) {
+			// use same temporary directory as above
 		}
 
 	}

--- a/documentation/src/test/java/example/resource/NewDemo.java
+++ b/documentation/src/test/java/example/resource/NewDemo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.resource;
+
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ResourceSupplier.New;
+import org.junit.jupiter.api.extension.ResourceSupplier.Singleton;
+
+class NewDemo {
+
+	@Test
+	void usingFreshServerInstance(@New(WebServer.class) WebServer server) {
+		List<String> actual = WebServer.getLines(server.getUri());
+		assertLinesMatch(Collections.singletonList("counter = 1"), actual);
+	}
+
+	@Test
+	void usingSharedServerInstance(@Singleton(WebServer.class) WebServer server) {
+		List<String> actual = WebServer.getLines(server.getUri());
+		assertLinesMatch(Collections.singletonList("counter = [1|2|3|4]"), actual);
+	}
+
+}

--- a/documentation/src/test/java/example/resource/SingletonDemo.java
+++ b/documentation/src/test/java/example/resource/SingletonDemo.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.resource;
+
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ResourceSupplier.Singleton;
+
+class SingletonDemo {
+
+	@Test
+	void usingSharedServerInstance(@Singleton(WebServer.class) WebServer server) {
+		List<String> actual = WebServer.getLines(server.getUri());
+		assertLinesMatch(Collections.singletonList("counter = [1|2|3|4]"), actual);
+	}
+
+	@Test
+	void usingSharedServerInstance(@Singleton(WebServer.class) HttpServer server) {
+		String host = server.getAddress().getHostName();
+		int port = server.getAddress().getPort();
+		List<String> actual = WebServer.getLines(URI.create("http://" + host + ":" + port));
+		assertLinesMatch(Collections.singletonList("counter = [1|2|3|4]"), actual);
+	}
+
+	@Nested
+	class SecondLayer {
+
+		@Test
+		void usingSharedServerInstance(@Singleton(WebServer.class) WebServer server) {
+			List<String> actual = WebServer.getLines(server.getUri());
+			assertLinesMatch(Collections.singletonList("counter = [1|2|3|4]"), actual);
+		}
+	}
+}

--- a/documentation/src/test/java/example/resource/WebServer.java
+++ b/documentation/src/test/java/example/resource/WebServer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.extension.ResourceSupplier;
+
+public class WebServer implements ResourceSupplier<HttpServer>, HttpHandler {
+
+	public static List<String> getLines(URI uri) {
+		String result;
+		try {
+			try (InputStream inputStream = uri.toURL().openStream()) {
+				result = new Scanner(inputStream).useDelimiter("\\A").next();
+			}
+		}
+		catch (IOException exception) {
+			result = exception.toString();
+		}
+		return Arrays.asList(result.split("\\R"));
+	}
+
+	private final AtomicInteger counter;
+	private final HttpServer httpServer;
+
+	public WebServer() {
+		this.counter = new AtomicInteger();
+		this.httpServer = createAndStartHttpServerOnFreePort();
+	}
+
+	private HttpServer createAndStartHttpServerOnFreePort() {
+		try {
+			HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+			server.createContext("/", this);
+			server.start();
+			return server;
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Creating HttpServer failed!", e);
+		}
+	}
+
+	@Override
+	public void close() {
+		httpServer.stop(1);
+	}
+
+	@Override
+	public HttpServer get() {
+		return httpServer;
+	}
+
+	public URI getUri() {
+		String host = httpServer.getAddress().getHostName();
+		int port = httpServer.getAddress().getPort();
+		return URI.create("http://" + host + ":" + port);
+	}
+
+	@Override
+	public void handle(HttpExchange exchange) throws IOException {
+		String response = "counter = " + counter.incrementAndGet();
+		exchange.sendResponseHeaders(200, response.length());
+		try (OutputStream os = exchange.getResponseBody()) {
+			os.write(response.getBytes());
+		}
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ResourceSupplier.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ResourceSupplier.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.platform.commons.JUnitException;
+
+public interface ResourceSupplier<R> extends AutoCloseable, CloseableResource, Supplier<R> {
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+	@interface New {
+
+		Class<? extends ResourceSupplier<?>> value();
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.PARAMETER)
+	@interface Singleton {
+
+		Class<? extends ResourceSupplier<?>> value();
+	}
+
+	default Object as(Class<?> parameterType) {
+		// TODO find unique converter, like String Object#toString() or File Path#toFile()?
+		throw new UnsupportedOperationException("Can't convert to " + parameterType);
+	}
+
+	@Override
+	default void close() throws IOException {
+		R instance = get();
+		if (instance instanceof AutoCloseable) {
+			try {
+				((AutoCloseable) instance).close();
+			}
+			catch (Exception e) {
+				throw new JUnitException("Closing '" + instance + "' failed", e);
+			}
+		}
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/support/io/Temporary.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/support/io/Temporary.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.support.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ResourceSupplier;
+import org.junit.platform.commons.util.FileUtils;
+
+public class Temporary implements ResourceSupplier<Path> {
+
+	/**
+	 * Same as {@code @New(Temporary.class)}.
+	 */
+	@Target({ ElementType.FIELD, ElementType.PARAMETER })
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@New(Temporary.class)
+	public @interface Directory {
+	}
+
+	private final Path path;
+
+	public Temporary() {
+		this("junit-jupiter-temporary");
+	}
+
+	public Temporary(String prefix) {
+		try {
+			this.path = createTemporaryDirectory(prefix);
+		}
+		catch (IOException e) {
+			throw new ParameterResolutionException("creating ", e);
+		}
+	}
+
+	protected Path createTemporaryDirectory(String prefix) throws IOException {
+		return Files.createTempDirectory(prefix + '-');
+	}
+
+	protected void deleteTemporaryDirectory() throws IOException {
+		FileUtils.deletePath(path);
+	}
+
+	@Override
+	public Path get() {
+		return path;
+	}
+
+	@Override
+	public Object as(Class<?> parameterType) {
+		if (parameterType.isAssignableFrom(File.class)) {
+			return path.toFile();
+		}
+		if (parameterType == URI.class) {
+			return path.toUri();
+		}
+		throw new UnsupportedOperationException("Can't convert Path to " + parameterType);
+	}
+
+	@Override
+	public void close() {
+		try {
+			deleteTemporaryDirectory();
+		}
+		catch (IOException ignore) {
+			// for now...
+		}
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
@@ -55,7 +55,9 @@ public class ExtensionRegistry {
 		new ScriptExecutionCondition(), //
 		new RepeatedTestExtension(), //
 		new TestInfoParameterResolver(), //
-		new TestReporterParameterResolver()));
+		new TestReporterParameterResolver(), //
+		new ResourceSupplierExtension() //
+	));
 
 	/**
 	 * Factory for creating and populating a new root registry with the default

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ResourceSupplierExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ResourceSupplierExtension.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.junit.platform.commons.support.ReflectionSupport.newInstance;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.ResourceSupplier;
+import org.junit.jupiter.api.extension.ResourceSupplier.New;
+import org.junit.jupiter.api.extension.ResourceSupplier.Singleton;
+
+class ResourceSupplierExtension implements ParameterResolver {
+
+	private static final Namespace NAMESPACE = Namespace.create(ResourceSupplierExtension.class);
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameter, ExtensionContext __) {
+		return parameter.isAnnotated(New.class) ^ parameter.isAnnotated(Singleton.class);
+	}
+
+	@Override
+	public Object resolveParameter(ParameterContext parameter, ExtensionContext extension) {
+		ResourceSupplier<?> supplier = supplier(parameter, extension);
+		Class<?> parameterType = parameter.getParameter().getType();
+		if (ResourceSupplier.class.isAssignableFrom(parameterType)) {
+			return supplier;
+		}
+		Object instance = supplier.get();
+		if (parameterType.isAssignableFrom(instance.getClass())) {
+			return instance;
+		}
+		try {
+			return supplier.as(parameterType);
+		}
+		catch (UnsupportedOperationException ignore) {
+			// fall-through
+		}
+		throw new ParameterResolutionException("Parameter type " + parameterType + " isn't compatible with "
+				+ ResourceSupplier.class + " nor " + instance.getClass());
+	}
+
+	private ResourceSupplier<?> supplier(ParameterContext parameter, ExtensionContext context) {
+		Optional<New> newAnnotation = parameter.findAnnotation(New.class);
+		if (newAnnotation.isPresent()) {
+			Class<? extends ResourceSupplier<?>> type = newAnnotation.get().value();
+			String key = type.getName() + '@' + parameter.getIndex();
+			ResourceSupplier<?> resourceSupplier = newInstance(type);
+			context.getStore(NAMESPACE).put(key, resourceSupplier);
+			return resourceSupplier;
+		}
+
+		Optional<Singleton> singletonAnnotation = parameter.findAnnotation(Singleton.class);
+		if (singletonAnnotation.isPresent()) {
+			Class<? extends ResourceSupplier<?>> type = singletonAnnotation.get().value();
+			String key = type.getName();
+			ExtensionContext.Store store = context.getRoot().getStore(NAMESPACE);
+			return store.getOrComputeIfAbsent(key, k -> newInstance(type), ResourceSupplier.class);
+		}
+
+		throw new ParameterResolutionException("Can't resolve resource supplier for: " + parameter);
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistryTests.java
@@ -47,7 +47,7 @@ class ExtensionRegistryTests {
 	void newRegistryWithoutParentHasDefaultExtensions() {
 		List<Extension> extensions = registry.getExtensions(Extension.class);
 
-		assertEquals(5, extensions.size());
+		assertEquals(6, extensions.size());
 		assertDefaultGlobalExtensionsAreRegistered();
 	}
 
@@ -59,7 +59,7 @@ class ExtensionRegistryTests {
 
 		List<Extension> extensions = registry.getExtensions(Extension.class);
 
-		assertEquals(6, extensions.size());
+		assertEquals(7, extensions.size());
 		assertDefaultGlobalExtensionsAreRegistered();
 
 		assertExtensionRegistered(registry, ServiceLoaderExtension.class);
@@ -158,7 +158,7 @@ class ExtensionRegistryTests {
 		assertExtensionRegistered(registry, TestInfoParameterResolver.class);
 		assertExtensionRegistered(registry, TestReporterParameterResolver.class);
 
-		assertEquals(2, countExtensions(registry, ParameterResolver.class));
+		assertEquals(3, countExtensions(registry, ParameterResolver.class));
 		assertEquals(2, countExtensions(registry, ExecutionCondition.class));
 		assertEquals(1, countExtensions(registry, TestTemplateInvocationContextProvider.class));
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/FileUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/FileUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static java.util.stream.Collectors.joining;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class FileUtils {
+
+	public static void deletePath(Path path) throws IOException {
+		Map<Path, IOException> failures = deleteAllFilesAndDirectories(path);
+		if (failures.isEmpty()) {
+			return;
+		}
+		throw createIOExceptionWithAttachedFailures(path, failures);
+	}
+
+	private static Map<Path, IOException> deleteAllFilesAndDirectories(Path path) {
+		// trivial case: delete empty directory right away
+		try {
+			if (Files.deleteIfExists(path)) {
+				return Collections.emptyMap();
+			}
+		}
+		catch (IOException ignored) {
+			// fall-through
+		}
+
+		// default case: walk the tree...
+		Map<Path, IOException> failures = new TreeMap<>();
+		try (Stream<Path> stream = Files.walk(path)) {
+			Stream<Path> selected = stream.sorted((p, q) -> -p.compareTo(q));
+			for (Path item : selected.collect(Collectors.toList())) {
+				Files.deleteIfExists(item);
+			}
+		}
+		catch (IOException e) {
+			failures.put(path, e);
+		}
+
+		return failures;
+	}
+
+	private static IOException createIOExceptionWithAttachedFailures(Path path, Map<Path, IOException> failures) {
+
+		String joinedPaths = failures.keySet().stream() //
+				.peek(FileUtils::tryToDeleteOnExit) //
+				.map(other -> FileUtils.relativizeSafely(path, other)) //
+				.map(String::valueOf) //
+				.collect(joining(", "));
+
+		IOException exception = new IOException("Failed to delete temp directory " + path.toAbsolutePath()
+				+ ". The following paths could not be deleted (see suppressed exceptions for details): " + joinedPaths);
+		failures.values().forEach(exception::addSuppressed);
+		return exception;
+	}
+
+	private static void tryToDeleteOnExit(Path path) {
+		try {
+			path.toFile().deleteOnExit();
+		}
+		catch (UnsupportedOperationException ignore) {
+		}
+	}
+
+	private static Path relativizeSafely(Path path, Path other) {
+		try {
+			return path.relativize(other);
+		}
+		catch (IllegalArgumentException e) {
+			return other;
+		}
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/PackageCyclesDetectionTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/PackageCyclesDetectionTests.java
@@ -29,7 +29,7 @@ class PackageCyclesDetectionTests {
 	void moduleDoesNotContainCyclicPackageReferences(String module) {
 		var jar = Helper.createJarPath(module);
 		var result = new CyclesDetector(jar, this::ignore).run(Configuration.of());
-		assertEquals(0, result.getExitCode(), "result=" + result);
+		assertEquals(0, result.getExitCode(), "cycles=" + result.getOutputLines("cycles"));
 	}
 
 	private boolean ignore(String source, String target) {


### PR DESCRIPTION
## Overview

Addresses part of #1555 by providing a new default extension handling `@New` and `@Singleton` annotations.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
