### PR TITLE
Supply expected and actual values for failed boolean assertions for enhanced IDE support. Issue: #1781

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M1.adoc
@@ -43,7 +43,8 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* Supply expected and actual values for failed boolean assertions for enhanced IDE
+  support.
 
 
 [[release-notes-5.5.0-M1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertFalse.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertFalse.java
@@ -37,13 +37,13 @@ class AssertFalse {
 
 	static void assertFalse(boolean condition, String message) {
 		if (condition) {
-			fail(buildPrefix(message) + EXPECTED_FALSE);
+			fail(buildPrefix(message) + EXPECTED_FALSE, false, true);
 		}
 	}
 
 	static void assertFalse(boolean condition, Supplier<String> messageSupplier) {
 		if (condition) {
-			fail(buildPrefix(nullSafeGet(messageSupplier)) + EXPECTED_FALSE);
+			fail(buildPrefix(nullSafeGet(messageSupplier)) + EXPECTED_FALSE, false, true);
 		}
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTrue.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTrue.java
@@ -37,13 +37,13 @@ class AssertTrue {
 
 	static void assertTrue(boolean condition, String message) {
 		if (!condition) {
-			fail(buildPrefix(message) + EXPECTED_TRUE);
+			fail(buildPrefix(message) + EXPECTED_TRUE, true, false);
 		}
 	}
 
 	static void assertTrue(boolean condition, Supplier<String> messageSupplier) {
 		if (!condition) {
-			fail(buildPrefix(nullSafeGet(messageSupplier)) + EXPECTED_TRUE);
+			fail(buildPrefix(nullSafeGet(messageSupplier)) + EXPECTED_TRUE, true, false);
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertFalseAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertFalseAssertionsTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertionTestUtils.assertExpectedAndActualValues;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -48,13 +49,14 @@ class AssertFalseAssertionsTests {
 	}
 
 	@Test
-	void assertFalseWithBooleanTrueAndDefaultMessage() {
+	void assertFalseWithBooleanTrueAndDefaultMessageWithExpectedAndActualValues() {
 		try {
 			assertFalse(true);
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "expected: <false> but was: <true>");
+			assertExpectedAndActualValues(ex, false, true);
 		}
 	}
 
@@ -66,6 +68,7 @@ class AssertFalseAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "test ==> expected: <false> but was: <true>");
+			assertExpectedAndActualValues(ex, false, true);
 		}
 	}
 
@@ -77,6 +80,7 @@ class AssertFalseAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "test ==> expected: <false> but was: <true>");
+			assertExpectedAndActualValues(ex, false, true);
 		}
 	}
 
@@ -88,6 +92,7 @@ class AssertFalseAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "test ==> expected: <false> but was: <true>");
+			assertExpectedAndActualValues(ex, false, true);
 		}
 	}
 
@@ -99,6 +104,7 @@ class AssertFalseAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "test ==> expected: <false> but was: <true>");
+			assertExpectedAndActualValues(ex, false, true);
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTrueAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTrueAssertionsTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertionTestUtils.assertExpectedAndActualValues;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,13 +49,14 @@ class AssertTrueAssertionsTests {
 	}
 
 	@Test
-	void assertTrueWithBooleanFalseAndDefaultMessage() {
+	void assertTrueWithBooleanFalseAndDefaultMessageWithExpectedAndActualValues() {
 		try {
 			assertTrue(false);
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "expected: <true> but was: <false>");
+			assertExpectedAndActualValues(ex, true, false);
 		}
 	}
 
@@ -66,6 +68,7 @@ class AssertTrueAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "test ==> expected: <true> but was: <false>");
+			assertExpectedAndActualValues(ex, true, false);
 		}
 	}
 
@@ -77,6 +80,7 @@ class AssertTrueAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "test ==> expected: <true> but was: <false>");
+			assertExpectedAndActualValues(ex, true, false);
 		}
 	}
 
@@ -88,6 +92,7 @@ class AssertTrueAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "test ==> expected: <true> but was: <false>");
+			assertExpectedAndActualValues(ex, true, false);
 		}
 	}
 
@@ -99,6 +104,7 @@ class AssertTrueAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "test ==> expected: <true> but was: <false>");
+			assertExpectedAndActualValues(ex, true, false);
 		}
 	}
 


### PR DESCRIPTION
## Overview
Solution for #1781 

Supply actual and expected values to `org.opentest4j.AssertionFailedError` constructor in  `assertTrue()` and `assertFalse()` methods in `org.junit.jupiter.api.Assertions`. 
This will make assertions APIs consistent & these values are used by tools like Eclipse.


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
