### PR TITLE
Auto-detect enum type from method signature

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -49,6 +49,7 @@ on GitHub.
 
 * Support for String delimiters in `@CsvSource` and `@CsvFileSource`.
 * Documented support for comments in CSV files loaded via `@CsvFileSource`.
+* Auto-detection of enum type from method signature for `@EnumSource`.
 * New `TypeBasedParameterResolver<T>` abstract base class that serves as a generic adapter
   for the `ParameterResolver` API and simplifies the implementation of a custom resolver
   that supports parameters of a specific type.

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1019,14 +1019,24 @@ blank strings supplied via `@ValueSource`.
 [[writing-tests-parameterized-tests-sources-EnumSource]]
 ===== @EnumSource
 
-`@EnumSource` provides a convenient way to use `Enum` constants. The annotation provides
-an optional `names` parameter that lets you specify which constants shall be used. If
-omitted, all constants will be used like in the following example.
+`@EnumSource` provides a convenient way to use `Enum` constants.
 
 [source,java,indent=0]
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_example]
 ----
+
+The annotation's `value` parameter is optional. When omitted, the declared type of the
+first method parameter is used. The test will fail if it does not reference an enum type.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_example_autodetection]
+----
+
+The annotation provides an optional `names` parameter that lets you specify which
+constants shall be used. If omitted, all constants will be used like in the following
+example.
 
 [source,java,indent=0]
 ----

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1026,9 +1026,9 @@ blank strings supplied via `@ValueSource`.
 include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_example]
 ----
 
-The annotation's `value` parameter is optional. When omitted, the declared type of the
+The annotation's `value` attribute is optional. When omitted, the declared type of the
 first method parameter is used. The test will fail if it does not reference an enum type.
-Thus, the `value` parameter is required in the above example because the method parameter
+Thus, the `value` attribute is required in the above example because the method parameter
 is declared as `TemporalUnit`, i.e. the interface implemented by `ChronoUnit`, which isn't
 an enum type. Changing the method parameter type to `ChronoUnit` allows to omit the
 explicit enum type from the annotation as follows.
@@ -1038,7 +1038,7 @@ explicit enum type from the annotation as follows.
 include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_example_autodetection]
 ----
 
-The annotation provides an optional `names` parameter that lets you specify which
+The annotation provides an optional `names` attribute that lets you specify which
 constants shall be used. If omitted, all constants will be used like in the following
 example.
 
@@ -1047,7 +1047,7 @@ example.
 include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_include_example]
 ----
 
-The `@EnumSource` annotation also provides an optional `mode` parameter that enables
+The `@EnumSource` annotation also provides an optional `mode` attribute that enables
 fine-grained control over which constants are passed to the test method. For example, you
 can exclude names from the enum constant pool or specify regular expressions as in the
 following examples.

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1028,6 +1028,10 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_example]
 
 The annotation's `value` parameter is optional. When omitted, the declared type of the
 first method parameter is used. The test will fail if it does not reference an enum type.
