### PR TITLE
Deprecate "Script-based Conditions" for removal

### DIFF
--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -173,7 +173,7 @@ val compileModule by tasks.registering(JavaCompile::class) {
 tasks.compileJava {
 	// See: https://docs.oracle.com/en/java/javase/11/tools/javac.html
 	options.compilerArgs.addAll(listOf(
-			"-Xlint", // Enables all recommended warnings.
+			"-Xlint:all,-deprecation", // Enables all recommended warnings.
 			"-Werror" // Terminates compilation when warnings occur.
 	))
 	if (modularProjects.contains(project)) {

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.5.0-RC1.adoc
@@ -48,7 +48,10 @@ on GitHub.
 
 ==== Deprecations and Breaking Changes
 
-* ❓
+* Script-based condition APIs and their supporting implementations are deprecated with
+  the intent to remove them in JUnit Jupiter 5.6. Users should instead rely on a
+  combination of other built-in conditions or create and use a custom implementation of
+  `ExecutionCondition` to evaluate the same conditions.
 
 ==== New Features and Improvements
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -413,15 +413,14 @@ include::{testDir}/example/ConditionalTestExecutionDemo.java[tags=user_guide_env
 [[writing-tests-conditional-execution-scripts]]
 ==== Script-based Conditions
 
+WARNING: Conditional test execution via `{EnabledIf}` and `{DisabledIf}` is _deprecated_
+for removal in a future release of JUnit Jupiter.
+
 JUnit Jupiter provides the ability to either _enable_ or _disable_ a container or test
 depending on the evaluation of a script configured via the `{EnabledIf}` or
 `{DisabledIf}` annotation. Scripts can be written in JavaScript, Groovy, or any other
 scripting language for which there is support for the Java Scripting API, defined by JSR
 223.
-
-WARNING: Conditional test execution via `{EnabledIf}` and `{DisabledIf}` is currently an
-_experimental_ feature. Consult the table in <<api-evolution-experimental-apis>> for
-details.
 
 TIP: If the logic of your script depends only on the current operating system, the
 current Java Runtime Environment version, a particular JVM system property, or a

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -116,6 +116,13 @@ import org.apiguardian.api.API;
  * this annotation may be used in conjunction with other {@code @Enabled*} or
  * {@code @Disabled*} annotations in this package.
  *
+ * @deprecated Script-based condition APIs and their supporting implementations
+ * are deprecated with the intent to remove them in JUnit Jupiter 5.6. Users
+ * should instead rely on a combination of other built-in conditions or create
+ * and use a custom implementation of
+ * {@link org.junit.jupiter.api.extension.ExecutionCondition ExecutionCondition}
+ * to evaluate the same conditions.
+ *
  * @since 5.1
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
@@ -133,7 +140,8 @@ import org.apiguardian.api.API;
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "5.1")
+@API(status = DEPRECATED, since = "5.5")
+@Deprecated
 public @interface DisabledIf {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -116,6 +116,13 @@ import org.apiguardian.api.API;
  * this annotation may be used in conjunction with other {@code @Enabled*} or
  * {@code @Disabled*} annotations in this package.
  *
+ * @deprecated Script-based condition APIs and their supporting implementations
+ * are deprecated with the intent to remove them in JUnit Jupiter 5.6. Users
+ * should instead rely on a combination of other built-in conditions or create
+ * and use a custom implementation of
+ * {@link org.junit.jupiter.api.extension.ExecutionCondition ExecutionCondition}
+ * to evaluate the same conditions.
+ *
  * @since 5.1
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
@@ -133,7 +140,8 @@ import org.apiguardian.api.API;
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "5.1")
+@API(status = DEPRECATED, since = "5.5")
+@Deprecated
 public @interface EnabledIf {
 
 	/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
@@ -52,11 +52,16 @@ public class ExtensionRegistry {
 
 	private static final List<Extension> DEFAULT_EXTENSIONS = Collections.unmodifiableList(Arrays.asList(//
 		new DisabledCondition(), //
-		new ScriptExecutionCondition(), //
+		newScriptExecutionCondition(), //
 		new TempDirectory(), //
 		new RepeatedTestExtension(), //
 		new TestInfoParameterResolver(), //
 		new TestReporterParameterResolver()));
+
+	@SuppressWarnings("deprecation")
+	private static Extension newScriptExecutionCondition() {
+		return new ScriptExecutionCondition();
+	}
 
 	/**
 	 * Factory for creating and populating a new root registry with the default

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionCondition.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionCondition.java
@@ -35,6 +35,7 @@ import org.junit.platform.commons.util.BlacklistedExceptions;
  * @see EnabledIf
  * @see #evaluateExecutionCondition(ExtensionContext)
  */
+@Deprecated
 class ScriptExecutionCondition implements ExecutionCondition {
 
 	private static final ConditionEvaluationResult ENABLED_NO_ELEMENT = enabled("AnnotatedElement not present");

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluator.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluator.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.engine.script.ScriptExecutionManager;
  *
  * @since 5.1
  */
+@Deprecated
 class ScriptExecutionEvaluator implements ScriptExecutionCondition.Evaluator {
 
 	private static final ConditionEvaluationResult ENABLED_ALL = enabled("All results are enabled");

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/script/Script.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/script/Script.java
@@ -27,6 +27,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @see ScriptExecutionManager
  */
 @API(status = INTERNAL, since = "5.1")
+@Deprecated
 public final class Script {
 
 	/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/script/ScriptAccessor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/script/ScriptAccessor.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * @since 5.1
  */
 @API(status = INTERNAL, since = "5.1")
+@Deprecated
 public interface ScriptAccessor {
 
 	/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/script/ScriptExecutionManager.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/script/ScriptExecutionManager.java
@@ -32,6 +32,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  */
 @API(status = INTERNAL, since = "5.1")
+@Deprecated
 public class ScriptExecutionManager {
 
 	private final ScriptEngineManager scriptEngineManager = new ScriptEngineManager();

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionConditionTests.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
  *
  * @since 5.1
  */
+@Deprecated
 class ScriptExecutionConditionTests extends AbstractJupiterTestEngineTests {
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluatorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ScriptExecutionEvaluatorTests.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.engine.script.ScriptExecutionManager;
  *
  * @since 5.1
  */
+@Deprecated
 class ScriptExecutionEvaluatorTests extends AbstractJupiterTestEngineTests {
 
 	private final Bindings bindings = createDefaultContextBindings();

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/script/ScriptExecutionManagerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/script/ScriptExecutionManagerTests.java
@@ -37,6 +37,7 @@ import org.junit.platform.commons.PreconditionViolationException;
  *
  * @since 5.1
  */
+@Deprecated
 class ScriptExecutionManagerTests {
 
 	private final Bindings bindings = createDefaultContextBindings();

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/script/ScriptTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/script/ScriptTests.java
@@ -30,6 +30,7 @@ import org.junit.platform.commons.JUnitException;
  *
  * @since 5.1
  */
+@Deprecated
 class ScriptTests {
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/DisabledIfTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/DisabledIfTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
  *
  * @since 1.1
  */
+@Deprecated
 @DisabledIf("false")
 class DisabledIfTests {
 

--- a/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/extensions/EnabledIfTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.condition.EnabledIf;
  *
  * @since 1.1
  */
+@Deprecated
 @EnabledIf("true")
 class EnabledIfTests {
 


### PR DESCRIPTION
## Overview

Closes #1882

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
