### PR TITLE
Introduce @Requirement annotation

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Requirement.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Requirement.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.*;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code @Requirement} marks a test to show that was written to ensure the correct implementation of the annotated requirement.
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = EXPERIMENTAL)
+public @interface Requirement {
+
+	String id();
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Requirement.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Requirement.java
@@ -17,7 +17,8 @@ import java.lang.annotation.*;
 import org.apiguardian.api.API;
 
 /**
- * {@code @Requirement} marks a test to show that was written to ensure the correct implementation of the annotated requirement.
+ * {@code @Requirement} marks a test to show that it was written to ensure the correct
+ * implementation of the annotated requirement.
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
@@ -25,5 +26,10 @@ import org.apiguardian.api.API;
 @API(status = EXPERIMENTAL)
 public @interface Requirement {
 
+	/**
+	 * The id of the requirement.
+	 * 
+	 * @return requirements id
+	 */
 	String id();
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Requirement.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Requirement.java
@@ -12,7 +12,11 @@ package org.junit.jupiter.api;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
 
@@ -28,7 +32,7 @@ public @interface Requirement {
 
 	/**
 	 * The id of the requirement.
-	 * 
+	 *
 	 * @return requirements id
 	 */
 	String id();

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Test.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Test.java
@@ -12,11 +12,7 @@ package org.junit.jupiter.api;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.annotation.Testable;
@@ -69,6 +65,7 @@ import org.junit.platform.commons.annotation.Testable;
  * @see AfterAll
  * @see BeforeEach
  * @see AfterEach
+ * @see Requirement
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Test.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Test.java
@@ -12,7 +12,11 @@ package org.junit.jupiter.api;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.annotation.Testable;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInfo.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInfo.java
@@ -38,6 +38,7 @@ import org.apiguardian.api.API;
  * @see AfterAll
  * @see DisplayName
  * @see Tag
+ * @see Requirement
  */
 @API(status = STABLE, since = "5.0")
 public interface TestInfo {
@@ -106,5 +107,10 @@ public interface TestInfo {
 	 * Get the {@link Method} associated with the current test or container, if available.
 	 */
 	Optional<Method> getTestMethod();
+
+	/**
+	 * Get the id of the {@link Requirement} associated with the current test, if available.
+	 */
+	String getRequirement();
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -15,13 +15,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 import org.apiguardian.api.API;
@@ -359,31 +353,16 @@ public interface ExtensionContext {
 	Store getStore(Namespace namespace);
 
 	/**
+	 * Get the value of the {@Link Requirement} annotation of the test case.
+	 * 
+	 * @return the value of the annotation. Returns {@code null} when no annotation was set or its value is null/blank.
+	 */
+	String getRequirement();
+
+	/**
 	 * {@code Store} provides methods for extensions to save and retrieve data.
 	 */
 	interface Store {
-
-		/**
-		 * Classes implementing this interface indicate that they want to {@link #close}
-		 * some underlying resource or resources when the enclosing {@link Store Store}
-		 * is closed.
-		 *
-		 * <p>Note that the {@code CloseableResource} API is only honored for
-		 * objects stored within an extension context {@link Store Store}.
-		 *
-		 * @since 5.1
-		 */
-		@API(status = STABLE, since = "5.1")
-		interface CloseableResource {
-
-			/**
-			 * Close underlying resources.
-			 *
-			 * @throws Throwable any throwable will be caught and rethrown
-			 */
-			void close() throws Throwable;
-
-		}
 
 		/**
 		 * Get the value that is stored under the supplied {@code key}.
@@ -590,6 +569,28 @@ public interface ExtensionContext {
 		 */
 		<V> V remove(Object key, Class<V> requiredType);
 
+		/**
+		 * Classes implementing this interface indicate that they want to {@link #close}
+		 * some underlying resource or resources when the enclosing {@link Store Store}
+		 * is closed.
+		 *
+		 * <p>Note that the {@code CloseableResource} API is only honored for
+		 * objects stored within an extension context {@link Store Store}.
+		 *
+		 * @since 5.1
+		 */
+		@API(status = STABLE, since = "5.1")
+		interface CloseableResource {
+
+			/**
+			 * Close underlying resources.
+			 *
+			 * @throws Throwable any throwable will be caught and rethrown
+			 */
+			void close() throws Throwable;
+
+		}
+
 	}
 
 	/**
@@ -607,6 +608,11 @@ public interface ExtensionContext {
 		 * all extensions.
 		 */
 		public static final Namespace GLOBAL = Namespace.create(new Object());
+		private final List<?> parts;
+
+		private Namespace(Object... parts) {
+			this.parts = new ArrayList<>(Arrays.asList(parts));
+		}
 
 		/**
 		 * Create a namespace which restricts access to data to all extensions
@@ -620,12 +626,6 @@ public interface ExtensionContext {
 			Preconditions.notEmpty(parts, "parts array must not be null or empty");
 			Preconditions.containsNoNullElements(parts, "individual parts must not be null");
 			return new Namespace(parts);
-		}
-
-		private final List<?> parts;
-
-		private Namespace(Object... parts) {
-			this.parts = new ArrayList<>(Arrays.asList(parts));
 		}
 
 		@Override

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -15,7 +15,13 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.apiguardian.api.API;
@@ -354,7 +360,7 @@ public interface ExtensionContext {
 
 	/**
 	 * Get the value of the {@Link Requirement} annotation of the test case.
-	 * 
+	 *
 	 * @return the value of the annotation. Returns {@code null} when no annotation was set or its value is null/blank.
 	 */
 	String getRequirement();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -13,7 +13,11 @@ package org.junit.jupiter.engine.descriptor;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -13,11 +13,7 @@ package org.junit.jupiter.engine.descriptor;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
 
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
@@ -81,6 +77,11 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 	@Override
 	public String getDisplayName() {
 		return getTestDescriptor().getDisplayName();
+	}
+
+	@Override
+	public String getRequirement() {
+		return getTestDescriptor().getRequirement();
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -70,6 +70,11 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 		this.configuration = configuration;
 	}
 
+	JupiterTestDescriptor(UniqueId uniqueId, String displayName, TestSource source,
+			JupiterConfiguration configuration) {
+		this(uniqueId, displayName, source, configuration, null);
+	}
+
 	// --- TestDescriptor ------------------------------------------------------
 
 	static Set<TestTag> getTags(AnnotatedElement element) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -10,14 +10,20 @@
 
 package org.junit.jupiter.engine.descriptor;
 
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toSet;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.DisplayNameUtils.determineDisplayName;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 import static org.junit.platform.commons.util.AnnotationUtils.findRepeatableAnnotations;
 
 import java.lang.reflect.AnnotatedElement;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apiguardian.api.API;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -48,12 +48,18 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
 	MethodBasedTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
 		this(uniqueId, determineDisplayNameForMethod(testClass, testMethod, configuration), testClass, testMethod,
-			configuration);
+			configuration, RequirementUtils.determineRequirementId(testMethod));
 	}
 
 	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
-		super(uniqueId, displayName, MethodSource.from(testClass, testMethod), configuration);
+		this(uniqueId, displayName, testClass, testMethod, configuration,
+			RequirementUtils.determineRequirementId(testMethod));
+	}
+
+	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod,
+			JupiterConfiguration configuration, String requirement) {
+		super(uniqueId, displayName, MethodSource.from(testClass, testMethod), configuration, requirement);
 
 		this.testClass = Preconditions.notNull(testClass, "Class must not be null");
 		this.testMethod = testMethod;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/RequirementUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/RequirementUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Requirement;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.StringUtils;
+
+/**
+ * Collection of utilities for working with the {@link Requirement} annotation.
+ *
+ * @see org.junit.jupiter.api.Requirement
+ */
+final class RequirementUtils {
+
+	private static final Logger logger = LoggerFactory.getLogger(RequirementUtils.class);
+
+	/**
+	 * Checks of the element is annotated with the {@link Requirement} annotation and returns its value when not blank.
+	 * If the element is not properly annotated then NULL is returned as it's unclear if the element was written
+	 * to ensure the correct implementation of a specific requirement.
+	 *
+	 * @param element Element to check for annotation
+	 * @return id of the requirement. NULL if annotation is blank or not set.
+	 */
+	static String determineRequirementId(AnnotatedElement element) {
+		Preconditions.notNull(element, "Annotated element must not be null");
+		Optional<Requirement> requirementIdAnnotation = findAnnotation(element, Requirement.class);
+		if (requirementIdAnnotation.isPresent()) {
+			String requirementId = requirementIdAnnotation.get().id().trim();
+
+			// When the annotation was used the value must be not blank.
+			if (StringUtils.isBlank(requirementId)) {
+				logger.warn(() -> String.format(
+					"Configuration error: @Requirement on [%s] must be declared with a non-empty requirement id."
+							+ "Annotation is ignored.",
+					element));
+			}
+			else {
+				return requirementId;
+			}
+		}
+		return null;
+	}
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java
@@ -44,12 +44,18 @@ class TestInfoParameterResolver implements ParameterResolver {
 		private final Set<String> tags;
 		private final Optional<Class<?>> testClass;
 		private final Optional<Method> testMethod;
+		private final String requirement;
 
 		DefaultTestInfo(ExtensionContext extensionContext) {
 			this.displayName = extensionContext.getDisplayName();
 			this.tags = extensionContext.getTags();
 			this.testClass = extensionContext.getTestClass();
 			this.testMethod = extensionContext.getTestMethod();
+			this.requirement = extensionContext.getRequirement();
+		}
+
+		private static Object nullSafeGet(Optional<?> optional) {
+			return optional != null ? optional.orElse(null) : null;
 		}
 
 		@Override
@@ -73,6 +79,11 @@ class TestInfoParameterResolver implements ParameterResolver {
 		}
 
 		@Override
+		public String getRequirement() {
+			return this.requirement;
+		}
+
+		@Override
 		public String toString() {
 			// @formatter:off
 			return new ToStringBuilder(this)
@@ -80,12 +91,9 @@ class TestInfoParameterResolver implements ParameterResolver {
 					.append("tags", this.tags)
 					.append("testClass", nullSafeGet(this.testClass))
 					.append("testMethod", nullSafeGet(this.testMethod))
+					.append("requirement", this.requirement)
 					.toString();
 			// @formatter:on
-		}
-
-		private static Object nullSafeGet(Optional<?> optional) {
-			return optional != null ? optional.orElse(null) : null;
 		}
 
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/RequirementTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/RequirementTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import java.util.List;
+
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.platform.engine.TestDescriptor;
+
+/**
+ * Check Annotated requirements.
+ *
+ * @see Requirement
+ */
+class RequirementTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void testRequirementAnnotation() {
+		check(RequirementTestCase.class, List.of( //
+			"RequirementTests$RequirementTestCase: null", //
+			"testEmptyAnnotation(): null", //
+			"testNoAnnotation(): null", "testRequirementWithId(): Req 11"));
+	}
+
+	private void check(Class<?> testClass, List<String> expectedRequirements) {
+		var request = request().selectors(selectClass(testClass)).build();
+		var descriptors = discoverTests(request).getDescendants();
+		var sortedNamesRequirements = descriptors.stream().map(this::describe).sorted().collect(toList());
+		assertLinesMatch(expectedRequirements, sortedNamesRequirements);
+	}
+
+	private String describe(TestDescriptor descriptor) {
+		return descriptor.getDisplayName() + ": " + descriptor.getRequirement();
+	}
+
+	static class RequirementTestCase {
+		@Requirement(id = "")
+		@Test
+		void testEmptyAnnotation() {
+		}
+
+		@Test
+		void testNoAnnotation() {
+		}
+
+		@Requirement(id = "Req 11")
+		@Test
+		void testRequirementWithId() {
+		}
+	}
+
+}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -232,6 +232,11 @@ class ParameterizedTestExtensionTests {
 			public Store getStore(Namespace namespace) {
 				return new NamespaceAwareStore(store, namespace);
 			}
+
+			@Override
+			public String getRequirement() {
+				return null;
+			}
 		};
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -31,6 +31,23 @@ import org.junit.platform.commons.util.Preconditions;
 public interface TestDescriptor {
 
 	/**
+	 * Determine if the supplied descriptor (or any of its descendants)
+	 * {@linkplain TestDescriptor#isTest() is a test} or
+	 * {@linkplain TestDescriptor#mayRegisterTests() may potentially register
+	 * tests dynamically}.
+	 *
+	 * @param testDescriptor the {@code TestDescriptor} to check for tests; never
+	 * {@code null}
+	 * @return {@code true} if the descriptor is a test, contains tests, or may
+	 * later register tests dynamically
+	 */
+	static boolean containsTests(TestDescriptor testDescriptor) {
+		Preconditions.notNull(testDescriptor, "TestDescriptor must not be null");
+		return testDescriptor.isTest() || testDescriptor.mayRegisterTests()
+				|| testDescriptor.getChildren().stream().anyMatch(TestDescriptor::containsTests);
+	}
+
+	/**
 	 * Get the unique identifier (UID) for this descriptor.
 	 *
 	 * <p>Uniqueness must be guaranteed across an entire test plan,
@@ -196,23 +213,6 @@ public interface TestDescriptor {
 	}
 
 	/**
-	 * Determine if the supplied descriptor (or any of its descendants)
-	 * {@linkplain TestDescriptor#isTest() is a test} or
-	 * {@linkplain TestDescriptor#mayRegisterTests() may potentially register
-	 * tests dynamically}.
-	 *
-	 * @param testDescriptor the {@code TestDescriptor} to check for tests; never
-	 * {@code null}
-	 * @return {@code true} if the descriptor is a test, contains tests, or may
-	 * later register tests dynamically
-	 */
-	static boolean containsTests(TestDescriptor testDescriptor) {
-		Preconditions.notNull(testDescriptor, "TestDescriptor must not be null");
-		return testDescriptor.isTest() || testDescriptor.mayRegisterTests()
-				|| testDescriptor.getChildren().stream().anyMatch(TestDescriptor::containsTests);
-	}
-
-	/**
 	 * Remove this descriptor from the hierarchy unless it is a root or contains
 	 * tests.
 	 *
@@ -252,21 +252,14 @@ public interface TestDescriptor {
 	}
 
 	/**
-	 * Visitor for the tree-like {@link TestDescriptor} structure.
+	 * Get the value of the Requirement annotation.
 	 *
-	 * @see TestDescriptor#accept(Visitor)
+	 * <p>The <em>Requirement</em> annotation can be used to show if a test was written to ensure the correct
+	 * implementation of a requirement.
+	 *
+	 * @return the id of the requirement; max be {@code null} when not set or blank
 	 */
-	@FunctionalInterface
-	interface Visitor {
-
-		/**
-		 * Visit a {@link TestDescriptor}.
-		 *
-		 * @param descriptor the {@code TestDescriptor} to visit; never {@code null}
-		 */
-		void visit(TestDescriptor descriptor);
-
-	}
+	String getRequirement();
 
 	/**
 	 * Supported types for {@link TestDescriptor TestDescriptors}.
@@ -303,6 +296,23 @@ public interface TestDescriptor {
 		public boolean isTest() {
 			return this == TEST || this == CONTAINER_AND_TEST;
 		}
+
+	}
+
+	/**
+	 * Visitor for the tree-like {@link TestDescriptor} structure.
+	 *
+	 * @see TestDescriptor#accept(Visitor)
+	 */
+	@FunctionalInterface
+	interface Visitor {
+
+		/**
+		 * Visit a {@link TestDescriptor}.
+		 *
+		 * @param descriptor the {@code TestDescriptor} to visit; never {@code null}
+		 */
+		void visit(TestDescriptor descriptor);
 
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -10,20 +10,20 @@
 
 package org.junit.platform.engine.support.descriptor;
 
-import org.apiguardian.api.API;
-import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.TestSource;
-import org.junit.platform.engine.TestTag;
-import org.junit.platform.engine.UniqueId;
+import static java.util.Collections.emptySet;
+import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.util.Collections.emptySet;
-import static org.apiguardian.api.API.Status.STABLE;
+import org.apiguardian.api.API;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
 
 /**
  * Abstract base implementation of {@link TestDescriptor} that may be used by

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -37,14 +37,6 @@ import org.junit.platform.engine.UniqueId;
 @API(status = STABLE, since = "1.0")
 public abstract class AbstractTestDescriptor implements TestDescriptor {
 
-	private final UniqueId uniqueId;
-
-	private final String displayName;
-
-	private final TestSource source;
-
-	private TestDescriptor parent;
-
 	/**
 	 * The synchronized set of children associated with this {@code TestDescriptor}.
 	 *
@@ -57,6 +49,11 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	 * set should be used instead of a set local to the subclass.
 	 */
 	protected final Set<TestDescriptor> children = Collections.synchronizedSet(new LinkedHashSet<>(16));
+	private final UniqueId uniqueId;
+	private final String displayName;
+	private final TestSource source;
+	private TestDescriptor parent;
+	private String requirement;
 
 	/**
 	 * Create a new {@code AbstractTestDescriptor} with the supplied
@@ -69,7 +66,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	 * @see #AbstractTestDescriptor(UniqueId, String, TestSource)
 	 */
 	protected AbstractTestDescriptor(UniqueId uniqueId, String displayName) {
-		this(uniqueId, displayName, null);
+		this(uniqueId, displayName, null, null);
 	}
 
 	/**
@@ -85,9 +82,27 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	 * @see #AbstractTestDescriptor(UniqueId, String)
 	 */
 	protected AbstractTestDescriptor(UniqueId uniqueId, String displayName, TestSource source) {
+		this(uniqueId, displayName, source, null);
+	}
+
+	/**
+	 * Create a new {@code AbstractTestDescriptor} with the supplied
+	 * {@link UniqueId}, display name, and source.
+	 *
+	 * @param uniqueId the unique ID of this {@code TestDescriptor}; never
+	 * {@code null}
+	 * @param displayName the display name for this {@code TestDescriptor};
+	 * never {@code null} or blank
+	 * @param source the source of the test or container described by this
+	 * {@code TestDescriptor}; can be {@code null}
+	 * @param requirement the annotated requirement of the test; can be {@code null}   
+	 * @see #AbstractTestDescriptor(UniqueId, String, TestSource)
+	 */
+	protected AbstractTestDescriptor(UniqueId uniqueId, String displayName, TestSource source, String requirement) {
 		this.uniqueId = Preconditions.notNull(uniqueId, "UniqueId must not be null");
 		this.displayName = Preconditions.notBlank(displayName, "displayName must not be null or blank");
 		this.source = source;
+		this.requirement = requirement;
 	}
 
 	@Override
@@ -108,6 +123,11 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	@Override
 	public Optional<TestSource> getSource() {
 		return Optional.ofNullable(this.source);
+	}
+
+	@Override
+	public String getRequirement() {
+		return this.requirement;
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -95,7 +95,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	 * never {@code null} or blank
 	 * @param source the source of the test or container described by this
 	 * {@code TestDescriptor}; can be {@code null}
-	 * @param requirement the annotated requirement of the test; can be {@code null}   
+	 * @param requirement the annotated requirement of the test; can be {@code null}
 	 * @see #AbstractTestDescriptor(UniqueId, String, TestSource)
 	 */
 	protected AbstractTestDescriptor(UniqueId uniqueId, String displayName, TestSource source, String requirement) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -10,20 +10,20 @@
 
 package org.junit.platform.engine.support.descriptor;
 
-import static java.util.Collections.emptySet;
-import static org.apiguardian.api.API.Status.STABLE;
-
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Optional;
-import java.util.Set;
-
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static org.apiguardian.api.API.Status.STABLE;
 
 /**
  * Abstract base implementation of {@link TestDescriptor} that may be used by
@@ -83,6 +83,21 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	 */
 	protected AbstractTestDescriptor(UniqueId uniqueId, String displayName, TestSource source) {
 		this(uniqueId, displayName, source, null);
+	}
+
+	/**
+	 * Create a new {@code AbstractTestDescriptor} with the supplied
+	 * {@link UniqueId}, display name, and source.
+	 *
+	 * @param uniqueId the unique ID of this {@code TestDescriptor}; never
+	 * {@code null}
+	 * @param displayName the display name for this {@code TestDescriptor};
+	 * never {@code null} or blank
+	 * @param requirement the annotated requirement of the test; can be {@code null}
+	 * @see #AbstractTestDescriptor(UniqueId, String)
+	 */
+	protected AbstractTestDescriptor(UniqueId uniqueId, String displayName, String requirement) {
+		this(uniqueId, displayName, null, requirement);
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -47,6 +47,7 @@ public final class TestIdentifier implements Serializable {
 	private final TestSource source;
 	private final Set<TestTag> tags;
 	private final Type type;
+	private final String requirement;
 
 	/**
 	 * Factory for creating a new {@link TestIdentifier} from a {@link TestDescriptor}.
@@ -62,11 +63,13 @@ public final class TestIdentifier implements Serializable {
 		String parentId = testDescriptor.getParent().map(
 			parentDescriptor -> parentDescriptor.getUniqueId().toString()).orElse(null);
 		String legacyReportingName = testDescriptor.getLegacyReportingName();
-		return new TestIdentifier(uniqueId, displayName, source, tags, type, parentId, legacyReportingName);
+		String requirement = testDescriptor.getRequirement();
+		return new TestIdentifier(uniqueId, displayName, source, tags, type, parentId, legacyReportingName,
+			requirement);
 	}
 
 	TestIdentifier(String uniqueId, String displayName, TestSource source, Set<TestTag> tags, Type type,
-			String parentId, String legacyReportingName) {
+			String parentId, String legacyReportingName, String requirement) {
 		Preconditions.notNull(type, "TestDescriptor.Type must not be null");
 		this.uniqueId = uniqueId;
 		this.parentId = parentId;
@@ -75,6 +78,7 @@ public final class TestIdentifier implements Serializable {
 		this.tags = unmodifiableSet(new LinkedHashSet<>(tags));
 		this.type = type;
 		this.legacyReportingName = legacyReportingName;
+		this.requirement = requirement;
 	}
 
 	/**
@@ -187,6 +191,15 @@ public final class TestIdentifier implements Serializable {
 		return this.tags;
 	}
 
+	/**
+	 * Get the value of the annotated requirement.
+	 *
+	 * @see TestDescriptor#getRequirement()
+	 */
+	public String getRequirement() {
+		return this.requirement;
+	};
+
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof TestIdentifier) {
@@ -212,6 +225,7 @@ public final class TestIdentifier implements Serializable {
 				.append("source", this.source)
 				.append("tags", this.tags)
 				.append("type", this.type)
+				.append("requirement", this.requirement)
 				.toString();
 		// @formatter:on
 	}

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -147,6 +147,12 @@ class XmlReportWriter {
 		writer.writeAttribute("name", getName(testIdentifier));
 		writer.writeAttribute("classname", getClassName(testIdentifier));
 		writer.writeAttribute("time", getTime(testIdentifier, numberFormat));
+
+		String requirement = getRequirement(testIdentifier);
+		if (null != requirement) {
+			writer.writeAttribute("requirement", requirement);
+		}
+
 		newLine(writer);
 
 		writeSkippedOrErrorOrFailureElement(testIdentifier, writer);
@@ -164,6 +170,10 @@ class XmlReportWriter {
 
 	private String getName(TestIdentifier testIdentifier) {
 		return testIdentifier.getLegacyReportingName();
+	}
+
+	private String getRequirement(TestIdentifier testIdentifier) {
+		return testIdentifier.getRequirement();
 	}
 
 	private String getClassName(TestIdentifier testIdentifier) {
@@ -276,8 +286,17 @@ class XmlReportWriter {
 	}
 
 	private String formatNonStandardAttributesAsString(TestIdentifier testIdentifier) {
-		return "unique-id: " + testIdentifier.getUniqueId() //
+		String nonStandardAttributesString = "unique-id: " + testIdentifier.getUniqueId() //
 				+ "\ndisplay-name: " + testIdentifier.getDisplayName();
+
+		String requirement = testIdentifier.getRequirement();
+
+		if (null != requirement) {
+			return nonStandardAttributesString //
+					+ "\nrequirement: " + requirement;
+		}
+
+		return nonStandardAttributesString;
 	}
 
 	private void writeOutputElements(String elementName, List<String> elements, XMLStreamWriter writer)

--- a/platform-tests/src/test/java/org/junit/platform/fakes/TestDescriptorStub.java
+++ b/platform-tests/src/test/java/org/junit/platform/fakes/TestDescriptorStub.java
@@ -22,6 +22,10 @@ public class TestDescriptorStub extends AbstractTestDescriptor {
 		super(uniqueId, displayName);
 	}
 
+	public TestDescriptorStub(UniqueId uniqueId, String displayName, String requirement) {
+		super(uniqueId, displayName, requirement);
+	}
+
 	@Override
 	public Type getType() {
 		return getChildren().isEmpty() ? Type.TEST : Type.CONTAINER;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
@@ -57,7 +57,8 @@ class TestIdentifierTests {
 	void serialization() throws Exception {
 		TestIdentifier identifier = serializeAndDeserialize(//
 			new TestIdentifier("uniqueId", "displayName", ClassSource.from(TestIdentifierTests.class),
-				singleton(TestTag.create("aTag")), TestDescriptor.Type.TEST, "parentId", "reportingName"));
+				singleton(TestTag.create("aTag")), TestDescriptor.Type.TEST, "parentId", "reportingName",
+				"requirement"));
 
 		assertEquals("uniqueId", identifier.getUniqueId());
 		assertEquals("displayName", identifier.getDisplayName());
@@ -68,6 +69,7 @@ class TestIdentifierTests {
 		assertTrue(identifier.isTest());
 		assertFalse(identifier.isContainer());
 		assertThat(identifier.getParentId()).contains("parentId");
+		assertEquals("requirement", identifier.getRequirement());
 	}
 
 }

--- a/platform-tests/src/test/resources/jenkins-junit.xsd
+++ b/platform-tests/src/test/resources/jenkins-junit.xsd
@@ -75,6 +75,7 @@
             <xs:attribute name="time" type="xs:string" use="optional"/>
             <xs:attribute name="classname" type="xs:string" use="optional"/>
             <xs:attribute name="status" type="xs:string" use="optional"/>
+            <xs:attribute name="requirement" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
## Overview

I'm opening this pull request for issue #1900 to ask for some feedback about my attempt to implement the new annotation.

I orient myself at the "@Displayname" annotation and did the following steps

1. Defined the new annotation
2. Extended the extensionContext, testDescriptor and tesInfo interfaces for it
3. Added the new attribute to the AbstractTestDescriptor and modifided extending classes
4. Extended the XSD and the XMLWriter to write the new attribute

On the one hand side I think that should do it, on the other side I think something is missing. What's definitly missing is an updated documentation module. Havn't done that yet as I want to ask for feedback while updating the documentation in parallel.

_Nevertheless thanks to @sormuras helping me fixing IntelliJ and giving a short introduction into gradle and the junit modules_


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