+Thus, the `value` parameter is required in the above example because the method parameter
+is declared as `TemporalUnit`, i.e. the interface implemented by `ChronoUnit`, which isn't
+an enum type. Changing the method parameter type to `ChronoUnit` allows to omit the
+explicit enum type from the annotation as follows.
 
 [source,java,indent=0]
 ----

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -24,10 +24,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -109,36 +110,41 @@ class ParameterizedTestDemo {
 
 	// tag::EnumSource_example[]
 	@ParameterizedTest
-	@EnumSource(TimeUnit.class)
-	void testWithEnumSource(TimeUnit timeUnit) {
-		assertNotNull(timeUnit);
+	@EnumSource(ChronoUnit.class)
+	void testWithEnumSource(TemporalUnit unit) {
+		assertNotNull(unit);
 	}
 	// end::EnumSource_example[]
 
+	// tag::EnumSource_example_autodetection[]
+	@ParameterizedTest
+	@EnumSource
+	void testWithEnumSourceWithAutoDetection(ChronoUnit unit) {
+		assertNotNull(unit);
+	}
+	// end::EnumSource_example_autodetection[]
+
 	// tag::EnumSource_include_example[]
 	@ParameterizedTest
-	@EnumSource(value = TimeUnit.class, names = { "DAYS", "HOURS" })
-	void testWithEnumSourceInclude(TimeUnit timeUnit) {
-		assertTrue(EnumSet.of(TimeUnit.DAYS, TimeUnit.HOURS).contains(timeUnit));
+	@EnumSource(names = { "DAYS", "HOURS" })
+	void testWithEnumSourceInclude(ChronoUnit unit) {
+		assertTrue(EnumSet.of(ChronoUnit.DAYS, ChronoUnit.HOURS).contains(unit));
 	}
 	// end::EnumSource_include_example[]
 
 	// tag::EnumSource_exclude_example[]
 	@ParameterizedTest
-	@EnumSource(value = TimeUnit.class, mode = EXCLUDE, names = { "DAYS", "HOURS" })
-	void testWithEnumSourceExclude(TimeUnit timeUnit) {
-		assertFalse(EnumSet.of(TimeUnit.DAYS, TimeUnit.HOURS).contains(timeUnit));
-		assertTrue(timeUnit.name().length() > 5);
+	@EnumSource(mode = EXCLUDE, names = { "ERAS", "FOREVER" })
+	void testWithEnumSourceExclude(ChronoUnit unit) {
+		assertFalse(EnumSet.of(ChronoUnit.ERAS, ChronoUnit.FOREVER).contains(unit));
 	}
 	// end::EnumSource_exclude_example[]
 
 	// tag::EnumSource_regex_example[]
 	@ParameterizedTest
-	@EnumSource(value = TimeUnit.class, mode = MATCH_ALL, names = "^(M|N).+SECONDS$")
-	void testWithEnumSourceRegex(TimeUnit timeUnit) {
-		String name = timeUnit.name();
-		assertTrue(name.startsWith("M") || name.startsWith("N"));
-		assertTrue(name.endsWith("SECONDS"));
+	@EnumSource(mode = MATCH_ALL, names = "^.*DAYS$")
+	void testWithEnumSourceRegex(ChronoUnit unit) {
+		assertTrue(unit.name().endsWith("DAYS"));
 	}
 	// end::EnumSource_regex_example[]
 
@@ -261,7 +267,7 @@ class ParameterizedTestDemo {
 	// tag::implicit_conversion_example[]
 	@ParameterizedTest
 	@ValueSource(strings = "SECONDS")
-	void testWithImplicitArgumentConversion(TimeUnit argument) {
+	void testWithImplicitArgumentConversion(ChronoUnit argument) {
 		assertNotNull(argument.name());
 	}
 	// end::implicit_conversion_example[]
@@ -297,11 +303,11 @@ class ParameterizedTestDemo {
 	// @formatter:off
 	// tag::explicit_conversion_example[]
 	@ParameterizedTest
-	@EnumSource(TimeUnit.class)
+	@EnumSource(ChronoUnit.class)
 	void testWithExplicitArgumentConversion(
 			@ConvertWith(ToStringArgumentConverter.class) String argument) {
 
-		assertNotNull(TimeUnit.valueOf(argument));
+		assertNotNull(ChronoUnit.valueOf(argument));
 	}
 
 	// end::explicit_conversion_example[]
@@ -312,6 +318,9 @@ class ParameterizedTestDemo {
 		@Override
 		protected Object convert(Object source, Class<?> targetType) {
 			assertEquals(String.class, targetType, "Can only convert to String");
+			if (source instanceof Enum<?>) {
+				return ((Enum<?>) source).name();
+			}
 			return String.valueOf(source);
 		}
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumArgumentsProvider.java
@@ -61,9 +61,9 @@ class EnumArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<Enu
 			Method method = context.getRequiredTestMethod();
 			Class<?>[] parameterTypes = method.getParameterTypes();
 			Preconditions.condition(parameterTypes.length > 0,
-				() -> "At least one parameter is required on test method: " + method.toGenericString());
+				() -> "Test method must declare at least one parameter: " + method.toGenericString());
 			Preconditions.condition(Enum.class.isAssignableFrom(parameterTypes[0]),
-				() -> "First parameter must reference an Enum type (alternatively, use the annotation's 'value' parameter to specify the type explicitly): "
+				() -> "First parameter must reference an Enum type (alternatively, use the annotation's 'value' attribute to specify the type explicitly): "
 						+ method.toGenericString());
 			enumClass = parameterTypes[0];
 		}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.params.provider;
 
-import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toSet;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
@@ -20,7 +19,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -31,10 +29,14 @@ import org.junit.platform.commons.util.Preconditions;
 
 /**
  * {@code @EnumSource} is an {@link ArgumentsSource} for constants of a
- * specified {@linkplain #value Enum}.
+ * an {@link Enum}.
  *
  * <p>The enum constants will be provided as arguments to the annotated
  * {@code @ParameterizedTest} method.
+ *
+ * <p>The enum type can be specified explicitly using the {@link #value}
+ * attribute. Otherwise, the declared type of the first parameter of the
+ * {@code @ParameterizedTest} method is used.
  *
  * <p>The set of enum constants can be restricted via the {@link #names} and
  * {@link #mode} attributes.
@@ -56,7 +58,7 @@ public @interface EnumSource {
 	 * @see #names
 	 * @see #mode
 	 */
-	Class<? extends Enum<?>> value();
+	Class<? extends Enum<?>> value() default NullEnum.class;
 
 	/**
 	 * The names of enum constants to provide, or regular expressions to select
@@ -118,19 +120,19 @@ public @interface EnumSource {
 		 */
 		MATCH_ANY(Mode::validatePatterns, (name, patterns) -> patterns.stream().anyMatch(name::matches));
 
-		private final BiConsumer<EnumSource, Set<String>> validator;
+		private final Validator validator;
 		private final BiPredicate<String, Set<String>> selector;
 
-		private Mode(BiConsumer<EnumSource, Set<String>> validator, BiPredicate<String, Set<String>> selector) {
+		Mode(Validator validator, BiPredicate<String, Set<String>> selector) {
 			this.validator = validator;
 			this.selector = selector;
 		}
 
-		void validate(EnumSource enumSource, Set<String> names) {
+		void validate(EnumSource enumSource, Set<? extends Enum<?>> constants, Set<String> names) {
 			Preconditions.notNull(enumSource, "EnumSource must not be null");
 			Preconditions.notNull(names, "names must not be null");
 
-			validator.accept(enumSource, names);
+			validator.validate(enumSource, constants, names);
 		}
 
 		boolean select(Enum<?> constant, Set<String> names) {
@@ -140,15 +142,16 @@ public @interface EnumSource {
 			return selector.test(constant.name(), names);
 		}
 
-		private static void validateNames(EnumSource enumSource, Set<String> names) {
+		private static void validateNames(EnumSource enumSource, Set<? extends Enum<?>> constants, Set<String> names) {
 			// Do not map using Enum::name here since it results in a rawtypes warning
 			// that fails our Gradle build which is configured with -Werror.
-			Set<String> allNames = stream(enumSource.value().getEnumConstants()).map(e -> e.name()).collect(toSet());
+			Set<String> allNames = constants.stream().map(Enum::name).collect(toSet());
 			Preconditions.condition(allNames.containsAll(names),
 				() -> "Invalid enum constant name(s) in " + enumSource + ". Valid names include: " + allNames);
 		}
 
-		private static void validatePatterns(EnumSource enumSource, Set<String> names) {
+		private static void validatePatterns(EnumSource enumSource, Set<? extends Enum<?>> constants,
+				Set<String> names) {
 			try {
 				names.forEach(Pattern::compile);
 			}
@@ -156,6 +159,10 @@ public @interface EnumSource {
 				throw new PreconditionViolationException(
 					"Pattern compilation failed for a regular expression supplied in " + enumSource, e);
 			}
+		}
+
+		private interface Validator {
+			void validate(EnumSource enumSource, Set<? extends Enum<?>> constants, Set<String> names);
 		}
 
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -55,6 +55,9 @@ public @interface EnumSource {
 	/**
 	 * The enum type that serves as the source of the enum constants.
 	 *
+	 * <p>If this attribute is not set explicitly, the declared type of the
+	 * first parameter of the {@code @ParameterizedTest} method is used.
+	 *
 	 * @see #names
 	 * @see #mode
 	 */

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullEnum.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullEnum.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+/**
+ * Dummy enum class to be used as default value of annotation attributes.
+ *
+ * @since 5.6
+ * @see EnumSource#value()
+ */
+enum NullEnum {
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullEnum.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullEnum.java
@@ -10,11 +10,15 @@
 
 package org.junit.jupiter.params.provider;
 
+import org.apiguardian.api.API;
+
 /**
- * Dummy enum class to be used as default value of annotation attributes.
+ * Dummy enum class used as default value for optional attributes of
+ * annotations.
  *
  * @since 5.6
  * @see EnumSource#value()
  */
-enum NullEnum {
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public enum NullEnum {
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
@@ -102,7 +102,7 @@ class EnumArgumentsProviderTests {
 
 		Exception exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(NullEnum.class));
-		assertThat(exception).hasMessageStartingWith("At least one parameter is required on test method");
+		assertThat(exception).hasMessageStartingWith("Test method must declare at least one parameter");
 	}
 
 	static class TestCase {

--- a/platform-tests/src/test/java/org/junit/platform/console/options/PicocliCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/PicocliCommandLineOptionsParserTests.java
@@ -91,7 +91,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidDetails(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -111,7 +111,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidDetailsTheme(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -130,7 +130,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidIncludeClassNamePatterns(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -142,7 +142,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidExcludeClassNamePatterns(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -170,7 +170,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidIncludedPackages(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -185,7 +185,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidExcludedPackages(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -200,7 +200,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidIncludedTags(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -218,7 +218,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidExcludedTags(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -236,7 +236,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidIncludedEngines(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -253,7 +253,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidExcludedEngines(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -270,7 +270,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidAdditionalClasspathEntries(ArgsType type) {
 		Path dir = Paths.get(".");
 		// @formatter:off
@@ -295,7 +295,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidXmlReportsDirs(ArgsType type) {
 		Path dir = Paths.get("build", "test-results");
 		// @formatter:off
@@ -312,7 +312,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidUriSelectors(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -333,7 +333,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidFileSelectors(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -354,7 +354,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidDirectorySelectors(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -375,7 +375,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidModuleSelectors(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -396,7 +396,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidPackageSelectors(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -417,7 +417,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidClassSelectors(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -438,7 +438,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidMethodSelectors(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -460,7 +460,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidClasspathResourceSelectors(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -481,7 +481,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseClasspathScanningEntries(ArgsType type) {
 		Path dir = Paths.get(".");
 		// @formatter:off
@@ -502,7 +502,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseValidConfigurationParameters(ArgsType type) {
 		// @formatter:off
 		assertAll(
@@ -526,7 +526,7 @@ class PicocliCommandLineOptionsParserTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(ArgsType.class)
+	@EnumSource
 	void parseInvalidConfigurationParametersWithDuplicateKey(ArgsType type) {
 		Exception e = assertThrows(JUnitException.class, () -> type.parseArgLine("--config foo=bar --config foo=baz"));
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategyTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategyTests.java
@@ -82,7 +82,7 @@ class DefaultParallelExecutionConfigurationStrategyTests {
 	}
 
 	@ParameterizedTest
-	@EnumSource(DefaultParallelExecutionConfigurationStrategy.class)
+	@EnumSource
 	void createsStrategyFromConfigParam(DefaultParallelExecutionConfigurationStrategy strategy) {
 		when(configParams.get("strategy")).thenReturn(Optional.of(strategy.name().toLowerCase()));
 


### PR DESCRIPTION
The `value` parameter of the `EnumSource` annotation is now optional.
When omitted, the declared type of the first method parameter is used.
The test will fail if it does not reference an enum type.

Resolves #1973.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
