### PR TITLE
Make console printing listeners public (and other reporting enhancements)

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.platform.engine.discovery.ClassNameFilter;
+import org.junit.platform.reporting.console.Theme;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
+import org.junit.platform.reporting.console.Theme;
 
 /**
  * @since 1.0

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -26,13 +26,16 @@ import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.ClassLoaderUtils;
 import org.junit.platform.console.options.CommandLineOptions;
 import org.junit.platform.console.options.Details;
-import org.junit.platform.console.options.Theme;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
+import org.junit.platform.reporting.console.FlatPrintingListener;
+import org.junit.platform.reporting.console.Theme;
+import org.junit.platform.reporting.console.TreePrintingListener;
+import org.junit.platform.reporting.console.VerboseTreePrintingListener;
 import org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener;
 
 /**

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -108,18 +108,18 @@ public class ConsoleTestExecutor {
 	}
 
 	private Optional<TestExecutionListener> createDetailsPrintingListener(PrintWriter out) {
-		boolean disableAnsiColors = options.isAnsiColorOutputDisabled();
+		boolean useAnsiColors = !options.isAnsiColorOutputDisabled();
 		Theme theme = options.getTheme();
 		switch (options.getDetails()) {
 			case SUMMARY:
 				// summary listener is always created and registered
 				return Optional.empty();
 			case FLAT:
-				return Optional.of(new FlatPrintingListener(out, disableAnsiColors));
+				return Optional.of(new FlatPrintingListener(out, useAnsiColors));
 			case TREE:
-				return Optional.of(new TreePrintingListener(out, disableAnsiColors, theme));
+				return Optional.of(new TreePrintingListener(out, useAnsiColors, theme));
 			case VERBOSE:
-				return Optional.of(new VerboseTreePrintingListener(out, disableAnsiColors, 16, theme));
+				return Optional.of(new VerboseTreePrintingListener(out, useAnsiColors, 16, theme));
 			default:
 				return Optional.empty();
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -130,7 +130,7 @@ public final class TestIdentifier implements Serializable {
 	 *
 	 * @return the legacy reporting name; never {@code null} or blank
 	 * @see org.junit.platform.engine.TestDescriptor#getLegacyReportingName()
-	 * @see org.junit.platform.launcher.listeners.LegacyReportingUtils
+	 * @see org.junit.platform.reporting.legacy.LegacyReportingUtils
 	 */
 	public String getLegacyReportingName() {
 		return this.legacyReportingName;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/Color.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/Color.java
@@ -8,7 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.TestIdentifier;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/FlatPrintingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/FlatPrintingListener.java
@@ -8,9 +8,9 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
-import static org.junit.platform.console.tasks.Color.NONE;
+import static org.junit.platform.reporting.console.Color.NONE;
 
 import java.io.PrintWriter;
 import java.util.regex.Pattern;
@@ -25,7 +25,7 @@ import org.junit.platform.launcher.TestPlan;
 /**
  * @since 1.0
  */
-class FlatPrintingListener implements TestExecutionListener {
+public class FlatPrintingListener implements TestExecutionListener {
 
 	private static final Pattern LINE_START_PATTERN = Pattern.compile("(?m)^");
 
@@ -34,7 +34,7 @@ class FlatPrintingListener implements TestExecutionListener {
 	private final PrintWriter out;
 	private final boolean disableAnsiColors;
 
-	FlatPrintingListener(PrintWriter out, boolean disableAnsiColors) {
+	public FlatPrintingListener(PrintWriter out, boolean disableAnsiColors) {
 		this.out = out;
 		this.disableAnsiColors = disableAnsiColors;
 	}

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/FlatPrintingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/FlatPrintingListener.java
@@ -10,11 +10,13 @@
 
 package org.junit.platform.reporting.console;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.junit.platform.reporting.console.Color.NONE;
 
 import java.io.PrintWriter;
 import java.util.regex.Pattern;
 
+import org.apiguardian.api.API;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
@@ -23,8 +25,21 @@ import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
+ * Listener that prints output to the provided {@link PrintWriter} instance. The
+ * output is flat rather than hierarchical.
+ * <p>
+ *
+ * Optionally will use ANSI escape codes to colorize the output.
+ * <p>
+ *
+ * For hierarchical output, see {@link TreePrintingListener} or
+ * {@link VerboseTreePrintingListener}.
+ *
  * @since 1.0
+ * @see TreePrintingListener
+ * @see VerboseTreePrintingListener
  */
+@API(status = EXPERIMENTAL, since = "1.6")
 public class FlatPrintingListener implements TestExecutionListener {
 
 	private static final Pattern LINE_START_PATTERN = Pattern.compile("(?m)^");
@@ -32,11 +47,37 @@ public class FlatPrintingListener implements TestExecutionListener {
 	static final String INDENTATION = "             ";
 
 	private final PrintWriter out;
-	private final boolean disableAnsiColors;
+	private final boolean useAnsiColors;
 
-	public FlatPrintingListener(PrintWriter out, boolean disableAnsiColors) {
+	/**
+	 * Creates a new listener that prints monochromatic flat output to
+	 * {@code System.out}.
+	 */
+	public FlatPrintingListener() {
+		this(new PrintWriter(System.out));
+	}
+
+	/**
+	 * Creates a new listener that prints monochromatic flat output to the given
+	 * printer.
+	 *
+	 * @param out the printer to which the listener will print.
+	 */
+	public FlatPrintingListener(PrintWriter out) {
+		this(out, false);
+	}
+
+	/**
+	 * Creates a new listener that prints flat output to the given printer with ANSI
+	 * colors disabled.
+	 *
+	 * @param out           the printer to which the listener will print.
+	 * @param useAnsiColors {@code true} to use ANSI color codes to colorize the
+	 *                      output, {@code false} to use monochromatic output.
+	 */
+	public FlatPrintingListener(PrintWriter out, boolean useAnsiColors) {
 		this.out = out;
-		this.disableAnsiColors = disableAnsiColors;
+		this.useAnsiColors = useAnsiColors;
 	}
 
 	@Override
@@ -96,20 +137,21 @@ public class FlatPrintingListener implements TestExecutionListener {
 	}
 
 	private void println(Color color, String message) {
-		if (this.disableAnsiColors) {
-			this.out.println(message);
-		}
-		else {
+		if (this.useAnsiColors) {
 			// Use string concatenation to avoid ANSI disruption on console
 			this.out.println(color + message + NONE);
+		}
+		else {
+			this.out.println(message);
 		}
 	}
 
 	/**
 	 * Indent the given message if it is a multi-line string.
 	 *
-	 * <p>{@link #INDENTATION} is used to prefix the start of each new line
-	 * except the first one.
+	 * <p>
+	 * {@link #INDENTATION} is used to prefix the start of each new line except the
+	 * first one.
 	 *
 	 * @param message the message to indent
 	 * @return indented message

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/Theme.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/Theme.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.reporting.console;
 
-import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -19,9 +19,15 @@ import org.apiguardian.api.API;
 import org.junit.platform.engine.TestExecutionResult;
 
 /**
+ * Themes used for printing the decorations for the trees in
+ * hierarchical console printers. Current two options are
+ * ASCII and Unicode.
+ *
+ * Moved from {@link org.junit.platform.console.options} in 1.6.
+ *
  * @since 1.0
  */
-@API(status = INTERNAL, since = "1.0")
+@API(status = EXPERIMENTAL, since = "1.6")
 public enum Theme {
 
 	/**

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/Theme.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/Theme.java
@@ -8,7 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.options;
+package org.junit.platform.reporting.console;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreeNode.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreeNode.java
@@ -8,7 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
 import java.util.Optional;
 import java.util.Queue;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreePrinter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreePrinter.java
@@ -8,15 +8,15 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
-import static org.junit.platform.console.tasks.Color.CONTAINER;
-import static org.junit.platform.console.tasks.Color.FAILED;
-import static org.junit.platform.console.tasks.Color.GREEN;
-import static org.junit.platform.console.tasks.Color.NONE;
-import static org.junit.platform.console.tasks.Color.SKIPPED;
-import static org.junit.platform.console.tasks.Color.YELLOW;
+import static org.junit.platform.reporting.console.Color.CONTAINER;
+import static org.junit.platform.reporting.console.Color.FAILED;
+import static org.junit.platform.reporting.console.Color.GREEN;
+import static org.junit.platform.reporting.console.Color.NONE;
+import static org.junit.platform.reporting.console.Color.SKIPPED;
+import static org.junit.platform.reporting.console.Color.YELLOW;
 
 import java.io.PrintWriter;
 import java.util.Iterator;
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.platform.commons.util.StringUtils;
-import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestExecutionResult.Status;
 import org.junit.platform.engine.reporting.ReportEntry;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreePrinter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreePrinter.java
@@ -35,12 +35,12 @@ class TreePrinter {
 
 	private final PrintWriter out;
 	private final Theme theme;
-	private final boolean disableAnsiColors;
+	private final boolean useAnsiColors;
 
-	TreePrinter(PrintWriter out, Theme theme, boolean disableAnsiColors) {
+	TreePrinter(PrintWriter out, Theme theme, boolean useAnsiColors) {
 		this.out = out;
 		this.theme = theme;
-		this.disableAnsiColors = disableAnsiColors;
+		this.useAnsiColors = useAnsiColors;
 	}
 
 	void print(TreeNode node) {
@@ -171,7 +171,7 @@ class TreePrinter {
 	}
 
 	private String color(Color color, String text) {
-		if (disableAnsiColors || color == NONE) {
+		if (!useAnsiColors || color == NONE) {
 			return text;
 		}
 		return color.toString() + text + NONE.toString();

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreePrintingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreePrintingListener.java
@@ -10,6 +10,8 @@
 
 package org.junit.platform.reporting.console;
 
+import static org.junit.platform.reporting.console.Theme.ASCII;
+
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,7 +24,24 @@ import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
+ * Listener that prints output to the provided {@link PrintWriter} instance. The
+ * output is flat rather than hierarchical.
+ * <p>
+ *
+ * Optionally will use ANSI escape codes to colorize the output.
+ * <p>
+ *
+ * Can be configured to use plain ASCII or Unicode characters for the tree
+ * elements.
+ *
+ * Note that this listener buffers the results and prints them all at the end
+ * when {@link #testPlanExecutionFinished(TestPlan) testPlanExecutionFinished()}
+ * is called. If you want to see the test results printed as they execute, try
+ * the {@link VerboseTreePrintingListener}.
+ *
  * @since 1.0
+ * @see FlatPrintingListener
+ * @see VerboseTreePrintingListener
  */
 public class TreePrintingListener implements TestExecutionListener {
 
@@ -30,8 +49,35 @@ public class TreePrintingListener implements TestExecutionListener {
 	private TreeNode root;
 	private final TreePrinter treePrinter;
 
-	public TreePrintingListener(PrintWriter out, boolean disableAnsiColors, Theme theme) {
-		this.treePrinter = new TreePrinter(out, theme, disableAnsiColors);
+	/**
+	 * Creates a new listener that prints hierarchical output to {@code System.out}
+	 * using a monochromatic {@link Theme#ASCII ASCII} theme.
+	 */
+	public TreePrintingListener() {
+		this(new PrintWriter(System.out));
+	}
+
+	/**
+	 * Creates a new listener that prints hierarchical output to the given printer
+	 * using a monochromatic {@link Theme#ASCII ASCII} theme.
+	 *
+	 * @param out the printer to which the listener will print.
+	 */
+	public TreePrintingListener(PrintWriter out) {
+		this(out, false, ASCII);
+	}
+
+	/**
+	 * Creates a new listener that prints hierarchical output to the given printer.
+	 *
+	 * @param out           the printer to which the listener will print.
+	 * @param useAnsiColors {@code true} to use ANSI color codes to colorize the
+	 *                      output, {@code false} to use monochromatic output.
+	 * @param theme         the style to use when printing the hierarchy (see
+	 *                      {@link Theme}).
+	 */
+	public TreePrintingListener(PrintWriter out, boolean useAnsiColors, Theme theme) {
+		this.treePrinter = new TreePrinter(out, theme, useAnsiColors);
 	}
 
 	private TreeNode addNode(TestIdentifier testIdentifier, Supplier<TreeNode> nodeSupplier) {

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreePrintingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/TreePrintingListener.java
@@ -8,14 +8,13 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
-import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -25,13 +24,13 @@ import org.junit.platform.launcher.TestPlan;
 /**
  * @since 1.0
  */
-class TreePrintingListener implements TestExecutionListener {
+public class TreePrintingListener implements TestExecutionListener {
 
 	private final Map<String, TreeNode> nodesByUniqueId = new ConcurrentHashMap<>();
 	private TreeNode root;
 	private final TreePrinter treePrinter;
 
-	TreePrintingListener(PrintWriter out, boolean disableAnsiColors, Theme theme) {
+	public TreePrintingListener(PrintWriter out, boolean disableAnsiColors, Theme theme) {
 		this.treePrinter = new TreePrinter(out, theme, disableAnsiColors);
 	}
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/VerboseTreePrintingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/VerboseTreePrintingListener.java
@@ -8,16 +8,15 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
 import static org.junit.platform.commons.util.ExceptionUtils.readStackTrace;
-import static org.junit.platform.console.tasks.Color.NONE;
+import static org.junit.platform.reporting.console.Color.NONE;
 
 import java.io.PrintWriter;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -27,7 +26,7 @@ import org.junit.platform.launcher.TestPlan;
 /**
  * @since 1.0
  */
-class VerboseTreePrintingListener implements TestExecutionListener {
+public class VerboseTreePrintingListener implements TestExecutionListener {
 
 	private final PrintWriter out;
 	private final boolean disableAnsiColors;
@@ -36,7 +35,8 @@ class VerboseTreePrintingListener implements TestExecutionListener {
 	private final String[] verticals;
 	private long executionStartedMillis;
 
-	VerboseTreePrintingListener(PrintWriter out, boolean disableAnsiColors, int maxContainerNestingLevel, Theme theme) {
+	public VerboseTreePrintingListener(PrintWriter out, boolean disableAnsiColors, int maxContainerNestingLevel,
+			Theme theme) {
 		this.out = out;
 		this.disableAnsiColors = disableAnsiColors;
 		this.theme = theme;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/package-info.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/console/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Support for printing test results to text base streams. Useful
+ * for producing decorated console-based output.
+ *
+ * Three listeners are provided for three different formats:
+ * <ol>
+ *   <li>{@link FlatPrintingListener}</li>
+ *   <li>{@link TreePrintingListener}</li>
+ *   <li>{@link VerboseTreePrintingListener}</li>
+ * </ol>
+ *
+ * These listeners were in {@link org.junit.platform.console.tasks}
+ * since 1.0 of {@code junit-platform-console}. They were moved here
+ * and made public for general use in 1.6.
+ *
+ * @since 1.6
+ */
+
+package org.junit.platform.reporting.console;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/LegacyReportingUtils.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/LegacyReportingUtils.java
@@ -8,7 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.launcher.listeners;
+package org.junit.platform.reporting.legacy;
 
 import static org.apiguardian.api.API.Status.MAINTAINED;
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -19,6 +19,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Clock;
+import java.util.Optional;
+import java.util.function.Function;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -31,12 +33,13 @@ import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
- * {@code LegacyXmlReportGeneratingListener} is a {@link TestExecutionListener} that
- * generates a separate XML report for each {@linkplain TestPlan#getRoots() root}
- * in the {@link TestPlan}.
+ * {@code LegacyXmlReportGeneratingListener} is a {@link TestExecutionListener}
+ * that generates a separate XML report for each {@linkplain TestPlan#getRoots()
+ * root} in the {@link TestPlan}.
  *
- * <p>Note that the generated XML format is compatible with the <em>legacy</em>
- * de facto standard for JUnit 4 based test reports that was made popular by the
+ * <p>
+ * Note that the generated XML format is compatible with the <em>legacy</em> de
+ * facto standard for JUnit 4 based test reports that was made popular by the
  * Ant build system.
  *
  * @since 1.4
@@ -49,22 +52,54 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 	private final Path reportsDir;
 	private final PrintWriter out;
 	private final Clock clock;
+	private final Function<TestIdentifier, Optional<String>> rootFileName;
 
 	private XmlReportData reportData;
 
+	/**
+	 * Creates a legacy xml report generating listener that outputs one file per test root.
+	 *
+	 * @param reportsDir the directory into which the xml report files will be written.
+	 * @param out writer to output diagnostic information.
+	 */
 	public LegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out) {
-		this(reportsDir, out, Clock.systemDefaultZone());
+		this(reportsDir, out, Clock.systemDefaultZone(), LegacyXmlReportGeneratingListener::defaultRootFileName);
+	}
+
+	/**
+	 * Creates a legacy xml report generating listener with custom function for
+	 * determining root nodes.
+	 * <p>
+	 *
+	 * This constructor takes a function that can be used to change the behavior
+	 * for when output files are written. The supplied {@code rootFileName} function
+	 * is called every time a test is skipped or completed - if it returns a string,
+	 * an xml report is generated for this node using the string as the basis of the
+	 * filename; otherwise if it returns empty no file is written for this node.
+	 *
+	 * @param reportsDir the directory into which the xml report files will be written.
+	 * @param out writer to output diagnostic information.
+	 * @param rootFileName function that returns an optional string for the file name
+	 *     to which the supplied test should be written. If the function returns a string,
+	 *     the node (and its children) will be written to a file; otherwise if it returns empty no
+	 *     file will be written for this node.
+	 */
+	public LegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out,
+			Function<TestIdentifier, Optional<String>> rootFileName) {
+		this(reportsDir, out, Clock.systemDefaultZone(), rootFileName);
 	}
 
 	// For tests only
 	LegacyXmlReportGeneratingListener(String reportsDir, PrintWriter out, Clock clock) {
-		this(Paths.get(reportsDir), out, clock);
+		this(Paths.get(reportsDir), out, clock, LegacyXmlReportGeneratingListener::defaultRootFileName);
 	}
 
-	private LegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out, Clock clock) {
+	private LegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out, Clock clock,
+			Function<TestIdentifier, Optional<String>> rootFileName) {
 		this.reportsDir = reportsDir;
 		this.out = out;
 		this.clock = clock;
+		this.rootFileName = rootFileName;
 	}
 
 	@Override
@@ -106,10 +141,7 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 	}
 
 	private void writeXmlReportInCaseOfRoot(TestIdentifier testIdentifier) {
-		if (isRoot(testIdentifier)) {
-			String rootName = UniqueId.parse(testIdentifier.getUniqueId()).getSegments().get(0).getValue();
-			writeXmlReportSafely(testIdentifier, rootName);
-		}
+		rootFileName.apply(testIdentifier).ifPresent(x -> writeXmlReportSafely(testIdentifier, x));
 	}
 
 	private void writeXmlReportSafely(TestIdentifier testIdentifier, String rootName) {
@@ -122,8 +154,28 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 		}
 	}
 
-	private boolean isRoot(TestIdentifier testIdentifier) {
-		return !testIdentifier.getParentId().isPresent();
+	/**
+	 * Signify that the specified node should be written to a file. The optional
+	 * returned string is used as the basis of the filename. If an empty optional is
+	 * returned, then no file is written for this node.
+	 * <p>
+	 * This default implementation returns the uniqueId segment if it is a root test
+	 * identifier (ie, it has no parent); otherwise it returns empty. Thus one file
+	 * will be written for every root node in the test. Override this if you want to
+	 * control when files are written (eg, one per test class or one per engine
+	 * instead of one per test root) by supplying a custom function to the
+	 * constructor.
+	 *
+	 * @param testIdentifier the identifier of the test being checked for writing to
+	 *                       a file.
+	 * @return An {@code Optional} containing the filename stub if the data is to be
+	 *         written to a file, or empty if it is not to be written.
+	 */
+	private static Optional<String> defaultRootFileName(TestIdentifier testIdentifier) {
+		if (!testIdentifier.getParentId().isPresent()) {
+			return Optional.of(UniqueId.parse(testIdentifier.getUniqueId()).getSegments().get(0).getValue());
+		}
+		return Optional.empty();
 	}
 
 	private void printException(String message, Exception exception) {

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -40,7 +40,7 @@ import javax.xml.stream.XMLStreamWriter;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.listeners.LegacyReportingUtils;
+import org.junit.platform.reporting.legacy.LegacyReportingUtils;
 
 /**
  * {@code XmlReportWriter} writes an XML report whose format is compatible

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.platform.console.options.Details;
-import org.junit.platform.console.options.Theme;
+import org.junit.platform.reporting.console.Theme;
 
 /**
  * @since 1.0

--- a/platform-tests/src/test/java/org/junit/platform/console/options/PicocliCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/PicocliCommandLineOptionsParserTests.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.reporting.console.Theme;
 
 /**
  * @since 1.0

--- a/platform-tests/src/test/java/org/junit/platform/console/options/ThemeTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/ThemeTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.reporting.console.Theme;
 
 class ThemeTests {
 

--- a/platform-tests/src/test/java/org/junit/platform/reporting/LegacyReportingUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/LegacyReportingUtilsTests.java
@@ -8,7 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.launcher.listeners;
+package org.junit.platform.reporting;
 
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,6 +21,7 @@ import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.reporting.legacy.LegacyReportingUtils;
 
 /**
  * @since 1.0.3

--- a/platform-tests/src/test/java/org/junit/platform/reporting/console/FlatPrintingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/console/FlatPrintingListenerTests.java
@@ -70,7 +70,7 @@ class FlatPrintingListenerTests {
 	}
 
 	private FlatPrintingListener listener(StringWriter stringWriter) {
-		return new FlatPrintingListener(new PrintWriter(stringWriter), true);
+		return new FlatPrintingListener(new PrintWriter(stringWriter), false);
 	}
 
 	private static TestIdentifier newTestIdentifier() {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/console/TreeNodeTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/console/TreeNodeTests.java
@@ -8,7 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/platform-tests/src/test/java/org/junit/platform/reporting/console/TreePrinterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/console/TreePrinterTests.java
@@ -8,7 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;

--- a/platform-tests/src/test/java/org/junit/platform/reporting/console/TreePrinterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/console/TreePrinterTests.java
@@ -51,7 +51,7 @@ class TreePrinterTests {
 
 	@Test
 	void emptyTree() {
-		new TreePrinter(out, Theme.UNICODE, true).print(new TreeNode("<root>"));
+		new TreePrinter(out, Theme.UNICODE, false).print(new TreeNode("<root>"));
 		assertIterableEquals(Collections.singletonList("╷"), actual());
 	}
 
@@ -62,7 +62,7 @@ class TreePrinterTests {
 		root.addChild(new TreeNode(identifier("e-1", "engine one")).setResult(successful()));
 		root.addChild(new TreeNode(identifier("e-2", "engine two")).setResult(failed(null)));
 		root.addChild(new TreeNode(identifier("e-3", "engine three")).setResult(aborted(null)));
-		new TreePrinter(out, Theme.UNICODE, true).print(root);
+		new TreePrinter(out, Theme.UNICODE, false).print(root);
 		assertIterableEquals( //
 			Arrays.asList( //
 				"╷", //
@@ -78,7 +78,7 @@ class TreePrinterTests {
 	void printNodeHandlesNullMessageThrowableGracefully() {
 		TestExecutionResult result = TestExecutionResult.failed(new NullPointerException());
 		TreeNode node = new TreeNode(identifier("NPE", "test()")).setResult(result);
-		new TreePrinter(out, Theme.ASCII, true).print(node);
+		new TreePrinter(out, Theme.ASCII, false).print(node);
 		assertLinesMatch(Arrays.asList(".", "+-- test() [X] java.lang.NullPointerException"), actual());
 	}
 
@@ -102,7 +102,7 @@ class TreePrinterTests {
 		m2.addReportEntry(ReportEntry.from("key", "m-2"));
 		c1.addChild(m2);
 
-		new TreePrinter(out, Theme.UNICODE, true).print(root);
+		new TreePrinter(out, Theme.UNICODE, false).print(root);
 		assertLinesMatch(List.of( //
 			"╷", //
 			"└─ engine one ✔", //

--- a/platform-tests/src/test/java/org/junit/platform/reporting/console/VerboseTreeListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/console/VerboseTreeListenerTests.java
@@ -80,7 +80,7 @@ class VerboseTreeListenerTests {
 	}
 
 	private VerboseTreePrintingListener listener(StringWriter stringWriter) {
-		return new VerboseTreePrintingListener(new PrintWriter(stringWriter), true, 16, Theme.ASCII);
+		return new VerboseTreePrintingListener(new PrintWriter(stringWriter), false, 16, Theme.ASCII);
 	}
 
 	private static TestIdentifier newTestIdentifier() {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/console/VerboseTreeListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/console/VerboseTreeListenerTests.java
@@ -8,16 +8,14 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.console.tasks;
+package org.junit.platform.reporting.console;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.platform.console.tasks.FlatPrintingListener.INDENTATION;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.platform.engine.TestExecutionResult.failed;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.UniqueId;
@@ -26,9 +24,9 @@ import org.junit.platform.fakes.TestDescriptorStub;
 import org.junit.platform.launcher.TestIdentifier;
 
 /**
- * @since 1.0
+ * @since 1.3.2
  */
-class FlatPrintingListenerTests {
+class VerboseTreeListenerTests {
 
 	private static final String EOL = System.lineSeparator();
 
@@ -38,11 +36,14 @@ class FlatPrintingListenerTests {
 		listener(stringWriter).executionSkipped(newTestIdentifier(), "Test" + EOL + "disabled");
 		String[] lines = lines(stringWriter);
 
-		assertEquals(3, lines.length);
-		assertAll("lines in the output", //
-			() -> assertEquals("Skipped:     demo-test ([engine:demo-engine])", lines[0]), //
-			() -> assertEquals(INDENTATION + "=> Reason: Test", lines[1]), //
-			() -> assertEquals(INDENTATION + "disabled", lines[2]));
+		assertLinesMatch(List.of( //
+			"+-- %c ool test", //
+			"     tags: []", //
+			" uniqueId: [engine:demo-engine]", //
+			"   parent: []", //
+			"   reason: Test", //
+			"             disabled", //
+			"   status: [S] SKIPPED"), List.of(lines));
 	}
 
 	@Test
@@ -51,11 +52,7 @@ class FlatPrintingListenerTests {
 		listener(stringWriter).reportingEntryPublished(newTestIdentifier(), ReportEntry.from("foo", "bar"));
 		String[] lines = lines(stringWriter);
 
-		assertEquals(2, lines.length);
-		assertAll("lines in the output", //
-			() -> assertEquals("Reported:    demo-test ([engine:demo-engine])", lines[0]), //
-			() -> assertTrue(lines[1].startsWith(INDENTATION + "=> Reported values: ReportEntry [timestamp =")), //
-			() -> assertTrue(lines[1].endsWith(", foo = 'bar']")));
+		assertLinesMatch(List.of("  reports: ReportEntry \\[timestamp = .+, foo = 'bar'\\]"), List.of(lines));
 	}
 
 	@Test
@@ -64,17 +61,30 @@ class FlatPrintingListenerTests {
 		listener(stringWriter).executionFinished(newTestIdentifier(), failed(new AssertionError("Boom!")));
 		String[] lines = lines(stringWriter);
 
-		assertAll("lines in the output", //
-			() -> assertEquals("Finished:    demo-test ([engine:demo-engine])", lines[0]), //
-			() -> assertEquals(INDENTATION + "=> Exception: java.lang.AssertionError: Boom!", lines[1]));
+		assertLinesMatch(List.of("   caught: java.lang.AssertionError: Boom!", //
+			">> STACKTRACE >>", //
+			" duration: \\d+ ms", //
+			"   status: [X] FAILED"), List.of(lines));
 	}
 
-	private FlatPrintingListener listener(StringWriter stringWriter) {
-		return new FlatPrintingListener(new PrintWriter(stringWriter), true);
+	@Test
+	void failureMessageWithFormatSpecifier() {
+		StringWriter stringWriter = new StringWriter();
+		listener(stringWriter).executionFinished(newTestIdentifier(), failed(new AssertionError("%crash")));
+		String[] lines = lines(stringWriter);
+
+		assertLinesMatch(List.of("   caught: java.lang.AssertionError: %crash", //
+			">> STACKTRACE >>", //
+			" duration: \\d+ ms", //
+			"   status: [X] FAILED"), List.of(lines));
+	}
+
+	private VerboseTreePrintingListener listener(StringWriter stringWriter) {
+		return new VerboseTreePrintingListener(new PrintWriter(stringWriter), true, 16, Theme.ASCII);
 	}
 
 	private static TestIdentifier newTestIdentifier() {
-		TestDescriptorStub testDescriptor = new TestDescriptorStub(UniqueId.forEngine("demo-engine"), "demo-test");
+		TestDescriptorStub testDescriptor = new TestDescriptorStub(UniqueId.forEngine("demo-engine"), "%c ool test");
 		return TestIdentifier.from(testDescriptor);
 	}
 


### PR DESCRIPTION
## Overview

This is an implementation of #1963, with a couple of other changes thrown in.

I created a new package in junit-platform-reporting called `org.junit.platform.reporting.console` and moved all the three listener class implementations into that package. I also had to remove a couple of the ancillary classes along with them that were used for configuring the listeners (`Theme`, `Color`), or for implementing some of their core functionality (`TreePrinter`). This part was fairly straightforward, and hopefully uncontroversial. The listener classes and those used for configuration were made public; the implementation classes were left package private.

In order to make the classes more user friendly, I added some overloaded constructors with default options and added some documentation. The documentation is based on my reading of the code - hopefully I didn't get it too wrong (in particular, if someone could check my comments about the relative merits & functionality of the `TreePrintingListener` vs `VerboseTreePrintingListener`, that would be appreciated).

I marked all of the newly publicized classes with the `@API` annotation, marking them as experimental as of 1.6.

Internally, the console listeners all had a flag `disableAnsiColors`. I have taken the opportunity to flip the polarity on this and called it `useAnsiColors`, as this is easy to do while the API is not public. The console executor still processes the command line the same way and takes care of the conversion.

Another changes was to move `LegacyReportingUtils` from `junit-platform-launcher` to `junit-platform-reporting`. Reasoning:

* It seems to belong more properly in that module rather than in the launcher module - it is a reporting tool, not a launching tool.
* The only place in the JUnit 5 source tree where it was actually used is in the reporting module (`LegacyXmlReportGeneratingListener`).
* The fact that this class was split and in the wrong package/module caused me a few headaches when I was trying to use it in an OSGi context.

Finally, I added a feature to `LegacyXmlReportGeneratingListener` so that you can override the behaviour as to when an xml file is generated. The original implementation would generate one file per root in the test hierarchy. The new feature allows you to override this so that you can (eg) produce one xml file per test class, or per other container level. This is a feature that I would have found useful for the Bnd JUnit Platform tester implementation. This feature is isolated to its own commit and if necessary could be hived off to its own PR.

Thoughts/comments/suggestions welcome!