### PR TITLE
ci: only publish on success

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ jobs:
       env:
         ORG_GRADLE_PROJECT_nexusUsername: $(nexusUsername)
         ORG_GRADLE_PROJECT_nexusPassword: $(nexusPassword)
-  condition: and(eq(variables['System.PullRequest.IsFork'], False), and(eq(variables['Build.Reason'], 'IndividualCI'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/releases/'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))))
+  condition: and(succeeded(), and(eq(variables['System.PullRequest.IsFork'], False), and(eq(variables['Build.Reason'], 'IndividualCI'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/releases/'), eq(variables['Build.SourceBranch'], 'refs/heads/master')))))
 
 - job: update_documentation
   dependsOn: linux_11
@@ -111,4 +111,4 @@ jobs:
       displayName: Publish
       env:
         GRGIT_USER: $(githubToken)
-  condition: and(eq(variables['System.PullRequest.IsFork'], False), and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/master')))
+  condition: and(succeeded(), and(eq(variables['System.PullRequest.IsFork'], False), and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))))


### PR DESCRIPTION
Only run the publish steps when the build was successful, per https://github.com/junit-team/junit5/issues/1810#issuecomment-473516522.

Note that since the publish dependencies _only_ depend on the `linux_11` build, it's possible to publish even if the macOS (for instance) build fails.  I'm happy to tweak this if requested.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass