### PR TITLE
Make Azure Pipeline build work on Windows/Mac/Linux

### DIFF
--- a/azure-gradle-step.yml
+++ b/azure-gradle-step.yml
@@ -1,13 +1,13 @@
 steps:
   - task: Gradle@2
-  inputs:
-    workingDirectory: ''
-    gradleWrapperFile: 'gradlew'
-    gradleOptions: '-Xmx3072m'
-    options: '--scan --warning-mode=all -Dplatform.tooling.support.tests.enabled=true'
-    javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.11'
-    jdkArchitectureOption: 'x64'
-    publishJUnitResults: true
-    testResultsFiles: '**/TEST-*.xml'
-    tasks: 'build'
+    inputs:
+      workingDirectory: ''
+      gradleWrapperFile: 'gradlew'
+      gradleOptions: '-Xmx3072m'
+      options: '--scan --warning-mode=all -Dplatform.tooling.support.tests.enabled=true'
+      javaHomeOption: 'JDKVersion'
+      jdkVersionOption: '1.11'
+      jdkArchitectureOption: 'x64'
+      publishJUnitResults: true
+      testResultsFiles: '**/TEST-*.xml'
+      tasks: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,14 +15,14 @@ jobs:
   steps:
     - template: azure-gradle-step.yml
 
-  - job: Mac
-    pool:
-      vmImage: 'macOS-10.13'
-    steps:
-      - template: azure-gradle-step.yml
+- job: Mac
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+    - template: azure-gradle-step.yml
 
-  - job: Windows
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - template: azure-gradle-step.yml
+- job: Windows
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+    - template: azure-gradle-step.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,37 @@
+# Gradle
+# Build your Java project and run tests with Gradle using a Gradle wrapper script.
+# Add steps that analyze code, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/java
+
+trigger:
+  branches:
+    include:
+    - master
+
+jobs:
+- job: Linux
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  #- checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+  #  clean: false
+  #  fetchDepth: 1
+  - script: ./gradlew --version
+  - task: Gradle@2
+    inputs:
+      workingDirectory: ''
+      gradleWrapperFile: 'gradlew'
+      gradleOptions: '-Xmx3072m'
+      options: '--scan --warning-mode=all -Dplatform.tooling.support.tests.enabled=true'
+      javaHomeOption: 'JDKVersion'
+      jdkVersionOption: '1.11'
+      jdkArchitectureOption: 'x64'
+      publishJUnitResults: true
+      testResultsFiles: '**/TEST-*.xml'
+      tasks: 'build'
+#  - job: Mac_OS
+#    pool:
+#      vmImage: 'macOS-10.13'
+#  - job: Windows
+#    pool:
+#      vmImage: 'windows-2019


### PR DESCRIPTION
## Overview

Enhances the build pipeline on Azure DevOps to use three agents (Windows, Linux, and Mac). Related to #1795

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---