### PR TITLE
Introduce TypeBasedParameterResolver adapter

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -118,9 +118,11 @@ endif::[]
 :TempDirectory:                              {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java[TempDirectory]
 :TestInfoParameterResolver:                  {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java[TestInfoParameterResolver]
 :TestReporterParameterResolver:              {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestReporterParameterResolver.java[TestReporterParameterResolver]
+:TypeBasedParameterResolver:                 {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TypeBasedParameterResolver.java[TypeBasedParameterResolver]
 // Jupiter Examples
 :CustomAnnotationParameterResolver:          {current-branch}/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/CustomAnnotationParameterResolver.java[CustomAnnotationParameterResolver]
 :CustomTypeParameterResolver:                {current-branch}/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/CustomTypeParameterResolver.java[CustomTypeParameterResolver]
+:TypeBasedMapOfListsParameterResolver        {current-branch}/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/TypeBasedMapOfListsParameterResolver.java[TypeBasedMapOfListsParameterResolver]
 // Jupiter Migration Support
 :EnableJUnit4MigrationSupport:               {javadoc-root}/org/junit/jupiter/migrationsupport/EnableJUnit4MigrationSupport.html[@EnableJUnit4MigrationSupport]
 :EnableRuleMigrationSupport:                 {javadoc-root}/org/junit/jupiter/migrationsupport/rules/EnableRuleMigrationSupport.html[@EnableRuleMigrationSupport]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -29,6 +29,8 @@ on GitHub.
 * New `printFailuresTo(PrintWriter, int)` method in `TestExecutionSummary` that allows one
   to specify the maximum number of lines to print for exception stack traces.
 
+* New `TypeBasedParameterResolver<T>` - a generic adapter of `ParameterResolver` - that eases the creation
+  of custom resolver by providing a type-based `supportsParameter` default implementation.
 
 [[release-notes-5.6.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -325,8 +325,13 @@ If a _test class_ constructor, _test method_, or _lifecycle method_ (see
 _resolved_ at runtime by a `ParameterResolver`. A `ParameterResolver` can either be
 built-in (see `{TestInfoParameterResolver}`) or <<extensions-registration,registered by
 the user>>. Generally speaking, parameters may be resolved by _name_, _type_,
-_annotation_, or any combination thereof. For concrete examples, consult the source code
-for `{CustomTypeParameterResolver}` and `{CustomAnnotationParameterResolver}`.
+_annotation_, or any combination thereof.
+
+A convenient generic adapter `{TypeBasedParameterResolver}` is available if you want to adopt an injection strategy only based
+on the type of the parameter.
+
+For concrete examples, consult the source code
+for `{CustomTypeParameterResolver}`, `{CustomAnnotationParameterResolver}` and `{TypeBasedMapOfListsParameterResolver}`.
 
 [WARNING]
 ====

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -654,6 +654,11 @@ class MyRandomParametersTest {
 For real-world use cases, check out the source code for the `{MockitoExtension}` and the
 `{SpringExtension}`.
 
+A generic`{TypeBasedParameterResolver}` is provided when the type of the parameter to inject is the only condition
+for your `{ParameterResolver}` to be executed. The `supportsParameters` method is implemented behind the scene
+and supports templated types.
+
+
 [[writing-tests-test-interfaces-and-default-methods]]
 === Test Interfaces and Default Methods
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TypeBasedParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TypeBasedParameterResolver.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * {@link ParameterResolver} adapter which resolve a parameter based on its type.
+ * @param <T> the type of the parameter to resolve
+ * @since 5.6
+ */
+public abstract class TypeBasedParameterResolver<T> implements ParameterResolver {
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		String enclosedType = getEnclosedType();
+		return getParameterTypeName(parameterContext).equals(enclosedType);
+	}
+
+	private String getParameterTypeName(ParameterContext parameterContext) {
+		return parameterContext.getParameter().getParameterizedType().getTypeName();
+	}
+
+	private String getEnclosedType() {
+		String instanceEffectiveType = this.getClass().getGenericSuperclass().getTypeName();
+		return instanceEffectiveType.substring(TypeBasedParameterResolver.class.getName().length() + 1,
+			instanceEffectiveType.length() - 1);
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/TypeBasedMapOfListsParameterResolver.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/TypeBasedMapOfListsParameterResolver.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.execution.injection.sample;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.engine.extension.TypeBasedParameterResolver;
+
+/**
+ * @since 5.6
+ */
+public class TypeBasedMapOfListsParameterResolver extends TypeBasedParameterResolver<Map<String, List<Integer>>> {
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		Map<String, List<Integer>> map = new TreeMap<>();
+		map.put("ids", asList(1, 42));
+		return map;
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ParameterResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ParameterResolverTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine.extension;
 
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,6 +24,7 @@ import static org.junit.platform.testkit.engine.TestExecutionResultConditions.in
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -49,6 +51,7 @@ import org.junit.jupiter.engine.execution.injection.sample.NullIntegerParameterR
 import org.junit.jupiter.engine.execution.injection.sample.NumberParameterResolver;
 import org.junit.jupiter.engine.execution.injection.sample.PrimitiveArrayParameterResolver;
 import org.junit.jupiter.engine.execution.injection.sample.PrimitiveIntegerParameterResolver;
+import org.junit.jupiter.engine.execution.injection.sample.TypeBasedMapOfListsParameterResolver;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.Events;
@@ -470,6 +473,13 @@ class ParameterResolverTests extends AbstractJupiterTestEngineTests {
 		void testMapOfStrings(Map<String, String> map) {
 			assertNotNull(map);
 			assertEquals("value", map.get("key"));
+		}
+
+		@Test
+		@ExtendWith(TypeBasedMapOfListsParameterResolver.class)
+		void testMapOfLists(Map<String, List<Integer>> map) {
+			assertNotNull(map);
+			assertEquals(asList(1, 42), map.get("ids"));
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TypeBasedParameterResolverTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TypeBasedParameterResolverTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.mockito.Mockito;
+
+class TypeBasedParameterResolverTest {
+
+	private ParameterResolver basicTypeParameterResolver = new BasicTypeParameterResolver();
+	private ParameterResolver templatedTypeParameterResolver = new TemplatedTypeParameterResolver();
+
+	@Test
+	void supportsParameterForBasicTypes() {
+		Parameter parameter1 = findParameterOfMethod("methodWithBasicTypeParameter", String.class);
+		assertTrue(basicTypeParameterResolver.supportsParameter(parameterContext(parameter1), null));
+
+		Parameter parameter2 = findParameterOfMethod("methodWithObjectParameter", Object.class);
+		assertFalse(basicTypeParameterResolver.supportsParameter(parameterContext(parameter2), null));
+	}
+
+	@Test
+	void supportsParameterForTemplatedTypes() {
+		Parameter parameter1 = findParameterOfMethod("methodWithTemplatedTypeParameter", Map.class);
+		assertTrue(templatedTypeParameterResolver.supportsParameter(parameterContext(parameter1), null));
+
+		Parameter parameter2 = findParameterOfMethod("methodWithAnotherTemplatedTypeParameter", Map.class);
+		assertFalse(templatedTypeParameterResolver.supportsParameter(parameterContext(parameter2), null));
+	}
+
+	private static ParameterContext parameterContext(Parameter parameter) {
+		ParameterContext parameterContext = Mockito.mock(ParameterContext.class);
+		when(parameterContext.getParameter()).thenReturn(parameter);
+		return parameterContext;
+	}
+
+	private Parameter findParameterOfMethod(String methodName, Class<?>... parameterTypes) {
+		Method method = ReflectionUtils.findMethod(Sample.class, methodName, parameterTypes).get();
+		return method.getParameters()[0];
+	}
+
+	class BasicTypeParameterResolver extends TypeBasedParameterResolver<String> {
+
+		@Override
+		public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			return "test";
+		}
+	}
+
+	class TemplatedTypeParameterResolver extends TypeBasedParameterResolver<Map<String, List<Integer>>> {
+
+		@Override
+		public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			return emptyMap();
+		}
+	}
+
+	class Sample {
+		void methodWithBasicTypeParameter(String string) {
+		}
+
+		void methodWithObjectParameter(Object nothing) {
+		}
+
+		void methodWithTemplatedTypeParameter(Map<String, List<Integer>> map) {
+		}
+
+		void methodWithAnotherTemplatedTypeParameter(Map<String, List<Object>> nothing) {
+		}
+	}
+}


### PR DESCRIPTION
## Overview

Implementation of a ParameterResolver adapter `TypeBasedParameterResolver` which is handling for the developer the supportsParameter when he wants to implement a type-based resolver. This way he only have to implement the resolveParameter method. e.g.
```java
public class TypeBasedMapOfListsParameterResolver extends TypeBasedParameterResolver<Map<String, List<Integer>>> {
	@Override
	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
			throws ParameterResolutionException {
		Map<String, List<Integer>> map = new TreeMap<>();
		map.put("ids", asList(1, 42));
		return map;
	}
}
```

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
