### PR TITLE
Add support for boolean to @ValueSource

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M1.adoc
@@ -26,6 +26,8 @@ on GitHub.
 * Configurable test discovery implementation that can be reused by different test engines
   (see Javadoc of `org.junit.platform.engine.support.discovery`).
 * New `isFinal()` and `isNotFinal()` methods in `ModifierSupport`.
+* `@ValueSource` now additionally supports literal values of type `boolean` for
+  parameterized tests.
 
 
 [[release-notes-5.5.0-M1-junit-jupiter]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -964,6 +964,7 @@ The following types of literal values are supported by `@ValueSource`.
 - `float`
 - `double`
 - `char`
+- `boolean`
 - `java.lang.String`
 - `java.lang.Class`
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueArgumentsProvider.java
@@ -42,6 +42,7 @@ class ValueArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<Va
 					source.floats(),
 					source.doubles(),
 					source.chars(),
+					source.booleans(),
 					source.strings(),
 					source.classes()
 				)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueSource.java
@@ -26,8 +26,9 @@ import org.apiguardian.api.API;
  *
  * <p>Supported types include {@link #shorts}, {@link #bytes}, {@link #ints},
  * {@link #longs}, {@link #floats}, {@link #doubles}, {@link #chars},
- * {@link #strings}, and {@link #classes}. Note, however, that only one of the
- * supported types may be specified per {@code @ValueSource} declaration.
+ * {@link #booleans}, {@link #strings}, and {@link #classes}. Note, however,
+ * that only one of the supported types may be specified per
+ * {@code @ValueSource} declaration.
  *
  * <p>The supplied literal values will be provided as arguments to the
  * annotated {@code @ParameterizedTest} method.
@@ -85,6 +86,13 @@ public @interface ValueSource {
 	 * @since 5.1
 	 */
 	char[] chars() default {};
+
+	/**
+	 * The {@code boolean} values to use as sources of arguments; must not be empty.
+	 *
+	 * @since 5.5
+	 */
+	boolean[] booleans() default {};
 
 	/**
 	 * The {@link String} values to use as sources of arguments; must not be empty.

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ValueArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/ValueArgumentsProviderTests.java
@@ -29,7 +29,7 @@ class ValueArgumentsProviderTests {
 	void multipleInputsAreNotAllowed() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(new short[1], new byte[0], new int[1], new long[0], new float[0], new double[0],
-				new char[0], new String[0], new Class<?>[0]));
+				new char[0], new boolean[0], new String[0], new Class<?>[0]));
 
 		assertThat(exception).hasMessageContaining(
 			"Exactly one type of input must be provided in the @ValueSource annotation, but there were 2");
@@ -39,7 +39,7 @@ class ValueArgumentsProviderTests {
 	void onlyEmptyInputsAreNotAllowed() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(new short[0], new byte[0], new int[0], new long[0], new float[0], new double[0],
-				new char[0], new String[0], new Class<?>[0]));
+				new char[0], new boolean[0], new String[0], new Class<?>[0]));
 
 		assertThat(exception).hasMessageContaining(
 			"Exactly one type of input must be provided in the @ValueSource annotation, but there were 0");
@@ -51,7 +51,7 @@ class ValueArgumentsProviderTests {
 	@Test
 	void providesShorts() {
 		Stream<Object[]> arguments = provideArguments(new short[] { 23, 42 }, new byte[0], new int[0], new long[0],
-			new float[0], new double[0], new char[0], new String[0], new Class<?>[0]);
+			new float[0], new double[0], new char[0], new boolean[0], new String[0], new Class<?>[0]);
 
 		assertThat(arguments).containsExactly(array((short) 23), array((short) 42));
 	}
@@ -62,7 +62,7 @@ class ValueArgumentsProviderTests {
 	@Test
 	void providesBytes() {
 		Stream<Object[]> arguments = provideArguments(new short[0], new byte[] { 23, 42 }, new int[0], new long[0],
-			new float[0], new double[0], new char[0], new String[0], new Class<?>[0]);
+			new float[0], new double[0], new char[0], new boolean[0], new String[0], new Class<?>[0]);
 
 		assertThat(arguments).containsExactly(array((byte) 23), array((byte) 42));
 	}
@@ -70,7 +70,7 @@ class ValueArgumentsProviderTests {
 	@Test
 	void providesInts() {
 		Stream<Object[]> arguments = provideArguments(new short[0], new byte[0], new int[] { 23, 42 }, new long[0],
-			new float[0], new double[0], new char[0], new String[0], new Class<?>[0]);
+			new float[0], new double[0], new char[0], new boolean[0], new String[0], new Class<?>[0]);
 
 		assertThat(arguments).containsExactly(array(23), array(42));
 	}
@@ -78,7 +78,7 @@ class ValueArgumentsProviderTests {
 	@Test
 	void providesLongs() {
 		Stream<Object[]> arguments = provideArguments(new short[0], new byte[0], new int[0], new long[] { 23, 42 },
-			new float[0], new double[0], new char[0], new String[0], new Class<?>[0]);
+			new float[0], new double[0], new char[0], new boolean[0], new String[0], new Class<?>[0]);
 
 		assertThat(arguments).containsExactly(array(23L), array(42L));
 	}
@@ -89,7 +89,7 @@ class ValueArgumentsProviderTests {
 	@Test
 	void providesFloats() {
 		Stream<Object[]> arguments = provideArguments(new short[0], new byte[0], new int[0], new long[0],
-			new float[] { 23.32F, 42.24F }, new double[0], new char[0], new String[0], new Class<?>[0]);
+			new float[] { 23.32F, 42.24F }, new double[0], new char[0], new boolean[0], new String[0], new Class<?>[0]);
 
 		assertThat(arguments).containsExactly(array(23.32F), array(42.24F));
 	}
@@ -97,7 +97,7 @@ class ValueArgumentsProviderTests {
 	@Test
 	void providesDoubles() {
 		Stream<Object[]> arguments = provideArguments(new short[0], new byte[0], new int[0], new long[0], new float[0],
-			new double[] { 23.32, 42.24 }, new char[0], new String[0], new Class<?>[0]);
+			new double[] { 23.32, 42.24 }, new char[0], new boolean[0], new String[0], new Class<?>[0]);
 
 		assertThat(arguments).containsExactly(array(23.32), array(42.24));
 	}
@@ -108,15 +108,26 @@ class ValueArgumentsProviderTests {
 	@Test
 	void providesChars() {
 		Stream<Object[]> arguments = provideArguments(new short[0], new byte[0], new int[0], new long[0], new float[0],
-			new double[0], new char[] { 'a', 'b', 'c' }, new String[0], new Class<?>[0]);
+			new double[0], new char[] { 'a', 'b', 'c' }, new boolean[0], new String[0], new Class<?>[0]);
 
 		assertThat(arguments).containsExactly(array('a'), array('b'), array('c'));
+	}
+
+	/**
+	 * @since 5.5
+	 */
+	@Test
+	void providesBooleans() {
+		Stream<Object[]> arguments = provideArguments(new short[0], new byte[0], new int[0], new long[0], new float[0],
+			new double[0], new char[0], new boolean[] { true, false }, new String[0], new Class<?>[0]);
+
+		assertThat(arguments).containsExactly(array(true), array(false));
 	}
 
 	@Test
 	void providesStrings() {
 		Stream<Object[]> arguments = provideArguments(new short[0], new byte[0], new int[0], new long[0], new float[0],
-			new double[0], new char[0], new String[] { "foo", "bar" }, new Class<?>[0]);
+			new double[0], new char[0], new boolean[0], new String[] { "foo", "bar" }, new Class<?>[0]);
 
 		assertThat(arguments).containsExactly(array("foo"), array("bar"));
 	}
@@ -127,13 +138,13 @@ class ValueArgumentsProviderTests {
 	@Test
 	void providesClasses() {
 		Stream<Object[]> arguments = provideArguments(new short[0], new byte[0], new int[0], new long[0], new float[0],
-			new double[0], new char[0], new String[0], new Class<?>[] { Integer.class, getClass() });
+			new double[0], new char[0], new boolean[0], new String[0], new Class<?>[] { Integer.class, getClass() });
 
 		assertThat(arguments).containsExactly(array(Integer.class), array(getClass()));
 	}
 
 	private static Stream<Object[]> provideArguments(short[] shorts, byte[] bytes, int[] ints, long[] longs,
-			float[] floats, double[] doubles, char[] chars, String[] strings, Class<?>[] classes) {
+			float[] floats, double[] doubles, char[] chars, boolean[] booleans, String[] strings, Class<?>[] classes) {
 
 		ValueSource annotation = mock(ValueSource.class);
 		when(annotation.shorts()).thenReturn(shorts);
@@ -143,6 +154,7 @@ class ValueArgumentsProviderTests {
 		when(annotation.floats()).thenReturn(floats);
 		when(annotation.doubles()).thenReturn(doubles);
 		when(annotation.chars()).thenReturn(chars);
+		when(annotation.booleans()).thenReturn(booleans);
 		when(annotation.strings()).thenReturn(strings);
 		when(annotation.classes()).thenReturn(classes);
 


### PR DESCRIPTION
Issue: #1780

## Overview

adding additional support for boolean to `@ValueSource` based on feature request #1780 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
