### PR TITLE
 Shallow clone during Azure Pipelines CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,6 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-    - bash: env
     - template: src/azure/azure-gradle-step.yml
 
 - job: linux_12

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,8 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
+    - checkout: self
+      fetchDepth: 1
     - template: src/azure/azure-gradle-step.yml
 
 - job: linux_12
@@ -17,6 +19,8 @@ jobs:
     vmImage: 'ubuntu-16.04'
   container: openjdk:12
   steps:
+    - checkout: self
+      fetchDepth: 1
     - template: src/azure/azure-gradle-step.yml
       parameters:
         publishTestResults: true
@@ -27,6 +31,8 @@ jobs:
     vmImage: 'ubuntu-16.04'
   container: openjdk:13
   steps:
+    - checkout: self
+      fetchDepth: 1
     - template: src/azure/azure-gradle-step.yml
       parameters:
         continueOnError: true
@@ -35,12 +41,16 @@ jobs:
   pool:
     vmImage: 'macOS-10.13'
   steps:
+    - checkout: self
+      fetchDepth: 1
     - template: src/azure/azure-gradle-step.yml
 
 - job: Windows
   pool:
     vmImage: 'windows-2019'
   steps:
+    - checkout: self
+      fetchDepth: 1
     - template: src/azure/azure-gradle-step.yml
 
 - job: coverage
@@ -48,6 +58,8 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
+    - checkout: self
+      fetchDepth: 1
     - bash: |
         set -e
         export JAVA_HOME="${JAVA_HOME_11_X64}"
@@ -66,6 +78,8 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
+    - checkout: self
+      fetchDepth: 1
     - bash: |
         set -e
         export JAVA_HOME="${JAVA_HOME_11_X64}"
@@ -79,6 +93,8 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
+    - checkout: self
+      fetchDepth: 1
     - bash: |
         set -e
         export JAVA_HOME="${JAVA_HOME_11_X64}"


### PR DESCRIPTION
## Overview

Enable shallow clone during Azure Pipelines CI.

(Unfortunately, this is configurable for each individual build run, so it needs to be repeated.)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
