### PR TITLE
azure-pipelines: more complete port of travis conf

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,23 +1,89 @@
-# Gradle
-# Build your Java project and run tests with Gradle using a Gradle wrapper script.
-# Add steps that analyze code, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/java
-
 trigger:
-- master
+  branches:
+    include:
+    - master
 
-pool:
-  vmImage: 'Ubuntu-16.04'
+jobs:
+- job: linux_11
+  displayName: Linux (OpenJDK 11)
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - bash: env
+    - template: src/azure/azure-gradle-step.yml
 
-steps:
-- task: Gradle@2
-  inputs:
-    workingDirectory: ''
-    gradleWrapperFile: 'gradlew'
-    gradleOptions: '-Xmx3072m'
-    javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.11'
-    jdkArchitectureOption: 'x64'
-    publishJUnitResults: false
-    testResultsFiles: '**/TEST-*.xml'
-    tasks: 'build'
+- job: linux_12
+  displayName: Linux (OpenJDK 12)
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: openjdk:12
+  steps:
+    - template: src/azure/azure-gradle-step.yml
+      parameters:
+        publishTestResults: true
+
+- job: linux_13
+  displayName: Linux (OpenJDK 13)
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: openjdk:13
+  steps:
+    - template: src/azure/azure-gradle-step.yml
+      parameters:
+        continueOnError: true
+
+- job: Mac
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+    - template: src/azure/azure-gradle-step.yml
+
+- job: Windows
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+    - template: src/azure/azure-gradle-step.yml
+
+- job: coverage
+  displayName: Coverage
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - bash: |
+        set -e
+        export JAVA_HOME="${JAVA_HOME_11_X64}"
+        ./gradlew --scan --stacktrace --warning-mode=all -PenableJaCoCo build jacocoRootReport
+        bash <(curl -s https://codecov.io/bash)
+      displayName: Coverage
+    - task: PublishCodeCoverageResults@1
+      displayName: Publish Coverage Results
+      inputs:
+        codeCoverageTool: 'JaCoCo'
+        summaryFileLocation: '**/build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml'
+        reportDirectory: '**/build/reports/jacoco/jacocoRootReport/html'
+
+- job: publish_artifacts
+  displayName: Publish Snapshot Artifacts
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - bash: |
+        set -e
+        export JAVA_HOME="${JAVA_HOME_11_X64}"
+        ./gradlew --scan publish -x check
+      displayName: Publish
+  condition: and(eq(variables['System.PullRequest.IsFork'], False), and(eq(variables['Build.Reason'], 'IndividualCI'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/releases/'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))))
+
+- job: update_documentation
+  displayName: Update Snapshot Documentation
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - bash: |
+        set -e
+        export JAVA_HOME="${JAVA_HOME_11_X64}"
+        sudo apt-get install graphviz
+        ./src/publishDocumentationSnapshotOnlyIfNecessary.sh
+      displayName: Publish
+  condition: and(eq(variables['System.PullRequest.IsFork'], False), and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/master')))
+

--- a/src/azure/azure-gradle-step.yml
+++ b/src/azure/azure-gradle-step.yml
@@ -1,0 +1,21 @@
+parameters:
+  continueOnError: false
+  publishTestResults: false
+
+steps:
+  - bash: |
+      set -e
+      # when executing on an Azure Pipelines build agent (not in a container)
+      # default to java 11
+      if [ -n "${JAVA_HOME_11_X64}" ]; then
+        export JAVA_HOME="${JAVA_HOME_11_X64}"
+      fi
+      ./gradlew --version
+      ./gradlew --scan --warning-mode=all -Dplatform.tooling.support.tests.enabled=true build
+    displayName: Test
+    continueOnError: ${{ parameters.continueOnError }}
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    inputs:
+      testResultsFiles: '**/build/test-results/test/TEST-*.xml'
+    condition: eq(${{ parameters.publishTestResults }}, true)


### PR DESCRIPTION
## Overview

A more complete port of the Travis configuration.  I talked with @brunoborges about porting more of the CI invocation over to Azure Pipelines; this picks up from his #1796 with a few differences:

1. For the Java 11 (Linux), macOS and Windows-based builds, this runs directly on the Azure Pipelines build agents, since they have Java 11 installed.
2. For the Java 12 and Java 13 based builds, this runs within the OpenJDK docker images.  The Azure Pipelines build agents do not have a Java 12 or 13 runtime installed, so the preferred mechanism is to [run within a docker image](https://devblogs.microsoft.com/devops/cross-platform-container-builds-with-azure-pipelines/).
3. Just run gradle on the command line instead of trying to run the gradle task.  This allows us to use the same script configuration and template for both the container-based builds and the on-agent builds.
4. Only one of the builds (I chose the Java 12 Linux build) publishes test results, per @sormuras's request in #1796.

Outstanding Issues:

1. The publish steps do _not_ succeed.  (Thankfully.)  They require authentication which obviously I did not configure, as I do not have that information.  I'm happy to help configure secret variables so that we can move that forward.

Please let me know how else I can help!  😀 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass