### PR TITLE
README Junit5 repo link as HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ consumption in other projects via the following command.
 The following sections list the dependency metadata for the JUnit Platform, JUnit
 Jupiter, and JUnit Vintage.
 
-See also <http://repo1.maven.org/maven2/org/junit/> for releases and <https://oss.sonatype.org/content/repositories/snapshots/org/junit/> for snapshots.
+See also <https://repo1.maven.org/maven2/org/junit/> for releases and <https://oss.sonatype.org/content/repositories/snapshots/org/junit/> for snapshots.
 
 ### JUnit Platform
 


### PR DESCRIPTION
Using an HTTP connection to an artifact server can leave you vulnerable to MITM attack. Linked below is a POC created back in the days when Maven Central didn't support HTTPS that dynamically re-writes jar files as they are downloaded by maven.
https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/

The README isn't currently really advising people to use this url directly, but still, best to be safe.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
