### PR TITLE
[ConsoleLauncher] Extend stack trace output

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-RC1.adoc
@@ -37,7 +37,8 @@ repository on GitHub.
 * The `Launcher` API now provides an `execute(TestPlan, TestExecutionListener...)`
   method that allows one to execute a previously discovered `TestPlan`.
 * `@RunWith(JUnitPlatform.class)` no longer executes test discovery twice.
-
+* Add root cause and suppressed exceptions in the stack trace printed by
+  the `ConsoleLauncher`.
 
 [[release-notes-5.4.0-RC1-junit-jupiter]]
 === JUnit Jupiter

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
@@ -13,6 +13,7 @@ package org.junit.platform.launcher.listeners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.PrintWriter;
@@ -187,7 +188,39 @@ class SummaryGenerationTests {
 		);
 	}
 
-	@SuppressWarnings("deprecation")
+	@Test
+	public void reportingCircularFailure() {
+		IllegalArgumentException iaeCausedBy = new IllegalArgumentException("Illegal Argument Exception");
+		RuntimeException failedException = new RuntimeException("Runtime Exception", iaeCausedBy);
+		NullPointerException npeSuppressed = new NullPointerException("Null Pointer Exception");
+		failedException.addSuppressed(npeSuppressed);
+		npeSuppressed.addSuppressed(iaeCausedBy);
+
+		TestDescriptorStub testDescriptor = new TestDescriptorStub(UniqueId.root("root", "2"), "failingTest") {
+
+			@Override
+			public Optional<TestSource> getSource() {
+				return Optional.of(ClassSource.from(Object.class));
+			}
+		};
+		TestIdentifier failed = TestIdentifier.from(testDescriptor);
+
+		listener.testPlanExecutionStarted(testPlan);
+		listener.executionStarted(failed);
+		listener.executionFinished(failed, TestExecutionResult.failed(failedException));
+		listener.testPlanExecutionFinished(testPlan);
+
+		assertEquals(1, listener.getSummary().getTestsFailedCount());
+
+		String failuresString = failuresAsString();
+		assertAll("failures", //
+			() -> assertTrue(failuresString.contains("Suppressed: " + npeSuppressed), "Suppressed exception"), //
+			() -> assertTrue(failuresString.contains("Circular reference: " + iaeCausedBy), "Circular reference"), //
+			() -> assertFalse(failuresString.contains("Caused by: "),
+				"'Caused by: ' omitted because of Circular reference") //
+		);
+	}
+
 	private TestIdentifier createTestIdentifier(String uniqueId) {
 		TestIdentifier identifier = TestIdentifier.from(
 			new TestDescriptorStub(UniqueId.root("test", uniqueId), uniqueId));

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
@@ -151,7 +151,10 @@ class SummaryGenerationTests {
 
 	@Test
 	void reportingCorrectFailures() {
-		RuntimeException failedException = new RuntimeException("failed");
+		IllegalArgumentException iaeCausedBy = new IllegalArgumentException("Illegal Argument Exception");
+		RuntimeException failedException = new RuntimeException("Runtime Exception", iaeCausedBy);
+		NullPointerException npeSuppressed = new NullPointerException("Null Pointer Exception");
+		failedException.addSuppressed(npeSuppressed);
 
 		TestDescriptorStub testDescriptor = new TestDescriptorStub(UniqueId.root("root", "2"), "failingTest") {
 
@@ -178,7 +181,9 @@ class SummaryGenerationTests {
 			() -> assertTrue(failuresString.contains("Failures (1)"), "test failures"), //
 			() -> assertTrue(failuresString.contains(Object.class.getName()), "source"), //
 			() -> assertTrue(failuresString.contains("failingTest"), "display name"), //
-			() -> assertTrue(failuresString.contains("=> " + failedException), "exception") //
+			() -> assertTrue(failuresString.contains("=> " + failedException), "main exception"), //
+			() -> assertTrue(failuresString.contains("Caused by: " + iaeCausedBy), "Caused by exception"), //
+			() -> assertTrue(failuresString.contains("Suppressed: " + npeSuppressed), "Suppressed exception") //
 		);
 	}
 


### PR DESCRIPTION
Include root cause and suppressed exceptions in the stack trace printed
by the Console Launcher

Resolves #1693.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
