### PR TITLE
Run Gradle/Maven/Ant tests with Java 8

### DIFF
--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -52,7 +52,7 @@ tasks.test {
 		// Pass "java.home.N" system properties from sources like "~/.gradle/gradle.properties".
 		// Values will be picked up by: platform.tooling.support.Helper::getJavaHome
 		for (N in 8..99) {
-			val home = project.properties["java.home.$N"]
+			val home = project.properties["java.home.$N"] ?: System.getenv("JDK$N")
 			if (home != null) systemProperty("java.home.$N", home)
 		}
 		// TODO Enabling parallel execution fails due to Gradle's listener not being thread-safe:

--- a/platform-tooling-support-tests/projects/ant-starter/build.xml
+++ b/platform-tooling-support-tests/projects/ant-starter/build.xml
@@ -24,6 +24,7 @@
     </target>
 
     <target name="init">
+        <echo message="Using Java version: ${java.version}"/>
         <mkdir dir="build/main"/>
         <mkdir dir="build/test"/>
         <mkdir dir="build/test-report"/>

--- a/platform-tooling-support-tests/projects/gradle-starter/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/gradle-starter/build.gradle.kts
@@ -38,4 +38,8 @@ tasks.test {
 	reports {
 		html.isEnabled = true
 	}
+
+	doFirst {
+		println("Using Java version: ${JavaVersion.current()}")
+	}
 }

--- a/platform-tooling-support-tests/projects/maven-starter/pom.xml
+++ b/platform-tooling-support-tests/projects/maven-starter/pom.xml
@@ -9,7 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <junit.jupiter.version>${env.JUNIT_JUPITER_VERSION}</junit.jupiter.version>
     </properties>
 
@@ -31,6 +32,24 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+                                println("Using Java version: ${java.version}")
+                            </source>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/platform-tooling-support-tests/projects/vintage/pom.xml
+++ b/platform-tooling-support-tests/projects/vintage/pom.xml
@@ -9,7 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <vintageVersion>${env.JUNIT_VINTAGE_VERSION}</vintageVersion>
         <junit4Version>4.12</junit4Version>
     </properties>

--- a/platform-tooling-support-tests/src/main/java/platform/tooling/support/Request.java
+++ b/platform-tooling-support-tests/src/main/java/platform/tooling/support/Request.java
@@ -110,7 +110,10 @@ public class Request {
 			configuration.setTimeout(getTimeout());
 			configuration.getEnvironment().putAll(getEnvironment());
 
-			return tool.run(configuration.build());
+			var result = tool.run(configuration.build());
+			System.out.println(result.getOutput("out"));
+			System.err.println(result.getOutput("err"));
+			return result;
 		}
 		catch (Exception e) {
 			throw new IllegalStateException("run failed", e);
@@ -142,6 +145,11 @@ public class Request {
 
 		public Builder setTool(Tool tool) {
 			request.tool = tool;
+			return this;
+		}
+
+		public Builder setJavaHome(Path javaHome) {
+			putEnvironment("JAVA_HOME", javaHome.normalize().toAbsolutePath().toString());
 			return this;
 		}
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
@@ -10,6 +10,7 @@
 
 package platform.tooling.support.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -20,6 +21,9 @@ import java.util.List;
 import de.sormuras.bartholdy.tool.Ant;
 
 import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
 import platform.tooling.support.Request;
 
 /**
@@ -34,6 +38,7 @@ class AntStarterTests {
 				.setTool(Ant.install("1.10.6", Paths.get("build", "test-tools"))) //
 				.setProject("ant-starter") //
 				.addArguments("-verbose", "-lib", standalone.toAbsolutePath()) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.build() //
 				.run();
 
@@ -41,6 +46,7 @@ class AntStarterTests {
 
 		assertEquals(0, result.getExitCode());
 		assertEquals("", result.getOutput("err"), "error log isn't empty");
+		assertThat(result.getOutput("out")).contains("Using Java version: 1.8");
 		assertLinesMatch(List.of(">> HEAD >>", //
 			"test.junit.launcher:", //
 			">>>>", //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleKotlinExtensionsTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleKotlinExtensionsTests.java
@@ -20,14 +20,14 @@ import java.time.Duration;
 import de.sormuras.bartholdy.tool.GradleWrapper;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
 import platform.tooling.support.Request;
 
 /**
  * @since 1.3
  */
-@DisabledOnJre(JRE.JAVA_14)
 class GradleKotlinExtensionsTests {
 
 	@Test
@@ -37,6 +37,7 @@ class GradleKotlinExtensionsTests {
 				.setProject("gradle-kotlin-extensions") //
 				.addArguments("build", "--no-daemon", "--debug", "--stacktrace") //
 				.setTimeout(Duration.ofMinutes(2)) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.build() //
 				.run();
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleMissingEngineTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleMissingEngineTests.java
@@ -21,14 +21,14 @@ import de.sormuras.bartholdy.Tool;
 import de.sormuras.bartholdy.tool.GradleWrapper;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
 import platform.tooling.support.Request;
 
 /**
  * @since 1.3
  */
-@DisabledOnJre(JRE.JAVA_14)
 class GradleMissingEngineTests {
 
 	@Test
@@ -43,12 +43,13 @@ class GradleMissingEngineTests {
 				.setWorkspace(project + '-' + version) //
 				.setTool(gradle) //
 				.addArguments("build", "--no-daemon", "--debug", "--stacktrace") //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.build() //
 				.run();
 
 		assumeFalse(result.isTimedOut(), () -> "tool timed out: " + result);
 
-		assertEquals(1, result.getExitCode(), result.toString());
+		assertEquals(1, result.getExitCode());
 		assertLinesMatch(List.of( //
 			">> HEAD >>", //
 			".+DEBUG.+Cannot create Launcher without at least one TestEngine.+", //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleStarterTests.java
@@ -10,6 +10,7 @@
 
 package platform.tooling.support.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -20,14 +21,14 @@ import java.time.Duration;
 import de.sormuras.bartholdy.tool.GradleWrapper;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
 import platform.tooling.support.Request;
 
 /**
  * @since 1.3
  */
-@DisabledOnJre(JRE.JAVA_14)
 class GradleStarterTests {
 
 	@Test
@@ -37,12 +38,14 @@ class GradleStarterTests {
 				.setProject("gradle-starter") //
 				.addArguments("build", "--no-daemon", "--debug", "--stacktrace") //
 				.setTimeout(Duration.ofMinutes(2)) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.build() //
 				.run();
 
 		assumeFalse(result.isTimedOut(), () -> "tool timed out: " + result);
 
-		assertEquals(0, result.getExitCode(), result.toString());
+		assertEquals(0, result.getExitCode());
 		assertTrue(result.getOutputLines("out").stream().anyMatch(line -> line.contains("BUILD SUCCESSFUL")));
+		assertThat(result.getOutput("out")).contains("Using Java version: 1.8");
 	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
@@ -54,10 +54,10 @@ class JavaVersionsTests {
 				.setWorkspace("java-versions-" + version) //
 				.addArguments("--debug", "verify") //
 				.setTimeout(Duration.ofMinutes(2)) //
-				.putEnvironment("JAVA_HOME", javaHome.toString()) //
+				.setJavaHome(javaHome) //
 				.build().run();
 		assumeFalse(result.isTimedOut(), () -> "tool timed out: " + result);
-		assertEquals(0, result.getExitCode(), result.toString());
+		assertEquals(0, result.getExitCode());
 		assertEquals("", result.getOutput("err"));
 		return result.getOutputLines("out");
 	}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
@@ -10,6 +10,7 @@
 
 package platform.tooling.support.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -17,6 +18,9 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
 import platform.tooling.support.Request;
 
 /**
@@ -31,14 +35,16 @@ class MavenStarterTests {
 				.setProject("maven-starter") //
 				.addArguments("--debug", "verify") //
 				.setTimeout(Duration.ofMinutes(2)) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.build() //
 				.run();
 
 		assumeFalse(result.isTimedOut(), () -> "tool timed out: " + result);
 
-		assertEquals(0, result.getExitCode(), result.toString());
+		assertEquals(0, result.getExitCode());
 		assertEquals("", result.getOutput("err"));
 		assertTrue(result.getOutputLines("out").contains("[INFO] BUILD SUCCESS"));
 		assertTrue(result.getOutputLines("out").contains("[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0"));
+		assertThat(result.getOutput("out")).contains("Using Java version: 1.8");
 	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
@@ -68,7 +68,7 @@ class MultiReleaseJarTests {
 		result.getOutputLines("out").forEach(System.out::println);
 		result.getOutputLines("err").forEach(System.err::println);
 
-		assertEquals(0, result.getExitCode(), result.toString());
+		assertEquals(0, result.getExitCode());
 		assertEquals("", result.getOutput("err"));
 		assertTrue(result.getOutputLines("out").contains("[INFO] BUILD SUCCESS"));
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageGradleIntegrationTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageGradleIntegrationTests.java
@@ -21,13 +21,13 @@ import de.sormuras.bartholdy.Result;
 import de.sormuras.bartholdy.tool.GradleWrapper;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
 import platform.tooling.support.Request;
 
-@DisabledOnJre(JRE.JAVA_14)
 class VintageGradleIntegrationTests {
 
 	@Test
@@ -57,6 +57,7 @@ class VintageGradleIntegrationTests {
 	private Result run(String version) {
 		Result result = Request.builder() //
 				.setTool(new GradleWrapper(Paths.get(".."))) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.setProject("vintage") //
 				.setWorkspace("vintage-gradle-" + version) //
 				.addArguments("clean", "test", "--stacktrace") //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageMavenIntegrationTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageMavenIntegrationTests.java
@@ -21,6 +21,9 @@ import de.sormuras.bartholdy.Result;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
 import platform.tooling.support.Request;
 
 class VintageMavenIntegrationTests {
@@ -54,6 +57,7 @@ class VintageMavenIntegrationTests {
 	private Result run(String version) {
 		Result result = Request.builder() //
 				.setTool(Request.maven()) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.setProject("vintage") //
 				.setWorkspace("vintage-maven-" + version) //
 				.addArguments("clean", "test", "--debug") //


### PR DESCRIPTION
Instead of disabling the tests on Java 14, we now run tests for Gradle/Maven/Ant builds with JDK 8. Not only does that remove the need for Gradle to support the latest EA release, it also provides basic coverage that ensures that we can run on Java 8.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
