### PR TITLE
Make emptyValue configurable in @CsvSource and @CsvFileSource

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M2.adoc
@@ -40,7 +40,7 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* New `emptyValue` property in `CsvFileSource` and `CsvSource`.
+* New `emptyValue` attribute in `@CsvFileSource` and `@CsvSource`.
 
 
 [[release-notes-5.5.0-M2-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M2.adoc
@@ -41,6 +41,7 @@ on GitHub.
 ==== New Features and Improvements
 
 * New `booleans` property in `ValueSource`.
+* New `emptyValue` property in `CsvFileSource` and `CsvSource`.
 
 
 [[release-notes-5.5.0-M2-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1134,9 +1134,9 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=CsvSource_example]
 
 `@CsvSource` uses a single quote `'` as its quote character. See the `'lemon, lime'` value
 in the example above and in the table below. An empty, quoted value `''` results in an
-empty `String`; whereas, an entirely _empty_ value is interpreted as a `null` reference.
-An `ArgumentConversionException` is raised if the target type of a `null` reference is a
-primitive type.
+empty `String` unless the `emptyValue` attribute is set; whereas, an entirely _empty_
+value is interpreted as a `null` reference. An `ArgumentConversionException` is raised if
+the target type of a `null` reference is a primitive type.
 
 [cols="50,50"]
 |===
@@ -1167,10 +1167,10 @@ include::{testResourcesDir}/two-column.csv[]
 
 NOTE: In contrast to the syntax used in `@CsvSource`, `@CsvFileSource` uses a double
 quote `"` as the quote character. See the `"United States of America"` value in the
-example above. An empty, quoted value `""` results in an empty `String` unless emptyValue
-is set; whereas, an entirely _empty_ value is interpreted as a `null` reference. An
-`ArgumentConversionException` is raised if the target type of a `null` reference is a
-primitive type.
+example above. An empty, quoted value `""` results in an empty `String` unless the
+`emptyValue` attribute is set; whereas, an entirely _empty_ value is interpreted as a
+`null` reference. An `ArgumentConversionException` is raised if the target type of a
+`null` reference is a primitive type.
 
 [[writing-tests-parameterized-tests-sources-ArgumentsSource]]
 ===== @ArgumentsSource

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1167,8 +1167,8 @@ include::{testResourcesDir}/two-column.csv[]
 
 NOTE: In contrast to the syntax used in `@CsvSource`, `@CsvFileSource` uses a double
 quote `"` as the quote character. See the `"United States of America"` value in the
-example above. An empty, quoted value `""` results in an empty `String`; whereas, an
-entirely _empty_ value is interpreted as a `null` reference. An
+example above. An empty, quoted value `""` results in an empty `String` unless emptyValue
+is set; whereas, an entirely _empty_ value is interpreted as a `null` reference. An
 `ArgumentConversionException` is raised if the target type of a `null` reference is a
 primitive type.
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -45,7 +45,7 @@ class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvS
 		settings.getFormat().setLineSeparator(LINE_SEPARATOR);
 		settings.getFormat().setQuote('\'');
 		settings.getFormat().setQuoteEscape('\'');
-		settings.setEmptyValue("");
+		settings.setEmptyValue(this.annotation.emptyValue());
 		settings.setAutoConfigurationEnabled(false);
 		CsvParser csvParser = new CsvParser(settings);
 		AtomicLong index = new AtomicLong(0);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
@@ -72,7 +72,7 @@ class CsvFileArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<
 		settings.getFormat().setLineSeparator(annotation.lineSeparator());
 		settings.getFormat().setQuote('"');
 		settings.getFormat().setQuoteEscape('"');
-		settings.setEmptyValue("");
+		settings.setEmptyValue(annotation.emptyValue());
 		settings.setAutoConfigurationEnabled(false);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -76,7 +76,10 @@ public @interface CsvFileSource {
 	 * <p>Typically used to skip header lines.
 	 *
 	 * <p>Defaults to {@code 0}.
+	 *
+	 * @since 5.1
 	 */
+	@API(status = EXPERIMENTAL, since = "5.1")
 	int numLinesToSkip() default 0;
 
 	/**
@@ -85,7 +88,10 @@ public @interface CsvFileSource {
 	 * <p>This value replaces quoted empty strings read from the input.
 	 *
 	 * <p>Defaults to {@code ""}.
+	 *
+	 * @since 5.5
 	 */
+	@API(status = EXPERIMENTAL, since = "5.5")
 	String emptyValue() default "";
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -80,11 +80,11 @@ public @interface CsvFileSource {
 	int numLinesToSkip() default 0;
 
 	/**
-	 * The empty value definition to use when reading the CSV files.
+	 * The empty value to use when reading the CSV files.
 	 *
-	 * <p>When reading, if the parser does not read any character from the input, and the input is within quotes, the empty is used instead of an empty string
+	 * <p>This value replaces quoted empty strings read from the input.
 	 *
-	 * <p>Defaults to empty string.
+	 * <p>Defaults to {@code ""}.
 	 */
 	String emptyValue() default "";
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -79,4 +79,11 @@ public @interface CsvFileSource {
 	 */
 	int numLinesToSkip() default 0;
 
+	/**
+	 * The empty value definition to use when reading the CSV files.
+	 *
+	 * <p>Defaults to empty string.
+	 */
+	String emptyValue() default "";
+
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -82,6 +82,8 @@ public @interface CsvFileSource {
 	/**
 	 * The empty value definition to use when reading the CSV files.
 	 *
+	 * <p>When reading, if the parser does not read any character from the input, and the input is within quotes, the empty is used instead of an empty string
+	 *
 	 * <p>Defaults to empty string.
 	 */
 	String emptyValue() default "";

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -55,4 +55,11 @@ public @interface CsvSource {
 	 */
 	char delimiter() default ',';
 
+	/**
+	 * The empty value definition to use when reading the {@linkplain #value lines}.
+	 *
+	 * <p>Defaults to empty string.
+	 */
+	String emptyValue() default "";
+
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -56,11 +56,11 @@ public @interface CsvSource {
 	char delimiter() default ',';
 
 	/**
-	 * The empty value definition to use when reading the {@linkplain #value lines}.
+	 * The empty value to use when reading the {@linkplain #value lines}.
 	 *
-	 * <p>When reading, if the parser does not read any character from the input, and the input is within quotes, the empty is used instead of an empty string
+	 * <p>This value replaces quoted empty strings read from the input.
 	 *
-	 * <p>Defaults to empty string.
+	 * <p>Defaults to {@code ""}.
 	 */
 	String emptyValue() default "";
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -58,6 +58,8 @@ public @interface CsvSource {
 	/**
 	 * The empty value definition to use when reading the {@linkplain #value lines}.
 	 *
+	 * <p>When reading, if the parser does not read any character from the input, and the input is within quotes, the empty is used instead of an empty string
+	 *
 	 * <p>Defaults to empty string.
 	 */
 	String emptyValue() default "";

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -61,7 +61,10 @@ public @interface CsvSource {
 	 * <p>This value replaces quoted empty strings read from the input.
 	 *
 	 * <p>Defaults to {@code ""}.
+	 *
+	 * @since 5.5
 	 */
+	@API(status = EXPERIMENTAL, since = "5.5")
 	String emptyValue() default "";
 
 }


### PR DESCRIPTION
## Overview

When using `@CsvSource` or `@CsvFileSource` in a parameterized test,
if the CSV parser does not read any character from the input, and the
input is within quotes, and emptyValue is configured, an emptyValue is
returned instead of default `""`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass


Closes #1788

---

I hereby agree to the terms of the JUnit Contributor License Agreement.