### PR TITLE
[#1091] Modules via "module" source set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ val vintageProjects by extra(listOf(
 ))
 
 val mavenizedProjects by extra(platformProjects + jupiterProjects + vintageProjects)
+val modularProjects by extra(mavenizedProjects.filter{ it != project(":junit-platform-console-standalone") })
 
 val license by extra(License(
 		name = "Eclipse Public License v2.0",

--- a/buildSrc/src/main/kotlin/JavaLibraryExtension.kt
+++ b/buildSrc/src/main/kotlin/JavaLibraryExtension.kt
@@ -2,7 +2,6 @@ import org.gradle.api.JavaVersion
 
 @Suppress("UnstableApiUsage")
 open class JavaLibraryExtension {
-    var automaticModuleName: String? = null
     var mainJavaVersion: JavaVersion = Versions.jvmTarget
     var testJavaVersion: JavaVersion = JavaVersion.VERSION_11
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -29,7 +29,7 @@ object Versions {
     val gitPublishPlugin = "2.1.1"
     val jmhPlugin = "0.4.8"
     val nexusPublishPlugin = "0.2.0"
-    val shadowPlugin = "4.0.1"
+    val shadowPlugin = "5.0.0"
     val spotlessPlugin = "3.18.0"
     val versioningPlugin = "2.8.2"
     val versionsPlugin = "0.21.0"
@@ -42,7 +42,7 @@ object Versions {
     val jruby = "9.1.17.0"
 
     // Tools
-    val checkstyle = "8.10"
+    val checkstyle = "8.19"
     val jacoco = "0.8.2"
     val jmh = "1.21"
     val ktlint = "0.24.0"

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -210,18 +210,17 @@ afterEvaluate {
 		sourceCompatibility = "9"
 		targetCompatibility = "9"
 		options.encoding = "UTF-8"
-		options.compilerArgs.addAll(listOf("--release", "9",
+		options.compilerArgs.addAll(listOf(
+				"-Xlint",
+				"--release", "9",
 				"--module-source-path", files(mavenizedProjects.map { "${it.projectDir}/src/module" }).asPath,
-				"--module-path", modulePath,
-				"--patch-module", javaModuleName + "=" + classpath.asPath
+				"--module-path", modulePath
 		))
 		mavenizedProjects.forEach {
-			if (it == project) {
-				return@forEach
-			}
 			val module = javaModuleName(it)
-			val source = "${it.projectDir}/src/main/java"
-			options.compilerArgs.addAll(listOf("--patch-module", "$module=$source"))
+			val patch = if (it == project) classpath.asPath else "${it.projectDir}/src/main/java"
+			options.compilerArgs.add("--patch-module")
+			options.compilerArgs.add("$module=$patch")
 		}
 		classpath = files()
 	}

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -236,7 +236,8 @@ tasks {
 		configFile = rootProject.file("src/checkstyle/checkstyleMain.xml")
 	}
 	tasks.named<Checkstyle>("checkstyleModule") {
-		enabled = false
+		configFile = rootProject.file("src/checkstyle/checkstyleMain.xml")
+		exclude("module-info.java")
 	}
 	checkstyleTest {
 		configFile = rootProject.file("src/checkstyle/checkstyleTest.xml")

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -213,6 +213,7 @@ afterEvaluate {
 		options.compilerArgs.addAll(listOf(
 				"-Xlint",
 				"--release", "9",
+				"--module-version", "${project.version}",
 				"--module-source-path", files(mavenizedProjects.map { "${it.projectDir}/src/module" }).asPath,
 				"--module-path", modulePath
 		))

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -157,17 +157,6 @@ tasks.jar {
 	}
 }
 
-afterEvaluate {
-	val automaticModuleName = extension.automaticModuleName
-	if (automaticModuleName != null) {
-		tasks.jar {
-			manifest {
-				attributes("Automatic-Module-Name" to automaticModuleName)
-			}
-		}
-	}
-}
-
 tasks.compileJava {
 	options.encoding = "UTF-8"
 

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -27,7 +27,7 @@ sourceSets {
 		java {
 			srcDir("src/module/$javaModuleName")
 		}
-		compileClasspath += main.get().output
+		compileClasspath += main.get().output + configurations["compileClasspath"]
 	}
 	test {
 		runtimeClasspath += shadowed

--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "JUnit Jupiter API"
 
-javaLibrary {
-	automaticModuleName = "org.junit.jupiter.api"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 	api("org.opentest4j:opentest4j:${Versions.ota4j}")

--- a/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java
+++ b/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.jupiter.api {
+	requires org.apiguardian.api;
+	requires transitive org.junit.platform.commons;
+	requires org.opentest4j;
+
+	exports org.junit.jupiter.api;
+	exports org.junit.jupiter.api.condition;
+	exports org.junit.jupiter.api.extension;
+	exports org.junit.jupiter.api.function;
+	exports org.junit.jupiter.api.io;
+	exports org.junit.jupiter.api.parallel;
+}

--- a/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java
+++ b/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java
@@ -10,8 +10,9 @@
 
 module org.junit.jupiter.api {
 	requires org.apiguardian.api;
-	requires transitive org.junit.platform.commons;
 	requires org.opentest4j;
+
+	requires transitive org.junit.platform.commons;
 
 	exports org.junit.jupiter.api;
 	exports org.junit.jupiter.api.condition;

--- a/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
+++ b/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
@@ -7,10 +7,6 @@ apply(from = "$rootDir/gradle/testing.gradle.kts")
 
 description = "JUnit Jupiter Engine"
 
-javaLibrary {
-	automaticModuleName = "org.junit.jupiter.engine"
-}
-
 tasks.compileTestGroovy {
 	sourceCompatibility = javaLibrary.testJavaVersion.majorVersion
 	targetCompatibility = javaLibrary.testJavaVersion.majorVersion

--- a/junit-jupiter-engine/src/module/org.junit.jupiter.engine/module-info.java
+++ b/junit-jupiter-engine/src/module/org.junit.jupiter.engine/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.jupiter.engine {
+}

--- a/junit-jupiter-engine/src/module/org.junit.jupiter.engine/module-info.java
+++ b/junit-jupiter-engine/src/module/org.junit.jupiter.engine/module-info.java
@@ -9,4 +9,11 @@
  */
 
 module org.junit.jupiter.engine {
+	requires org.apiguardian.api;
+
+	requires org.junit.jupiter.api;
+	requires org.junit.platform.engine;
+
+	provides org.junit.platform.engine.TestEngine
+			with org.junit.jupiter.engine.JupiterTestEngine;
 }

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -6,10 +6,6 @@ apply(from = "$rootDir/gradle/testing.gradle.kts")
 
 description = "JUnit Jupiter Migration Support"
 
-javaLibrary {
-	automaticModuleName = "org.junit.jupiter.migrationsupport"
-}
-
 dependencies {
 	api("junit:junit:${Versions.junit4}")
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")

--- a/junit-jupiter-migrationsupport/src/module/org.junit.jupiter.migrationsupport/module-info.java
+++ b/junit-jupiter-migrationsupport/src/module/org.junit.jupiter.migrationsupport/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.jupiter.migrationsupport {
+}

--- a/junit-jupiter-params/junit-jupiter-params.gradle.kts
+++ b/junit-jupiter-params/junit-jupiter-params.gradle.kts
@@ -10,7 +10,6 @@ description = "JUnit Jupiter Params"
 javaLibrary {
 	// TODO workaround for shadow plugin, should be fixed by 4.0.4
 	testJavaVersion = JavaVersion.VERSION_1_10
-	automaticModuleName = "org.junit.jupiter.params"
 }
 
 dependencies {

--- a/junit-jupiter-params/junit-jupiter-params.gradle.kts
+++ b/junit-jupiter-params/junit-jupiter-params.gradle.kts
@@ -40,7 +40,7 @@ tasks {
 		}
 		from("$buildDir/classes/java/module/org.junit.jupiter.params") {
 			include("module-info.class")
-		}		
+		}
 	}
 	test {
 		// in order to run the test against the shadowJar

--- a/junit-jupiter-params/junit-jupiter-params.gradle.kts
+++ b/junit-jupiter-params/junit-jupiter-params.gradle.kts
@@ -38,6 +38,9 @@ tasks {
 			include("LICENSE-univocity-parsers.md")
 			into("META-INF")
 		}
+		from("$buildDir/classes/java/module/org.junit.jupiter.params") {
+			include("module-info.class")
+		}		
 	}
 	test {
 		// in order to run the test against the shadowJar

--- a/junit-jupiter-params/src/module/org.junit.jupiter.params/module-info.java
+++ b/junit-jupiter-params/src/module/org.junit.jupiter.params/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.jupiter.params {
+}

--- a/junit-jupiter/junit-jupiter.gradle.kts
+++ b/junit-jupiter/junit-jupiter.gradle.kts
@@ -9,7 +9,3 @@ dependencies {
 	api(project(":junit-jupiter-params"))
 	runtimeOnly(project(":junit-jupiter-engine"))
 }
-
-javaLibrary {
-	automaticModuleName = "org.junit.jupiter"
-}

--- a/junit-jupiter/src/module/org.junit.jupiter/module-info.java
+++ b/junit-jupiter/src/module/org.junit.jupiter/module-info.java
@@ -10,5 +10,6 @@
 
 module org.junit.jupiter {
 	requires transitive org.junit.jupiter.api;
-	requires transitive static org.junit.jupiter.engine;
+	requires transitive org.junit.jupiter.params;
+	requires transitive org.junit.jupiter.engine;
 }

--- a/junit-jupiter/src/module/org.junit.jupiter/module-info.java
+++ b/junit-jupiter/src/module/org.junit.jupiter/module-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.jupiter {
+	requires transitive org.junit.jupiter.api;
+	requires transitive static org.junit.jupiter.engine;
+}

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "JUnit Platform Commons"
 
-javaLibrary {
-	automaticModuleName = "org.junit.platform.commons"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 }

--- a/junit-platform-commons/src/module/org.junit.platform.commons/module-info.java
+++ b/junit-platform-commons/src/module/org.junit.platform.commons/module-info.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.commons {
+	requires java.compiler; // usage of `javax.lang.model.SourceVersion` in `PackageUtils`
+	requires java.logging;
+	requires static org.apiguardian.api;
+
+	exports org.junit.platform.commons;
+	exports org.junit.platform.commons.annotation;
+	exports org.junit.platform.commons.support;
+
+	exports org.junit.platform.commons.function to
+			org.junit.platform.engine,
+			org.junit.platform.console,
+			org.junit.platform.launcher,
+			org.junit.jupiter.engine,
+			org.junit.vintage.engine;
+
+	exports org.junit.platform.commons.logging to
+			org.junit.platform.engine,
+			org.junit.platform.console,
+			org.junit.platform.launcher,
+			org.junit.jupiter.engine,
+			org.junit.vintage.engine;
+
+	exports org.junit.platform.commons.util to
+			org.junit.platform.engine,
+			org.junit.platform.console,
+			org.junit.platform.launcher,
+			org.junit.jupiter.api,
+			org.junit.jupiter.engine,
+			org.junit.vintage.engine;
+}

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -5,10 +5,6 @@ plugins {
 
 description = "JUnit Platform Console"
 
-javaLibrary {
-	automaticModuleName = "org.junit.platform.console"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -23,6 +23,9 @@ tasks {
 			include("LICENSE-picocli.md")
 			into("META-INF")
 		}
+		from("$buildDir/classes/java/module/org.junit.platform.console") {
+			include("module-info.class")
+		}
 	}
 	jar {
 		enabled = false

--- a/junit-platform-console/src/module/org.junit.platform.console/module-info.java
+++ b/junit-platform-console/src/module/org.junit.platform.console/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.console {
+}

--- a/junit-platform-engine/junit-platform-engine.gradle.kts
+++ b/junit-platform-engine/junit-platform-engine.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "JUnit Platform Engine API"
 
-javaLibrary {
-	automaticModuleName = "org.junit.platform.engine"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 	api("org.opentest4j:opentest4j:${Versions.ota4j}")

--- a/junit-platform-engine/src/module/org.junit.platform.engine/module-info.java
+++ b/junit-platform-engine/src/module/org.junit.platform.engine/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.engine {
+}

--- a/junit-platform-engine/src/module/org.junit.platform.engine/module-info.java
+++ b/junit-platform-engine/src/module/org.junit.platform.engine/module-info.java
@@ -9,4 +9,8 @@
  */
 
 module org.junit.platform.engine {
+	requires org.apiguardian.api;
+	requires org.opentest4j;
+
+	requires org.junit.platform.commons;
 }

--- a/junit-platform-launcher/junit-platform-launcher.gradle.kts
+++ b/junit-platform-launcher/junit-platform-launcher.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "JUnit Platform Launcher"
 
-javaLibrary {
-	automaticModuleName = "org.junit.platform.launcher"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 

--- a/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
+++ b/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.launcher {
+}

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "JUnit Platform Reporting"
 
-javaLibrary {
-	automaticModuleName = "org.junit.platform.reporting"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 

--- a/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
+++ b/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.reporting {
+}

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "JUnit Platform Runner"
 
-javaLibrary {
-	automaticModuleName = "org.junit.platform.runner"
-}
-
 dependencies {
 	api("junit:junit:${Versions.junit4}")
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")

--- a/junit-platform-runner/src/module/org.junit.platform.runner/module-info.java
+++ b/junit-platform-runner/src/module/org.junit.platform.runner/module-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.runner {
+	exports org.junit.platform.runner;
+}

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "JUnit Platform Suite API"
 
-javaLibrary {
-	automaticModuleName = "org.junit.platform.suite.api"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 }

--- a/junit-platform-suite-api/src/module/org.junit.platform.suite.api/module-info.java
+++ b/junit-platform-suite-api/src/module/org.junit.platform.suite.api/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.suite.api {
+}

--- a/junit-platform-testkit/junit-platform-testkit.gradle.kts
+++ b/junit-platform-testkit/junit-platform-testkit.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 description = "JUnit Platform Test Kit"
 
-javaLibrary {
-	automaticModuleName = "org.junit.platform.testkit"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 	api("org.assertj:assertj-core:${Versions.assertJ}")

--- a/junit-platform-testkit/src/module/org.junit.platform.testkit/module-info.java
+++ b/junit-platform-testkit/src/module/org.junit.platform.testkit/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.platform.testkit {
+}

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -6,10 +6,6 @@ apply(from = "$rootDir/gradle/testing.gradle.kts")
 
 description = "JUnit Vintage Engine"
 
-javaLibrary {
-	automaticModuleName = "org.junit.vintage.engine"
-}
-
 dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 	api(project(":junit-platform-engine"))

--- a/junit-vintage-engine/src/module/org.junit.vintage.engine/module-info.java
+++ b/junit-vintage-engine/src/module/org.junit.vintage.engine/module-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+module org.junit.vintage.engine {
+}

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-api.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-api.expected.txt
@@ -1,10 +1,11 @@
->> 1 line header: No module descriptor found. Derived automatic module. >>
-
-org.junit.jupiter.api@${jupiterVersion} automatic
+org.junit.jupiter.api@${jupiterVersion} jar:file:.+!module-info.class
+exports org.junit.jupiter.api
+exports org.junit.jupiter.api.condition
+exports org.junit.jupiter.api.extension
+exports org.junit.jupiter.api.function
+exports org.junit.jupiter.api.io
+exports org.junit.jupiter.api.parallel
 requires java.base mandated
-contains org.junit.jupiter.api
-contains org.junit.jupiter.api.condition
-contains org.junit.jupiter.api.extension
-contains org.junit.jupiter.api.function
-contains org.junit.jupiter.api.io
-contains org.junit.jupiter.api.parallel
+requires org.apiguardian.api
+requires org.junit.platform.commons transitive
+requires org.opentest4j

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-engine.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-engine.expected.txt
@@ -1,14 +1,3 @@
->> 1 line header: No module descriptor found. Derived automatic module. >>
-
-org.junit.jupiter.engine@${jupiterVersion} automatic
+org.junit.jupiter.engine@${jupiterVersion} jar:file:.+!module-info.class
 requires java.base mandated
-provides org.junit.platform.engine.TestEngine with org.junit.jupiter.engine.[J|j]upiter[T|t]est[E|e]ngine
-contains org.junit.jupiter.engine
-contains org.junit.jupiter.engine.config
-contains org.junit.jupiter.engine.descriptor
-contains org.junit.jupiter.engine.discovery
-contains org.junit.jupiter.engine.discovery.predicates
-contains org.junit.jupiter.engine.execution
-contains org.junit.jupiter.engine.extension
-contains org.junit.jupiter.engine.script
-contains org.junit.jupiter.engine.support
+provides org.junit.platform.engine.TestEngine with org.junit.jupiter.engine.JupiterTestEngine

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter.expected.txt
@@ -1,4 +1,4 @@
->> 1 line header: No module descriptor found. Derived automatic module. >>
-
-org.junit.jupiter@${jupiterVersion} automatic
+org.junit.jupiter@${jupiterVersion} jar:file:.+!module-info.class
 requires java.base mandated
+requires org.junit.jupiter.api transitive
+requires org.junit.jupiter.engine static transitive

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JarDescribeModuleTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JarDescribeModuleTests.java
@@ -68,7 +68,7 @@ class JarDescribeModuleTests {
 		var moduleDescriptor = ModuleFinder.of(modulePath).findAll().iterator().next().descriptor();
 		var moduleName = moduleDescriptor.name();
 		for (var packageName : moduleDescriptor.packages()) {
-			assertTrue(packageName.startsWith(moduleName));
+			assertTrue(packageName.startsWith(moduleName), packageName + " / " + moduleName);
 		}
 	}
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManifestTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManifestTests.java
@@ -43,7 +43,6 @@ class ManifestTests {
 			assertValue(attributes, "Implementation-Title", module);
 			assertValue(attributes, "Implementation-Version", version);
 			assertValue(attributes, "Implementation-Vendor", "junit.org");
-			assertValue(attributes, "Automatic-Module-Name", "org." + module.replace('-', '.'));
 			switch (module) {
 				case "junit-platform-commons":
 					assertValue(attributes, "Multi-Release", "true");

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,8 @@
 pluginManagement {
+	repositories {
+		gradlePluginPortal()
+		maven(url = "https://jitpack.io")
+	}
 	resolutionStrategy {
 		eachPlugin {
 			when (requested.id.id) {
@@ -8,7 +12,7 @@ pluginManagement {
 				"com.diffplug.gradle.spotless" -> useVersion(Versions.spotlessPlugin)
 				"org.ajoberstar.git-publish" -> useVersion(Versions.gitPublishPlugin)
 				"org.jetbrains.kotlin.jvm" -> useVersion(Versions.kotlin)
-				"com.github.johnrengelman.shadow" -> useVersion(Versions.shadowPlugin)
+				"com.github.johnrengelman.shadow" -> useModule("com.github.sormuras:shadow:no-minimize-no-tracker-SNAPSHOT")
 				"org.asciidoctor.convert" -> useVersion(Versions.asciidoctorPlugin)
 				"me.champeau.gradle.jmh" -> useVersion(Versions.jmhPlugin)
 				"de.marcphilipp.nexus-publish" -> useVersion(Versions.nexusPublishPlugin)


### PR DESCRIPTION
## Overview

Draft PR #1091 using a dedicated `module` source set containing `module-info.java` files.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
