### PR TITLE
[#1091] Modules via @moditect

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -29,6 +29,7 @@ object Versions {
     val gitPublishPlugin = "2.1.1"
     val jmhPlugin = "0.4.8"
     val nexusPublishPlugin = "0.2.0"
+    val moditectPlugin = "1.0.0-beta2"
     val shadowPlugin = "4.0.1"
     val spotlessPlugin = "3.18.0"
     val versioningPlugin = "2.8.2"

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.spi.ToolProvider
-
 plugins {
 	`java-library`
 	eclipse
@@ -135,25 +133,6 @@ tasks.jar {
 				"Implementation-Version" to project.version,
 				"Implementation-Vendor" to "junit.org"
 		)
-	}
-
-	// If available, compile and include classes for other Java versions.
-	listOf("9").forEach { version ->
-		val versionedProject = findProject(":${project.name}-java-$version")
-		if (versionedProject != null) {
-			// We're only interested in the compiled classes. So we depend
-			// on the classes task and change (-C) to the destination
-			// directory of the version-aware project later.
-			dependsOn(versionedProject.tasks.matching { it.name == "classes" })
-			doLast {
-				ToolProvider.findFirst("jar").get().run(System.out, System.err,
-						"--update",
-						"--file", archiveFile.get().asFile.absolutePath,
-						"--release", version,
-						"-C", versionedProject.tasks.compileJava.get().destinationDir.toString(),
-						".")
-			}
-		}
 	}
 }
 

--- a/junit-platform-commons-java-9/junit-platform-commons-java-9.gradle.kts
+++ b/junit-platform-commons-java-9/junit-platform-commons-java-9.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.spi.ToolProvider
+
 plugins {
 	`java-library-conventions`
 }
@@ -15,4 +17,24 @@ dependencies {
 javaLibrary {
 	// Compiles against the public, supported and documented Java 9 API.
 	mainJavaVersion = JavaVersion.VERSION_1_9
+}
+
+tasks.jar {
+	enabled = true
+	doLast {
+		val commons = project(":junit-platform-commons")
+		val archive = commons.tasks.jar.get().archiveFile.get().asFile.absolutePath
+		println(commons)
+		println(archive)
+		ToolProvider.findFirst("jar").get().run(System.out, System.err,
+				"--verbose",
+				"--update",
+				"--file", archive,
+				"--release", "9",
+				"-C", tasks.compileJava.get().destinationDir.absolutePath,
+				".")
+		ToolProvider.findFirst("jar").get().run(System.out, System.err,
+				"--describe-module",
+				"--file", archive)
+	}
 }

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	`java-library-conventions`
+	id("org.moditect.gradleplugin")
 }
 
 description = "JUnit Platform Commons"
@@ -10,4 +11,15 @@ javaLibrary {
 
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
+}
+
+moditect {
+	addMainModuleInfo {
+		overwriteExistingFiles.set(true)
+		module {
+			moduleInfo {
+				name = "org." + project.name.replace('-', '.')
+			}
+		}
+	}
 }

--- a/junit-platform-engine/junit-platform-engine.gradle.kts
+++ b/junit-platform-engine/junit-platform-engine.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	`java-library-conventions`
+	id("org.moditect.gradleplugin")
 }
 
 description = "JUnit Platform Engine API"
@@ -15,4 +16,15 @@ dependencies {
 	api(project(":junit-platform-commons"))
 
 	testImplementation("org.assertj:assertj-core:${Versions.assertJ}")
+}
+
+moditect {
+	addMainModuleInfo {
+		overwriteExistingFiles.set(true)
+		module {
+			moduleInfo {
+				name = "org." + project.name.replace('-', '.')
+			}
+		}
+	}
 }

--- a/junit-platform-launcher/junit-platform-launcher.gradle.kts
+++ b/junit-platform-launcher/junit-platform-launcher.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	`java-library-conventions`
+	id("org.moditect.gradleplugin")
 }
 
 description = "JUnit Platform Launcher"
