### PR TITLE
Introduce getOrDefault() in ExtensionContext.Store

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -399,6 +399,7 @@ public interface ExtensionContext {
 		 * @param key the key; never {@code null}
 		 * @return the value; potentially {@code null}
 		 * @see #get(Object, Class)
+		 * @see #getOrDefault(Object, Class, Object)
 		 */
 		Object get(Object key);
 
@@ -416,8 +417,34 @@ public interface ExtensionContext {
 		 * @param <V> the value type
 		 * @return the value; potentially {@code null}
 		 * @see #get(Object)
+		 * @see #getOrDefault(Object, Class, Object)
 		 */
 		<V> V get(Object key, Class<V> requiredType);
+
+		/**
+		 * Get the value of the specified required type that is stored under
+		 * the supplied {@code key}, or the supplied {@code defaultValue} if no
+		 * value is found for the supplied {@code key} in this store or in an
+		 * ancestor.
+		 *
+		 * <p>If no value is stored in the current {@link ExtensionContext}
+		 * for the supplied {@code key}, ancestors of the context will be queried
+		 * for a value with the same {@code key} in the {@code Namespace} used
+		 * to create this store.
+		 *
+		 * @param key the key; never {@code null}
+		 * @param requiredType the required type of the value; never {@code null}
+		 * @param defaultValue the default value
+		 * @param <V> the value type
+		 * @return the value; potentially {@code null}
+		 * @see #get(Object, Class)
+		 * @since 5.5
+		 */
+		@API(status = STABLE, since = "5.5")
+		default <V> V getOrDefault(Object key, Class<V> requiredType, V defaultValue) {
+			V value = get(key, requiredType);
+			return (value != null ? value : defaultValue);
+		}
 
 		/**
 		 * Get the object of type {@code type} that is present in this

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextStoreConcurrencyTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextStoreConcurrencyTests.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
  *
  * @since 5.0
  */
-class ExtensionStoreConcurrencyTests {
+class ExtensionContextStoreConcurrencyTests {
 
 	private final AtomicInteger count = new AtomicInteger();
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextStoreTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionContextStoreTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ExtensionContextException;
+
+/**
+ * Unit tests for {@link NamespaceAwareStore} and {@link ExtensionValuesStore}.
+ *
+ * @since 5.5
+ * @see ExtensionContextStoreConcurrencyTests
+ * @see ExtensionValuesStoreTests
+ */
+class ExtensionContextStoreTests {
+
+	private static final String KEY = "key";
+	private static final String VALUE = "value";
+
+	private final ExtensionValuesStore parentStore = new ExtensionValuesStore(null);
+	private final ExtensionValuesStore localStore = new ExtensionValuesStore(parentStore);
+	private final Store store = new NamespaceAwareStore(localStore, Namespace.GLOBAL);
+
+	@Test
+	void getOrDefaultWithNoValuePresent() {
+		assertThat(store.get(KEY)).isNull();
+
+		assertThat(store.getOrDefault(KEY, boolean.class, true)).isTrue();
+		assertThat(store.getOrDefault(KEY, String.class, VALUE)).isEqualTo(VALUE);
+	}
+
+	@Test
+	void getOrDefaultRequestingIncompatibleType() {
+		localStore.put(Namespace.GLOBAL, KEY, VALUE);
+		assertThat(store.get(KEY)).isEqualTo(VALUE);
+
+		Exception exception = assertThrows(ExtensionContextException.class,
+			() -> store.getOrDefault(KEY, boolean.class, true));
+		assertThat(exception).hasMessageContaining("is not of required type");
+	}
+
+	@Test
+	void getOrDefaultWithValueInLocalStore() {
+		localStore.put(Namespace.GLOBAL, KEY, VALUE);
+		assertThat(store.get(KEY)).isEqualTo(VALUE);
+
+		assertThat(store.getOrDefault(KEY, String.class, VALUE)).isEqualTo(VALUE);
+	}
+
+	@Test
+	void getOrDefaultWithValueInParentStore() {
+		parentStore.put(Namespace.GLOBAL, KEY, VALUE);
+		assertThat(store.get(KEY)).isEqualTo(VALUE);
+
+		assertThat(store.getOrDefault(KEY, String.class, VALUE)).isEqualTo(VALUE);
+	}
+
+}


### PR DESCRIPTION
Implements #1932

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](http://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](http://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](http://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
