### PR TITLE
Introduce Launcher.execute(TestPlan)

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-RC1.adoc
@@ -27,11 +27,14 @@ repository on GitHub.
 
 ==== Deprecations and Breaking Changes
 
-* ❓
+* `TestPlan.add(TestIdentifier)` has always been considered _internal_ and is now
+  appropriately annotated with `@API(status = INTERNAL)`.
 
 ==== New Features and Improvements
 
-* ❓
+* The `Launcher` API now provides an `execute(TestPlan, TestExecutionListener...)`
+  method that allows one to execute a previously discovered `TestPlan`.
+* `@RunWith(JUnitPlatform.class)` no longer executes test discovery twice.
 
 
 [[release-notes-5.4.0-RC1-junit-jupiter]]

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
@@ -64,20 +64,14 @@ public interface Launcher {
 	 * {@link LauncherDiscoveryRequest} by querying all registered engines and
 	 * collecting their results.
 	 *
-	 * @apiNote This method should only be called to generate a preview of the
-	 * test tree when executing tests is not desired. First calling this method
-	 * to get access to the {@link TestPlan} and then {@link #execute} causes
-	 * test discovery to be executed twice which may result in a significant
-	 * performance degradation. Instead, {@link #execute} should be called
-	 * directly and a {@link TestExecutionListener} that overrides
-	 * {@link TestExecutionListener#testPlanExecutionStarted(TestPlan)} should
-	 * be registered to get access to the test tree, for example to render it in
-	 * an IDE.
+	 * @apiNote This method may be called to generate a preview of the test
+	 * tree. The resulting {@link TestPlan} is unmodifiable and may be passed to
+	 * {@link #execute(TestPlan, TestExecutionListener...)} for execution.
 	 *
 	 * @param launcherDiscoveryRequest the launcher discovery request; never
 	 * {@code null}
-	 * @return a {@code TestPlan} that contains all resolved {@linkplain
-	 * TestIdentifier identifiers} from all registered engines
+	 * @return an unmodifiable {@code TestPlan} that contains all resolved
+	 * {@linkplain TestIdentifier identifiers} from all registered engines
 	 */
 	TestPlan discover(LauncherDiscoveryRequest launcherDiscoveryRequest);
 
@@ -91,14 +85,33 @@ public interface Launcher {
 	 * <p>Supplied test execution listeners are registered in addition to already
 	 * registered listeners but only for the supplied launcher discovery request.
 	 *
-	 * @apiNote In order to get access to the test tree, for example to render
-	 * it in an IDE, register a {@link TestExecutionListener} that overrides
-	 * {@link TestExecutionListener#testPlanExecutionStarted(TestPlan)} instead
-	 * of calling {@link #discover} first.
+	 * @apiNote Calling this method will cause test discovery to be executed for
+	 * all registered engines. If the same {@link LauncherDiscoveryRequest} was
+	 * previously passed to {@link #discover(LauncherDiscoveryRequest)}, you
+	 * should instead call {@link #execute(TestPlan, TestExecutionListener...)}
+	 * and pass the already acquired {@link TestPlan} to avoid the potential
+	 * performance degradation (e.g., classpath scanning) of running test
+	 * discovery twice.
 	 *
 	 * @param launcherDiscoveryRequest the launcher discovery request; never {@code null}
 	 * @param listeners additional test execution listeners; never {@code null}
 	 */
 	void execute(LauncherDiscoveryRequest launcherDiscoveryRequest, TestExecutionListener... listeners);
+
+	/**
+	 * Execute the supplied {@link TestPlan} and notify
+	 * {@linkplain #registerTestExecutionListeners registered listeners} about
+	 * the progress and results of the execution.
+	 *
+	 * <p>Supplied test execution listeners are registered in addition to
+	 * already registered listeners but only for the execution of the supplied
+	 * test plan.
+	 *
+	 * @param testPlan the test plan to execute; never {@code null}
+	 * @param listeners additional test execution listeners; never {@code null}
+	 * @since 1.4
+	 */
+	@API(status = STABLE, since = "1.4")
+	void execute(TestPlan testPlan, TestExecutionListener... listeners);
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -52,7 +52,7 @@ import org.junit.platform.engine.TestDescriptor.Visitor;
  * @see TestExecutionListener
  */
 @API(status = STABLE, since = "1.0")
-public final class TestPlan {
+public class TestPlan {
 
 	private final Set<TestIdentifier> roots = Collections.synchronizedSet(new LinkedHashSet<>(4));
 
@@ -82,7 +82,8 @@ public final class TestPlan {
 		return testPlan;
 	}
 
-	private TestPlan(boolean containsTests) {
+	@API(status = INTERNAL, since = "1.4")
+	protected TestPlan(boolean containsTests) {
 		this.containsTests = containsTests;
 	}
 
@@ -91,6 +92,7 @@ public final class TestPlan {
 	 *
 	 * @param testIdentifier the identifier to add; never {@code null}
 	 */
+	@API(status = INTERNAL, since = "1.0")
 	public void add(TestIdentifier testIdentifier) {
 		Preconditions.notNull(testIdentifier, "testIdentifier must not be null");
 		allIdentifiers.put(testIdentifier.getUniqueId(), testIdentifier);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/Root.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
@@ -30,6 +31,15 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
 class Root {
 
 	private final Map<TestEngine, TestDescriptor> testEngineDescriptors = new LinkedHashMap<>(4);
+	private final ConfigurationParameters configurationParameters;
+
+	Root(ConfigurationParameters configurationParameters) {
+		this.configurationParameters = configurationParameters;
+	}
+
+	public ConfigurationParameters getConfigurationParameters() {
+		return configurationParameters;
+	}
 
 	/**
 	 * Add an {@code engine}'s root {@link TestDescriptor}.

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/UnmodifiableTestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/UnmodifiableTestPlan.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.platform.commons.util.PreconditionViolationException;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+class UnmodifiableTestPlan extends TestPlan {
+
+	private final Root root;
+	private final TestPlan delegate;
+
+	static UnmodifiableTestPlan from(Root root) {
+		TestPlan delegate = TestPlan.from(root.getEngineDescriptors());
+		return new UnmodifiableTestPlan(root, delegate);
+	}
+
+	private UnmodifiableTestPlan(Root root, TestPlan delegate) {
+		super(delegate.containsTests());
+		this.root = root;
+		this.delegate = delegate;
+	}
+
+	Root getRoot() {
+		return root;
+	}
+
+	TestPlan getDelegate() {
+		return delegate;
+	}
+
+	@Override
+	public void add(TestIdentifier testIdentifier) {
+		throw new UnsupportedOperationException("TestPlan must not be modified");
+	}
+
+	@Override
+	public Set<TestIdentifier> getRoots() {
+		return delegate.getRoots();
+	}
+
+	@Override
+	public Optional<TestIdentifier> getParent(TestIdentifier child) {
+		return delegate.getParent(child);
+	}
+
+	@Override
+	public Set<TestIdentifier> getChildren(TestIdentifier parent) {
+		return delegate.getChildren(parent);
+	}
+
+	@Override
+	public Set<TestIdentifier> getChildren(String parentId) {
+		return delegate.getChildren(parentId);
+	}
+
+	@Override
+	public TestIdentifier getTestIdentifier(String uniqueId) throws PreconditionViolationException {
+		return delegate.getTestIdentifier(uniqueId);
+	}
+
+	@Override
+	public long countTestIdentifiers(Predicate<? super TestIdentifier> predicate) {
+		return delegate.countTestIdentifiers(predicate);
+	}
+
+	@Override
+	public Set<TestIdentifier> getDescendants(TestIdentifier parent) {
+		return delegate.getDescendants(parent);
+	}
+
+	@Override
+	public boolean containsTests() {
+		return delegate.containsTests();
+	}
+
+}

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatformTestTree.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatformTestTree.java
@@ -40,14 +40,18 @@ import org.junit.runner.manipulation.Filter;
 class JUnitPlatformTestTree {
 
 	private final Map<TestIdentifier, Description> descriptions = new HashMap<>();
-	private final TestPlan plan;
+	private final TestPlan testPlan;
 	private final Function<TestIdentifier, String> nameExtractor;
 	private final Description suiteDescription;
 
-	JUnitPlatformTestTree(TestPlan plan, Class<?> testClass) {
-		this.plan = plan;
+	JUnitPlatformTestTree(TestPlan testPlan, Class<?> testClass) {
+		this.testPlan = testPlan;
 		this.nameExtractor = useTechnicalNames(testClass) ? this::getTechnicalName : TestIdentifier::getDisplayName;
-		this.suiteDescription = generateSuiteDescription(plan, testClass);
+		this.suiteDescription = generateSuiteDescription(testPlan, testClass);
+	}
+
+	public TestPlan getTestPlan() {
+		return testPlan;
 	}
 
 	private static boolean useTechnicalNames(Class<?> testClass) {
@@ -83,9 +87,8 @@ class JUnitPlatformTestTree {
 	}
 
 	void addDynamicDescription(TestIdentifier newIdentifier, String parentId) {
-		Description parent = getDescription(this.plan.getTestIdentifier(parentId));
-		this.plan.add(newIdentifier);
-		buildDescription(newIdentifier, parent, this.plan);
+		Description parent = getDescription(this.testPlan.getTestIdentifier(parentId));
+		buildDescription(newIdentifier, parent, this.testPlan);
 	}
 
 	private void buildDescription(TestIdentifier identifier, Description parent, TestPlan testPlan) {
@@ -128,7 +131,7 @@ class JUnitPlatformTestTree {
 
 	Set<TestIdentifier> getTestsInSubtree(TestIdentifier ancestor) {
 		// @formatter:off
-		return plan.getDescendants(ancestor).stream()
+		return testPlan.getDescendants(ancestor).stream()
 				.filter(TestIdentifier::isTest)
 				.collect(toCollection(LinkedHashSet::new));
 		// @formatter:on
@@ -145,7 +148,7 @@ class JUnitPlatformTestTree {
 
 	private Predicate<? super TestIdentifier> isALeaf(Set<TestIdentifier> identifiers) {
 		return testIdentifier -> {
-			Set<TestIdentifier> descendants = plan.getDescendants(testIdentifier);
+			Set<TestIdentifier> descendants = testPlan.getDescendants(testIdentifier);
 			return identifiers.stream().noneMatch(descendants::contains);
 		};
 	}


### PR DESCRIPTION
This commit adds a new overload for `Launcher.execute()` that accepts a
`TestPlan` directly thus avoiding running test discovery twice when
`discover()` is called prior to `execute()`. The `JUnitPlatform` runner
is changed to make use of this new feature.

Resolves #1695.