@@ -12,4 +13,15 @@ dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 
 	api(project(":junit-platform-engine"))
+}
+
+moditect {
+	addMainModuleInfo {
+		overwriteExistingFiles.set(true)
+		module {
+			moduleInfo {
+				name = "org." + project.name.replace('-', '.')
+			}
+		}
+	}
 }

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	`java-library-conventions`
+	id("org.moditect.gradleplugin")
 }
 
 description = "JUnit Platform Reporting"
@@ -12,4 +13,15 @@ dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 
 	api(project(":junit-platform-launcher"))
+}
+
+moditect {
+	addMainModuleInfo {
+		overwriteExistingFiles.set(true)
+		module {
+			moduleInfo {
+				name = "org." + project.name.replace('-', '.')
+			}
+		}
+	}
 }

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	`java-library-conventions`
+	id("org.moditect.gradleplugin")
 }
 
 description = "JUnit Platform Runner"
@@ -14,4 +15,16 @@ dependencies {
 
 	api(project(":junit-platform-launcher"))
 	api(project(":junit-platform-suite-api"))
+}
+
+
+moditect {
+	addMainModuleInfo {
+		overwriteExistingFiles.set(true)
+		module {
+			moduleInfo {
+				name = "org." + project.name.replace('-', '.')
+			}
+		}
+	}
 }

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	`java-library-conventions`
+	id("org.moditect.gradleplugin")
 }
 
 description = "JUnit Platform Suite API"
@@ -10,4 +11,15 @@ javaLibrary {
 
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
+}
+
+moditect {
+	addMainModuleInfo {
+		overwriteExistingFiles.set(true)
+		module {
+			moduleInfo {
+				name = "org." + project.name.replace('-', '.')
+			}
+		}
+	}
 }

--- a/junit-platform-testkit/junit-platform-testkit.gradle.kts
+++ b/junit-platform-testkit/junit-platform-testkit.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	`java-library-conventions`
+	id("org.moditect.gradleplugin")
 }
 
 description = "JUnit Platform Test Kit"
@@ -14,4 +15,15 @@ dependencies {
 	api("org.opentest4j:opentest4j:${Versions.ota4j}")
 
 	api(project(":junit-platform-launcher"))
+}
+
+moditect {
+	addMainModuleInfo {
+		overwriteExistingFiles.set(true)
+		module {
+			moduleInfo {
+				name = "org." + project.name.replace('-', '.')
+			}
+		}
+	}
 }

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
 	`java-library-conventions`
+	id("org.moditect.gradleplugin")
 }
 
 apply(from = "$rootDir/gradle/testing.gradle.kts")
@@ -21,4 +22,17 @@ dependencies {
 	testImplementation(project(":junit-platform-runner"))
 	testImplementation(project(path = ":junit-jupiter-engine", configuration = "testArtifacts"))
 	testImplementation(project(":junit-platform-testkit"))
+}
+
+
+moditect {
+	addMainModuleInfo {
+		overwriteExistingFiles.set(true)
+		module {
+			moduleInfo {
+				name = "org." + project.name.replace('-', '.')
+				exports = "!*;"
+			}
+		}
+	}
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,8 @@
 pluginManagement {
+	repositories {
+		gradlePluginPortal()
+		maven(url = "https://jitpack.io")
+	}
 	resolutionStrategy {
 		eachPlugin {
 			when (requested.id.id) {
@@ -12,6 +16,7 @@ pluginManagement {
 				"org.asciidoctor.convert" -> useVersion(Versions.asciidoctorPlugin)
 				"me.champeau.gradle.jmh" -> useVersion(Versions.jmhPlugin)
 				"de.marcphilipp.nexus-publish" -> useVersion(Versions.nexusPublishPlugin)
+				"org.moditect.gradleplugin" -> useVersion(Versions.moditectPlugin)
 			}
 		}
 	}


### PR DESCRIPTION
## Overview

Use @moditect to inject module descriptors.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
