### PR TITLE
Move LegacyReportingUtils to junit-platform-reporting

### DIFF
--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/LegacyReportingUtils.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/LegacyReportingUtils.java
@@ -8,12 +8,11 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.launcher.listeners;
+package org.junit.platform.reporting.legacy;
 
-import static org.apiguardian.api.API.Status.DEPRECATED;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import org.apiguardian.api.API;
-import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
@@ -22,12 +21,12 @@ import org.junit.platform.launcher.TestPlan;
  * Utility methods for dealing with legacy reporting infrastructure, such as
  * reporting systems built on the Ant-based XML reporting format for JUnit 4.
  *
+ * This class was formerly from {@code junit-platform-launcher}
+ * in {@link org.junit.platform.launcher.listeners} package.
+ *
  * @since 1.0.3
- * @deprecated Use {@link org.junit.platform.reporting.legacy.LegacyReportingUtils}
- * instead.
  */
-@Deprecated
-@API(status = DEPRECATED, since = "1.6")
+@API(status = MAINTAINED, since = "1.6")
 public class LegacyReportingUtils {
 
 	private LegacyReportingUtils() {
@@ -50,36 +49,8 @@ public class LegacyReportingUtils {
 	 *                 never {@code null}
 	 * @see TestIdentifier#getLegacyReportingName
 	 */
+	@SuppressWarnings("deprecation")
 	public static String getClassName(TestPlan testPlan, TestIdentifier testIdentifier) {
-		Preconditions.notNull(testPlan, "testPlan must not be null");
-		Preconditions.notNull(testIdentifier, "testIdentifier must not be null");
-		for (TestIdentifier current = testIdentifier; current != null; current = getParent(testPlan, current)) {
-			ClassSource source = getClassSource(current);
-			if (source != null) {
-				return source.getClassName();
-			}
-		}
-		return getParentLegacyReportingName(testPlan, testIdentifier);
-	}
-
-	private static TestIdentifier getParent(TestPlan testPlan, TestIdentifier testIdentifier) {
-		return testPlan.getParent(testIdentifier).orElse(null);
-	}
-
-	private static ClassSource getClassSource(TestIdentifier current) {
-		// @formatter:off
-		return current.getSource()
-				.filter(ClassSource.class::isInstance)
-				.map(ClassSource.class::cast)
-				.orElse(null);
-		// @formatter:on
-	}
-
-	private static String getParentLegacyReportingName(TestPlan testPlan, TestIdentifier testIdentifier) {
-		// @formatter:off
-		return testPlan.getParent(testIdentifier)
-				.map(TestIdentifier::getLegacyReportingName)
-				.orElse("<unrooted>");
-		// @formatter:on
+		return org.junit.platform.launcher.listeners.LegacyReportingUtils.getClassName(testPlan, testIdentifier);
 	}
 }

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/LegacyReportingUtils.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/LegacyReportingUtils.java
@@ -27,7 +27,7 @@ import org.junit.platform.launcher.TestPlan;
  * @since 1.0.3
  */
 @API(status = MAINTAINED, since = "1.6")
-public class LegacyReportingUtils {
+public final class LegacyReportingUtils {
 
 	private LegacyReportingUtils() {
 		/* no-op */

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -41,7 +41,7 @@ import javax.xml.stream.XMLStreamWriter;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.listeners.LegacyReportingUtils;
+import org.junit.platform.reporting.legacy.LegacyReportingUtils;
 
 /**
  * {@code XmlReportWriter} writes an XML report whose format is compatible

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/LegacyReportingUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/LegacyReportingUtilsTests.java
@@ -8,7 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.launcher.listeners;
+package org.junit.platform.reporting.legacy;
 
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +37,9 @@ class LegacyReportingUtilsTests {
 
 		assertThat(getClassName(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
 		assertThat(getClassName(uniqueId)).isEqualTo("Foo");
+
+		assertThat(getClassNameFromOldLocation(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
+		assertThat(getClassNameFromOldLocation(uniqueId)).isEqualTo("Foo");
 	}
 
 	@Test
@@ -58,11 +61,23 @@ class LegacyReportingUtilsTests {
 		assertThat(getClassName(classUniqueId)).isEqualTo(LegacyReportingUtilsTests.class.getName());
 		assertThat(getClassName(subUniqueId)).isEqualTo(LegacyReportingUtilsTests.class.getName());
 		assertThat(getClassName(subSubUniqueId)).isEqualTo(LegacyReportingUtilsTests.class.getName());
+
+		assertThat(getClassNameFromOldLocation(engineDescriptor.getUniqueId())).isEqualTo("<unrooted>");
+		assertThat(getClassNameFromOldLocation(classUniqueId)).isEqualTo(LegacyReportingUtilsTests.class.getName());
+		assertThat(getClassNameFromOldLocation(subUniqueId)).isEqualTo(LegacyReportingUtilsTests.class.getName());
+		assertThat(getClassNameFromOldLocation(subSubUniqueId)).isEqualTo(LegacyReportingUtilsTests.class.getName());
 	}
 
 	private String getClassName(UniqueId uniqueId) {
 		TestPlan testPlan = TestPlan.from(singleton(engineDescriptor));
 		return LegacyReportingUtils.getClassName(testPlan, testPlan.getTestIdentifier(uniqueId.toString()));
+	}
+
+	@SuppressWarnings("deprecation")
+	private String getClassNameFromOldLocation(UniqueId uniqueId) {
+		TestPlan testPlan = TestPlan.from(singleton(engineDescriptor));
+		return org.junit.platform.launcher.listeners.LegacyReportingUtils.getClassName(testPlan,
+			testPlan.getTestIdentifier(uniqueId.toString()));
 	}
 
 	private TestDescriptor createTestDescriptor(UniqueId uniqueId, String displayName, TestSource source) {


### PR DESCRIPTION
Moved LegacyReportingUtils from junit-platform-launcher to junit-platform-reporting as being more appropriate. Old implementation in the launcher package left in place for compatibility with 3rd party code, but deprecated for future removal. Resolves #1978.

Left the old unit test in-place to guard against regressions. Future dev should be done in the new copy.

---

I hereby agree to the terms of the JUnit Contributor License Agreement.