### PR TITLE
Add @API to modifier-related methods

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -234,10 +234,12 @@ public final class ReflectionUtils {
 		return Modifier.isPrivate(member.getModifiers());
 	}
 
+	@API(status = INTERNAL, since = "1.4")
 	public static boolean isNotPrivate(Class<?> clazz) {
 		return !isPrivate(clazz);
 	}
 
+	@API(status = INTERNAL, since = "1.1")
 	public static boolean isNotPrivate(Member member) {
 		return !isPrivate(member);
 	}
@@ -257,6 +259,7 @@ public final class ReflectionUtils {
 		return Modifier.isStatic(clazz.getModifiers());
 	}
 
+	@API(status = INTERNAL, since = "1.4")
 	public static boolean isNotStatic(Class<?> clazz) {
 		return !isStatic(clazz);
 	}
@@ -266,6 +269,7 @@ public final class ReflectionUtils {
 		return Modifier.isStatic(member.getModifiers());
 	}
 
+	@API(status = INTERNAL, since = "1.1")
 	public static boolean isNotStatic(Member member) {
 		return !isStatic(member);
 	}


### PR DESCRIPTION
## Overview

Follow up for #1763. Added `@API` annotations with correct `since` values for modifier-related methods in `ModifierSupport` and `ReflectionUtils`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
