### PR TITLE
Use fully-qualified class name as legacy reporting name for Vintage tests

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -16,6 +16,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethods;
+import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -65,6 +66,12 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 
 	public Description getDescription() {
 		return description;
+	}
+
+	@Override
+	public String getLegacyReportingName() {
+		String className = description.getClassName();
+		return isNotBlank(className) ? className : super.getLegacyReportingName();
 	}
 
 	@Override

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/descriptor/VintageTestDescriptorTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/descriptor/VintageTestDescriptorTests.java
@@ -12,6 +12,7 @@ package org.junit.vintage.engine.descriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Optional;
 
@@ -36,6 +37,26 @@ class VintageTestDescriptorTests {
 		MethodSource methodSource = (MethodSource) sourceOptional.get();
 		assertEquals(ConcreteTest.class.getName(), methodSource.getClassName());
 		assertEquals("theTest", methodSource.getMethodName());
+	}
+
+	@Test
+	void legacyReportingNameIncludesClassName() {
+		Description description = Description.createTestDescription(ConcreteTest.class, "legacyTest");
+		VintageTestDescriptor testDescriptor = new VintageTestDescriptor(uniqueId, description);
+
+		assertEquals(ConcreteTest.class.getName(), testDescriptor.getLegacyReportingName(),
+			"Legacy reporting name should include fully-qualified class name when available.");
+		assertNotEquals(testDescriptor.getDisplayName(), testDescriptor.getLegacyReportingName());
+	}
+
+	@Test
+	void legacyReportingNameFallbackToDisplayName() {
+		String suiteName = "Legacy Suite";
+		Description description = Description.createSuiteDescription(suiteName);
+		VintageTestDescriptor testDescriptor = new VintageTestDescriptor(uniqueId, description);
+
+		assertEquals(testDescriptor.getDisplayName(), testDescriptor.getLegacyReportingName());
+		assertEquals(suiteName, testDescriptor.getLegacyReportingName());
 	}
 
 	private abstract static class AbstractTestBase {


### PR DESCRIPTION
## Overview

Prior to this PR VintageTestDescriptor was always using displayName
for legacy reporting purposes. As a result of #1475 displayName for
vintage tests was updated to be the simple class name which in turn
affected test reports that are based on legacy reporting name.
This PR updates VintageTestDescriptor to use fully-qualified class name
for legacy reporting if that is available.

For example:

Running following vintage tests
org.example.third.TestClassOneTest, org.example.second.TestClassOneTest, org.example.first.TestClassOneTest

started to produce the following output:

```
[INFO] --- maven-surefire-plugin:2.22.1:test (default-test) @ example ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestClassOneTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in TestClassOneTest
[INFO] Running TestClassOneTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in TestClassOneTest
[INFO] Running TestClassOneTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in TestClassOneTest
```
and produces surefire report files:
```
TestClassOneTest.txt
TEST-TestClassOneTest.xml
```
With proposed changes output will look like:

```
[INFO] --- maven-surefire-plugin:2.22.1:test (default-test) @ example ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.example.third.TestClassOneTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.example.third.TestClassOneTest
[INFO] Running org.example.second.TestClassOneTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.example.second.TestClassOneTest
[INFO] Running org.example.first.TestClassOneTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.example.first.TestClassOneTest
```

and will produce following surefire reports:
```
org.example.first.TestClassOneTest.txt
org.example.second.TestClassOneTest.txt
org.example.third.TestClassOneTest.txt
TEST-org.example.first.TestClassOneTest.xml
TEST-org.example.second.TestClassOneTest.xml
TEST-org.example.third.TestClassOneTest.xml
```
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
