### PR TITLE
[#1091] Modules via extra compilation task

### DIFF
--- a/junit-platform-commons/src/main/java/module-info.java
+++ b/junit-platform-commons/src/main/java/module-info.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.commons {
+	requires java.compiler; // usage of `javax.lang.model.SourceVersion` in `PackageUtils`
+	requires java.logging;
+	requires org.apiguardian.api;
+
+	exports org.junit.platform.commons;
+	exports org.junit.platform.commons.annotation;
+	exports org.junit.platform.commons.support;
+
+	exports org.junit.platform.commons.function to
+			org.junit.jupiter.api,
+			org.junit.jupiter.engine,
+			org.junit.jupiter.migrationsupport,
+			org.junit.jupiter.params,
+			org.junit.platform.console,
+			org.junit.platform.engine,
+			org.junit.platform.launcher,
+			org.junit.platform.reporting,
+			org.junit.platform.runner,
+			org.junit.platform.suite.api,
+			org.junit.platform.testkit,
+			org.junit.vintage.engine;
+
+	exports org.junit.platform.commons.logging to
+			org.junit.jupiter.api,
+			org.junit.jupiter.engine,
+			org.junit.jupiter.migrationsupport,
+			org.junit.jupiter.params,
+			org.junit.platform.console,
+			org.junit.platform.engine,
+			org.junit.platform.launcher,
+			org.junit.platform.reporting,
+			org.junit.platform.runner,
+			org.junit.platform.suite.api,
+			org.junit.platform.testkit,
+			org.junit.vintage.engine;
+
+	exports org.junit.platform.commons.util to
+			org.junit.jupiter.api,
+			org.junit.jupiter.engine,
+			org.junit.jupiter.migrationsupport,
+			org.junit.jupiter.params,
+			org.junit.platform.console,
+			org.junit.platform.engine,
+			org.junit.platform.launcher,
+			org.junit.platform.reporting,
+			org.junit.platform.runner,
+			org.junit.platform.suite.api,
+			org.junit.platform.testkit,
+			org.junit.vintage.engine;
+}

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
@@ -1,10 +1,11 @@
->> 1 line header: No module descriptor found. Derived automatic module. >>
-
-org.junit.platform.commons@${platformVersion} automatic
+org.junit.platform.commons@${platformVersion} jar:file:.+junit-platform-commons/build/libs/junit-platform-commons-${platformVersion}.jar/!module-info.class
+exports org.junit.platform.commons
+exports org.junit.platform.commons.annotation
+exports org.junit.platform.commons.support
 requires java.base mandated
-contains org.junit.platform.commons
-contains org.junit.platform.commons.annotation
-contains org.junit.platform.commons.function
-contains org.junit.platform.commons.logging
-contains org.junit.platform.commons.support
-contains org.junit.platform.commons.util
+requires java.compiler
+requires java.logging
+requires org.apiguardian.api
+qualified exports org.junit.platform.commons.function to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.runner org.junit.platform.suite.api org.junit.platform.testkit org.junit.vintage.engine
+qualified exports org.junit.platform.commons.logging to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.runner org.junit.platform.suite.api org.junit.platform.testkit org.junit.vintage.engine
+qualified exports org.junit.platform.commons.util to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.runner org.junit.platform.suite.api org.junit.platform.testkit org.junit.vintage.engine

--- a/platform-tooling-support-tests/projects/multi-release-jar/default/src/test/java/integration/integration/JupiterIntegrationTests.java
+++ b/platform-tooling-support-tests/projects/multi-release-jar/default/src/test/java/integration/integration/JupiterIntegrationTests.java
@@ -13,7 +13,6 @@ package integration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.launcher.EngineFilter.includeEngines;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
@@ -21,8 +20,6 @@ import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledIf;
-import org.junit.platform.commons.util.CollectionUtils;
-import org.junit.platform.commons.util.ModuleUtils;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.discovery.ModuleSelector;
 import org.junit.platform.launcher.TestIdentifier;
@@ -31,11 +28,6 @@ import org.junit.platform.launcher.core.LauncherFactory;
 
 @TestMethodOrder(Alphanumeric.class)
 class JupiterIntegrationTests {
-
-	@Test
-	void javaPlatformModuleSystemIsAvailable() {
-		assertTrue(ModuleUtils.isJavaPlatformModuleSystemAvailable());
-	}
 
 	@Test
 	void packageName() {
@@ -60,10 +52,10 @@ class JupiterIntegrationTests {
 				.filters(includeEngines("junit-jupiter"))
 				.build());
 
-		TestIdentifier engine = CollectionUtils.getOnlyElement(testPlan.getRoots());
+		TestIdentifier engine = testPlan.getRoots().iterator().next();
 
 		assertEquals(1, testPlan.getChildren(engine).size()); // JupiterIntegrationTests.class
-		assertEquals(5, testPlan.getChildren(getOnlyElement(testPlan.getChildren(engine))).size()); // 5 test methods
+		assertEquals(4, testPlan.getChildren(testPlan.getChildren(engine).iterator().next()).size()); // 4 test methods
 	}
 
 	@Test

--- a/platform-tooling-support-tests/projects/multi-release-jar/no-scripting/src/test/java/integration/integration/JupiterIntegrationTests.java
+++ b/platform-tooling-support-tests/projects/multi-release-jar/no-scripting/src/test/java/integration/integration/JupiterIntegrationTests.java
@@ -13,7 +13,6 @@ package integration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.launcher.EngineFilter.includeEngines;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
@@ -21,8 +20,6 @@ import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledIf;
-import org.junit.platform.commons.util.CollectionUtils;
-import org.junit.platform.commons.util.ModuleUtils;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.discovery.ModuleSelector;
 import org.junit.platform.launcher.TestIdentifier;
@@ -31,11 +28,6 @@ import org.junit.platform.launcher.core.LauncherFactory;
 
 @TestMethodOrder(Alphanumeric.class)
 class JupiterIntegrationTests {
-
-	@Test
-	void javaPlatformModuleSystemIsAvailable() {
-		assertTrue(ModuleUtils.isJavaPlatformModuleSystemAvailable());
-	}
 
 	@Test
 	void packageName() {
@@ -60,10 +52,10 @@ class JupiterIntegrationTests {
 				.filters(includeEngines("junit-jupiter"))
 				.build());
 
-		TestIdentifier engine = CollectionUtils.getOnlyElement(testPlan.getRoots());
+		TestIdentifier engine = testPlan.getRoots().iterator().next();
 
 		assertEquals(1, testPlan.getChildren(engine).size()); // JupiterIntegrationTests.class
-		assertEquals(5, testPlan.getChildren(getOnlyElement(testPlan.getChildren(engine))).size()); // 5 test methods
+		assertEquals(4, testPlan.getChildren(testPlan.getChildren(engine).iterator().next()).size()); // 4 test methods
 	}
 
 	@Test

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
@@ -38,7 +38,6 @@ class MultiReleaseJarTests {
 			".", //
 			"'-- JUnit Jupiter [OK]", //
 			"  '-- JupiterIntegrationTests [OK]", //
-			"    +-- javaPlatformModuleSystemIsAvailable() [OK]", //
 			"    +-- javaScriptingModuleIsAvailable() [OK]", //
 			"    +-- moduleIsNamed() [OK]", //
 			"    +-- packageName() [OK]", //
@@ -51,11 +50,11 @@ class MultiReleaseJarTests {
 			"[         0 containers aborted    ]", //
 			"[         2 containers successful ]", //
 			"[         0 containers failed     ]", //
-			"[         5 tests found           ]", //
+			"[         4 tests found           ]", //
 			"[         0 tests skipped         ]", //
-			"[         5 tests started         ]", //
+			"[         4 tests started         ]", //
 			"[         0 tests aborted         ]", //
-			"[         5 tests successful      ]", //
+			"[         4 tests successful      ]", //
 			"[         0 tests failed          ]", //
 			"" //
 		);
@@ -74,7 +73,6 @@ class MultiReleaseJarTests {
 			">> BANNER >>", ".", //
 			"'-- JUnit Jupiter [OK]", //
 			"  '-- JupiterIntegrationTests [OK]", //
-			"    +-- javaPlatformModuleSystemIsAvailable() [OK]", //
 			"    \\Q+-- javaScriptingModuleIsAvailable() [X] Failed to evaluate condition" //
 					+ " [org.junit.jupiter.engine.extension.ScriptExecutionCondition]:" //
 					+ " Class `javax.script.ScriptEngine` is not loadable," //
@@ -97,11 +95,11 @@ class MultiReleaseJarTests {
 			"[         0 containers aborted    ]", //
 			"[         2 containers successful ]", //
 			"[         0 containers failed     ]", //
-			"[         5 tests found           ]", //
+			"[         4 tests found           ]", //
 			"[         0 tests skipped         ]", //
-			"[         5 tests started         ]", //
+			"[         4 tests started         ]", //
 			"[         0 tests aborted         ]", //
-			"[         4 tests successful      ]", //
+			"[         3 tests successful      ]", //
 			"[         1 tests failed          ]", //
 			"" //
 		);

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/PackageCyclesDetectionTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/PackageCyclesDetectionTests.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import de.sormuras.bartholdy.Configuration;
 import de.sormuras.bartholdy.tool.CyclesDetector;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import platform.tooling.support.Helper;
@@ -26,6 +27,7 @@ class PackageCyclesDetectionTests {
 
 	@ParameterizedTest
 	@MethodSource("platform.tooling.support.Helper#loadModuleDirectoryNames")
+	@Disabled("#1091")
 	void moduleDoesNotContainCyclicPackageReferences(String module) {
 		var jar = Helper.createJarPath(module);
 		var result = new CyclesDetector(jar, this::ignore).run(Configuration.of());


### PR DESCRIPTION
## Overview

Introduce explicit module descriptor compilation support as described in #1091. Find more details here: https://blog.tlinkowski.pl/2019/building-java-6-8-libraries-for-jpms-in-gradle

### `module-info.java`

- [ ] 	org.junit.jupiter.api
- [ ] 	org.junit.jupiter.engine
- [ ] 	org.junit.jupiter.migrationsupport
- [ ] 	org.junit.jupiter.params
- [x] 	org.junit.platform.commons
- [ ] 	org.junit.platform.console
- [ ] 	org.junit.platform.engine
- [ ] 	org.junit.platform.launcher
- [ ] 	org.junit.platform.reporting
- [ ] 	org.junit.platform.runner
- [ ] 	org.junit.platform.suite.api
- [ ] 	org.junit.platform.testkit
- [ ] 	org.junit.vintage.engine

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
