### PR TITLE
Remove parentheses when generating display name with ReplaceUnderscores

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-M2.adoc
@@ -65,6 +65,8 @@ on GitHub.
   details)
 * New Kotlin friendly `assertDoesNotThrow` assertion added as top-level functions in the
   `org.junit.jupiter.api` package
+* Remove extra parentheses when generating a display name with ReplaceUnderscores for a
+  test method without parameters.
 
 
 [[release-notes-5.5.0-M2-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -125,12 +125,19 @@ public interface DisplayNameGenerator {
 
 		@Override
 		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
-			// don't replace underscores in parameter type names
-			return replaceUnderscores(testMethod.getName()) + parameterTypesAsString(testMethod);
+			String displayName = replaceUnderscores(testMethod.getName());
+			if (hasParameters(testMethod)) {
+				displayName += ' ' + parameterTypesAsString(testMethod);
+			}
+			return displayName;
 		}
 
 		private String replaceUnderscores(String name) {
 			return name.replace('_', ' ');
+		}
+
+		private boolean hasParameters(Method method) {
+			return method.getParameterTypes().length > 0;
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -61,7 +61,7 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 			"TEST: test with underscores", //
 			"TEST: testUsingCamelCase and also UnderScores", //
 			"TEST: testUsingCamelCase and also UnderScores keepingParameterTypeNamesIntact (TestInfo)", //
-			"TEST: testUsingCamelCaseStyle"
+			"TEST: testUsingCamelCaseStyle" //
 		);
 		check(UnderscoreStyleTestCase.class, expectedDisplayNames);
 		check(UnderscoreStyleInheritedFromSuperClassTestCase.class, expectedDisplayNames);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -56,12 +56,13 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 		var expectedDisplayNames = List.of( //
 			"CONTAINER: DisplayNameGenerationTests\\$UnderscoreStyle.*", //
 			"TEST: @DisplayName prevails", //
-			"TEST: test with underscores()", //
-			"TEST: test()", //
-			"TEST: test(TestInfo)", //
-			"TEST: testUsingCamelCase and also UnderScores keepingParameterTypeNamesIntact(TestInfo)", //
-			"TEST: testUsingCamelCase and also UnderScores()", //
-			"TEST: testUsingCamelCaseStyle()");
+			"TEST: test", //
+			"TEST: test (TestInfo)", //
+			"TEST: test with underscores", //
+			"TEST: testUsingCamelCase and also UnderScores", //
+			"TEST: testUsingCamelCase and also UnderScores keepingParameterTypeNamesIntact (TestInfo)", //
+			"TEST: testUsingCamelCaseStyle"
+		);
 		check(UnderscoreStyleTestCase.class, expectedDisplayNames);
 		check(UnderscoreStyleInheritedFromSuperClassTestCase.class, expectedDisplayNames);
 	}
@@ -86,13 +87,13 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 			"CONTAINER: A new stack", //
 			"CONTAINER: A stack", //
 			"CONTAINER: After pushing an element to an empty stack", //
-			"TEST: is empty()", //
-			"TEST: is instantiated using its noarg constructor()", //
-			"TEST: peek returns that element without removing it from the stack()", //
-			"TEST: pop returns that element and leaves an empty stack()", //
-			"TEST: the stack is no longer empty()", //
-			"TEST: throws an EmptyStackException when peeked()", //
-			"TEST: throws an EmptyStackException when popped()" //
+			"TEST: is empty", //
+			"TEST: is instantiated using its noarg constructor", //
+			"TEST: peek returns that element without removing it from the stack", //
+			"TEST: pop returns that element and leaves an empty stack", //
+			"TEST: the stack is no longer empty", //
+			"TEST: throws an EmptyStackException when peeked", //
+			"TEST: throws an EmptyStackException when popped" //
 		));
 	}
 


### PR DESCRIPTION
## Overview

Implements the improvement suggested in #1875.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
