### PR TITLE
AnnotatedElement parameter support in declaratively registered extensions' constructors

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -74,6 +74,15 @@ in which they are declared in the source code. For example, the execution of tes
 both `MyFirstTests` and `MySecondTests` will be extended by the `FooExtension` and
 `BarExtension`, **in exactly that order**.
 
+===== Configuring declaratively registered extension using annotations
+
+During registration process, extension is instantiated via its default constructor.
+
+However, if extension has a constructor with `AnnotatedElement` parameter, it will be called
+and the respective `@ExtendWith`-annotated element will be passed to it.
+
+This allows to extract other annotations on the element and configure the extension.
+
 [[extensions-registration-programmatic]]
 ==== Programmatic Extension Registration
 

--- a/documentation/src/test/java/example/registration/ParameterizedExtension.java
+++ b/documentation/src/test/java/example/registration/ParameterizedExtension.java
@@ -1,27 +1,39 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package example.registration;
+
+import java.lang.reflect.AnnotatedElement;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
-import java.lang.reflect.AnnotatedElement;
-
 public class ParameterizedExtension implements ParameterResolver {
 
-    private final String parameter;
+	private final String parameter;
 
-    public ParameterizedExtension(AnnotatedElement annotatedElement) {
-        parameter = annotatedElement.getAnnotation(WithParameterizedExtension.class).value();
-    }
+	public ParameterizedExtension(AnnotatedElement annotatedElement) {
+		parameter = annotatedElement.getAnnotation(WithParameterizedExtension.class).value();
+	}
 
-    @Override
-    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return parameterContext.getParameter().getType() == String.class;
-    }
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		return parameterContext.getParameter().getType() == String.class;
+	}
 
-    @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return parameter;
-    }
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		return parameter;
+	}
 }

--- a/documentation/src/test/java/example/registration/ParameterizedExtension.java
+++ b/documentation/src/test/java/example/registration/ParameterizedExtension.java
@@ -1,0 +1,27 @@
+package example.registration;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.lang.reflect.AnnotatedElement;
+
+public class ParameterizedExtension implements ParameterResolver {
+
+    private final String parameter;
+
+    public ParameterizedExtension(AnnotatedElement annotatedElement) {
+        parameter = annotatedElement.getAnnotation(WithParameterizedExtension.class).value();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == String.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameter;
+    }
+}

--- a/documentation/src/test/java/example/registration/ParameterizedExtensionDemo.java
+++ b/documentation/src/test/java/example/registration/ParameterizedExtensionDemo.java
@@ -1,14 +1,24 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
 package example.registration;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 @WithParameterizedExtension("foo")
 public class ParameterizedExtensionDemo {
 
-    @Test
-    void parameterIsPassedToExtension(String param) {
-        assertEquals("foo", param);
-    }
+	@Test
+	void parameterIsPassedToExtension(String param) {
+		assertEquals("foo", param);
+	}
 }

--- a/documentation/src/test/java/example/registration/ParameterizedExtensionDemo.java
+++ b/documentation/src/test/java/example/registration/ParameterizedExtensionDemo.java
@@ -1,0 +1,14 @@
+package example.registration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WithParameterizedExtension("foo")
+public class ParameterizedExtensionDemo {
+
+    @Test
+    void parameterIsPassedToExtension(String param) {
+        assertEquals("foo", param);
+    }
+}

--- a/documentation/src/test/java/example/registration/WithParameterizedExtension.java
+++ b/documentation/src/test/java/example/registration/WithParameterizedExtension.java
@@ -1,0 +1,12 @@
+package example.registration;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(ParameterizedExtension.class)
+public @interface WithParameterizedExtension {
+    String value();
+}

--- a/documentation/src/test/java/example/registration/WithParameterizedExtension.java
+++ b/documentation/src/test/java/example/registration/WithParameterizedExtension.java
@@ -1,12 +1,22 @@
-package example.registration;
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
 
