### PR TITLE
Introduce 'junit-jupiter' aggregator module

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ See also <http://repo1.maven.org/maven2/org/junit/> for releases and <https://os
 - **Group ID**: `org.junit.jupiter`
 - **Version**: `5.3.2` or `5.4.0-SNAPSHOT`
 - **Artifact IDs** and **Automatic-Module-Name**:
+  - `junit-jupiter` (`org.junit.jupiter`)
   - `junit-jupiter-api` (`org.junit.jupiter.api`)
   - `junit-jupiter-engine` (`org.junit.jupiter.engine`)
   - `junit-jupiter-migrationsupport` (`org.junit.jupiter.migrationsupport`)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ val platformProjects by extra(listOf(
 ))
 
 val jupiterProjects by extra(listOf(
+		project(":junit-jupiter"),
 		project(":junit-jupiter-api"),
 		project(":junit-jupiter-engine"),
 		project(":junit-jupiter-migrationsupport"),

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-M1.adoc
@@ -71,6 +71,10 @@ repository on GitHub.
 
 ==== New Features and Improvements
 
+* New `org.junit.jupiter:junit-jupiter` module that aggregates all required dependencies
+  to ease getting started with JUnit Jupiter. It contains the compile/api dependencies to
+  `junit-jupiter-api` and `junit-jupiter-params` and also the runtime dependency to
+  `junit-jupiter-engine`.
 * `Assertions.assertEquals()` variants that compare floating point numbers using a delta
   now support a _delta_ of zero.
 * New `Assertions.assertEquals()` variants that accept mixed boxed and unboxed primitive

--- a/documentation/src/docs/asciidoc/user-guide/appendix.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/appendix.adoc
@@ -47,6 +47,10 @@ snapshot artifacts are deployed to Sonatype's {snapshot-repo}[snapshots reposito
 * *Group ID*: `org.junit.jupiter`
 * *Version*: `{jupiter-version}`
 * *Artifact IDs*:
+  `junit-jupiter`::
+    JUnit Jupiter aggregator module that only provides dependencies to `junit-jupiter-api`,
+    `junit-jupiter-params` and `junit-jupiter-engine` for convenient inclusion in dependency
+    management configurations.
   `junit-jupiter-api`::
     JUnit Jupiter API for <<writing-tests,writing tests>> and <<extensions,extensions>>.
   `junit-jupiter-engine`::
@@ -106,6 +110,7 @@ skinparam {
 }
 
 package org.junit.jupiter {
+    [junit-jupiter] as jupiter
     [junit-jupiter-api] as jupiter_api
     [junit-jupiter-engine] as jupiter_engine
     [junit-jupiter-params] as jupiter_params
@@ -143,6 +148,10 @@ package org.apiguardian {
         readability.
     endnote
 }
+
+jupiter ..> jupiter_api
+jupiter ..> jupiter_params
+jupiter ..> jupiter_engine
 
 jupiter_api ..> opentest4j
 jupiter_api ..> commons

--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -1,13 +1,9 @@
-import org.gradle.plugins.ide.eclipse.model.Classpath
-import org.gradle.plugins.ide.eclipse.model.ProjectDependency
-
 description = "JUnit Jupiter API"
 
 dependencies {
 	api("org.opentest4j:opentest4j:${Versions.ota4j}")
 	api(project(":junit-platform-commons"))
 	compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
-	runtimeOnly(project(":junit-jupiter-engine"))
 }
 
 tasks.jar {
@@ -17,12 +13,3 @@ tasks.jar {
 		)
 	}
 }
-
-// Remove runtimeOnly dependency on junit-jupiter-engine and junit-platform-engine.
-// See https://github.com/junit-team/junit5/issues/1669
-eclipse.classpath.file.whenMerged(Action<Classpath> {
-	entries.removeAll {
-		it is ProjectDependency &&
-				(it.path.contains("junit-jupiter-engine") || it.path.contains("junit-platform-engine"))
-	}
-})

--- a/junit-jupiter/junit-jupiter.gradle.kts
+++ b/junit-jupiter/junit-jupiter.gradle.kts
@@ -1,0 +1,15 @@
+description = "JUnit Jupiter (Aggregator)"
+
+dependencies {
+	api(project(":junit-jupiter-api"))
+	api(project(":junit-jupiter-params"))
+	runtimeOnly(project(":junit-jupiter-engine"))
+}
+
+tasks.jar {
+	manifest {
+		attributes(
+				"Automatic-Module-Name" to "org.junit.jupiter"
+		)
+	}
+}

--- a/platform-tooling-support-tests/projects/gradle-starter/build.gradle
+++ b/platform-tooling-support-tests/projects/gradle-starter/build.gradle
@@ -25,9 +25,7 @@ repositories {
 }
 
 dependencies {
-	testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
-	testImplementation("org.junit.jupiter:junit-jupiter-params:${jupiterVersion}")
-	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
+	testImplementation("org.junit.jupiter:junit-jupiter:${jupiterVersion}")
 }
 
 test {

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter.expected.txt
@@ -1,0 +1,4 @@
+>> 1 line header: No module descriptor found. Derived automatic module. >>
+
+org.junit.jupiter@${jupiterVersion} automatic
+requires java.base mandated

--- a/platform-tooling-support-tests/projects/maven-starter/pom.xml
+++ b/platform-tooling-support-tests/projects/maven-starter/pom.xml
@@ -9,27 +9,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>10</java.version>
+        <maven.compiler.release>11</maven.compiler.release>
         <junit.jupiter.version>${env.JUNIT_JUPITER_VERSION}</junit.jupiter.version>
-        <junit.platform.version>${env.JUNIT_PLATFORM_VERSION}</junit.platform.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
@@ -39,11 +26,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
+                <version>3.8.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -51,15 +34,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>sonatype-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
 </project>

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/HelperTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/HelperTests.java
@@ -30,6 +30,7 @@ class HelperTests {
 	@Test
 	void loadModuleDirectoryNames() {
 		assertLinesMatch(List.of( //
+			"junit-jupiter", //
 			"junit-jupiter-api", //
 			"junit-jupiter-engine", //
 			"junit-jupiter-migrationsupport", //

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ require(javaVersion.isJava11Compatible) {
 rootProject.name = "junit5"
 
 include("documentation")
+include("junit-jupiter")
 include("junit-jupiter-api")
 include("junit-jupiter-engine")
 include("junit-jupiter-migrationsupport")


### PR DESCRIPTION
## Overview

Introduce `junit-jupiter` aggregator module with the following Maven coordinates:

```
<groupId>org.junit.jupiter</groupId>
<artifactId>junit-jupiter</artifactId>
<version>5.4.0-SNAPSHOT</version>
```

The generated `jar` is almost empty, it only contains a `MANIFEST.MF` file and a `pom.xml` with the following dependencies:

```xml
  <dependencies>
    <dependency>
      <groupId>org.junit.jupiter</groupId>
      <artifactId>junit-jupiter-api</artifactId>
      <version>5.4.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.junit.jupiter</groupId>
      <artifactId>junit-jupiter-params</artifactId>
      <version>5.4.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.apiguardian</groupId>
      <artifactId>apiguardian-api</artifactId>
      <version>1.0.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.junit.jupiter</groupId>
      <artifactId>junit-jupiter-engine</artifactId>
      <version>5.4.0-SNAPSHOT</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
```

Closes #1629 
Reverts and closes #1669 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

