### PR TITLE
Fix regression when creating human-readable test names

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -73,7 +73,7 @@ class ParameterizedTestNameFormatter {
 
 	private Object[] makeReadable(MessageFormat format, Object[] arguments) {
 		Format[] formats = format.getFormatsByArgumentIndex();
-		Object[] result = Arrays.copyOf(arguments, Math.min(arguments.length, formats.length));
+		Object[] result = Arrays.copyOf(arguments, Math.min(arguments.length, formats.length), Object[].class);
 		for (int i = 0; i < result.length; i++) {
 			if (formats[i] == null) {
 				result[i] = StringUtils.nullSafeToString(arguments[i]);

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -116,6 +116,14 @@ class ParameterizedTestNameFormatterTests {
 	}
 
 	@Test
+	void formatDoesNotRaiseAnArrayStoreException() {
+		ParameterizedTestNameFormatter formatter = new ParameterizedTestNameFormatter("{0} -> {1}", "enigma");
+
+		Object[] arguments = new Number[] { 1, 2 };
+		assertEquals("1 -> 2", formatter.format(1, arguments));
+	}
+
+	@Test
 	void throwsReadableExceptionForInvalidPattern() {
 		ParameterizedTestNameFormatter formatter = new ParameterizedTestNameFormatter("{index", "enigma");
 

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/aggregator/DisplayNameTests.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/aggregator/DisplayNameTests.kt
@@ -22,12 +22,14 @@ object DisplayNameTests {
     fun data() = arrayOf(
             arrayOf("A", 1),
             arrayOf("B", 2),
-            arrayOf("C", 3)
+            arrayOf("C", 3),
+            arrayOf("", 4), // empty is okay
+            arrayOf(null, 5) // null was the problem
     )
 
     @ParameterizedTest
     @MethodSource("data")
-    fun test(char: String, number: Int, info: TestInfo) {
+    fun test(char: String?, number: Int, info: TestInfo) {
         assertEquals("[$number] $char, $number", info.displayName)
     }
 }


### PR DESCRIPTION
## Overview

Prior to this commit `Arrays.copyOf()` was used without specifying the resulting array type in order to create a human-readable names for parameterized tests. Now, type `Object[]` is passed as an argument to ensure the resulting array may contain any valid instance, here an instance of `String`.

Fixes #1836

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
