### PR TITLE
Add support for String delimiters in @CsvSource and @CsvFileSource

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -48,7 +48,7 @@ on GitHub.
 ==== New Features and Improvements
 
 * Documented the support of commented lines in CSV file with `@CsvFileSource`.
-* Add support for String delimiters in `@CsvSource`.
+* Add support for String delimiters in `@CsvSource` and `@CsvFileSource`.
 
 [[release-notes-5.6.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -48,7 +48,7 @@ on GitHub.
 ==== New Features and Improvements
 
 * Documented the support of commented lines in CSV file with `@CsvFileSource`.
-
+* Add support for String delimiters in `@CsvSource`.
 
 [[release-notes-5.6.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1160,6 +1160,10 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=CsvFileSource_example
 include::{testResourcesDir}/two-column.csv[]
 ----
 
+As with `@CsvSource`, the default delimiter is `,` but you can use another character by
+setting the `delimiter` attribute. Alternatively, the `delimiterString` attribute allows
+to use a `String` delimiter. However, both attributes cannot be set simultaneously.
+
 NOTE: In contrast to the syntax used in `@CsvSource`, `@CsvFileSource` uses a double
 quote `"` as the quote character. See the `"United States of America"` value in the
 example above. An empty, quoted value `""` results in an empty `String` unless the

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1122,6 +1122,10 @@ include::{testDir}/example/ExternalMethodSourceDemo.java[tags=external_MethodSou
 include::{testDir}/example/ParameterizedTestDemo.java[tags=CsvSource_example]
 ----
 
+The default delimiter is `,` but you can use another character by setting the `delimiter`
+attribute. The `delimiterString` attributes also allows you to use a String as a delimiter.
+However, both attributes cannot be set simultaneously.
+
 `@CsvSource` uses a single quote `'` as its quote character. See the `'lemon, lime'` value
 in the example above and in the table below. An empty, quoted value `''` results in an
 empty `String` unless the `emptyValue` attribute is set; whereas, an entirely _empty_

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1123,7 +1123,7 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=CsvSource_example]
 ----
 
 The default delimiter is `,` but you can use another character by setting the `delimiter`
-attribute. The `delimiterString` attributes also allows you to use a String as a delimiter.
+attribute. Alternatively, the `delimiterString` attribute allows to use a `String` delimiter.
 However, both attributes cannot be set simultaneously.
 
 `@CsvSource` uses a single quote `'` as its quote character. See the `'lemon, lime'` value

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsParser.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsParser.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import java.lang.annotation.Annotation;
+
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
+
+import org.junit.platform.commons.PreconditionViolationException;
+
+public class CsvArgumentsParser {
+
+	private static final String DEFAULT_DELIMITER = ",";
+	private static final String LINE_SEPARATOR = "\n";
+	private static final char SINGLE_QUOTE = '\'';
+	private static final char DOUBLE_QUOTE = '"';
+	private static final char EMPTY_CHAR = '\0';
+
+	private String delimiter;
+	private String lineSeparator;
+	private char quote;
+	private String emptyValue;
+
+	private CsvArgumentsParser(String delimiter, String lineSeparator, char quote, String emptyValue) {
+		this.delimiter = delimiter;
+		this.lineSeparator = lineSeparator;
+		this.quote = quote;
+		this.emptyValue = emptyValue;
+	}
+
+	public static CsvArgumentsParser from(CsvSource annotation) {
+		String delimiter = selectDelimiter(annotation, annotation.delimiter(), annotation.delimiterString());
+		return new CsvArgumentsParser(delimiter, LINE_SEPARATOR, SINGLE_QUOTE, annotation.emptyValue());
+	}
+
+	public static CsvArgumentsParser from(CsvFileSource annotation) {
+		String delimiter = selectDelimiter(annotation, annotation.delimiter(), annotation.delimiterString());
+		return new CsvArgumentsParser(delimiter, annotation.lineSeparator(), DOUBLE_QUOTE, annotation.emptyValue());
+	}
+
+	private static String selectDelimiter(Annotation annotation, char delimiter, String delimiterString) {
+		if (delimiter != EMPTY_CHAR && !delimiterString.isEmpty()) {
+			throw new PreconditionViolationException(
+				"delimiter and delimiterString cannot be simultaneously set in " + annotation);
+		}
+		if (delimiter != EMPTY_CHAR) {
+			return String.valueOf(delimiter);
+		}
+		if (!delimiterString.isEmpty()) {
+			return delimiterString;
+		}
+		return DEFAULT_DELIMITER;
+	}
+
+	CsvParser getParser() {
+		CsvParserSettings csvParserSettings = buildParserSettings();
+		return new CsvParser(csvParserSettings);
+	}
+
+	private CsvParserSettings buildParserSettings() {
+		CsvParserSettings settings = new CsvParserSettings();
+		settings.getFormat().setDelimiter(delimiter);
+		settings.getFormat().setLineSeparator(lineSeparator);
+		settings.getFormat().setQuote(quote);
+		settings.getFormat().setQuoteEscape(quote);
+		settings.setEmptyValue(emptyValue);
+		settings.setAutoConfigurationEnabled(false);
+		// Do not use the built-in support for skipping rows/lines since it will
+		// throw an IllegalArgumentException if the file does not contain at least
+		// the number of specified lines to skip.
+		// settings.setNumberOfRowsToSkip(annotation.numLinesToSkip());
+		return settings;
+	}
+
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -57,7 +57,7 @@ class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvS
 	private String getDelimiterFrom(CsvSource annotation) {
 		if (annotation.delimiter() != EMPTY_CHAR && !annotation.delimiterString().isEmpty()) {
 			throw new PreconditionViolationException(
-				"delimiter and delimiterString cannot be simultaneously set in " + this.annotation);
+				"delimiter and delimiterString cannot be simultaneously set in " + annotation);
 		}
 		if (annotation.delimiter() != EMPTY_CHAR) {
 			return String.valueOf(annotation.delimiter());

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -30,24 +30,47 @@ import org.junit.platform.commons.util.Preconditions;
 class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvSource> {
 
 	private static final String LINE_SEPARATOR = "\n";
+	private static final String DEFAULT_DELIMITER = ",";
+	private static final char EMPTY_CHAR = '\0';
 
 	private CsvSource annotation;
+	private CsvParserSettings settings;
 
 	@Override
 	public void accept(CsvSource annotation) {
 		this.annotation = annotation;
+		this.settings = buildParserSettings(annotation);
+	}
+
+	private CsvParserSettings buildParserSettings(CsvSource annotation) {
+		CsvParserSettings settings = new CsvParserSettings();
+		String delimiter = getDelimiterFrom(annotation);
+		settings.getFormat().setDelimiter(delimiter);
+		settings.getFormat().setLineSeparator(LINE_SEPARATOR);
+		settings.getFormat().setQuote('\'');
+		settings.getFormat().setQuoteEscape('\'');
+		settings.setEmptyValue(annotation.emptyValue());
+		settings.setAutoConfigurationEnabled(false);
+		return settings;
+	}
+
+	private String getDelimiterFrom(CsvSource annotation) {
+		if (annotation.delimiter() != EMPTY_CHAR && !annotation.delimiterString().isEmpty()) {
+			throw new PreconditionViolationException(
+					"delimiter and delimiterString cannot be simultaneously set in " + this.annotation);
+		}
+		if (annotation.delimiter() != EMPTY_CHAR) {
+			return String.valueOf(annotation.delimiter());
+		}
+		if (!annotation.delimiterString().isEmpty()) {
+			return annotation.delimiterString();
+		}
+		return DEFAULT_DELIMITER;
 	}
 
 	@Override
 	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-		CsvParserSettings settings = new CsvParserSettings();
-		settings.getFormat().setDelimiter(this.annotation.delimiter());
-		settings.getFormat().setLineSeparator(LINE_SEPARATOR);
-		settings.getFormat().setQuote('\'');
-		settings.getFormat().setQuoteEscape('\'');
-		settings.setEmptyValue(this.annotation.emptyValue());
-		settings.setAutoConfigurationEnabled(false);
-		CsvParser csvParser = new CsvParser(settings);
+		CsvParser csvParser = new CsvParser(this.settings);
 		AtomicLong index = new AtomicLong(0);
 
 		// @formatter:off

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -57,7 +57,7 @@ class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvS
 	private String getDelimiterFrom(CsvSource annotation) {
 		if (annotation.delimiter() != EMPTY_CHAR && !annotation.delimiterString().isEmpty()) {
 			throw new PreconditionViolationException(
-					"delimiter and delimiterString cannot be simultaneously set in " + this.annotation);
+				"delimiter and delimiterString cannot be simultaneously set in " + this.annotation);
 		}
 		if (annotation.delimiter() != EMPTY_CHAR) {
 			return String.valueOf(annotation.delimiter());

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -66,10 +66,17 @@ public @interface CsvFileSource {
 
 	/**
 	 * The column delimiter to use when reading the CSV files.
-	 *
-	 * <p>Defaults to {@code ","}.
+	 * This can't be set simultaneously with {@link #delimiterString delimiterString}.
+	 * If neither attributes are set, the delimiter will be ','.
 	 */
-	char delimiter() default ',';
+	char delimiter() default '\0';
+
+	/**
+	 * The column delimiter to use when reading the CSV files.
+	 * This can't be set simultaneously with {@link #delimiter delimiter}.
+	 * If neither attributes are set, the delimiter will be ','.
+	 */
+	String delimiterString() default "";
 
 	/**
 	 * The number of lines to skip when reading the CSV files.

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -50,6 +50,8 @@ public @interface CsvSource {
 
 	/**
 	 * The column delimiter to use when reading the {@linkplain #value lines}.
+	 * This can't be set simultaneously with {@link #delimiterString delimiterString}.
+	 * If neither attributes are set, the delimiter will be ','.
 	 *
 	 * <p>Defaults to {@code '\0'}.
 	 */
@@ -57,6 +59,8 @@ public @interface CsvSource {
 
 	/**
 	 * The column delimiter to use when reading the {@linkplain #value lines}.
+	 * This can't be set simultaneously with {@link #delimiter delimiter}.
+	 * If neither attributes are set, the delimiter will be ','.
 	 *
 	 * <p>Defaults to {@code ""}.
 	 */

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -52,8 +52,6 @@ public @interface CsvSource {
 	 * The column delimiter to use when reading the {@linkplain #value lines}.
 	 * This can't be set simultaneously with {@link #delimiterString delimiterString}.
 	 * If neither attributes are set, the delimiter will be ','.
-	 *
-	 * <p>Defaults to {@code '\0'}.
 	 */
 	char delimiter() default '\0';
 
@@ -61,8 +59,6 @@ public @interface CsvSource {
 	 * The column delimiter to use when reading the {@linkplain #value lines}.
 	 * This can't be set simultaneously with {@link #delimiter delimiter}.
 	 * If neither attributes are set, the delimiter will be ','.
-	 *
-	 * <p>Defaults to {@code ""}.
 	 */
 	String delimiterString() default "";
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -51,9 +51,16 @@ public @interface CsvSource {
 	/**
 	 * The column delimiter to use when reading the {@linkplain #value lines}.
 	 *
-	 * <p>Defaults to {@code ','}.
+	 * <p>Defaults to {@code '\0'}.
 	 */
-	char delimiter() default ',';
+	char delimiter() default '\0';
+
+	/**
+	 * The column delimiter to use when reading the {@linkplain #value lines}.
+	 *
+	 * <p>Defaults to {@code ""}.
+	 */
+	String delimiterString() default "";
 
 	/**
 	 * The empty value to use when reading the {@linkplain #value lines}.

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -114,10 +114,9 @@ class CsvArgumentsProviderTests {
 	@Test
 	void throwsExceptionIfBothDelimitersAreSimultaneouslySet() {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
-				() -> provideArguments(",", ',', "", "foo"));
+			() -> provideArguments(",", ',', "", "foo"));
 
-		assertThat(exception)
-				.hasMessageContaining("delimiter and delimiterString cannot be simultaneously set in");
+		assertThat(exception).hasMessageContaining("delimiter and delimiterString cannot be simultaneously set in");
 	}
 
 	private Stream<Object[]> provideArguments(char delimiter, String emptyValue, String... value) {
@@ -128,7 +127,8 @@ class CsvArgumentsProviderTests {
 		return provideArguments(delimiterString, '\0', emptyValue, value);
 	}
 
-	private Stream<Object[]> provideArguments(String delimiterString, char delimiter, String emptyValue, String... value) {
+	private Stream<Object[]> provideArguments(String delimiterString, char delimiter, String emptyValue,
+			String... value) {
 		CsvSource annotation = mock(CsvSource.class);
 		when(annotation.value()).thenReturn(value);
 		when(annotation.delimiter()).thenReturn(delimiter);

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -116,7 +116,7 @@ class CsvArgumentsProviderTests {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(",", ',', "", "foo"));
 
-		assertThat(exception).hasMessageContaining("delimiter and delimiterString cannot be simultaneously set in");
+		assertThat(exception).hasMessageStartingWith("delimiter and delimiterString cannot be simultaneously set in");
 	}
 
 	private Stream<Object[]> provideArguments(char delimiter, String emptyValue, String... value) {

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.PreconditionViolationException;
 
 /**
  * @since 5.0
@@ -103,10 +104,35 @@ class CsvArgumentsProviderTests {
 		assertThat(arguments).containsExactly(new Object[][] { { "", "" }, { null, null } });
 	}
 
+	@Test
+	void providesArgumentsWithStringDelimiter() {
+		Stream<Object[]> arguments = provideArguments(",", "", "foo, bar", "bar, foo");
+
+		assertThat(arguments).containsExactly(new String[] { "foo", "bar" }, new String[] { "bar", "foo" });
+	}
+
+	@Test
+	void throwsExceptionIfBothDelimitersAreSimultaneouslySet() {
+		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
+				() -> provideArguments(",", ',', "", "foo"));
+
+		assertThat(exception)
+				.hasMessageContaining("delimiter and delimiterString cannot be simultaneously set in");
+	}
+
 	private Stream<Object[]> provideArguments(char delimiter, String emptyValue, String... value) {
+		return provideArguments("", delimiter, emptyValue, value);
+	}
+
+	private Stream<Object[]> provideArguments(String delimiterString, String emptyValue, String... value) {
+		return provideArguments(delimiterString, '\0', emptyValue, value);
+	}
+
+	private Stream<Object[]> provideArguments(String delimiterString, char delimiter, String emptyValue, String... value) {
 		CsvSource annotation = mock(CsvSource.class);
 		when(annotation.value()).thenReturn(value);
 		when(annotation.delimiter()).thenReturn(delimiter);
+		when(annotation.delimiterString()).thenReturn(delimiterString);
 		when(annotation.emptyValue()).thenReturn(emptyValue);
 
 		CsvArgumentsProvider provider = new CsvArgumentsProvider();

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -34,7 +34,10 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void providesArgumentsForNewlineAndComma() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().lineSeparator("\n").delimiter(',').build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.lineSeparator("\n")//
+				.delimiter(',')//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments("foo, bar \n baz, qux \n", annotation);
 
@@ -43,7 +46,10 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void providesArgumentsForCarriageReturnAndSemicolon() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().lineSeparator("\r").delimiter(';').build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.lineSeparator("\r")//
+				.delimiter(';')//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments("foo; bar \r baz; qux", annotation);
 
@@ -52,8 +58,9 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void providesArgumentsWithStringDelimiter() {
-		CsvFileSource annotation = CsvFileSourceMock.builder()
-				.delimiterString(",").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.delimiterString(",")//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments("foo, bar \n baz, qux \n", annotation);
 
@@ -62,7 +69,10 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void throwsExceptionIfBothDelimitersAreSimultaneouslySet() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().delimiter(',').delimiterString(";").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.delimiter(',')//
+				.delimiterString(";")//
+				.build();
 
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments("foo", annotation));
@@ -72,7 +82,9 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void ignoresCommentedOutEntries() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().delimiter(',').build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.delimiter(',')//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments("foo, bar \n#baz, qux", annotation);
 
@@ -98,8 +110,10 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void readsFromSingleClasspathResource() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().charset("ISO-8859-1").resources(
-			"/single-column.csv").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.charset("ISO-8859-1")//
+				.resources("/single-column.csv")//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments(new CsvFileArgumentsProvider(), annotation);
 
@@ -109,8 +123,11 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void readsFromSingleClasspathResourceWithCustomEmptyValue() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().charset("ISO-8859-1").resources(
-			"/single-column.csv").emptyValue("vacio").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.charset("ISO-8859-1")//
+				.resources("/single-column.csv")//
+				.emptyValue("vacio")//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments(new CsvFileArgumentsProvider(), annotation);
 
@@ -120,8 +137,10 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void readsFromMultipleClasspathResources() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().charset("ISO-8859-1").resources("/single-column.csv",
-			"/single-column.csv").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.charset("ISO-8859-1")//
+				.resources("/single-column.csv", "/single-column.csv")//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments(new CsvFileArgumentsProvider(), annotation);
 
@@ -130,8 +149,11 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void readsFromSingleClasspathResourceWithHeaders() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().charset("ISO-8859-1").resources(
-			"/single-column.csv").numLinesToSkip(1).build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.charset("ISO-8859-1")//
+				.resources("/single-column.csv")//
+				.numLinesToSkip(1)//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments(new CsvFileArgumentsProvider(), annotation);
 
@@ -141,8 +163,11 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void readsFromSingleClasspathResourceWithMoreHeadersThanLines() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().charset("ISO-8859-1").resources(
-			"/single-column.csv").numLinesToSkip(10).build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.charset("ISO-8859-1")//
+				.resources("/single-column.csv")//
+				.numLinesToSkip(10)//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments(new CsvFileArgumentsProvider(), annotation);
 
@@ -151,8 +176,11 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void readsFromMultipleClasspathResourcesWithHeaders() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().charset("ISO-8859-1").resources("/single-column.csv",
-			"/single-column.csv").numLinesToSkip(1).build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.charset("ISO-8859-1")//
+				.resources("/single-column.csv", "/single-column.csv")//
+				.numLinesToSkip(1)//
+				.build();
 
 		Stream<Object[]> arguments = provideArguments(new CsvFileArgumentsProvider(), annotation);
 
@@ -163,7 +191,9 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void throwsExceptionForMissingClasspathResource() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().resources("/does-not-exist.csv").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.resources("/does-not-exist.csv")//
+				.build();
 
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(new CsvFileArgumentsProvider(), annotation).toArray());
@@ -173,7 +203,9 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void throwsExceptionForBlankClasspathResource() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().resources("    ").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.resources("    ")//
+				.build();
 
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(new CsvFileArgumentsProvider(), annotation).toArray());
@@ -183,8 +215,10 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void throwsExceptionForInvalidCharset() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().charset("Bogus-Charset").resources(
-			"/bogus-charset.csv").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.charset("Bogus-Charset")//
+				.resources("/bogus-charset.csv")//
+				.build();
 
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(new CsvFileArgumentsProvider(), annotation).toArray());
@@ -196,7 +230,9 @@ class CsvFileArgumentsProviderTests {
 
 	@Test
 	void throwsExceptionForInvalidCsvFormat() {
-		CsvFileSource annotation = CsvFileSourceMock.builder().resources("/broken.csv").build();
+		CsvFileSource annotation = CsvFileSourceMock.builder()//
+				.resources("/broken.csv")//
+				.build();
 
 		CsvParsingException exception = assertThrows(CsvParsingException.class,
 			() -> provideArguments(new CsvFileArgumentsProvider(), annotation).toArray());

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 
 class CsvFileSourceMock {
 
-	private String[] resources = new String[]{"foo/bar"};
+	private String[] resources = new String[] { "foo/bar" };
 	private String charset = "UTF-8";
 	private String lineSeparator = "\n";
 	private char delimiter = '\0';

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CsvFileSourceMock {
+
+	private String[] resources;
+	private String charset = "UTF-8";
+	private String lineSeparator = "\n";
+	private char delimiter = '\0';
+	private String emptyValue = "";
+	private int numLinesToSkip = 0;
+
+	private CsvFileSourceMock() {
+	}
+
+	static CsvFileSourceMock builder() {
+		return new CsvFileSourceMock();
+	}
+
+	CsvFileSourceMock resources(String... resources) {
+		this.resources = resources;
+		return this;
+	}
+
+	CsvFileSourceMock charset(String charset) {
+		this.charset = charset;
+		return this;
+	}
+
+	CsvFileSourceMock lineSeparator(String lineSeparator) {
+		this.lineSeparator = lineSeparator;
+		return this;
+	}
+
+	CsvFileSourceMock delimiter(char delimiter) {
+		this.delimiter = delimiter;
+		return this;
+	}
+
+	CsvFileSourceMock emptyValue(String emptyValue) {
+		this.emptyValue = emptyValue;
+		return this;
+	}
+
+	CsvFileSourceMock numLinesToSkip(int numLinesToSkip) {
+		this.numLinesToSkip = numLinesToSkip;
+		return this;
+	}
+
+	CsvFileSource build() {
+		CsvFileSource annotation = mock(CsvFileSource.class);
+		when(annotation.resources()).thenReturn(resources);
+		when(annotation.encoding()).thenReturn(charset);
+		when(annotation.lineSeparator()).thenReturn(lineSeparator);
+		when(annotation.delimiter()).thenReturn(delimiter);
+		when(annotation.emptyValue()).thenReturn(emptyValue);
+		when(annotation.numLinesToSkip()).thenReturn(numLinesToSkip);
+		return annotation;
+	}
+}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
@@ -19,6 +19,7 @@ class CsvFileSourceMock {
 	private String charset = "UTF-8";
 	private String lineSeparator = "\n";
 	private char delimiter = '\0';
+	private String delimiterString = "";
 	private String emptyValue = "";
 	private int numLinesToSkip = 0;
 
@@ -49,6 +50,11 @@ class CsvFileSourceMock {
 		return this;
 	}
 
+	CsvFileSourceMock delimiterString(String delimiterString) {
+		this.delimiterString = delimiterString;
+		return this;
+	}
+
 	CsvFileSourceMock emptyValue(String emptyValue) {
 		this.emptyValue = emptyValue;
 		return this;
@@ -65,6 +71,7 @@ class CsvFileSourceMock {
 		when(annotation.encoding()).thenReturn(charset);
 		when(annotation.lineSeparator()).thenReturn(lineSeparator);
 		when(annotation.delimiter()).thenReturn(delimiter);
+		when(annotation.delimiterString()).thenReturn(delimiterString);
 		when(annotation.emptyValue()).thenReturn(emptyValue);
 		when(annotation.numLinesToSkip()).thenReturn(numLinesToSkip);
 		return annotation;

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvFileSourceMock.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 
 class CsvFileSourceMock {
 
-	private String[] resources;
+	private String[] resources = new String[]{"foo/bar"};
 	private String charset = "UTF-8";
 	private String lineSeparator = "\n";
 	private char delimiter = '\0';
@@ -28,6 +28,10 @@ class CsvFileSourceMock {
 
 	static CsvFileSourceMock builder() {
 		return new CsvFileSourceMock();
+	}
+
+	static CsvFileSource getDefault() {
+		return new CsvFileSourceMock().build();
 	}
 
 	CsvFileSourceMock resources(String... resources) {


### PR DESCRIPTION
## Overview

Solves #1958 by adding a `delimiterString` attribute to the `@CsvSource` annotation.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
