### PR TITLE
Drop java.compiler dependence in org.junit.platform.commons

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -28,6 +28,8 @@ on GitHub.
 
 * New `printFailuresTo(PrintWriter, int)` method in `TestExecutionSummary` that allows one
   to specify the maximum number of lines to print for exception stack traces.
+* Implement equivalent of `SourceVersion.isName()` in `PackageUtils` in order to drop
+  `java.compiler` dependence in `org.junit.platform.commons`.
 
 
 [[release-notes-5.6.0-M1-junit-jupiter]]

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
@@ -169,7 +169,7 @@ public final class PackageUtils {
 		 * syntactically valid name, {@code false} otherwise.
 		 */
 		public static boolean isJavaName(String name) {
-			return isJavaIdentifier(name) && !isJavaKeyword(name);
+			return isJavaIdentifier(name) && isNotRestrictedKeyword(name);
 		}
 
 		private static boolean isJavaIdentifier(String s) {
@@ -190,8 +190,8 @@ public final class PackageUtils {
 			return true;
 		}
 
-		private static boolean isJavaKeyword(String s) {
-			return RESTRICTED_KEYWORDS.contains(s);
+		private static boolean isNotRestrictedKeyword(String s) {
+			return !RESTRICTED_KEYWORDS.contains(s);
 		}
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
@@ -140,6 +140,18 @@ public final class PackageUtils {
 		}
 	}
 
+	/**
+	 * Collection of utilities for working with qualified names in Java.
+	 *
+	 * <h3>DISCLAIMER</h3>
+	 *
+	 * <p>These utilities are intended solely for usage within the JUnit framework
+	 * itself. <strong>Any usage by external parties is not supported.</strong>
+	 * Use at your own risk!
+	 *
+	 * @since 1.5
+	 */
+	@API(status = INTERNAL, since = "1.5")
 	static class JavaNameUtils {
 
 		private static final List<String> RESTRICTED_KEYWORDS = Arrays.asList("strictfp", "assert", "enum", "_", "public",
@@ -148,8 +160,16 @@ public final class PackageUtils {
 			"break", "throw", "return", "this", "new", "super", "import", "instanceof", "goto", "const", "null", "true",
 			"false");
 
-		public static boolean isJavaName(String s) {
-			return isJavaIdentifier(s) && !isJavaKeyword(s);
+		/**
+		 * Returns whether or not {@code name} is a syntactically
+		 * valid qualified name.
+		 *
+		 * @param name the string to check
+		 * @return {@code true} if this string is a
+		 * syntactically valid name, {@code false} otherwise.
+		 */
+		public static boolean isJavaName(String name) {
+			return isJavaIdentifier(name) && !isJavaKeyword(name);
 		}
 
 		private static boolean isJavaIdentifier(String s) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
@@ -154,11 +154,11 @@ public final class PackageUtils {
 	@API(status = INTERNAL, since = "1.5")
 	static class JavaNameUtils {
 
-		private static final List<String> RESTRICTED_KEYWORDS = Arrays.asList("strictfp", "assert", "enum", "_", "public",
-			"protected", "private", "abstract", "static", "final", "transient", "volatile", "synchronized", "native",
-			"if", "else", "try", "catch", "finally", "do", "while", "for", "continue", "switch", "case", "default",
-			"break", "throw", "return", "this", "new", "super", "import", "instanceof", "goto", "const", "null", "true",
-			"false");
+		private static final List<String> RESTRICTED_KEYWORDS = Arrays.asList("strictfp", "assert", "enum", "_",
+			"public", "protected", "private", "abstract", "static", "final", "transient", "volatile", "synchronized",
+			"native", "if", "else", "try", "catch", "finally", "do", "while", "for", "continue", "switch", "case",
+			"default", "break", "throw", "return", "this", "new", "super", "import", "instanceof", "goto", "const",
+			"null", "true", "false");
 
 		/**
 		 * Returns whether or not {@code name} is a syntactically

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageUtils.java
@@ -16,8 +16,9 @@ import java.io.File;
 import java.net.URL;
 import java.security.CodeSource;
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -149,31 +150,30 @@ public final class PackageUtils {
 	 * itself. <strong>Any usage by external parties is not supported.</strong>
 	 * Use at your own risk!
 	 *
-	 * @since 1.5
+	 * @since 1.6
 	 */
-	@API(status = INTERNAL, since = "1.5")
 	static class JavaNameUtils {
 
-		private static final List<String> RESTRICTED_KEYWORDS = Arrays.asList("strictfp", "assert", "enum", "_",
-			"public", "protected", "private", "abstract", "static", "final", "transient", "volatile", "synchronized",
-			"native", "if", "else", "try", "catch", "finally", "do", "while", "for", "continue", "switch", "case",
-			"default", "break", "throw", "return", "this", "new", "super", "import", "instanceof", "goto", "const",
-			"null", "true", "false");
+		private static final Set<String> RESTRICTED_KEYWORDS = new HashSet<>(
+			Arrays.asList("_", "abstract", "assert", "break", "case", "catch", "const", "continue", "default", "do",
+				"else", "enum", "false", "final", "finally", "for", "goto", "if", "import", "instanceof", "native",
+				"new", "null", "private", "protected", "public", "return", "static", "strictfp", "super", "switch",
+				"synchronized", "this", "throw", "transient", "true", "try", "volatile", "while"));
 
 		/**
-		 * Returns whether or not {@code name} is a syntactically
+		 * Determine if the supplied {@code name} is a syntactically
 		 * valid qualified name.
 		 *
 		 * @param name the string to check
 		 * @return {@code true} if this string is a
 		 * syntactically valid name, {@code false} otherwise.
 		 */
-		public static boolean isJavaName(String name) {
-			return isJavaIdentifier(name) && isNotRestrictedKeyword(name);
+		static boolean isJavaName(String name) {
+			return isNotRestrictedKeyword(name) && isJavaIdentifier(name);
 		}
 
 		private static boolean isJavaIdentifier(String s) {
-			if (s.length() == 0) {
+			if (s.isEmpty()) {
 				return false;
 			}
 			int start = s.codePointAt(0);

--- a/junit-platform-commons/src/module/org.junit.platform.commons/module-info.java
+++ b/junit-platform-commons/src/module/org.junit.platform.commons/module-info.java
@@ -9,7 +9,6 @@
  */
 
 module org.junit.platform.commons {
-	requires java.compiler; // usage of `javax.lang.model.SourceVersion` in `PackageUtils`
 	requires java.logging; // TODO Is "requires transitive java.logging" needed here?
 	requires transitive org.apiguardian.api;
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/PackageUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/PackageUtilsTests.java
@@ -20,11 +20,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+import javax.lang.model.SourceVersion;
+
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.commons.util.PackageUtils.JavaNameUtils;
 import org.opentest4j.ValueWrapper;
 
 /**
@@ -117,6 +123,17 @@ class PackageUtilsTests {
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> PackageUtils.getAttribute(getClass(), ""));
 		assertEquals("name must not be blank", exception.getMessage());
+	}
+
+	@Nested
+	class JavaNameUtilsTest {
+
+		@ParameterizedTest
+		@ValueSource(strings = { "name", "_NAME", "null", "public", "$+!", "", "  ", "123" })
+		void isJavaName(String s) {
+			assertEquals(SourceVersion.isName(s), JavaNameUtils.isJavaName(s));
+		}
+
 	}
 
 }

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
@@ -4,7 +4,6 @@ exports org.junit.platform.commons.annotation
 exports org.junit.platform.commons.function
 exports org.junit.platform.commons.support
 requires java.base mandated
-requires java.compiler
 requires java.logging
 requires org.apiguardian.api transitive
 qualified exports org.junit.platform.commons.logging to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.runner org.junit.platform.suite.api org.junit.platform.testkit org.junit.vintage.engine


### PR DESCRIPTION
## Overview

Solves #1995 by implementing a custom version of `SourceVersion.isName()`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
