### PR TITLE
Issue: #1851 Support assertThrows() with suspending functions in Kotlin

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -12,6 +12,7 @@ object Versions {
     val ota4j = "1.2.0-SNAPSHOT"
     val picocli = "3.9.5"
     val univocity = "2.8.1"
+    val coroutines = "1.0.1"
 
     // Test Dependencies
     val archunit = "0.10.1"

--- a/buildSrc/src/main/kotlin/kotlin-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-library-conventions.gradle.kts
@@ -8,8 +8,8 @@ plugins {
 tasks.withType<KotlinCompile>().configureEach {
 	kotlinOptions {
 		jvmTarget = Versions.jvmTarget.toString()
-		apiVersion = "1.1"
-		languageVersion = "1.1"
+		apiVersion = "1.3"
+		languageVersion = "1.3"
 	}
 }
 

--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -9,6 +9,7 @@ javaLibrary {
 }
 
 dependencies {
+	api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 	api("org.opentest4j:opentest4j:${Versions.ota4j}")
 

--- a/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/KotlinAssertionsTests.kt
+++ b/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/KotlinAssertionsTests.kt
@@ -9,16 +9,14 @@
  */
 package org.junit.jupiter.api
 
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith
 import org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Util.failSuspend
 import org.opentest4j.AssertionFailedError
 import org.opentest4j.MultipleFailuresError
-import java.lang.AssertionError
-
 import java.util.stream.Stream
-
 import kotlin.reflect.KClass
 
 /**
@@ -54,9 +52,19 @@ class KotlinAssertionsTests {
         assertThrows<AssertionError> { fail("message") }
         assertThrows<AssertionError> { fail("message", AssertionError()) }
         assertThrows<AssertionError> { fail("message", null) }
-        assertThrows<AssertionError>("should fail") { fail({ "message" }) }
+        assertThrows<AssertionError>("should fail") { fail { "message" } }
         assertThrows<AssertionError>({ "should fail" }) { fail(AssertionError()) }
         assertThrows<AssertionError>({ "should fail" }) { fail(null as Throwable?) }
+    }
+
+    @Test
+    fun `assertThrows and fail with suspensions`() {
+        assertThrows<AssertionError> { failSuspend("message") }
+        assertThrows<AssertionError> { failSuspend("message", AssertionError()) }
+        assertThrows<AssertionError> { failSuspend("message", null) }
+        assertThrows<AssertionError>("should fail") { failSuspend { "message" } }
+        assertThrows<AssertionError>({ "should fail" }) { failSuspend(AssertionError()) }
+        assertThrows<AssertionError>({ "should fail" }) { failSuspend(null as Throwable?) }
     }
 
     @Test
@@ -92,6 +100,8 @@ class KotlinAssertionsTests {
             vararg exceptionTypes: KClass<out Throwable>
         ) =
             AssertAllAssertionsTests.assertExpectedExceptionTypes(
-                multipleFailuresError, *exceptionTypes.map { it.java }.toTypedArray())
+                multipleFailuresError,
+                *exceptionTypes.map { it.java }.toTypedArray()
+            )
     }
 }

--- a/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/Util.kt
+++ b/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/Util.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api
+
+/**
+ * Purely serves as a provider of fail assertions that have a suspend modifier.
+ *
+ * Is used to verify assertThrows() can handle suspending functions.
+ *
+ * @see KotlinFailAssertionsTests
+ * @see KotlinAssertionsTests
+ */
+object Util {
+    suspend fun failSuspend(message: (() -> String)?): Nothing = Assertions.fail<Nothing>(message)
+    suspend fun failSuspend(message: String?, throwable: Throwable? = null): Nothing = Assertions.fail<Nothing>(message, throwable)
+    suspend fun failSuspend(throwable: Throwable?): Nothing = Assertions.fail<Nothing>(throwable)
+}


### PR DESCRIPTION
## Overview

I have modified the assertThrows() functions to accept suspending functions as body. This means now all functions using the suspend modifier for a function can be used by this API as well. Conventional methods without suspend modifier can be passed as well, not resulting in different behaviour.

This should now be possible:

```
suspend fun test(): Nothing = throw Exception()

assertThrows<Exception> {
    test()
}
```

Few topics open for discussion:

- Util.kt added to provide suspending functions to assert failures, not sure if this is the most optimal place. Could be added to relevant tests as well as private functions, I am not totally sure.

Resolves #1851.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [ ] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [X] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
