### PR TITLE
Improve message of Assertions.assertDoesNotThrow

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
@@ -49,9 +49,7 @@ class AssertDoesNotThrow {
 			executable.execute();
 		}
 		catch (Throwable t) {
-			String message = buildPrefix(nullSafeGet(messageOrSupplier)) + "Unexpected exception thrown: "
-					+ t.getClass().getName() + addThrowableMessage(t);
-			throw new AssertionFailedError(message, t);
+			throw createAssertionFailedError(messageOrSupplier, t);
 		}
 	}
 
@@ -72,10 +70,14 @@ class AssertDoesNotThrow {
 			return supplier.get();
 		}
 		catch (Throwable t) {
-			String message = buildPrefix(nullSafeGet(messageOrSupplier)) + "Unexpected exception thrown: "
-					+ t.getClass().getName() + addThrowableMessage(t);
-			throw new AssertionFailedError(message, t);
+			throw createAssertionFailedError(messageOrSupplier, t);
 		}
+	}
+
+	private static AssertionFailedError createAssertionFailedError(Object messageOrSupplier, Throwable t) {
+		String message = buildPrefix(nullSafeGet(messageOrSupplier)) + "Unexpected exception thrown: "
+				+ t.getClass().getName() + addThrowableMessage(t);
+		return new AssertionFailedError(message, t);
 	}
 
 	private static String addThrowableMessage(Throwable t) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.junit.platform.commons.util.StringUtils;
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -49,7 +50,7 @@ class AssertDoesNotThrow {
 		}
 		catch (Throwable t) {
 			String message = buildPrefix(nullSafeGet(messageOrSupplier)) + "Unexpected exception thrown: "
-					+ t.getClass().getName();
+					+ t.getClass().getName() + addThrowableMessage(t);
 			throw new AssertionFailedError(message, t);
 		}
 	}
@@ -72,9 +73,13 @@ class AssertDoesNotThrow {
 		}
 		catch (Throwable t) {
 			String message = buildPrefix(nullSafeGet(messageOrSupplier)) + "Unexpected exception thrown: "
-					+ t.getClass().getName();
+					+ t.getClass().getName() + addThrowableMessage(t);
 			throw new AssertionFailedError(message, t);
 		}
+	}
+
+	private static String addThrowableMessage(Throwable t) {
+		return StringUtils.isBlank(t.getMessage()) ? "" : ": " + t.getMessage();
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertDoesNotThrowAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertDoesNotThrowAssertionsTests.java
@@ -108,6 +108,20 @@ class AssertDoesNotThrowAssertionsTests {
 	}
 
 	@Test
+	void assertDoesNotThrowWithExecutableThatThrowsACheckedExceptionWithMessage() {
+		String message = "Checked exception message";
+		try {
+			assertDoesNotThrow((Executable) () -> {
+				throw new IOException(message);
+			});
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "Unexpected exception thrown: " + IOException.class.getName() + ": " + message);
+		}
+	}
+
+	@Test
 	void assertDoesNotThrowWithExecutableThatThrowsARuntimeException() {
 		try {
 			assertDoesNotThrow((Executable) () -> {
@@ -117,6 +131,21 @@ class AssertDoesNotThrowAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "Unexpected exception thrown: " + IllegalStateException.class.getName());
+		}
+	}
+
+	@Test
+	void assertDoesNotThrowWithExecutableThatThrowsARuntimeExceptionWithMessage() {
+		String message = "Runtime exception message";
+		try {
+			assertDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException(message);
+			});
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex,
+				"Unexpected exception thrown: " + IllegalStateException.class.getName() + ": " + message);
 		}
 	}
 
@@ -146,6 +175,21 @@ class AssertDoesNotThrowAssertionsTests {
 	}
 
 	@Test
+	void assertDoesNotThrowWithExecutableThatThrowsAnExceptionWithMessageWithMessageString() {
+		String message = "Runtime exception message";
+		try {
+			assertDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException(message);
+			}, "Custom message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "Custom message ==> Unexpected exception thrown: "
+					+ IllegalStateException.class.getName() + ": " + message);
+		}
+	}
+
+	@Test
 	void assertDoesNotThrowWithExecutableThatThrowsAnExceptionWithMessageSupplier() {
 		try {
 			assertDoesNotThrow((Executable) () -> {
@@ -156,6 +200,21 @@ class AssertDoesNotThrowAssertionsTests {
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex,
 				"Custom message ==> Unexpected exception thrown: " + IllegalStateException.class.getName());
+		}
+	}
+
+	@Test
+	void assertDoesNotThrowWithExecutableThatThrowsAnExceptionWithMessageWithMessageSupplier() {
+		String message = "Runtime exception message";
+		try {
+			assertDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException(message);
+			}, () -> "Custom message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "Custom message ==> Unexpected exception thrown: "
+					+ IllegalStateException.class.getName() + ": " + message);
 		}
 	}
 


### PR DESCRIPTION
If an unexpected error is thrown, the throwable message is added to the resulting `AssertionFailedError`.

Issue: #1703

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