-import org.junit.jupiter.api.extension.ExtendWith;
+package example.registration;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(ParameterizedExtension.class)
 public @interface WithParameterizedExtension {
-    String value();
+	String value();
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -71,7 +71,7 @@ final class ExtensionUtils {
 				.collect(toList());
 		// @formatter:on
 
-		return ExtensionRegistry.createRegistryFrom(parentRegistry, extensionTypes);
+		return ExtensionRegistry.createRegistryFrom(parentRegistry, annotatedElement, extensionTypes);
 	}
 
 	/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
@@ -10,14 +10,10 @@
 
 package org.junit.jupiter.engine.extension;
 
-import org.apiguardian.api.API;
-import org.junit.jupiter.api.extension.Extension;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.ClassLoaderUtils;
-import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.commons.util.ReflectionUtils;
-import org.junit.platform.engine.ConfigurationParameters;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
@@ -31,10 +27,14 @@ import java.util.Set;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Stream.concat;
-import static org.apiguardian.api.API.Status.INTERNAL;
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.util.ClassLoaderUtils;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 
 /**
  * An {@code ExtensionRegistry} holds all registered extensions (i.e.
@@ -50,223 +50,219 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 @API(status = INTERNAL, since = "5.0")
 public class ExtensionRegistry {
 
-    public static final String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = "junit.jupiter.extensions.autodetection.enabled";
+	public static final String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = "junit.jupiter.extensions.autodetection.enabled";
 
-    private static final Logger logger = LoggerFactory.getLogger(ExtensionRegistry.class);
+	private static final Logger logger = LoggerFactory.getLogger(ExtensionRegistry.class);
 
-    private static final List<Extension> DEFAULT_EXTENSIONS = Collections.unmodifiableList(Arrays.asList(//
-            new DisabledCondition(), //
-            new ScriptExecutionCondition(), //
-            new RepeatedTestExtension(), //
-            new TestInfoParameterResolver(), //
-            new TestReporterParameterResolver()));
+	private static final List<Extension> DEFAULT_EXTENSIONS = Collections.unmodifiableList(Arrays.asList(//
+		new DisabledCondition(), //
+		new ScriptExecutionCondition(), //
+		new RepeatedTestExtension(), //
+		new TestInfoParameterResolver(), //
+		new TestReporterParameterResolver()));
 
-    /**
-     * Factory for creating and populating a new root registry with the default
-     * extensions.
-     *
-     * <p>If the {@link org.junit.jupiter.engine.Constants#EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME}
-     * configuration parameter has been set to {@code true}, extensions will be
-     * auto-detected using Java's {@link ServiceLoader} mechanism and automatically
-     * registered after the default extensions.
-     *
-     * @param configParams configuration parameters used to retrieve the extension
-     *                     auto-detection flag; never {@code null}
-     * @return a new {@code ExtensionRegistry}; never {@code null}
-     */
-    public static ExtensionRegistry createRegistryWithDefaultExtensions(ConfigurationParameters configParams) {
-        ExtensionRegistry extensionRegistry = new ExtensionRegistry(null);
+	/**
+	 * Factory for creating and populating a new root registry with the default
+	 * extensions.
+	 *
+	 * <p>If the {@link org.junit.jupiter.engine.Constants#EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME}
+	 * configuration parameter has been set to {@code true}, extensions will be
+	 * auto-detected using Java's {@link ServiceLoader} mechanism and automatically
+	 * registered after the default extensions.
+	 *
+	 * @param configParams configuration parameters used to retrieve the extension
+	 *                     auto-detection flag; never {@code null}
+	 * @return a new {@code ExtensionRegistry}; never {@code null}
+	 */
+	public static ExtensionRegistry createRegistryWithDefaultExtensions(ConfigurationParameters configParams) {
+		ExtensionRegistry extensionRegistry = new ExtensionRegistry(null);
 
-        // @formatter:off
+		// @formatter:off
         logger.trace(() -> "Registering default extensions: " + DEFAULT_EXTENSIONS.stream()
                 .map(extension -> extension.getClass().getName())
                 .collect(toList()));
         // @formatter:on
 
-        DEFAULT_EXTENSIONS.forEach(extensionRegistry::registerDefaultExtension);
+		DEFAULT_EXTENSIONS.forEach(extensionRegistry::registerDefaultExtension);
 
-        if (configParams.getBoolean(EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME).orElse(Boolean.FALSE)) {
-            registerAutoDetectedExtensions(extensionRegistry);
-        }
+		if (configParams.getBoolean(EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME).orElse(Boolean.FALSE)) {
+			registerAutoDetectedExtensions(extensionRegistry);
+		}
 
-        return extensionRegistry;
-    }
+		return extensionRegistry;
+	}
 
-    private static void registerAutoDetectedExtensions(ExtensionRegistry extensionRegistry) {
-        Iterable<Extension> extensions = ServiceLoader.load(Extension.class, ClassLoaderUtils.getDefaultClassLoader());
+	private static void registerAutoDetectedExtensions(ExtensionRegistry extensionRegistry) {
+		Iterable<Extension> extensions = ServiceLoader.load(Extension.class, ClassLoaderUtils.getDefaultClassLoader());
 
-        // @formatter:off
+		// @formatter:off
         logger.config(() -> "Registering auto-detected extensions: "
                 + StreamSupport.stream(extensions.spliterator(), false)
                 .map(extension -> extension.getClass().getName())
                 .collect(toList()));
         // @formatter:on
 
-        extensions.forEach(extensionRegistry::registerDefaultExtension);
-    }
+		extensions.forEach(extensionRegistry::registerDefaultExtension);
+	}
 
-    /**
-     * Factory for creating and populating a new registry from a list of
-     * extension types and a parent registry.
-     *
-     * @param parentRegistry   the parent registry
-     * @param annotatedElement the {@code AnnotatedElement} that provided the list of extension types
-     *                         with its annotations
-     * @param extensionTypes   the types of extensions to be registered in
-     *                         the new registry
-     * @return a new {@code ExtensionRegistry}; never {@code null}
-     */
-    public static ExtensionRegistry createRegistryFrom(ExtensionRegistry parentRegistry,
-                                                       AnnotatedElement annotatedElement,
-                                                       List<Class<? extends Extension>> extensionTypes) {
+	/**
+	 * Factory for creating and populating a new registry from a list of
+	 * extension types and a parent registry.
+	 *
+	 * @param parentRegistry   the parent registry
+	 * @param annotatedElement the {@code AnnotatedElement} that provided the list of extension types
+	 *                         with its annotations
+	 * @param extensionTypes   the types of extensions to be registered in
+	 *                         the new registry
+	 * @return a new {@code ExtensionRegistry}; never {@code null}
+	 */
+	public static ExtensionRegistry createRegistryFrom(ExtensionRegistry parentRegistry,
+			AnnotatedElement annotatedElement, List<Class<? extends Extension>> extensionTypes) {
 
-        Preconditions.notNull(parentRegistry, "parentRegistry must not be null");
+		Preconditions.notNull(parentRegistry, "parentRegistry must not be null");
 
-        ExtensionRegistry registry = new ExtensionRegistry(parentRegistry);
-        extensionTypes.forEach(t -> registry.registerExtension(t, annotatedElement));
-        return registry;
-    }
+		ExtensionRegistry registry = new ExtensionRegistry(parentRegistry);
+		extensionTypes.forEach(t -> registry.registerExtension(t, annotatedElement));
+		return registry;
+	}
 
-    private final ExtensionRegistry parent;
+	private final ExtensionRegistry parent;
 
-    private final Set<Class<? extends Extension>> registeredExtensionTypes = new LinkedHashSet<>();
+	private final Set<Class<? extends Extension>> registeredExtensionTypes = new LinkedHashSet<>();
 
-    private final List<Extension> registeredExtensions = new ArrayList<>();
+	private final List<Extension> registeredExtensions = new ArrayList<>();
 
-    private ExtensionRegistry(ExtensionRegistry parent) {
-        this.parent = parent;
-    }
+	private ExtensionRegistry(ExtensionRegistry parent) {
+		this.parent = parent;
+	}
 
-    /**
-     * Stream all {@code Extensions} of the specified type that are present
-     * in this registry or one of its ancestors.
-     *
-     * @param extensionType the type of {@link Extension} to stream
-     * @see #getReversedExtensions(Class)
-     * @see #getExtensions(Class)
-     */
-    public <E extends Extension> Stream<E> stream(Class<E> extensionType) {
-        if (this.parent == null) {
-            return streamLocal(extensionType);
-        }
-        return concat(this.parent.stream(extensionType), streamLocal(extensionType));
-    }
+	/**
+	 * Stream all {@code Extensions} of the specified type that are present
+	 * in this registry or one of its ancestors.
+	 *
+	 * @param extensionType the type of {@link Extension} to stream
+	 * @see #getReversedExtensions(Class)
+	 * @see #getExtensions(Class)
+	 */
+	public <E extends Extension> Stream<E> stream(Class<E> extensionType) {
+		if (this.parent == null) {
+			return streamLocal(extensionType);
+		}
+		return concat(this.parent.stream(extensionType), streamLocal(extensionType));
+	}
 
-    /**
-     * Stream all {@code Extensions} of the specified type that are present
-     * in this registry.
-     *
-     * <p>Extensions in ancestors are ignored.
-     *
-     * @param extensionType the type of {@link Extension} to stream
-     * @see #getReversedExtensions(Class)
-     */
-    private <E extends Extension> Stream<E> streamLocal(Class<E> extensionType) {
-        // @formatter:off
+	/**
+	 * Stream all {@code Extensions} of the specified type that are present
+	 * in this registry.
+	 *
+	 * <p>Extensions in ancestors are ignored.
+	 *
+	 * @param extensionType the type of {@link Extension} to stream
+	 * @see #getReversedExtensions(Class)
+	 */
+	private <E extends Extension> Stream<E> streamLocal(Class<E> extensionType) {
+		// @formatter:off
         return this.registeredExtensions.stream()
                 .filter(extensionType::isInstance)
                 .map(extensionType::cast);
         // @formatter:on
-    }
+	}
 
-    /**
-     * Get all {@code Extensions} of the specified type that are present
-     * in this registry or one of its ancestors.
-     *
-     * @param extensionType the type of {@link Extension} to get
-     * @see #getReversedExtensions(Class)
-     * @see #stream(Class)
-     */
-    public <E extends Extension> List<E> getExtensions(Class<E> extensionType) {
-        return stream(extensionType).collect(toCollection(ArrayList::new));
-    }
+	/**
+	 * Get all {@code Extensions} of the specified type that are present
+	 * in this registry or one of its ancestors.
+	 *
+	 * @param extensionType the type of {@link Extension} to get
+	 * @see #getReversedExtensions(Class)
+	 * @see #stream(Class)
+	 */
+	public <E extends Extension> List<E> getExtensions(Class<E> extensionType) {
+		return stream(extensionType).collect(toCollection(ArrayList::new));
+	}
 
-    /**
-     * Get all {@code Extensions} of the specified type that are present
-     * in this registry or one of its ancestors, in reverse order.
-     *
-     * @param extensionType the type of {@link Extension} to get
-     * @see #getExtensions(Class)
-     * @see #stream(Class)
-     */
-    public <E extends Extension> List<E> getReversedExtensions(Class<E> extensionType) {
-        List<E> extensions = getExtensions(extensionType);
-        Collections.reverse(extensions);
-        return extensions;
-    }
+	/**
+	 * Get all {@code Extensions} of the specified type that are present
+	 * in this registry or one of its ancestors, in reverse order.
+	 *
+	 * @param extensionType the type of {@link Extension} to get
+	 * @see #getExtensions(Class)
+	 * @see #stream(Class)
+	 */
+	public <E extends Extension> List<E> getReversedExtensions(Class<E> extensionType) {
+		List<E> extensions = getExtensions(extensionType);
+		Collections.reverse(extensions);
+		return extensions;
+	}
 
-    /**
-     * Determine if the supplied type is already registered in this registry or in a
-     * parent registry.
-     */
-    private boolean isAlreadyRegistered(Class<? extends Extension> extensionType) {
-        return (this.registeredExtensionTypes.contains(extensionType)
-                || (this.parent != null && this.parent.isAlreadyRegistered(extensionType)));
-    }
+	/**
+	 * Determine if the supplied type is already registered in this registry or in a
+	 * parent registry.
+	 */
+	private boolean isAlreadyRegistered(Class<? extends Extension> extensionType) {
+		return (this.registeredExtensionTypes.contains(extensionType)
+				|| (this.parent != null && this.parent.isAlreadyRegistered(extensionType)));
+	}
 
-    /**
-     * Instantiate an extension of the given type and register it in this registry.
-     *
-     * <p>Uses either the default constructor, or, if available, the constructor
-     * with {@code AnnotatedElement} parameter.
-     *
-     * <p>A new {@link Extension} will not be registered if an extension of the
-     * given type already exists in this registry or a parent registry.
-     *
-     * @param extensionType    the type of extension to register
-     * @param annotatedElement the {@code AnnotatedElement} that provided the list of extension types
-     *                         with its annotations. Will be passed to the constructor of extension
-     */
-    void registerExtension(Class<? extends Extension> extensionType,
-                           AnnotatedElement annotatedElement) {
-        if (!isAlreadyRegistered(extensionType)) {
-            List<Constructor<?>> parameterizedConstructors =
-                    ReflectionUtils.findConstructors(extensionType,
-                            c -> c.getParameterCount() == 1
-                                    && c.getParameterTypes()[0] == AnnotatedElement.class);
-            if (parameterizedConstructors.size() == 0) {
-                registerExtension(ReflectionUtils.newInstance(extensionType));
-            } else {
-                registerExtension(ReflectionUtils.newInstance(
-                        (Constructor<? extends Extension>) parameterizedConstructors.get(0),
-                        annotatedElement));
-            }
-            this.registeredExtensionTypes.add(extensionType);
-        }
-    }
+	/**
+	 * Instantiate an extension of the given type and register it in this registry.
+	 *
+	 * <p>Uses either the default constructor, or, if available, the constructor
+	 * with {@code AnnotatedElement} parameter.
+	 *
+	 * <p>A new {@link Extension} will not be registered if an extension of the
+	 * given type already exists in this registry or a parent registry.
+	 *
+	 * @param extensionType    the type of extension to register
+	 * @param annotatedElement the {@code AnnotatedElement} that provided the list of extension types
+	 *                         with its annotations. Will be passed to the constructor of extension
+	 */
+	void registerExtension(Class<? extends Extension> extensionType, AnnotatedElement annotatedElement) {
+		if (!isAlreadyRegistered(extensionType)) {
+			List<Constructor<?>> parameterizedConstructors = ReflectionUtils.findConstructors(extensionType,
+				c -> c.getParameterCount() == 1 && c.getParameterTypes()[0] == AnnotatedElement.class);
+			if (parameterizedConstructors.size() == 0) {
+				registerExtension(ReflectionUtils.newInstance(extensionType));
+			}
+			else {
+				registerExtension(ReflectionUtils.newInstance(
+					(Constructor<? extends Extension>) parameterizedConstructors.get(0), annotatedElement));
+			}
+			this.registeredExtensionTypes.add(extensionType);
+		}
+	}
 
-    private void registerDefaultExtension(Extension extension) {
-        this.registeredExtensions.add(extension);
-        this.registeredExtensionTypes.add(extension.getClass());
-    }
+	private void registerDefaultExtension(Extension extension) {
+		this.registeredExtensions.add(extension);
+		this.registeredExtensionTypes.add(extension.getClass());
+	}
 
-    private void registerExtension(Extension extension) {
-        registerExtension(extension, extension);
-    }
+	private void registerExtension(Extension extension) {
+		registerExtension(extension, extension);
+	}
 
-    /**
-     * Register the supplied {@link Extension} in this registry, without checking
-     * if an extension of that type already exists in this registry.
-     *
-     * <h4>Semantics for Source</h4>
-     *
-     * <p>If an extension is registered <em>declaratively</em> via
-     * {@link org.junit.jupiter.api.extension.ExtendWith @ExtendWith}, the
-     * {@code source} and the {@code extension} should be the same object.
-     * However, if an extension is registered <em>programmatically</em> via
-     * {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension},
-     * the {@code source} object should be the {@link java.lang.reflect.Field}
-     * that is annotated with {@code @RegisterExtension}. Similarly, if an
-     * extension is registered <em>programmatically</em> as a lambda expression
-     * or method reference, the {@code source} object should be the underlying
-     * {@link java.lang.reflect.Method} that implements the extension API.
-     *
-     * @param extension the extension to register
-     * @param source    the source of the extension
-     */
-    public void registerExtension(Extension extension, Object source) {
-        logger.trace(() -> String.format("Registering extension [%s] from source [%s].", extension, source));
-        this.registeredExtensions.add(extension);
-    }
+	/**
+	 * Register the supplied {@link Extension} in this registry, without checking
+	 * if an extension of that type already exists in this registry.
+	 *
+	 * <h4>Semantics for Source</h4>
+	 *
+	 * <p>If an extension is registered <em>declaratively</em> via
+	 * {@link org.junit.jupiter.api.extension.ExtendWith @ExtendWith}, the
+	 * {@code source} and the {@code extension} should be the same object.
+	 * However, if an extension is registered <em>programmatically</em> via
+	 * {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension},
+	 * the {@code source} object should be the {@link java.lang.reflect.Field}
+	 * that is annotated with {@code @RegisterExtension}. Similarly, if an
+	 * extension is registered <em>programmatically</em> as a lambda expression
+	 * or method reference, the {@code source} object should be the underlying
+	 * {@link java.lang.reflect.Method} that implements the extension API.
+	 *
+	 * @param extension the extension to register
+	 * @param source    the source of the extension
+	 */
+	public void registerExtension(Extension extension, Object source) {
+		logger.trace(() -> String.format("Registering extension [%s] from source [%s].", extension, source));
+		this.registeredExtensions.add(extension);
+	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
@@ -216,6 +216,7 @@ public class ExtensionRegistry {
 	 * @param annotatedElement the {@code AnnotatedElement} that provided the list of extension types
 	 *                         with its annotations. Will be passed to the constructor of extension
 	 */
+	@SuppressWarnings("unchecked")
 	void registerExtension(Class<? extends Extension> extensionType, AnnotatedElement annotatedElement) {
 		if (!isAlreadyRegistered(extensionType)) {
 			List<Constructor<?>> parameterizedConstructors = ReflectionUtils.findConstructors(extensionType,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
@@ -10,11 +10,17 @@
 
 package org.junit.jupiter.engine.extension;
 
-import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Stream.concat;
-import static org.apiguardian.api.API.Status.INTERNAL;
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.util.ClassLoaderUtils;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,14 +31,10 @@ import java.util.Set;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.apiguardian.api.API;
-import org.junit.jupiter.api.extension.Extension;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.ClassLoaderUtils;
-import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.commons.util.ReflectionUtils;
-import org.junit.platform.engine.ConfigurationParameters;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 /**
  * An {@code ExtensionRegistry} holds all registered extensions (i.e.
@@ -48,205 +50,223 @@ import org.junit.platform.engine.ConfigurationParameters;
 @API(status = INTERNAL, since = "5.0")
 public class ExtensionRegistry {
 
-	public static final String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = "junit.jupiter.extensions.autodetection.enabled";
+    public static final String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = "junit.jupiter.extensions.autodetection.enabled";
 
-	private static final Logger logger = LoggerFactory.getLogger(ExtensionRegistry.class);
+    private static final Logger logger = LoggerFactory.getLogger(ExtensionRegistry.class);
 
-	private static final List<Extension> DEFAULT_EXTENSIONS = Collections.unmodifiableList(Arrays.asList(//
-		new DisabledCondition(), //
-		new ScriptExecutionCondition(), //
-		new RepeatedTestExtension(), //
-		new TestInfoParameterResolver(), //
-		new TestReporterParameterResolver()));
+    private static final List<Extension> DEFAULT_EXTENSIONS = Collections.unmodifiableList(Arrays.asList(//
+            new DisabledCondition(), //
+            new ScriptExecutionCondition(), //
+            new RepeatedTestExtension(), //
+            new TestInfoParameterResolver(), //
+            new TestReporterParameterResolver()));
 
-	/**
-	 * Factory for creating and populating a new root registry with the default
-	 * extensions.
-	 *
-	 * <p>If the {@link org.junit.jupiter.engine.Constants#EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME}
-	 * configuration parameter has been set to {@code true}, extensions will be
-	 * auto-detected using Java's {@link ServiceLoader} mechanism and automatically
-	 * registered after the default extensions.
-	 *
-	 * @param configParams configuration parameters used to retrieve the extension
-	 * auto-detection flag; never {@code null}
-	 * @return a new {@code ExtensionRegistry}; never {@code null}
-	 */
-	public static ExtensionRegistry createRegistryWithDefaultExtensions(ConfigurationParameters configParams) {
-		ExtensionRegistry extensionRegistry = new ExtensionRegistry(null);
+    /**
+     * Factory for creating and populating a new root registry with the default
+     * extensions.
+     *
+     * <p>If the {@link org.junit.jupiter.engine.Constants#EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME}
+     * configuration parameter has been set to {@code true}, extensions will be
+     * auto-detected using Java's {@link ServiceLoader} mechanism and automatically
+     * registered after the default extensions.
+     *
+     * @param configParams configuration parameters used to retrieve the extension
+     *                     auto-detection flag; never {@code null}
+     * @return a new {@code ExtensionRegistry}; never {@code null}
+     */
+    public static ExtensionRegistry createRegistryWithDefaultExtensions(ConfigurationParameters configParams) {
+        ExtensionRegistry extensionRegistry = new ExtensionRegistry(null);
 
-		// @formatter:off
-		logger.trace(() -> "Registering default extensions: " + DEFAULT_EXTENSIONS.stream()
-						.map(extension -> extension.getClass().getName())
-						.collect(toList()));
-		// @formatter:on
+        // @formatter:off
+        logger.trace(() -> "Registering default extensions: " + DEFAULT_EXTENSIONS.stream()
+                .map(extension -> extension.getClass().getName())
+                .collect(toList()));
+        // @formatter:on
 
-		DEFAULT_EXTENSIONS.forEach(extensionRegistry::registerDefaultExtension);
+        DEFAULT_EXTENSIONS.forEach(extensionRegistry::registerDefaultExtension);
 
-		if (configParams.getBoolean(EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME).orElse(Boolean.FALSE)) {
-			registerAutoDetectedExtensions(extensionRegistry);
-		}
+        if (configParams.getBoolean(EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME).orElse(Boolean.FALSE)) {
+            registerAutoDetectedExtensions(extensionRegistry);
+        }
 
-		return extensionRegistry;
-	}
+        return extensionRegistry;
+    }
 
-	private static void registerAutoDetectedExtensions(ExtensionRegistry extensionRegistry) {
-		Iterable<Extension> extensions = ServiceLoader.load(Extension.class, ClassLoaderUtils.getDefaultClassLoader());
+    private static void registerAutoDetectedExtensions(ExtensionRegistry extensionRegistry) {
+        Iterable<Extension> extensions = ServiceLoader.load(Extension.class, ClassLoaderUtils.getDefaultClassLoader());
 
-		// @formatter:off
-		logger.config(() -> "Registering auto-detected extensions: "
-				+ StreamSupport.stream(extensions.spliterator(), false)
-						.map(extension -> extension.getClass().getName())
-						.collect(toList()));
-		// @formatter:on
+        // @formatter:off
+        logger.config(() -> "Registering auto-detected extensions: "
+                + StreamSupport.stream(extensions.spliterator(), false)
+                .map(extension -> extension.getClass().getName())
+                .collect(toList()));
+        // @formatter:on
 
-		extensions.forEach(extensionRegistry::registerDefaultExtension);
-	}
+        extensions.forEach(extensionRegistry::registerDefaultExtension);
+    }
 
-	/**
-	 * Factory for creating and populating a new registry from a list of
-	 * extension types and a parent registry.
-	 *
-	 * @param parentRegistry the parent registry
-	 * @param extensionTypes the types of extensions to be registered in
-	 * the new registry
-	 * @return a new {@code ExtensionRegistry}; never {@code null}
-	 */
-	public static ExtensionRegistry createRegistryFrom(ExtensionRegistry parentRegistry,
-			List<Class<? extends Extension>> extensionTypes) {
+    /**
+     * Factory for creating and populating a new registry from a list of
+     * extension types and a parent registry.
+     *
+     * @param parentRegistry   the parent registry
+     * @param annotatedElement the {@code AnnotatedElement} that provided the list of extension types
+     *                         with its annotations
+     * @param extensionTypes   the types of extensions to be registered in
+     *                         the new registry
+     * @return a new {@code ExtensionRegistry}; never {@code null}
+     */
+    public static ExtensionRegistry createRegistryFrom(ExtensionRegistry parentRegistry,
+                                                       AnnotatedElement annotatedElement,
+                                                       List<Class<? extends Extension>> extensionTypes) {
 
-		Preconditions.notNull(parentRegistry, "parentRegistry must not be null");
+        Preconditions.notNull(parentRegistry, "parentRegistry must not be null");
 
-		ExtensionRegistry registry = new ExtensionRegistry(parentRegistry);
-		extensionTypes.forEach(registry::registerExtension);
-		return registry;
-	}
+        ExtensionRegistry registry = new ExtensionRegistry(parentRegistry);
+        extensionTypes.forEach(t -> registry.registerExtension(t, annotatedElement));
+        return registry;
+    }
 
-	private final ExtensionRegistry parent;
+    private final ExtensionRegistry parent;
 
-	private final Set<Class<? extends Extension>> registeredExtensionTypes = new LinkedHashSet<>();
+    private final Set<Class<? extends Extension>> registeredExtensionTypes = new LinkedHashSet<>();
 
-	private final List<Extension> registeredExtensions = new ArrayList<>();
+    private final List<Extension> registeredExtensions = new ArrayList<>();
 
-	private ExtensionRegistry(ExtensionRegistry parent) {
-		this.parent = parent;
-	}
+    private ExtensionRegistry(ExtensionRegistry parent) {
+        this.parent = parent;
+    }
 
-	/**
-	 * Stream all {@code Extensions} of the specified type that are present
-	 * in this registry or one of its ancestors.
-	 *
-	 * @param extensionType the type of {@link Extension} to stream
-	 * @see #getReversedExtensions(Class)
-	 * @see #getExtensions(Class)
-	 */
-	public <E extends Extension> Stream<E> stream(Class<E> extensionType) {
-		if (this.parent == null) {
-			return streamLocal(extensionType);
-		}
-		return concat(this.parent.stream(extensionType), streamLocal(extensionType));
-	}
+    /**
+     * Stream all {@code Extensions} of the specified type that are present
+     * in this registry or one of its ancestors.
+     *
+     * @param extensionType the type of {@link Extension} to stream
+     * @see #getReversedExtensions(Class)
+     * @see #getExtensions(Class)
+     */
+    public <E extends Extension> Stream<E> stream(Class<E> extensionType) {
+        if (this.parent == null) {
+            return streamLocal(extensionType);
+        }
+        return concat(this.parent.stream(extensionType), streamLocal(extensionType));
+    }
 
-	/**
-	 * Stream all {@code Extensions} of the specified type that are present
-	 * in this registry.
-	 *
-	 * <p>Extensions in ancestors are ignored.
-	 *
-	 * @param extensionType the type of {@link Extension} to stream
-	 * @see #getReversedExtensions(Class)
-	 */
-	private <E extends Extension> Stream<E> streamLocal(Class<E> extensionType) {
-		// @formatter:off
-		return this.registeredExtensions.stream()
-				.filter(extensionType::isInstance)
-				.map(extensionType::cast);
-		// @formatter:on
-	}
+    /**
+     * Stream all {@code Extensions} of the specified type that are present
+     * in this registry.
+     *
+     * <p>Extensions in ancestors are ignored.
+     *
+     * @param extensionType the type of {@link Extension} to stream
+     * @see #getReversedExtensions(Class)
+     */
+    private <E extends Extension> Stream<E> streamLocal(Class<E> extensionType) {
+        // @formatter:off
+        return this.registeredExtensions.stream()
+                .filter(extensionType::isInstance)
+                .map(extensionType::cast);
+        // @formatter:on
+    }
 
-	/**
-	 * Get all {@code Extensions} of the specified type that are present
-	 * in this registry or one of its ancestors.
-	 *
-	 * @param extensionType the type of {@link Extension} to get
-	 * @see #getReversedExtensions(Class)
-	 * @see #stream(Class)
-	 */
-	public <E extends Extension> List<E> getExtensions(Class<E> extensionType) {
-		return stream(extensionType).collect(toCollection(ArrayList::new));
-	}
+    /**
+     * Get all {@code Extensions} of the specified type that are present
+     * in this registry or one of its ancestors.
+     *
+     * @param extensionType the type of {@link Extension} to get
+     * @see #getReversedExtensions(Class)
+     * @see #stream(Class)
+     */
+    public <E extends Extension> List<E> getExtensions(Class<E> extensionType) {
+        return stream(extensionType).collect(toCollection(ArrayList::new));
+    }
 
-	/**
-	 * Get all {@code Extensions} of the specified type that are present
-	 * in this registry or one of its ancestors, in reverse order.
-	 *
-	 * @param extensionType the type of {@link Extension} to get
-	 * @see #getExtensions(Class)
-	 * @see #stream(Class)
-	 */
-	public <E extends Extension> List<E> getReversedExtensions(Class<E> extensionType) {
-		List<E> extensions = getExtensions(extensionType);
-		Collections.reverse(extensions);
-		return extensions;
-	}
+    /**
+     * Get all {@code Extensions} of the specified type that are present
+     * in this registry or one of its ancestors, in reverse order.
+     *
+     * @param extensionType the type of {@link Extension} to get
+     * @see #getExtensions(Class)
+     * @see #stream(Class)
+     */
+    public <E extends Extension> List<E> getReversedExtensions(Class<E> extensionType) {
+        List<E> extensions = getExtensions(extensionType);
+        Collections.reverse(extensions);
+        return extensions;
+    }
 
-	/**
-	 * Determine if the supplied type is already registered in this registry or in a
-	 * parent registry.
-	 */
-	private boolean isAlreadyRegistered(Class<? extends Extension> extensionType) {
-		return (this.registeredExtensionTypes.contains(extensionType)
-				|| (this.parent != null && this.parent.isAlreadyRegistered(extensionType)));
-	}
+    /**
+     * Determine if the supplied type is already registered in this registry or in a
+     * parent registry.
+     */
+    private boolean isAlreadyRegistered(Class<? extends Extension> extensionType) {
+        return (this.registeredExtensionTypes.contains(extensionType)
+                || (this.parent != null && this.parent.isAlreadyRegistered(extensionType)));
+    }
 
-	/**
-	 * Instantiate an extension of the given type using its default constructor
-	 * and register it in this registry.
-	 *
-	 * <p>A new {@link Extension} will not be registered if an extension of the
-	 * given type already exists in this registry or a parent registry.
-	 *
-	 * @param extensionType the type of extension to register
-	 */
-	void registerExtension(Class<? extends Extension> extensionType) {
-		if (!isAlreadyRegistered(extensionType)) {
-			registerExtension(ReflectionUtils.newInstance(extensionType));
-			this.registeredExtensionTypes.add(extensionType);
-		}
-	}
+    /**
+     * Instantiate an extension of the given type and register it in this registry.
+     *
+     * <p>Uses either the default constructor, or, if available, the constructor
+     * with {@code AnnotatedElement} parameter.
+     *
+     * <p>A new {@link Extension} will not be registered if an extension of the
+     * given type already exists in this registry or a parent registry.
+     *
+     * @param extensionType    the type of extension to register
+     * @param annotatedElement the {@code AnnotatedElement} that provided the list of extension types
+     *                         with its annotations. Will be passed to the constructor of extension
+     */
+    void registerExtension(Class<? extends Extension> extensionType,
+                           AnnotatedElement annotatedElement) {
+        if (!isAlreadyRegistered(extensionType)) {
+            List<Constructor<?>> parameterizedConstructors =
+                    ReflectionUtils.findConstructors(extensionType,
+                            c -> c.getParameterCount() == 1
+                                    && c.getParameterTypes()[0] == AnnotatedElement.class);
+            if (parameterizedConstructors.size() == 0) {
+                registerExtension(ReflectionUtils.newInstance(extensionType));
+            } else {
+                registerExtension(ReflectionUtils.newInstance(
+                        (Constructor<? extends Extension>) parameterizedConstructors.get(0),
+                        annotatedElement));
+            }
+            this.registeredExtensionTypes.add(extensionType);
+        }
+    }
 
-	private void registerDefaultExtension(Extension extension) {
-		this.registeredExtensions.add(extension);
-		this.registeredExtensionTypes.add(extension.getClass());
-	}
+    private void registerDefaultExtension(Extension extension) {
+        this.registeredExtensions.add(extension);
+        this.registeredExtensionTypes.add(extension.getClass());
+    }
 
-	private void registerExtension(Extension extension) {
-		registerExtension(extension, extension);
-	}
+    private void registerExtension(Extension extension) {
+        registerExtension(extension, extension);
+    }
 
-	/**
-	 * Register the supplied {@link Extension} in this registry, without checking
-	 * if an extension of that type already exists in this registry.
-	 *
-	 * <h4>Semantics for Source</h4>
-	 *
-	 * <p>If an extension is registered <em>declaratively</em> via
-	 * {@link org.junit.jupiter.api.extension.ExtendWith @ExtendWith}, the
-	 * {@code source} and the {@code extension} should be the same object.
-	 * However, if an extension is registered <em>programmatically</em> via
-	 * {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension},
-	 * the {@code source} object should be the {@link java.lang.reflect.Field}
-	 * that is annotated with {@code @RegisterExtension}. Similarly, if an
-	 * extension is registered <em>programmatically</em> as a lambda expression
-	 * or method reference, the {@code source} object should be the underlying
-	 * {@link java.lang.reflect.Method} that implements the extension API.
-	 *
-	 * @param extension the extension to register
-	 * @param source the source of the extension
-	 */
-	public void registerExtension(Extension extension, Object source) {
-		logger.trace(() -> String.format("Registering extension [%s] from source [%s].", extension, source));
-		this.registeredExtensions.add(extension);
-	}
+    /**
+     * Register the supplied {@link Extension} in this registry, without checking
+     * if an extension of that type already exists in this registry.
+     *
+     * <h4>Semantics for Source</h4>
+     *
+     * <p>If an extension is registered <em>declaratively</em> via
+     * {@link org.junit.jupiter.api.extension.ExtendWith @ExtendWith}, the
+     * {@code source} and the {@code extension} should be the same object.
+     * However, if an extension is registered <em>programmatically</em> via
+     * {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension},
+     * the {@code source} object should be the {@link java.lang.reflect.Field}
+     * that is annotated with {@code @RegisterExtension}. Similarly, if an
+     * extension is registered <em>programmatically</em> as a lambda expression
+     * or method reference, the {@code source} object should be the underlying
+     * {@link java.lang.reflect.Method} that implements the extension API.
+     *
+     * @param extension the extension to register
+     * @param source    the source of the extension
+     */
+    public void registerExtension(Extension extension, Object source) {
+        logger.trace(() -> String.format("Registering extension [%s] from source [%s].", extension, source));
+        this.registeredExtensions.add(extension);
+    }
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistryTests.java
@@ -92,14 +92,14 @@ class ExtensionRegistryTests {
 	}
 
 	@Test
-	void registerExtensionByImplementingClassWithConstructorParameter(){
+	void registerExtensionByImplementingClassWithConstructorParameter() {
 		registry.registerExtension(ExtensionWithConstructor.class, MyAnnotatedClass.class);
 		assertSame(MyAnnotatedClass.class,
-				registry.getExtensions(ExtensionWithConstructor.class).get(0).annotatedElement);
+			registry.getExtensions(ExtensionWithConstructor.class).get(0).annotatedElement);
 	}
 
 	@Test
-	void registerExtensionByImplementingClassWithNullConstructorParameter(){
+	void registerExtensionByImplementingClassWithNullConstructorParameter() {
 		registry.registerExtension(ExtensionWithConstructor.class, null);
 		assertNull(registry.getExtensions(ExtensionWithConstructor.class).get(0).annotatedElement);
 	}
@@ -223,7 +223,7 @@ class ExtensionRegistryTests {
 
 		private final AnnotatedElement annotatedElement;
 
-		ExtensionWithConstructor(AnnotatedElement annotatedElement){
+		ExtensionWithConstructor(AnnotatedElement annotatedElement) {
 			this.annotatedElement = annotatedElement;
 		}
 
@@ -232,5 +232,6 @@ class ExtensionRegistryTests {
 		}
 	}
 
-	static class MyAnnotatedClass{}
+	static class MyAnnotatedClass {
+	}
 }


### PR DESCRIPTION
## Overview

Configuring extensions programmatically in `@RegisterExtension`-annotated static fields is fine. But sometimes we need static configuration for declaratively registered extensions, i. e. we want to initialize private final fields in `@ExtendWith`-defined extension classes.

The problem is that declaratively registered extensions are instantiated using default constructors. The proposed change adds support for constructors that accept `AnnotatedElement` as the only parameter. In this case we can extract all the information needed from other annotations on the element.

E. g. we could declare something like (see documentation/src/test/java/example/registration/ParameterizedExtensionDemo.java):

```java
@Retention(RetentionPolicy.RUNTIME)
@ExtendWith(ParameterizedExtension.class)
public @interface WithParameterizedExtension {
    String value();
}

public class ParameterizedExtension implements ParameterResolver {
    private final String parameter;
    public ParameterizedExtension(AnnotatedElement annotatedElement) {
        parameter = annotatedElement.getAnnotation(WithParameterizedExtension.class).value();
    }
....
```
And use this extension in the following manner:

```java
@WithParameterizedExtension("foo")
public class ParameterizedExtensionDemo {

    @Test
    void parameterIsPassedToExtension(String param) {
        assertEquals("foo", param);
    }
}
```


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
