### PR TITLE
Add more java.time types to implicit conversion

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1284,15 +1284,20 @@ integral types: `byte`, `short`, `int`, `long`, and their boxed counterparts.
 | `java.net.URL`             | `"http://junit.org/"`                    -> `new URL("http://junit.org/")`
 | `java.nio.charset.Charset` | `"UTF-8"`                                -> `Charset.forName("UTF-8")`
 | `java.nio.file.Path`       | `"/path/to/file"`                        -> `Paths.get("/path/to/file")`
+| `java.time.Duration`       | `"PT3S"`                                 -> `Duration.ofSeconds(3)`
 | `java.time.Instant`        | `"1970-01-01T00:00:00Z"`                 -> `Instant.ofEpochMilli(0)`
 | `java.time.LocalDateTime`  | `"2017-03-14T12:34:56.789"`              -> `LocalDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000)`
 | `java.time.LocalDate`      | `"2017-03-14"`                           -> `LocalDate.of(2017, 3, 14)`
 | `java.time.LocalTime`      | `"12:34:56.789"`                         -> `LocalTime.of(12, 34, 56, 789_000_000)`
+| `java.time.MonthDay`       | `"--03-14"`                              -> `MonthDay.of(3, 14)`
 | `java.time.OffsetDateTime` | `"2017-03-14T12:34:56.789Z"`             -> `OffsetDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC)`
 | `java.time.OffsetTime`     | `"12:34:56.789Z"`                        -> `OffsetTime.of(12, 34, 56, 789_000_000, ZoneOffset.UTC)`
+| `java.time.Period`         | `"P2M6D"`                                -> `Period.of(0, 2, 6)`
 | `java.time.YearMonth`      | `"2017-03"`                              -> `YearMonth.of(2017, 3)`
 | `java.time.Year`           | `"2017"`                                 -> `Year.of(2017)`
 | `java.time.ZonedDateTime`  | `"2017-03-14T12:34:56.789Z"`             -> `ZonedDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC)`
+| `java.time.ZoneId`         | `"Europe/Berlin"                         -> `ZoneId.of("Europe/Berlin")`
+| `java.time.ZoneOffset`     | `"+02:30"`                               -> `ZoneOffset.ofHoursMinutes(2, 30)`
 | `java.util.Currency`       | `"JPY"`                                  -> `Currency.getInstance("JPY")`
 | `java.util.Locale`         | `"en"`                                   -> `new Locale("en")`
 | `java.util.UUID`           | `"d043e930-7b3b-48e3-bdbe-5a3ccfb833db"` -> `UUID.fromString("d043e930-7b3b-48e3-bdbe-5a3ccfb833db")`

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -25,14 +25,19 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.MonthDay;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.Period;
 import java.time.Year;
 import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Currency;
@@ -185,18 +190,23 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 
 	private static class StringToJavaTimeConverter implements StringToObjectConverter {
 
-		private static final Map<Class<?>, Function<CharSequence, ?>> CONVERTERS;
+		private static final Map<Class<?>, Function<String, ?>> CONVERTERS;
 		static {
-			Map<Class<?>, Function<CharSequence, ?>> converters = new HashMap<>();
+			Map<Class<?>, Function<String, ?>> converters = new HashMap<>();
+			converters.put(Duration.class, Duration::parse);
 			converters.put(Instant.class, Instant::parse);
 			converters.put(LocalDate.class, LocalDate::parse);
 			converters.put(LocalDateTime.class, LocalDateTime::parse);
 			converters.put(LocalTime.class, LocalTime::parse);
+			converters.put(MonthDay.class, MonthDay::parse);
 			converters.put(OffsetDateTime.class, OffsetDateTime::parse);
 			converters.put(OffsetTime.class, OffsetTime::parse);
+			converters.put(Period.class, Period::parse);
 			converters.put(Year.class, Year::parse);
 			converters.put(YearMonth.class, YearMonth::parse);
 			converters.put(ZonedDateTime.class, ZonedDateTime::parse);
+			converters.put(ZoneId.class, ZoneId::of);
+			converters.put(ZoneOffset.class, ZoneOffset::of);
 			CONVERTERS = Collections.unmodifiableMap(converters);
 		}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -21,14 +21,18 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.MonthDay;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.Period;
 import java.time.Year;
 import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Currency;
@@ -179,18 +183,23 @@ class DefaultArgumentConverterTests {
 
 	@Test
 	void convertsStringsToJavaTimeInstances() {
+		assertConverts("PT1234.5678S", Duration.class, Duration.ofSeconds(1234, 567800000));
 		assertConverts("1970-01-01T00:00:00Z", Instant.class, Instant.ofEpochMilli(0));
 		assertConverts("2017-03-14", LocalDate.class, LocalDate.of(2017, 3, 14));
 		assertConverts("2017-03-14T12:34:56.789", LocalDateTime.class,
 			LocalDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000));
 		assertConverts("12:34:56.789", LocalTime.class, LocalTime.of(12, 34, 56, 789_000_000));
+		assertConverts("--03-14", MonthDay.class, MonthDay.of(3, 14));
 		assertConverts("2017-03-14T12:34:56.789Z", OffsetDateTime.class,
 			OffsetDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC));
 		assertConverts("12:34:56.789Z", OffsetTime.class, OffsetTime.of(12, 34, 56, 789_000_000, ZoneOffset.UTC));
+		assertConverts("P2M6D", Period.class, Period.of(0, 2, 6));
 		assertConverts("2017", Year.class, Year.of(2017));
 		assertConverts("2017-03", YearMonth.class, YearMonth.of(2017, 3));
 		assertConverts("2017-03-14T12:34:56.789Z", ZonedDateTime.class,
 			ZonedDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC));
+		assertConverts("Europe/Berlin", ZoneId.class, ZoneId.of("Europe/Berlin"));
+		assertConverts("+02:30", ZoneOffset.class, ZoneOffset.ofHoursMinutes(2, 30));
 	}
 
 	// --- java.util -----------------------------------------------------------


### PR DESCRIPTION
Add support for Duration, Period, MonthDay, ZoneId and ZoneOffset
Closes #1929

## Overview

Five new types added to the implicit converter. As far as I know, these only need to be added in one place. Tests have been added. Docs updated.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [X] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
