### PR TITLE
Add null value attribute to CsvSource and CsvFileSource

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -35,7 +35,6 @@ on GitHub.
 * Exceptions thrown by test engines during discovery and execution are now reported to
   `TestExecutionListeners`.
 
-
 [[release-notes-5.6.0-M1-junit-jupiter]]
 === JUnit Jupiter
 
@@ -59,6 +58,7 @@ on GitHub.
 * New `TypeBasedParameterResolver<T>` abstract base class that serves as a generic adapter
   for the `ParameterResolver` API and simplifies the implementation of a custom resolver
   that supports parameters of a specific type.
+* New `nullSymbols` attribute in `@CsvFileSource` and `@CsvSource`.
 
 
 [[release-notes-5.6.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1149,17 +1149,20 @@ cannot be set simultaneously.
 `@CsvSource` uses a single quote `'` as its quote character. See the `'lemon, lime'` value
 in the example above and in the table below. An empty, quoted value `''` results in an
 empty `String` unless the `emptyValue` attribute is set; whereas, an entirely _empty_
-value is interpreted as a `null` reference. An `ArgumentConversionException` is raised if
-the target type of a `null` reference is a primitive type.
+value is interpreted as a `null` reference.
+By specifying one or more `nullSymbols` any value can be interpreted as a `null` reference.
+An `ArgumentConversionException` is raised if the target type of a `null` reference
+is a primitive type.
 
 [cols="50,50"]
 |===
-| Example Input                            | Resulting Argument List
+| Example Input                                                             | Resulting Argument List
 
-| `@CsvSource({ "apple, banana" })`        | `"apple"`, `"banana"`
-| `@CsvSource({ "apple, 'lemon, lime'" })` | `"apple"`, `"lemon, lime"`
-| `@CsvSource({ "apple, ''" })`            | `"apple"`, `""`
-| `@CsvSource({ "apple, " })`              | `"apple"`, `null`
+| `@CsvSource({ "apple, banana" })`                                         | `"apple"`, `"banana"`
+| `@CsvSource({ "apple, 'lemon, lime'" })`                                  | `"apple"`, `"lemon, lime"`
+| `@CsvSource({ "apple, ''" })`                                             | `"apple"`, `""`
+| `@CsvSource({ "apple, " })`                                               | `"apple"`, `null`
+| `@CsvSource(value = { "apple, banana, NaN" }, nullSymbols = {"NaN"})`     | `"apple"`, `"banana"`, `null`
 |===
 
 [[writing-tests-parameterized-tests-sources-CsvFileSource]]
@@ -1192,8 +1195,9 @@ NOTE: In contrast to the syntax used in `@CsvSource`, `@CsvFileSource` uses a do
 quote `"` as the quote character. See the `"United States of America"` value in the
 example above. An empty, quoted value `""` results in an empty `String` unless the
 `emptyValue` attribute is set; whereas, an entirely _empty_ value is interpreted as a
-`null` reference. An `ArgumentConversionException` is raised if the target type of a
-`null` reference is a primitive type.
+`null` reference. By specifying one or more `nullSymbols` any value can be interpreted
+as a `null` reference. An `ArgumentConversionException` is raised if the target type
+of a `null` reference is a primitive type.
 
 [[writing-tests-parameterized-tests-sources-ArgumentsSource]]
 ===== @ArgumentsSource

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -15,6 +15,9 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import com.univocity.parsers.common.DefaultConversionProcessor;
+import com.univocity.parsers.common.processor.ObjectRowListProcessor;
+import com.univocity.parsers.conversions.Conversions;
 import com.univocity.parsers.csv.CsvParser;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -41,25 +44,38 @@ class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvS
 
 	@Override
 	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
 		AtomicLong index = new AtomicLong(0);
+		DefaultConversionProcessor processor = getConversionProcessor();
 
 		// @formatter:off
-		return Arrays.stream(this.annotation.value())
-				.map(line -> {
-					String[] parsedLine = null;
-					try {
-						parsedLine = this.csvParser.parseLine(line + LINE_SEPARATOR);
-					}
-					catch (Throwable throwable) {
-						handleCsvException(throwable, this.annotation);
-					}
-					Preconditions.notNull(parsedLine,
-						() -> "Line at index " + index.get() + " contains invalid CSV: \"" + line + "\"");
-					return parsedLine;
-				})
-				.peek(values -> index.incrementAndGet())
-				.map(Arguments::of);
-		// @formatter:on
+        return Arrays.stream(this.annotation.value())
+                .map(line -> {
+                    String[] parsedLine = null;
+                    try {
+                        parsedLine = this.csvParser.parseLine(line + LINE_SEPARATOR);
+                        if (parsedLine != null) {
+                            parsedLine = Arrays.copyOf(processor.applyConversions(parsedLine, null), parsedLine.length, String[].class);
+                        }
+                    } catch (Throwable throwable) {
+                        handleCsvException(throwable, this.annotation);
+                    }
+                    Preconditions.notNull(parsedLine,
+                                          () -> "Line at index " + index.get() + " contains invalid CSV: \"" + line + "\"");
+                    return parsedLine;
+                })
+                .peek(values -> index.incrementAndGet())
+                .map(Arguments::of);
+        // @formatter:on
+	}
+
+	private DefaultConversionProcessor getConversionProcessor() {
+		ObjectRowListProcessor processor = new ObjectRowListProcessor();
+		if (this.annotation.nullSymbols().length > 0) {
+			processor.convertAll(Conversions.toNull(this.annotation.nullSymbols()));
+		}
+
+		return processor;
 	}
 
 	static void handleCsvException(Throwable throwable, Annotation annotation) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -113,4 +113,14 @@ public @interface CsvFileSource {
 	@API(status = EXPERIMENTAL, since = "5.5")
 	String emptyValue() default "";
 
+	/**
+	 * A List of Strings that should be interpreted as {@code null}.
+	 *
+	 * <p>Defaults to {@code {}}.
+	 *
+	 * @since 5.6
+	 */
+	@API(status = EXPERIMENTAL, since = "5.6")
+	String[] nullSymbols() default {};
+
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -86,4 +86,13 @@ public @interface CsvSource {
 	@API(status = EXPERIMENTAL, since = "5.5")
 	String emptyValue() default "";
 
+	/**
+	 * A List of Strings that should be interpreted as {@code null}.
+	 *
+	 * <p>Defaults to {@code {}}.
+	 *
+	 * @since 5.6
+	 */
+	@API(status = EXPERIMENTAL, since = "5.6")
+	String[] nullSymbols() default {};
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -114,28 +114,36 @@ class CsvArgumentsProviderTests {
 	@Test
 	void throwsExceptionIfBothDelimitersAreSimultaneouslySet() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
-			() -> provideArguments(",", ',', "", "foo"));
+			() -> provideArguments(",", ',', "", new String[] {}, "foo"));
 
 		assertThat(exception)//
 				.hasMessageStartingWith("The delimiter and delimiterString attributes cannot be set simultaneously in")//
 				.hasMessageContaining("CsvSource");
 	}
 
+	@Test
+	void emptyValueIsAnEmptyWithCustomNullSymbolString() {
+		Stream<Object[]> arguments = provideArguments("", ',', "", new String[] { "empty" }, "vacio , , empty , ''");
+
+		assertThat(arguments).containsExactly(new String[] { "vacio", null, null, "" });
+	}
+
 	private Stream<Object[]> provideArguments(char delimiter, String emptyValue, String... value) {
-		return provideArguments("", delimiter, emptyValue, value);
+		return provideArguments("", delimiter, emptyValue, new String[] {}, value);
 	}
 
 	private Stream<Object[]> provideArguments(String delimiterString, String emptyValue, String... value) {
-		return provideArguments(delimiterString, '\0', emptyValue, value);
+		return provideArguments(delimiterString, '\0', emptyValue, new String[] {}, value);
 	}
 
 	private Stream<Object[]> provideArguments(String delimiterString, char delimiter, String emptyValue,
-			String... value) {
+			String[] nullSymbols, String... value) {
 		CsvSource annotation = mock(CsvSource.class);
 		when(annotation.value()).thenReturn(value);
 		when(annotation.delimiter()).thenReturn(delimiter);
 		when(annotation.delimiterString()).thenReturn(delimiterString);
 		when(annotation.emptyValue()).thenReturn(emptyValue);
+		when(annotation.nullSymbols()).thenReturn(nullSymbols);
 
 		CsvArgumentsProvider provider = new CsvArgumentsProvider();
 		provider.accept(annotation);

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -244,6 +244,19 @@ class CsvFileArgumentsProviderTests {
 				.hasRootCauseInstanceOf(ArrayIndexOutOfBoundsException.class);
 	}
 
+	@Test
+	void emptyValueIsAnEmptyWithCustomNullSymbolString() {
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.lineSeparator("\n")//
+				.delimiter(',')//
+				.nullSymbols(new String[] { "empty" }).build();
+
+		Stream<Object[]> arguments = provideArguments("vacio , , empty , ''\nempty, empty, foo, bar", annotation);
+
+		assertThat(arguments).containsExactly(new Object[] { "vacio", null, null, "''" },
+			new Object[] { null, null, "foo", "bar" });
+	}
+
 	private Stream<Object[]> provideArguments(String content, CsvFileSource annotation) {
 		return provideArguments(new ByteArrayInputStream(content.getBytes(UTF_8)), annotation);
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
@@ -25,6 +25,7 @@ class CsvFileSourceMock {
 	private String delimiterString = "";
 	private String emptyValue = "";
 	private int numLinesToSkip = 0;
+	private String[] nullSymbols = new String[] {};
 
 	private CsvFileSourceMock() {
 	}
@@ -72,6 +73,11 @@ class CsvFileSourceMock {
 		return this;
 	}
 
+	CsvFileSourceMock nullSymbols(String[] nullSymbols) {
+		this.nullSymbols = nullSymbols;
+		return this;
+	}
+
 	CsvFileSource build() {
 		CsvFileSource annotation = mock(CsvFileSource.class);
 		when(annotation.resources()).thenReturn(resources);
@@ -81,6 +87,7 @@ class CsvFileSourceMock {
 		when(annotation.delimiterString()).thenReturn(delimiterString);
 		when(annotation.emptyValue()).thenReturn(emptyValue);
 		when(annotation.numLinesToSkip()).thenReturn(numLinesToSkip);
+		when(annotation.nullSymbols()).thenReturn(nullSymbols);
 		return annotation;
 	}
 


### PR DESCRIPTION
## Overview
This PR implements the proposed enhancement in https://github.com/junit-team/junit5/issues/1856 .

It will introduce a `nullSymbols` attribute in the `CsvSource` and `CsvFileSource` Annotation. 
The `nullSymbols` will be converted into `null` if it is found in the CSV.


Resolves #1856 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
