### PR TITLE
fix LegacyXmlReportGeneratingListener to generate one xml file per test class

### DIFF
--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -51,6 +51,7 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 	private final Clock clock;
 
 	private XmlReportData reportData;
+	private TestPlan testPlan;
 
 	public LegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out) {
 		this(reportsDir, out, Clock.systemDefaultZone());
@@ -69,29 +70,37 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 
 	@Override
 	public void testPlanExecutionStarted(TestPlan testPlan) {
-		this.reportData = new XmlReportData(testPlan, clock);
-		try {
-			Files.createDirectories(this.reportsDir);
-		}
-		catch (IOException e) {
-			printException("Could not create reports directory: " + this.reportsDir, e);
-		}
+		this.testPlan = testPlan;
 	}
 
 	@Override
 	public void testPlanExecutionFinished(TestPlan testPlan) {
-		this.reportData = null;
+		this.testPlan = null;
 	}
 
 	@Override
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-		this.reportData.markSkipped(testIdentifier, reason);
-		writeXmlReportInCaseOfRoot(testIdentifier);
+		if (this.reportData != null) {
+			this.reportData.markSkipped(testIdentifier, reason);
+			writeXmlReportInCaseOfRoot(testIdentifier);
+		}
 	}
 
 	@Override
 	public void executionStarted(TestIdentifier testIdentifier) {
-		this.reportData.markStarted(testIdentifier);
+		if (isClassLevel(testIdentifier)) {
+			this.reportData = new XmlReportData(testPlan, clock);
+			try {
+				Files.createDirectories(this.reportsDir);
+			}
+			catch (IOException e) {
+				printException("Could not create reports directory: " + this.reportsDir, e);
+			}
+		}
+
+		if (this.reportData != null) {
+			this.reportData.markStarted(testIdentifier);
+		}
 	}
 
 	@Override
@@ -101,14 +110,16 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 
 	@Override
 	public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult result) {
-		this.reportData.markFinished(testIdentifier, result);
-		writeXmlReportInCaseOfRoot(testIdentifier);
+		if (this.reportData != null) {
+			this.reportData.markFinished(testIdentifier, result);
+			writeXmlReportInCaseOfRoot(testIdentifier);
+		}
 	}
 
 	private void writeXmlReportInCaseOfRoot(TestIdentifier testIdentifier) {
-		if (isRoot(testIdentifier)) {
-			String rootName = UniqueId.parse(testIdentifier.getUniqueId()).getSegments().get(0).getValue();
-			writeXmlReportSafely(testIdentifier, rootName);
+		if (isClassLevel(testIdentifier)) {
+			writeXmlReportSafely(testIdentifier, testIdentifier.getLegacyReportingName());
+			this.reportData = null;
 		}
 	}
 
@@ -122,8 +133,9 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 		}
 	}
 
-	private boolean isRoot(TestIdentifier testIdentifier) {
-		return !testIdentifier.getParentId().isPresent();
+	private boolean isClassLevel(TestIdentifier testIdentifier) {
+		final Optional<TestSource> source = testIdentifier.getSource();
+		return source.isPresent() && source.get() instanceof ClassSource;
 	}
 
 	private void printException(String message, Exception exception) {

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -26,6 +26,7 @@ import org.apiguardian.api.API;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
+import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -24,6 +24,7 @@ import javax.xml.stream.XMLStreamException;
 
 import org.apiguardian.api.API;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.ClassSource;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Clock;
+import java.util.Optional;
 
 import javax.xml.stream.XMLStreamException;
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -26,7 +26,6 @@ import javax.xml.stream.XMLStreamException;
 import org.apiguardian.api.API;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
-import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.TestExecutionListener;


### PR DESCRIPTION
edit: looks like you have tests that actually assert a different behavior, so not sure how to progress here...

## Overview

Currently, this listener generates one xml file per testPlan. The testPlan generally contains all tests discovered by jupiter engine (ie all classes and their test methods). 
So, overall, this listener produces just a single xml file named "TEST-junit-jupiter.xml", containing all test results.

However, junit4 behaviour was to generate one xml file per test class.

Many tools depend on this assumption, ie ant's html test report generator. 
Current listener implementation confuses this tool and makes it believe that tests are all present under class named 'JUnit Jupiter'.

This (rather hackish) change fixes it. 

To reproduce, you can use this main method (make sure there's some jupiter discoverable tests on the classpath):
```java
import java.io.File;
import java.io.FileInputStream;
import java.io.PrintWriter;
import javax.xml.parsers.DocumentBuilderFactory;
import org.apache.tools.ant.Project;
import org.apache.tools.ant.taskdefs.optional.junit.AggregateTransformer;
import org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator;
import org.apache.tools.ant.types.FileSet;
import org.junit.platform.engine.discovery.DiscoverySelectors;
import org.junit.platform.launcher.Launcher;
import org.junit.platform.launcher.LauncherDiscoveryRequest;
import org.junit.platform.launcher.core.LauncherConfig;
import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
import org.junit.platform.launcher.core.LauncherFactory;
import org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener;
import org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener;

public class LaunchTestsAndGenerateHtmlReport {
    public static void main(String[] args) throws Exception {
        final LauncherConfig.Builder config = LauncherConfig.builder();
        final Launcher launcher = LauncherFactory.create(config.build());

        final LauncherDiscoveryRequest request = new LauncherDiscoveryRequestBuilder()
                .selectors(DiscoverySelectors.selectPackage(""))
                .build();

        final File xmlDir = new File("./report/xml");
        launcher.execute(request, new LegacyXmlReportGeneratingListener(
                xmlDir.toPath(),
                new PrintWriter(System.err)
        ));

        final Project project = new Project();
        project.setBaseDir(new File("."));
        project.setProperty("java.io.tmpdir", "tmp");

        final XMLResultAggregator aggregator = new XMLResultAggregator();
        final FileSet fs = new FileSet();
        fs.setDir(xmlDir);
        fs.createPatternSet().createInclude().setName("**/*.xml");
        aggregator.setProject(project);
        aggregator.addFileSet(fs);
        aggregator.setTofile("./report/aggregated.xml");
        aggregator.execute();

        final AggregateTransformer report = aggregator.createReport();
        final AggregateTransformer.Format format = new AggregateTransformer.Format();
        format.setValue("frames");
        report.setFormat(format);
        report.setTodir(new File("./report/html"));

        report.setXmlDocument(DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(
                new FileInputStream("./report/aggregated.xml"))
        );
        report.transform();
    }
}
```

dependencies required to run, in maven format:
```xml
    <dependency>
        <groupId>org.junit.jupiter</groupId>
        <artifactId>junit-jupiter-engine</artifactId>
        <version>5.4.0-M1</version>
    </dependency>
    <dependency>
        <groupId>org.junit.platform</groupId>
        <artifactId>junit-platform-launcher</artifactId>
        <version>1.4.0-M1</version>
    </dependency>
    <dependency>
        <groupId>org.junit.platform</groupId>
        <artifactId>junit-platform-reporting</artifactId>
        <version>1.4.0-M1</version>
    </dependency>
    <dependency>
        <groupId>org.apache.ant</groupId>
        <artifactId>ant-junit</artifactId>
        <version>1.10.5</version>
    </dependency>
```
 
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass

PS Sorry for the commit thrash, had to copy-paste this code manually from my IDE, which had different import order settings and I didn't want to mess with yours...