### PR TITLE
Make maxStackTraceLines configurable in TestExecutionSummary

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
@@ -185,9 +185,14 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 	}
 
 	@Override
+	public void printFailuresTo(PrintWriter writer) {
+		printFailuresTo(writer, 10);
+	}
+
+	@Override
 	public void printFailuresTo(PrintWriter writer, int maxStackTraceLines) {
 		Preconditions.notNull(writer, "Writer must not be null");
-		Preconditions.condition(maxStackTraceLines >= 0, "Invalid negative value for maxStackTraceLines");
+		Preconditions.condition(maxStackTraceLines >= 0, "maxStackTraceLines must be a positive number");
 
 		if (getTotalFailureCount() > 0) {
 			writer.printf("%nFailures (%d):%n", getTotalFailureCount());

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -32,7 +33,6 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 
 	private static final String TAB = "  ";
 	private static final String DOUBLE_TAB = TAB + TAB;
-	private static final int MAX_STACKTRACE_LINES = 10;
 
 	private static final String CAUSED_BY = "Caused by: ";
 	private static final String SUPPRESSED = "Suppressed: ";
@@ -185,14 +185,19 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 	}
 
 	@Override
-	public void printFailuresTo(PrintWriter writer) {
+	public void printFailuresTo(PrintWriter writer, int maxStackTraceLines) {
+		Objects.requireNonNull(writer);
+		if (maxStackTraceLines < 0) {
+			throw new IllegalArgumentException("Invalid negative value for maxStackTraceLines");
+		}
+
 		if (getTotalFailureCount() > 0) {
 			writer.printf("%nFailures (%d):%n", getTotalFailureCount());
 			this.failures.forEach(failure -> {
 				writer.printf("%s%s%n", TAB, describeTest(failure.getTestIdentifier()));
 				printSource(writer, failure.getTestIdentifier());
 				writer.printf("%s=> %s%n", DOUBLE_TAB, failure.getException());
-				printStackTrace(writer, failure.getException(), MAX_STACKTRACE_LINES);
+				printStackTrace(writer, failure.getException(), maxStackTraceLines);
 			});
 			writer.flush();
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
@@ -17,10 +17,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
@@ -186,10 +186,8 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 
 	@Override
 	public void printFailuresTo(PrintWriter writer, int maxStackTraceLines) {
-		Objects.requireNonNull(writer);
-		if (maxStackTraceLines < 0) {
-			throw new IllegalArgumentException("Invalid negative value for maxStackTraceLines");
-		}
+		Preconditions.notNull(writer, "Writer must not be null");
+		Preconditions.condition(maxStackTraceLines >= 0, "Invalid negative value for maxStackTraceLines");
 
 		if (getTotalFailureCount() > 0) {
 			writer.printf("%nFailures (%d):%n", getTotalFailureCount());

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
@@ -133,6 +133,7 @@ public interface TestExecutionSummary {
 	/**
 	 * Print failed containers and tests, including sources and exception
 	 * messages, to the supplied {@link PrintWriter}.
+	 *
 	 * <p>The maximum number of lines to print for the exception stack traces
 	 * (if any) can be specified with the given {@code maxStackTraceLines}
 	 * parameter.
@@ -140,8 +141,17 @@ public interface TestExecutionSummary {
 	 * @param writer on which the printing is done; never {@code null}
 	 * @param maxStackTraceLines maximum number of lines to print; must be positive
 	 * @see #printTo(PrintWriter)
+	 * @since 1.6
 	 */
-	void printFailuresTo(PrintWriter writer, int maxStackTraceLines);
+	@API(status = MAINTAINED, since = "1.6")
+	default void printFailuresTo(PrintWriter writer, int maxStackTraceLines) {
+		/*
+		    Note: default behavior is to ignore maxStackTraceLines parameter.
+		    This was done to avoid breaking backward compatibility with existing
+		    classes extending this interface.
+		 */
+		printFailuresTo(writer);
+	}
 
 	/**
 	 * Get an immutable list of the failures of the test plan execution.

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
@@ -127,7 +127,20 @@ public interface TestExecutionSummary {
 	 *
 	 * @see #printTo(PrintWriter)
 	 */
-	void printFailuresTo(PrintWriter writer);
+	default void printFailuresTo(PrintWriter writer) {
+		printFailuresTo(writer, 10);
+	}
+
+	/**
+	 * Print failed containers and tests, including sources and exception
+	 * messages, to the supplied {@link PrintWriter}.
+	 * The maximum number of lines to print for the exception stack traces
+	 * (if any) can be specified with the given {@code maxStackTraceLines}
+	 * parameter.
+	 *
+	 * @see #printTo(PrintWriter)
+	 */
+	void printFailuresTo(PrintWriter writer, int maxStackTraceLines);
 
 	/**
 	 * Get an immutable list of the failures of the test plan execution.

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
@@ -125,19 +125,20 @@ public interface TestExecutionSummary {
 	 * Print failed containers and tests, including sources and exception
 	 * messages, to the supplied {@link PrintWriter}.
 	 *
+	 * @param writer on which the printing is done; never {@code null}
 	 * @see #printTo(PrintWriter)
 	 */
-	default void printFailuresTo(PrintWriter writer) {
-		printFailuresTo(writer, 10);
-	}
+	void printFailuresTo(PrintWriter writer);
 
 	/**
 	 * Print failed containers and tests, including sources and exception
 	 * messages, to the supplied {@link PrintWriter}.
-	 * The maximum number of lines to print for the exception stack traces
+	 * <p>The maximum number of lines to print for the exception stack traces
 	 * (if any) can be specified with the given {@code maxStackTraceLines}
 	 * parameter.
 	 *
+	 * @param writer on which the printing is done; never {@code null}
+	 * @param maxStackTraceLines maximum number of lines to print; must be positive
 	 * @see #printTo(PrintWriter)
 	 */
 	void printFailuresTo(PrintWriter writer, int maxStackTraceLines);

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherWrapperResult.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherWrapperResult.java
@@ -141,6 +141,11 @@ class ConsoleLauncherWrapperResult implements TestExecutionSummary {
 	}
 
 	@Override
+	public void printFailuresTo(PrintWriter writer) {
+		printFailuresTo(writer, 10);
+	}
+
+	@Override
 	public void printFailuresTo(PrintWriter writer, int maxStackTraceLines) {
 		checkTestExecutionSummaryState();
 		summary.printFailuresTo(writer, maxStackTraceLines);

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherWrapperResult.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherWrapperResult.java
@@ -141,9 +141,9 @@ class ConsoleLauncherWrapperResult implements TestExecutionSummary {
 	}
 
 	@Override
-	public void printFailuresTo(PrintWriter writer) {
+	public void printFailuresTo(PrintWriter writer, int maxStackTraceLines) {
 		checkTestExecutionSummaryState();
-		summary.printFailuresTo(writer);
+		summary.printFailuresTo(writer, maxStackTraceLines);
 	}
 
 	@Override


### PR DESCRIPTION
## Overview

Add the possibility of specifying the max stack trace when printing failures.
This is for issue #1947 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- ❌ Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
