### PR TITLE
Document comment support in @CsvFileSource

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -47,7 +47,7 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* Documented the support of commented lines in CSV file with `@CsvFileSource`.
 
 
 [[release-notes-5.6.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1142,7 +1142,8 @@ the target type of a `null` reference is a primitive type.
 ===== @CsvFileSource
 
 `@CsvFileSource` lets you use CSV files from the classpath. Each line from a CSV file
-results in one invocation of the parameterized test.
+results in one invocation of the parameterized test, except the ones that are commented
+out (i.e. starting with a `#` symbol).
 
 [source,java,indent=0]
 ----

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -26,7 +26,8 @@ import org.apiguardian.api.API;
  * resources}.
  *
  * <p>The lines of these CSV files will be provided as arguments to the
- * annotated {@code @ParameterizedTest} method.
+ * annotated {@code @ParameterizedTest} method. If some lines are commented
+ * out with a # symbol at the beginning of the line, they will be ignored.
  *
  * @since 5.0
  * @see CsvSource

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -47,6 +47,13 @@ class CsvFileArgumentsProviderTests {
 	}
 
 	@Test
+	void ignoresCommentedOutEntries() {
+		Stream<Object[]> arguments = provideArguments("foo, bar \n#baz, qux", "\n", ',', "");
+
+		assertThat(arguments).containsExactly(new Object[] { "foo", "bar" });
+	}
+
+	@Test
 	void closesInputStream() {
 		AtomicBoolean closed = new AtomicBoolean(false);
 		InputStream inputStream = new ByteArrayInputStream("foo".getBytes()) {


### PR DESCRIPTION
## Overview

Solves #1782 by adding documentation about the support of comments in @CsvFileSource.
Also added a unit test covering this use case.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
