### PR TITLE
Report intermediate containers finished lazily

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/EventType.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/EventType.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.execution;
+
+/**
+ * @since 5.4.1
+ */
+enum EventType {
+	REPORTED, SYNTHETIC
+}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/IgnoredParameterizedTestCase.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/IgnoredParameterizedTestCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import static java.util.Arrays.asList;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * @since 5.4.1
+ */
+@RunWith(Parameterized.class)
+public class IgnoredParameterizedTestCase {
+
+	@Parameters(name = "{0}")
+	public static Iterable<String> parameters() {
+		return asList("foo", "bar");
+	}
+
+	@Parameter
+	public String value;
+
+	@Test
+	@Ignore
+	public void test() {
+		// never called
+	}
+
+}


### PR DESCRIPTION
Since JUnit 4 does report events for intermediate containers, the
Vintage engine has to synthesize them. Until now this was done lazily
for start events, i.e. when the first child was started, but eagerly for
finish events, i.e. when the last static child of a container was
finished. However, the latter approach is problematic for containers
that contain both static and dynamic children, for example a Spock
specification with a regular and an unrolled feature method. Instead,
intermediate containers are now reported as finished as soon as a test
is started for which the container is not an ancestor.

Fixes #1819.