### PR TITLE
Add around() to Node to allow intercepting the whole execution

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -121,6 +121,20 @@ public interface Node<C extends EngineExecutionContext> {
 	}
 
 	/**
+	 * Wraps around the invocation of {@link #before(EngineExecutionContext)},
+	 * {@link #execute(EngineExecutionContext, DynamicTestExecutor)}, and
+	 * {@link #after(EngineExecutionContext)}.
+	 *
+	 * @param context context the context to execute in
+	 * @param invocation the wrapped invocation (must be invoked exactly once)
+	 * @since 1.4
+	 */
+	@API(status = EXPERIMENTAL, since = "1.4")
+	default void around(C context, Invocation<C> invocation) throws Exception {
+		invocation.invoke(context);
+	}
+
+	/**
 	 * Get the set of {@linkplain ExclusiveResource exclusive resources}
 	 * required to execute this node.
 	 *
@@ -282,4 +296,20 @@ public interface Node<C extends EngineExecutionContext> {
 		CONCURRENT
 	}
 
+	/**
+	 * Represents an invocation that runs with the supplied context.
+	 *
+	 * @param <C> the type of {@code EngineExecutionContext} used by the {@code HierarchicalTestEngine}
+	 * @since 1.4
+	 */
+	@API(status = EXPERIMENTAL, since = "1.4")
+	interface Invocation<C extends EngineExecutionContext> {
+
+		/**
+		 * Invoke this invocation with the supplied context.
+		 *
+		 * @param context the context to invoke in
+		 */
+		void invoke(C context) throws Exception;
+	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -115,26 +115,31 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 		started = true;
 
 		throwableCollector.execute(() -> {
-			// @formatter:off
-			List<NodeTestTask<C>> children = testDescriptor.getChildren().stream()
-					.map(descriptor -> new NodeTestTask<C>(taskContext, descriptor))
-					.collect(toCollection(ArrayList::new));
-			// @formatter:on
+			node.around(context, ctx -> {
+				context = ctx;
+				throwableCollector.execute(() -> {
+					// @formatter:off
+					List<NodeTestTask<C>> children = testDescriptor.getChildren().stream()
+							.map(descriptor -> new NodeTestTask<C>(taskContext, descriptor))
+							.collect(toCollection(ArrayList::new));
+					// @formatter:on
 
-			context = node.before(context);
+					context = node.before(context);
 
-			DynamicTestExecutor dynamicTestExecutor = new DefaultDynamicTestExecutor();
-			context = node.execute(context, dynamicTestExecutor);
+					final DynamicTestExecutor dynamicTestExecutor = new DefaultDynamicTestExecutor();
+					context = node.execute(context, dynamicTestExecutor);
 
-			if (!children.isEmpty()) {
-				children.forEach(child -> child.setParentContext(context));
-				taskContext.getExecutorService().invokeAll(children);
-			}
+					if (!children.isEmpty()) {
+						children.forEach(child -> child.setParentContext(context));
+						taskContext.getExecutorService().invokeAll(children);
+					}
 
-			dynamicTestExecutor.awaitFinished();
+					throwableCollector.execute(dynamicTestExecutor::awaitFinished);
+				});
+
+				throwableCollector.execute(() -> node.after(context));
+			});
 		});
-
-		throwableCollector.execute(() -> node.after(context));
 	}
 
 	private void cleanUp() {


### PR DESCRIPTION
## Overview

as discussed with @marcphilipp 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
