### PR TITLE
Avoid using deprecated gradle configurations in user guide

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -29,9 +29,9 @@ include the corresponding versions of the `junit-platform-launcher`,
 [subs=attributes+]
 ----
 // Only needed to run tests in a version of IntelliJ IDEA that bundles older versions
-testRuntime("org.junit.platform:junit-platform-launcher:{platform-version}")
-testRuntime("org.junit.jupiter:junit-jupiter-engine:{jupiter-version}")
-testRuntime("org.junit.vintage:junit-vintage-engine:{vintage-version}")
+testRuntimeOnly("org.junit.platform:junit-platform-launcher:{platform-version}")
+testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:{jupiter-version}")
+testRuntimeOnly("org.junit.vintage:junit-vintage-engine:{vintage-version}")
 ----
 
 .Additional Maven Dependencies
@@ -175,29 +175,29 @@ test {
 
 In order to run any tests at all, a `TestEngine` implementation must be on the classpath.
 
-To configure support for JUnit Jupiter based tests, configure a `testCompile` dependency
-on the JUnit Jupiter API and a `testRuntime` dependency on the JUnit Jupiter `TestEngine`
+To configure support for JUnit Jupiter based tests, configure a `testImplementation` dependency
+on the JUnit Jupiter API and a `testRuntimeOnly` dependency on the JUnit Jupiter `TestEngine`
 implementation similar to the following.
 
 [source,java,indent=0]
 [subs=attributes+]
 ----
 dependencies {
-	testCompile("org.junit.jupiter:junit-jupiter-api:{jupiter-version}")
-	testRuntime("org.junit.jupiter:junit-jupiter-engine:{jupiter-version}")
+	testImplementation("org.junit.jupiter:junit-jupiter-api:{jupiter-version}")
+	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:{jupiter-version}")
 }
 ----
 
-The JUnit Platform can run JUnit 4 based tests as long as you configure a `testCompile`
-dependency on JUnit 4 and a `testRuntime` dependency on the JUnit Vintage `TestEngine`
+The JUnit Platform can run JUnit 4 based tests as long as you configure a `testImplementation`
+dependency on JUnit 4 and a `testRuntimeOnly` dependency on the JUnit Vintage `TestEngine`
 implementation similar to the following.
 
 [source,java,indent=0]
 [subs=attributes+]
 ----
 dependencies {
-	testCompile("junit:junit:{junit4-version}")
-	testRuntime("org.junit.vintage:junit-vintage-engine:{vintage-version}")
+	testImplementation("junit:junit:{junit4-version}")
+	testRuntimeOnly("org.junit.vintage:junit-vintage-engine:{vintage-version}")
 }
 ----
 


### PR DESCRIPTION
## Overview

The user guide instructions used `testCompile` and `testRuntime` Gradle configurations, which are deprecated for quite a long time now (see file:///Users/jb/projects/gradle/subprojects/docs/build/docs/userguide/java_plugin.html#tab:configurations). This PR replaces them by `testImplementation` and `testRuntimeOnly`

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
