### PR TITLE
Add assertLinesMatch overloads taking a custom message

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M2.adoc
@@ -25,7 +25,10 @@ on GitHub.
 
 * `AnnotationSupport.findRepeatableAnnotations()` now finds repeatable annotations used as
   meta-annotations on other repeatable annotations.
-
+* New overloaded variants of `Assertions.assertLinesMatch(...)` that accept a `String` or a
+  `Supplier<String>` for a custom failure message.
+* `Assertions.assertLinesMatch`'s failure message now emits each expected and actual line
+  in a dedicated line.
 
 [[release-notes-5.5.0-M2-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.api;
 
 import static java.lang.String.format;
 import static java.lang.String.join;
+import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
+import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.platform.commons.util.Preconditions.condition;
 import static org.junit.platform.commons.util.Preconditions.notNull;
@@ -37,6 +39,14 @@ class AssertLinesMatch {
 	private final static int MAX_SNIPPET_LENGTH = 21;
 
 	static void assertLinesMatch(List<String> expectedLines, List<String> actualLines) {
+		assertLinesMatch(expectedLines, actualLines, (Object) null);
+	}
+
+	static void assertLinesMatch(List<String> expectedLines, List<String> actualLines, String message) {
+		assertLinesMatch(expectedLines, actualLines, (Object) message);
+	}
+
+	static void assertLinesMatch(List<String> expectedLines, List<String> actualLines, Object messageOrSupplier) {
 		notNull(expectedLines, "expectedLines must not be null");
 		notNull(actualLines, "actualLines must not be null");
 
@@ -50,7 +60,8 @@ class AssertLinesMatch {
 
 		// trivial case: when expecting more than actual lines available, something is wrong
 		if (expectedSize > actualSize) {
-			fail(expectedLines, actualLines, "expected %d lines, but only got %d", expectedSize, actualSize);
+			fail(expectedLines, actualLines, messageOrSupplier, "expected %d lines, but only got %d", expectedSize,
+				actualSize);
 		}
 
 		// simple case: both list are equally sized, compare them line-by-line
@@ -61,10 +72,11 @@ class AssertLinesMatch {
 			// else fall-through to "with fast-forward" matching
 		}
 
-		assertLinesMatchWithFastForward(expectedLines, actualLines);
+		assertLinesMatchWithFastForward(expectedLines, actualLines, messageOrSupplier);
 	}
 
-	private static void assertLinesMatchWithFastForward(List<String> expectedLines, List<String> actualLines) {
+	private static void assertLinesMatchWithFastForward(List<String> expectedLines, List<String> actualLines,
+			Object messageOrSupplier) {
 		Deque<String> expectedDeque = new ArrayDeque<>(expectedLines);
 		Deque<String> actualDeque = new ArrayDeque<>(actualLines);
 
@@ -73,8 +85,9 @@ class AssertLinesMatch {
 			int expectedLineNumber = expectedLines.size() - expectedDeque.size(); // 1-based line number
 			// trivial case: no more actual lines available
 			if (actualDeque.isEmpty()) {
-				fail(expectedLines, actualLines, "expected line #%d:`%s` not found - actual lines depleted",
-					expectedLineNumber, snippet(expectedLine));
+				fail(expectedLines, actualLines, messageOrSupplier,
+					"expected line #%d:`%s` not found - actual lines depleted", expectedLineNumber,
+					snippet(expectedLine));
 			}
 
 			String actualLine = actualDeque.peek();
@@ -95,8 +108,9 @@ class AssertLinesMatch {
 					if (fastForwardLimit == Integer.MAX_VALUE || fastForwardLimit == actualRemaining) {
 						return;
 					}
-					fail(expectedLines, actualLines, "terminal fast-forward(%d) error: fast-forward(%d) expected",
-						fastForwardLimit, actualRemaining);
+					fail(expectedLines, actualLines, messageOrSupplier,
+						"terminal fast-forward(%d) error: fast-forward(%d) expected", fastForwardLimit,
+						actualRemaining);
 				}
 
 				// fast-forward limit was given: use it
@@ -113,7 +127,8 @@ class AssertLinesMatch {
 				// fast-forward "unlimited": until next match
 				while (true) {
 					if (actualDeque.isEmpty()) {
-						fail(expectedLines, actualLines, "fast-forward(∞) didn't find: `%s`", snippet(expectedLine));
+						fail(expectedLines, actualLines, messageOrSupplier, "fast-forward(∞) didn't find: `%s`",
+							snippet(expectedLine));
 					}
 					if (matches(expectedLine, actualDeque.peek())) {
 						continue main;
@@ -122,13 +137,14 @@ class AssertLinesMatch {
 				}
 			}
 
-			fail(expectedLines, actualLines, "expected line #%d:`%s` doesn't match", expectedLineNumber,
-				snippet(expectedLine));
+			fail(expectedLines, actualLines, messageOrSupplier, "expected line #%d:`%s` doesn't match",
+				expectedLineNumber, snippet(expectedLine));
 		}
 
 		// after math
 		if (!actualDeque.isEmpty()) {
-			fail(expectedLines, actualLines, "more actual lines than expected: %d", actualDeque.size());
+			fail(expectedLines, actualLines, messageOrSupplier, "more actual lines than expected: %d",
+				actualDeque.size());
 		}
 	}
 
@@ -139,7 +155,8 @@ class AssertLinesMatch {
 		return line.substring(0, MAX_SNIPPET_LENGTH - 5) + "[...]";
 	}
 
-	private static void fail(List<String> expectedLines, List<String> actualLines, String format, Object... args) {
+	private static void fail(List<String> expectedLines, List<String> actualLines, Object messageOrSupplier,
+			String format, Object... args) {
 		if (expectedLines.size() > MAX_SNIPPET_LENGTH) {
 			expectedLines.subList(0, MAX_SNIPPET_LENGTH);
 		}
@@ -147,9 +164,12 @@ class AssertLinesMatch {
 			actualLines.subList(0, MAX_SNIPPET_LENGTH);
 		}
 		// use standard assertEquals(Object, Object, message) to let IDEs present the textual difference
-		String expected = join(System.lineSeparator(), expectedLines);
-		String actual = join(System.lineSeparator(), actualLines);
-		assertEquals(expected, actual, format(format, args));
+		String newLine = System.lineSeparator();
+		String expected = newLine + join(newLine, expectedLines) + newLine;
+		String actual = newLine + join(newLine, actualLines) + newLine;
+		String prefix = buildPrefix(nullSafeGet(messageOrSupplier));
+		String message = prefix + format(format, args);
+		assertEquals(expected, actual, message);
 	}
 
 	static boolean isFastForwardLine(String line) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -1576,9 +1576,41 @@ public class Assertions {
 	 * >> M A N Y  M O R E  E N T R I E S >>
 	 * drwxr-xr-x  0 root root   512 Sep 22  2017 var
 	 * }</pre>
+	 * <p>Fails with a generated failure message describing the difference.
 	 */
 	public static void assertLinesMatch(List<String> expectedLines, List<String> actualLines) {
 		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines);
+	}
+
+	/**
+	 * <em>Assert</em> that {@code expected} list of {@linkplain String}s matches {@code actual}
+	 * list.
+	 *
+	 * <p>Find a detailed description of the matching algorithm in {@link #assertLinesMatch(List, List)}.
+	 *
+	 * <p>Fails with the supplied failure {@code message} and the generated message.
+	 *
+	 * @see #assertLinesMatch(List, List)
+	 */
+	public static void assertLinesMatch(List<String> expectedLines, List<String> actualLines, String message) {
+		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines, message);
+	}
+
+	/**
+	 * <em>Assert</em> that {@code expected} list of {@linkplain String}s matches {@code actual}
+	 * list.
+	 *
+	 * <p>Find a detailed description of the matching algorithm in {@link #assertLinesMatch(List, List)}.
+	 *
+	 * <p>If necessary, a custom failure message will be retrieved lazily from the supplied
+	 * {@code messageSupplier}. Fails with the custom failure message prepended to
+	 * a generated failure message describing the difference.
+	 *
+	 * @see #assertLinesMatch(List, List)
+	 */
+	public static void assertLinesMatch(List<String> expectedLines, List<String> actualLines,
+			Supplier<String> messageSupplier) {
+		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines, messageSupplier);
 	}
 
 	// --- assertNotEquals -----------------------------------------------------

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.function.Supplier;
 
 import org.junit.platform.commons.util.PreconditionViolationException;
 import org.opentest4j.AssertionFailedError;
@@ -114,10 +115,14 @@ class AssertLinesMatchAssertionsTests {
 		List<String> actual = Arrays.asList("first line", "third line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
 		List<String> expectedErrorMessageLines = Arrays.asList( //
-			"expected 3 lines, but only got 2 ==> expected: <first line", //
+			"expected 3 lines, but only got 2 ==> expected: <", //
+			"first line", //
 			"second line", //
-			"third line> but was: <first line", //
-			"third line>");
+			"third line", //
+			"> but was: <", //
+			"first line", //
+			"third line", //
+			">");
 		assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
 	}
 
@@ -127,11 +132,15 @@ class AssertLinesMatchAssertionsTests {
 		List<String> actual = Arrays.asList("first line", "sec0nd line", "third line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
 		List<String> expectedErrorMessageLines = Arrays.asList( //
-			"expected line #2:`second line` doesn't match ==> expected: <first line", //
+			"expected line #2:`second line` doesn't match ==> expected: <", //
+			"first line", //
 			"second line", //
-			"third line> but was: <first line", //
+			"third line", //
+			"> but was: <", //
+			"first line", //
 			"sec0nd line", //
-			"third line>");
+			"third line", //
+			">");
 		assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
 	}
 
@@ -141,11 +150,15 @@ class AssertLinesMatchAssertionsTests {
 		List<String> actual = Arrays.asList("first line", "second line", "third line", "last line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
 		List<String> expectedErrorMessageLines = Arrays.asList( //
-			"more actual lines than expected: 1 ==> expected: <first line", //
+			"more actual lines than expected: 1 ==> expected: <", //
+			"first line", //
 			"second line", //
-			"third line> but was: <first line", //
+			"third line", "> but was: <", //
+			"first line", //
 			"second line", //
-			"third line", "last line>");
+			"third line", //
+			"last line", //
+			">");
 		assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
 	}
 
@@ -155,10 +168,14 @@ class AssertLinesMatchAssertionsTests {
 		List<String> actual = Arrays.asList("first line", "skipped", "last line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
 		List<String> expectedErrorMessageLines = Arrays.asList( //
-			"terminal fast-forward(1) error: fast-forward(2) expected ==> expected: <first line", //
-			">> 1 >>> but was: <first line", //
+			"terminal fast-forward(1) error: fast-forward(2) expected ==> expected: <", //
+			"first line", //
+			">> 1 >>", //
+			"> but was: <", //
+			"first line", //
 			"skipped", //
-			"last line>");
+			"last line", //
+			">");
 		assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
 	}
 
@@ -168,10 +185,12 @@ class AssertLinesMatchAssertionsTests {
 		List<String> actual = Arrays.asList("first line", "skipped", "last line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
 		List<String> expectedErrorMessageLines = Arrays.asList( //
-			"terminal fast-forward(100) error: fast-forward(2) expected ==> expected: <first line", //
-			">> 100 >>> but was: <first line", //
+			"terminal fast-forward(100) error: fast-forward(2) expected ==> expected: <", //
+			"first line", //
+			">> 100 >>", "> but was: <", "first line", //
 			"skipped", //
-			"last line>");
+			"last line", //
+			">");
 		assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
 	}
 
@@ -181,11 +200,15 @@ class AssertLinesMatchAssertionsTests {
 		List<String> actual = Arrays.asList("first line", "skipped", "last line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
 		List<String> expectedErrorMessageLines = Arrays.asList( //
-			"fast-forward(∞) didn't find: `not present` ==> expected: <first line", //
+			"fast-forward(∞) didn't find: `not present` ==> expected: <", //
+			"first line", //
 			">> fails, because next line is >>", //
-			"not present> but was: <first line", //
+			"not present", //
+			"> but was: <", //
+			"first line", //
 			"skipped", //
-			"last line>");
+			"last line", //
+			">");
 		assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
 	}
 
@@ -196,13 +219,17 @@ class AssertLinesMatchAssertionsTests {
 		List<String> actual = Arrays.asList("first line", "first skipped", "second skipped", "last line");
 		Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
 		List<String> expectedErrorMessageLines = Arrays.asList( //
-			"expected line #4:`not present` not found - actual lines depleted ==> expected: <first line", //
+			"expected line #4:`not present` not found - actual lines depleted ==> expected: <", //
+			"first line", //
 			">> fails, because final line is missing >>", //
 			"last line", //
-			"not present> but was: <first line", //
+			"not present", //
+			"> but was: <", //
+			"first line", //
 			"first skipped", //
 			"second skipped", //
-			"last line>");
+			"last line", //
+			">");
 		assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
 	}
 
@@ -248,5 +275,51 @@ class AssertLinesMatchAssertionsTests {
 			() -> assertFalse(AssertLinesMatch.matches("12", "123")),
 			() -> assertFalse(AssertLinesMatch.matches("..+", "1")),
 			() -> assertFalse(AssertLinesMatch.matches("\\d\\d+", "1")));
+	}
+
+	/**
+	 * @since 5.5
+	 */
+	@Nested
+	class WithCustomFailureMessage {
+		@Test
+		void simpleStringMessage() {
+			String message = "XXX";
+			List<String> expected = Arrays.asList("a", "b", "c");
+			List<String> actual = Arrays.asList("a", "d", "c");
+			Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual, message));
+			List<String> expectedErrorMessageLines = Arrays.asList( //
+				message + " ==> " + "expected line #2:`b` doesn't match ==> expected: <", //
+				"a", //
+				"b", //
+				"c", //
+				"> but was: <", //
+				"a", //
+				"d", //
+				"c", //
+				">");
+			assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
+		}
+
+		@Test
+		void stringSupplierWithMultiLineMessage() {
+			String message = "XXX\nYYY";
+			Supplier<String> supplier = () -> message;
+			List<String> expected = Arrays.asList("a", "b", "c");
+			List<String> actual = Arrays.asList("a", "d", "c");
+			Error error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual, supplier));
+			List<String> expectedErrorMessageLines = Arrays.asList( //
+				"XXX", //
+				"YYY ==> " + "expected line #2:`b` doesn't match ==> expected: <", //
+				"a", //
+				"b", //
+				"c", //
+				"> but was: <", //
+				"a", //
+				"d", //
+				"c", //
+				">");
+			assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
+		}
 	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JarDescribeModuleTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JarDescribeModuleTests.java
@@ -58,7 +58,8 @@ class JarDescribeModuleTests {
 			fail("No such file: " + expected);
 		}
 		var expectedLines = Files.lines(expected).map(Helper::replaceVersionPlaceholders).collect(Collectors.toList());
-		assertLinesMatch(expectedLines, result.getOutputLines("out"));
+		var origin = Path.of("projects", "jar-describe-module", module + ".expected.txt").toUri();
+		assertLinesMatch(expectedLines, result.getOutputLines("out"), () -> String.format("%s\nError", origin));
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
## Overview

Prior to this commit, `Assertions.assertLinesMatch` was the only assertion that didn't support user-supplied error messages. This commit adds overloads that take a String or Supplier<String> as a custom message. That message is prepended to the automatically generated detail message.

This commit also improves the textual layout of the automatically generated detail message by emitting each expected and actual line into a dedicated new line.

Closes #1855

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
