### PR TITLE
Enforce findMethod to prioritize specific over generic methods

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -887,6 +887,17 @@ class ReflectionUtilsTests {
 	}
 
 	@Test
+	void findMethodChooseSpecificOverGenericMethod() throws NoSuchMethodException {
+		String methodName = "foo";
+		Class<?> parameterType = Double.class;
+		Class<?> testClass = InterfaceWithSpecificAndGenericDefaultMethodImpl.class;
+
+		Method specificMethod = testClass.getMethod(methodName, parameterType);
+		Optional<Method> optional = findMethod(testClass, methodName, parameterType);
+		assertThat(optional).contains(specificMethod);
+	}
+
+	@Test
 	void findMethodsPreconditions() {
 		// @formatter:off
 		assertThrows(PreconditionViolationException.class, () -> findMethods(null, null));
@@ -1310,6 +1321,16 @@ class ReflectionUtilsTests {
 
 		void foo(Double number) {
 		}
+	}
+
+	interface InterfaceWithSpecificDefaultMethod {
+
+		default void foo(Double number) {
+		}
+	}
+
+	static class InterfaceWithSpecificAndGenericDefaultMethodImpl
+			implements InterfaceWithGenericDefaultMethod<Integer>, InterfaceWithSpecificDefaultMethod {
 	}
 
 	static class InterfaceWithOverriddenGenericDefaultMethodImpl implements InterfaceWithGenericDefaultMethod<Long> {


### PR DESCRIPTION
## Overview

As discussed in #981, `ReflectionUtils.findMethod` currently returns the first method that satisfies the signature requirements rather than the method with the most specific (non-generic) matching signature.

This can cause methods with matching generic signatures to be chosen over a matching non-generic signature. This test enforces that a matching non-generic signature is chosen over a matching generic signature.

This PR will fail the build until `ReflectionUtils.findMethod` prioritizes a method with non-generic parameters that satisfy the required signature over a method with generic parameters that satisfies the required signature. 

I think that the issue in the search algorithm lies [here](https://github.com/junit-team/junit5/blob/311bb71a793c07d7e3000a5d32204e0cf598f590/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java#L1237-L1242), where a method with a matching signature is immediately returned, making it ordering sensitive.
Perhaps instead of immediately returning the matching method, all matching methods should be saved and the most specific/non-generic method should be determined and returned?

I'd be happy to try and investigate the possibilities of such a solution.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
