### PR TITLE
Mention maven-failsafe-plugin version to be considered in User Guide

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -240,7 +240,7 @@ native support instead.
 ====
 
 Starting with https://issues.apache.org/jira/browse/SUREFIRE-1330[version 2.22.0], Maven
-Surefire provides
+Surefire and Maven Failsafe provide
 http://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html[native support]
 for executing tests on the JUnit Platform. The `pom.xml` file in the
 `{junit5-jupiter-starter-maven}` project demonstrates how to use it and can serve as a
@@ -263,6 +263,10 @@ following.
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>{surefire-version}</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
 				<version>{surefire-version}</version>
 			</plugin>
 		</plugins>
@@ -299,6 +303,10 @@ implementation similar to the following.
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>{surefire-version}</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
 				<version>{surefire-version}</version>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
## Overview

It took me some hours to understand why my integration tests run with JUnit4 provider although I configured maven surefire plugin as described in the guide. It turned out that I had to update maven-failsafe plugin version too. My pull request to the documentation reflects my learnings.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
