### PR TITLE
Replace ISO control characters in display names

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.4.0-RC1.adoc
@@ -39,7 +39,10 @@ repository on GitHub.
 * `@RunWith(JUnitPlatform.class)` no longer executes test discovery twice.
 * The root cause and suppressed exceptions are now included in the stack trace printed by
   the `ConsoleLauncher`.
-
+* The `ConsoleLauncher` now sanitizes user-provided display names before emitting
+  them: commong whitespace characters `\t`, `\n`, `\x0B`, `\f`, and `\r` are replaced by
+  a standard space character ` ` and all other ISO control characters emitted as a
+  dot `.`.
 
 [[release-notes-5.4.0-RC1-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
@@ -10,9 +10,11 @@
 
 package org.junit.platform.commons.util;
 
+import static java.util.regex.Pattern.UNICODE_CHARACTER_CLASS;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import org.apiguardian.api.API;
 
@@ -30,6 +32,9 @@ import org.apiguardian.api.API;
  */
 @API(status = INTERNAL, since = "1.0")
 public final class StringUtils {
+
+	private static final Pattern ISO_CONTROL_PATTERN = Pattern.compile("\\p{Cntrl}", UNICODE_CHARACTER_CLASS);
+	private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
 
 	private StringUtils() {
 		/* no-op */
@@ -180,4 +185,33 @@ public final class StringUtils {
 		}
 	}
 
+	/**
+	 * Replace all ISO control characters in the supplied {@link String}.
+	 *
+	 * @param str the string to check; may be {@code null}
+	 * @param replacement the replacement string; never {@code null}
+	 * @return The supplied string with all control characters replaced.
+	 *
+	 * @since 1.4
+	 */
+	@API(status = INTERNAL, since = "1.4")
+	public static String replaceIsoControlCharacters(String str, String replacement) {
+		Preconditions.notNull(replacement, "replacement must not be null");
+		return str == null ? null : ISO_CONTROL_PATTERN.matcher(str).replaceAll(replacement);
+	}
+
+	/**
+	 * Replace all whitespace characters in the supplied {@link String}.
+	 *
+	 * @param str the string to check; may be {@code null}
+	 * @param replacement the replacement string; never {@code null}
+	 * @return The supplied string with all whitespace characters replaced.
+	 *
+	 * @since 1.4
+	 */
+	@API(status = INTERNAL, since = "1.4")
+	public static String replaceWhitespaceCharacters(String str, String replacement) {
+		Preconditions.notNull(replacement, "replacement must not be null");
+		return str == null ? null : WHITESPACE_PATTERN.matcher(str).replaceAll(replacement);
+	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreeNode.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreeNode.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestIdentifier;
@@ -40,7 +41,7 @@ class TreeNode {
 	}
 
 	TreeNode(TestIdentifier identifier) {
-		this(identifier.getDisplayName());
+		this(createCaption(identifier.getDisplayName()));
 		this.identifier = identifier;
 		this.visible = true;
 	}
@@ -80,5 +81,12 @@ class TreeNode {
 
 	Optional<TestIdentifier> identifier() {
 		return Optional.ofNullable(identifier);
+	}
+
+	static String createCaption(String displayName) {
+		boolean normal = displayName.length() <= 80;
+		String caption = normal ? displayName : displayName.substring(0, 80) + "...";
+		String whites = StringUtils.replaceWhitespaceCharacters(caption, " ");
+		return StringUtils.replaceIsoControlCharacters(whites, ".");
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/StringUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/StringUtilsTests.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.commons.util.StringUtils.containsIsoControlCharacter;
 import static org.junit.platform.commons.util.StringUtils.containsWhitespace;
@@ -22,6 +24,8 @@ import static org.junit.platform.commons.util.StringUtils.doesNotContainWhitespa
 import static org.junit.platform.commons.util.StringUtils.isBlank;
 import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 import static org.junit.platform.commons.util.StringUtils.nullSafeToString;
+import static org.junit.platform.commons.util.StringUtils.replaceIsoControlCharacters;
+import static org.junit.platform.commons.util.StringUtils.replaceWhitespaceCharacters;
 
 import org.junit.jupiter.api.Test;
 
@@ -88,6 +92,35 @@ class StringUtilsTests {
 			() -> shouldNotContainIsoControlCharacter("hello world")
 		);
 		// @formatter:on
+	}
+
+	@Test
+	void replaceControlCharacters() {
+		assertNull(replaceIsoControlCharacters(null, ""));
+		assertEquals("", replaceIsoControlCharacters("", "."));
+		assertEquals("", replaceIsoControlCharacters("\t\n\r", ""));
+		assertEquals("...", replaceIsoControlCharacters("\t\n\r", "."));
+		assertEquals("...", replaceIsoControlCharacters("\u005Ct\u005Cn\u005Cr", "."));
+		assertEquals("abc", replaceIsoControlCharacters("abc", "?"));
+		assertEquals("...", replaceIsoControlCharacters("...", "?"));
+
+		assertThrows(PreconditionViolationException.class, () -> replaceIsoControlCharacters("", null));
+	}
+
+	@Test
+	void replacWhitespaceCharacters() {
+		assertNull(replaceWhitespaceCharacters(null, ""));
+		assertEquals("", replaceWhitespaceCharacters("", "."));
+		assertEquals("", replaceWhitespaceCharacters("\t\n\r", ""));
+		assertEquals("...", replaceWhitespaceCharacters("\t\n\r", "."));
+		assertEquals("...", replaceWhitespaceCharacters("\u005Ct\u005Cn\u005Cr", "."));
+		assertEquals("abc", replaceWhitespaceCharacters("abc", "?"));
+		assertEquals("...", replaceWhitespaceCharacters("...", "?"));
+		assertEquals(" ", replaceWhitespaceCharacters(" ", " "));
+		assertEquals(" ", replaceWhitespaceCharacters("\u000B", " "));
+		assertEquals(" ", replaceWhitespaceCharacters("\f", " "));
+
+		assertThrows(PreconditionViolationException.class, () -> replaceWhitespaceCharacters("", null));
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/TreeNodeTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/TreeNodeTests.java
@@ -12,6 +12,7 @@ package org.junit.platform.console.tasks;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -26,6 +27,19 @@ class TreeNodeTests {
 
 	private static final int NUM_THREADS = 2;
 	private static final int ITEMS_PER_THREAD = 1000;
+
+	@Test
+	void caption() {
+		assertEquals("", TreeNode.createCaption(""));
+		assertEquals("[@@]", TreeNode.createCaption("[@@]"));
+		assertEquals("[@ @]", TreeNode.createCaption("[@ @]"));
+		assertEquals("[@ @]", TreeNode.createCaption("[@\u000B@]"));
+		assertEquals("[@ @]", TreeNode.createCaption("[@\t@]"));
+		assertEquals("[@  @]", TreeNode.createCaption("[@\t\n@]"));
+		assertEquals("[@   @]", TreeNode.createCaption("[@\t\n\r@]"));
+		assertEquals("[@    @]", TreeNode.createCaption("[@\t\n\r\f@]"));
+		assertEquals("@".repeat(80) + "...", TreeNode.createCaption("@".repeat(1000) + "!"));
+	}
 
 	@Test
 	void childrenCanBeAddedConcurrently() throws Exception {


### PR DESCRIPTION
## Overview

Prior to this commit new line and other ISO control characters disrupted the layout of the tree-based test plan rendering emitted by the console launcher. Now, all ISO control characters found in display names are replaced by a single dot: '.'

Closes #1713

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
