### PR TITLE
Introduce support for final modifiers in ModifierSupport and ReflectionUtils

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ModifierSupport.java
@@ -199,4 +199,51 @@ public final class ModifierSupport {
 		return ReflectionUtils.isNotStatic(member);
 	}
 
+	/**
+	 * Determine if the supplied class is {@code final}.
+	 *
+	 * @param clazz the class to check; never {@code null}
+	 * @return {@code true} if the class is {@code final}
+	 * @see java.lang.reflect.Modifier#isFinal(int)
+	 */
+	public static boolean isFinal(Class<?> clazz) {
+		Preconditions.notNull(clazz, "Class must not be null");
+		return ReflectionUtils.isFinal(clazz);
+	}
+
+	/**
+	 * Determine if the supplied class is not {@code final}.
+	 *
+	 * @param clazz the class to check; never {@code null}
+	 * @return {@code true} if the class is not {@code final}
+	 * @see java.lang.reflect.Modifier#isFinal(int)
+	 */
+	public static boolean isNotFinal(Class<?> clazz) {
+		Preconditions.notNull(clazz, "Class must not be null");
+		return ReflectionUtils.isNotFinal(clazz);
+	}
+
+	/**
+	 * Determine if the supplied member is {@code final}.
+	 *
+	 * @param member the member to check; never {@code null}
+	 * @return {@code true} if the member is {@code final}
+	 * @see java.lang.reflect.Modifier#isFinal(int)
+	 */
+	public static boolean isFinal(Member member) {
+		Preconditions.notNull(member, "Member must not be null");
+		return ReflectionUtils.isFinal(member);
+	}
+
+	/**
+	 * Determine if the supplied member is not {@code final}.
+	 *
+	 * @param member the member to check; never {@code null}
+	 * @return {@code true} if the member is not {@code final}
+	 * @see java.lang.reflect.Modifier#isFinal(int)
+	 */
+	public static boolean isNotFinal(Member member) {
+		Preconditions.notNull(member, "Member must not be null");
+		return ReflectionUtils.isNotFinal(member);
+	}
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -262,6 +262,22 @@ public final class ReflectionUtils {
 		return !isStatic(member);
 	}
 
+	public static boolean isFinal(Class<?> clazz) {
+		return Modifier.isFinal(clazz.getModifiers());
+	}
+
+	public static boolean isNotFinal(Class<?> clazz) {
+		return !isFinal(clazz);
+	}
+
+	public static boolean isFinal(Member member) {
+		return Modifier.isFinal(member.getModifiers());
+	}
+
+	public static boolean isNotFinal(Member member) {
+		return !isFinal(member);
+	}
+
 	/**
 	 * Determine if the supplied class is an <em>inner class</em> (i.e., a
 	 * non-static member class).

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ModifierSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ModifierSupportTests.java
@@ -130,6 +130,38 @@ class ModifierSupportTests {
 		assertEquals(ReflectionUtils.isNotStatic(method), ModifierSupport.isNotStatic(method));
 	}
 
+	@Test
+	void isFinalPreconditions() {
+		assertPreconditionViolationException("Class", () -> ModifierSupport.isFinal((Class<?>) null));
+		assertPreconditionViolationException("Member", () -> ModifierSupport.isFinal((Member) null));
+	}
+
+	@Classes
+	void isFinalDelegates(Class<?> clazz) {
+		assertEquals(ReflectionUtils.isFinal(clazz), ModifierSupport.isFinal(clazz));
+	}
+
+	@Methods
+	void isFinalDelegates(Method method) {
+		assertEquals(ReflectionUtils.isFinal(method), ModifierSupport.isFinal(method));
+	}
+
+	@Test
+	void isNotFinalPreconditions() {
+		assertPreconditionViolationException("Class", () -> ModifierSupport.isNotFinal((Class<?>) null));
+		assertPreconditionViolationException("Member", () -> ModifierSupport.isNotFinal((Member) null));
+	}
+
+	@Classes
+	void isNotFinalDelegates(Class<?> clazz) {
+		assertEquals(ReflectionUtils.isNotFinal(clazz), ModifierSupport.isNotFinal(clazz));
+	}
+
+	@Methods
+	void isNotFinalDelegates(Method method) {
+		assertEquals(ReflectionUtils.isNotFinal(method), ModifierSupport.isNotFinal(method));
+	}
+
 	// -------------------------------------------------------------------------
 
 	// Intentionally non-static
@@ -171,13 +203,19 @@ class ModifierSupportTests {
 		}
 	}
 
+	final class FinalClass {
+
+		final void finalMethod() {
+		}
+	}
+
 	// -------------------------------------------------------------------------
 
 	@Target(ElementType.METHOD)
 	@Retention(RetentionPolicy.RUNTIME)
 	@ParameterizedTest
 	@ValueSource(classes = { PublicClass.class, PrivateClass.class, ProtectedClass.class, PackageVisibleClass.class,
-			AbstractClass.class, StaticClass.class })
+			AbstractClass.class, StaticClass.class, FinalClass.class })
 	@interface Classes {
 	}
 
@@ -195,7 +233,7 @@ class ModifierSupportTests {
 			ProtectedClass.class.getDeclaredMethod("protectedMethod"),
 			PackageVisibleClass.class.getDeclaredMethod("packageVisibleMethod"),
 			AbstractClass.class.getDeclaredMethod("abstractMethod"),
-			StaticClass.class.getDeclaredMethod("staticMethod"));
+			StaticClass.class.getDeclaredMethod("staticMethod"), FinalClass.class.getDeclaredMethod("finalMethod"));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -137,6 +137,24 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
+	void isFinal() throws Exception {
+		assertTrue(ReflectionUtils.isFinal(FinalClass.class));
+		assertTrue(ReflectionUtils.isFinal(FinalClass.class.getDeclaredMethod("finalMethod")));
+
+		assertFalse(ReflectionUtils.isFinal(PublicClass.class));
+		assertFalse(ReflectionUtils.isFinal(PublicClass.class.getDeclaredMethod("publicMethod")));
+	}
+
+	@Test
+	void isNotFinal() throws Exception {
+		assertTrue(ReflectionUtils.isNotFinal(PublicClass.class));
+		assertTrue(ReflectionUtils.isNotFinal(PublicClass.class.getDeclaredMethod("publicMethod")));
+
+		assertFalse(ReflectionUtils.isNotFinal(FinalClass.class));
+		assertFalse(ReflectionUtils.isNotFinal(FinalClass.class.getDeclaredMethod("finalMethod")));
+	}
+
+	@Test
 	void returnsVoid() throws Exception {
 		Class<?> clazz = ClassWithVoidAndNonVoidMethods.class;
 		assertTrue(ReflectionUtils.returnsVoid(clazz.getDeclaredMethod("voidMethod")));
@@ -1404,6 +1422,13 @@ class ReflectionUtilsTests {
 
 		@SuppressWarnings("unused")
 		void packageVisibleMethod() {
+		}
+	}
+
+	final class FinalClass {
+
+		@SuppressWarnings("unused")
+		final void finalMethod() {
 		}
 	}
 


### PR DESCRIPTION
## Overview

Added `isFinal`/`isNotFinal` methods to both `ReflectionUtils` and `ModifierSupport` to check for `final` modifier on classes or methods/fields. Methods for classes are added for symmetry with others. Tests included.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
