### PR TITLE
Introduce TypeBasedParameterResolver adapter

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -118,9 +118,11 @@ endif::[]
 :TempDirectory:                              {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java[TempDirectory]
 :TestInfoParameterResolver:                  {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestInfoParameterResolver.java[TestInfoParameterResolver]
 :TestReporterParameterResolver:              {current-branch}/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TestReporterParameterResolver.java[TestReporterParameterResolver]
+:TypeBasedParameterResolver:                 {current-branch}/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolver.java[TypeBasedParameterResolver]
 // Jupiter Examples
 :CustomAnnotationParameterResolver:          {current-branch}/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/CustomAnnotationParameterResolver.java[CustomAnnotationParameterResolver]
 :CustomTypeParameterResolver:                {current-branch}/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/CustomTypeParameterResolver.java[CustomTypeParameterResolver]
+:TypeBasedMapOfListsParameterResolver        {current-branch}/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/TypeBasedMapOfListsParameterResolver.java[TypeBasedMapOfListsParameterResolver]
 // Jupiter Migration Support
 :EnableJUnit4MigrationSupport:               {javadoc-root}/org/junit/jupiter/migrationsupport/EnableJUnit4MigrationSupport.html[@EnableJUnit4MigrationSupport]
 :EnableRuleMigrationSupport:                 {javadoc-root}/org/junit/jupiter/migrationsupport/rules/EnableRuleMigrationSupport.html[@EnableRuleMigrationSupport]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -28,7 +28,9 @@ on GitHub.
 
 * New `printFailuresTo(PrintWriter, int)` method in `TestExecutionSummary` that allows one
   to specify the maximum number of lines to print for exception stack traces.
-
+* New `TypeBasedParameterResolver<T>` - a generic adapter of `ParameterResolver` - that
+  eases the creation of custom resolver by providing a type-based `supportsParameter`
+  default implementation.
 
 [[release-notes-5.6.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -325,8 +325,14 @@ If a _test class_ constructor, _test method_, or _lifecycle method_ (see
 _resolved_ at runtime by a `ParameterResolver`. A `ParameterResolver` can either be
 built-in (see `{TestInfoParameterResolver}`) or <<extensions-registration,registered by
 the user>>. Generally speaking, parameters may be resolved by _name_, _type_,
-_annotation_, or any combination thereof. For concrete examples, consult the source code
-for `{CustomTypeParameterResolver}` and `{CustomAnnotationParameterResolver}`.
+_annotation_, or any combination thereof.
+
+A convenient generic adapter `{TypeBasedParameterResolver}` is available if you want to
+adopt an injection strategy only based on the type of the parameter.
+
+For concrete examples, consult the source code
+for `{CustomTypeParameterResolver}`, `{CustomAnnotationParameterResolver}` and
+`{TypeBasedMapOfListsParameterResolver}`.
 
 [WARNING]
 ====

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -654,6 +654,12 @@ class MyRandomParametersTest {
 For real-world use cases, check out the source code for the `{MockitoExtension}` and the
 `{SpringExtension}`.
 
+A generic`{TypeBasedParameterResolver}` is provided when the type of the parameter to
+inject is the only condition for your `{ParameterResolver}` to be executed.
+The `supportsParameters` method is implemented behind the scene and supports parametrized
+types.
+
+
 [[writing-tests-test-interfaces-and-default-methods]]
 === Test Interfaces and Default Methods
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolver.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension.support;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * {@link ParameterResolver} adapter which resolve a parameter based on its exact type.
+ *
+ * @param <T> the type of the parameter to resolve
+ * @since 5.6
+ */
+@API(status = EXPERIMENTAL)
+public abstract class TypeBasedParameterResolver<T> implements ParameterResolver {
+
+	private final Type supportedParameterType;
+
+	public TypeBasedParameterResolver() {
+		supportedParameterType = enclosedTypeOfParameterResolver();
+	}
+
+	@Override
+	public abstract T resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException;
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		return supportedParameterType.equals(getParameterType(parameterContext));
+	}
+
+	private Type getParameterType(ParameterContext parameterContext) {
+		return parameterContext.getParameter().getParameterizedType();
+	}
+
+	private Type enclosedTypeOfParameterResolver() {
+		return ((ParameterizedType) findTypeBasedParameterResolverSuperclass(
+			this.getClass())).getActualTypeArguments()[0];
+	}
+
+	private Type findTypeBasedParameterResolverSuperclass(Class<?> subClass) {
+		Type genericSuperclass = subClass.getGenericSuperclass();
+		if (genericSuperclass instanceof ParameterizedType) {
+			Type rawType = ((ParameterizedType) genericSuperclass).getRawType();
+			if (rawType == TypeBasedParameterResolver.class) {
+				return genericSuperclass;
+			}
+		}
+		return findTypeBasedParameterResolverSuperclass(subClass.getSuperclass());
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/package-info.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * JUnit Jupiter API support for writing extensions.
+ */
+
+package org.junit.jupiter.api.extension.support;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolverTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolverTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension.support;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.mockito.Mockito;
+
+class TypeBasedParameterResolverTest {
+
+	private ParameterResolver basicTypeParameterResolver = new BasicTypeParameterResolver();
+	private ParameterResolver subClassedBasicTypeParameterResolver = new SubClassedBasicTypeParameterResolver();
+	private ParameterResolver parametrizedTypeParameterResolver = new ParametrizedTypeParameterResolver();
+
+	@Test
+	void supportsParameterForBasicTypes() {
+		Parameter parameter1 = findParameterOfMethod("methodWithBasicTypeParameter", String.class);
+		assertTrue(basicTypeParameterResolver.supportsParameter(parameterContext(parameter1), null));
+		assertTrue(subClassedBasicTypeParameterResolver.supportsParameter(parameterContext(parameter1), null));
+
+		Parameter parameter2 = findParameterOfMethod("methodWithObjectParameter", Object.class);
+		assertFalse(basicTypeParameterResolver.supportsParameter(parameterContext(parameter2), null));
+	}
+
+	@Test
+	void supportsParameterForParametrizedTypes() {
+		Parameter parameter1 = findParameterOfMethod("methodWithParametrizedTypeParameter", Map.class);
+		assertTrue(parametrizedTypeParameterResolver.supportsParameter(parameterContext(parameter1), null));
+
+		Parameter parameter3 = findParameterOfMethod("methodWithAnotherParametrizedTypeParameter", Map.class);
+		assertFalse(parametrizedTypeParameterResolver.supportsParameter(parameterContext(parameter3), null));
+	}
+
+	@Test
+	void resolve() {
+		ExtensionContext extensionContext = extensionContext();
+		ParameterContext parameterContext = parameterContext(
+			findParameterOfMethod("methodWithBasicTypeParameter", String.class));
+		assertEquals("Displaying TestAnnotation",
+			basicTypeParameterResolver.resolveParameter(parameterContext, extensionContext));
+
+		Parameter parameter2 = findParameterOfMethod("methodWithParametrizedTypeParameter", Map.class);
+		assertEquals(Map.of("ids", asList(1, 42)),
+			parametrizedTypeParameterResolver.resolveParameter(parameterContext(parameter2), extensionContext));
+	}
+
+	private static ParameterContext parameterContext(Parameter parameter) {
+		ParameterContext parameterContext = Mockito.mock(ParameterContext.class);
+		when(parameterContext.getParameter()).thenReturn(parameter);
+		return parameterContext;
+	}
+
+	private static ExtensionContext extensionContext() {
+		ExtensionContext extensionContext = Mockito.mock(ExtensionContext.class);
+		when(extensionContext.getDisplayName()).thenReturn("Displaying");
+		return extensionContext;
+	}
+
+	private Parameter findParameterOfMethod(String methodName, Class<?>... parameterTypes) {
+		Method method = ReflectionUtils.findMethod(Sample.class, methodName, parameterTypes).get();
+		return method.getParameters()[0];
+	}
+
+	class BasicTypeParameterResolver extends TypeBasedParameterResolver<String> {
+
+		@Override
+		public String resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			Class parameterAnnotation = parameterContext.getParameter().getAnnotations()[0].annotationType();
+			return String.format("%s %s", extensionContext.getDisplayName(), parameterAnnotation.getSimpleName());
+		}
+	}
+
+	class SubClassedBasicTypeParameterResolver extends BasicTypeParameterResolver {
+	}
+
+	class ParametrizedTypeParameterResolver extends TypeBasedParameterResolver<Map<String, List<Integer>>> {
+		@Override
+		public Map<String, List<Integer>> resolveParameter(ParameterContext parameterContext,
+				ExtensionContext extensionContext) throws ParameterResolutionException {
+			return Map.of("ids", asList(1, 42));
+		}
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.PARAMETER)
+	@interface TestAnnotation {
+	}
+
+	class Sample {
+		void methodWithBasicTypeParameter(@TestAnnotation String string) {
+		}
+
+		void methodWithObjectParameter(Object nothing) {
+		}
+
+		void methodWithParametrizedTypeParameter(Map<String, List<Integer>> map) {
+		}
+
+		void methodWithAnotherParametrizedTypeParameter(Map<String, List<Object>> nothing) {
+		}
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/TypeBasedMapOfListsParameterResolver.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/TypeBasedMapOfListsParameterResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.execution.injection.sample;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
+
+/**
+ * @since 5.6
+ */
+public class TypeBasedMapOfListsParameterResolver extends TypeBasedParameterResolver<Map<String, List<Integer>>> {
+	@Override
+	public Map<String, List<Integer>> resolveParameter(ParameterContext parameterContext,
+			ExtensionContext extensionContext) throws ParameterResolutionException {
+		return Map.of("ids", asList(1, 42));
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ParameterResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ParameterResolverTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine.extension;
 
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,6 +24,7 @@ import static org.junit.platform.testkit.engine.TestExecutionResultConditions.in
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -49,6 +51,7 @@ import org.junit.jupiter.engine.execution.injection.sample.NullIntegerParameterR
 import org.junit.jupiter.engine.execution.injection.sample.NumberParameterResolver;
 import org.junit.jupiter.engine.execution.injection.sample.PrimitiveArrayParameterResolver;
 import org.junit.jupiter.engine.execution.injection.sample.PrimitiveIntegerParameterResolver;
+import org.junit.jupiter.engine.execution.injection.sample.TypeBasedMapOfListsParameterResolver;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.Events;
@@ -202,6 +205,19 @@ class ParameterResolverTests extends AbstractJupiterTestEngineTests {
 	void executeTestsForParameterizedTypesSelectingByFullyQualifiedMethodName() {
 		String fqmn = ReflectionUtils.getFullyQualifiedMethodName(ParameterizedTypeTestCase.class, "testMapOfStrings",
 			Map.class);
+
+		assertEventsForParameterizedTypes(executeTests(selectMethod(fqmn)));
+	}
+
+	@Test
+	void executeTestsForTypeBasedParameterResolverTestCaseSelectingByClass() {
+		assertEventsForParameterizedTypes(executeTestsForClass(TypeBasedParameterResolverTestCase.class));
+	}
+
+	@Test
+	void executeTestsForTypeBasedParameterResolverTestCaseSelectingByFullyQualifiedMethodName() {
+		String fqmn = ReflectionUtils.getFullyQualifiedMethodName(TypeBasedParameterResolverTestCase.class,
+			"testMapOfLists", Map.class);
 
 		assertEventsForParameterizedTypes(executeTests(selectMethod(fqmn)));
 	}
@@ -470,6 +486,15 @@ class ParameterResolverTests extends AbstractJupiterTestEngineTests {
 		void testMapOfStrings(Map<String, String> map) {
 			assertNotNull(map);
 			assertEquals("value", map.get("key"));
+		}
+	}
+
+	static class TypeBasedParameterResolverTestCase {
+		@Test
+		@ExtendWith(TypeBasedMapOfListsParameterResolver.class)
+		void testMapOfLists(Map<String, List<Integer>> map) {
+			assertNotNull(map);
+			assertEquals(asList(1, 42), map.get("ids"));
 		}
 	}
 


### PR DESCRIPTION
## Overview

Implementation of a ParameterResolver adapter `TypeBasedParameterResolver` which is handling for the developer the supportsParameter when he wants to implement a type-based resolver. This way he only have to implement the resolveParameter method. e.g.
```java
public class TypeBasedMapOfListsParameterResolver extends TypeBasedParameterResolver<Map<String, List<Integer>>> {
        @Override
	public Map<String, List<Integer>> resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
			throws ParameterResolutionException {
		return Map.of("ids", asList(1, 42));
	}
}
```

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
