### PR TITLE
Cache methods to improve performance of TestSource creation

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/LruCache.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/LruCache.java
@@ -28,7 +28,7 @@ public class LruCache<K, V> extends LinkedHashMap<K, V> {
 
 	private static final long serialVersionUID = 1L;
 
-	private int maxSize;
+	private final int maxSize;
 
 	public LruCache(int maxSize) {
 		super(maxSize + 1, 0.75f, true);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/LruCache.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/LruCache.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apiguardian.api.API;
+
+/**
+ * A simple LRU cache with a maximum size.
+ *
+ * @param <K> the type of keys maintained by this cache
+ * @param <V> the type of values maintained by this cache
+ */
+@API(status = INTERNAL, since = "1.6")
+public class LruCache<K, V> extends LinkedHashMap<K, V> {
+
+	private static final long serialVersionUID = 1L;
+
+	private int maxSize;
+
+	public LruCache(int maxSize) {
+		super(maxSize + 1, 0.75f, true);
+		this.maxSize = maxSize;
+	}
+
+	@Override
+	protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+		return size() > maxSize;
+	}
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/LruCache.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/LruCache.java
@@ -20,6 +20,8 @@ import org.apiguardian.api.API;
 /**
  * A simple LRU cache with a maximum size.
  *
+ * <p>This class is not thread-safe.
+ *
  * @param <K> the type of keys maintained by this cache
  * @param <V> the type of values maintained by this cache
  */
@@ -30,8 +32,18 @@ public class LruCache<K, V> extends LinkedHashMap<K, V> {
 
 	private final int maxSize;
 
+	/**
+	 * Create a new LRU cache that maintains at most the supplied number of
+	 * entries.
+	 *
+	 * <p>For optimal use of the internal data structures, you should pick a
+	 * number that's one below a power of two since this is based on a
+	 * {@link java.util.HashMap} and the eldest entry will be evicted after
+	 * adding the entry that increases the {@linkplain #size() size} to be above
+	 * {@code maxSize}.
+	 */
 	public LruCache(int maxSize) {
-		super(maxSize + 1, 0.75f, true);
+		super(maxSize + 1, 1, true);
 		this.maxSize = maxSize;
 	}
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
@@ -24,6 +24,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
+import org.junit.vintage.engine.descriptor.VintageEngineDescriptor;
 import org.junit.vintage.engine.discovery.VintageDiscoverer;
 import org.junit.vintage.engine.execution.RunnerExecutor;
 
@@ -65,16 +66,17 @@ public final class VintageTestEngine implements TestEngine {
 	@Override
 	public void execute(ExecutionRequest request) {
 		EngineExecutionListener engineExecutionListener = request.getEngineExecutionListener();
-		TestDescriptor engineTestDescriptor = request.getRootTestDescriptor();
-		engineExecutionListener.executionStarted(engineTestDescriptor);
-		RunnerExecutor runnerExecutor = new RunnerExecutor(engineExecutionListener);
-		executeAllChildren(runnerExecutor, engineTestDescriptor);
-		engineExecutionListener.executionFinished(engineTestDescriptor, successful());
+		VintageEngineDescriptor engineDescriptor = (VintageEngineDescriptor) request.getRootTestDescriptor();
+		engineExecutionListener.executionStarted(engineDescriptor);
+		RunnerExecutor runnerExecutor = new RunnerExecutor(engineExecutionListener,
+			engineDescriptor.getTestSourceProvider());
+		executeAllChildren(runnerExecutor, engineDescriptor);
+		engineExecutionListener.executionFinished(engineDescriptor, successful());
 	}
 
-	private void executeAllChildren(RunnerExecutor runnerExecutor, TestDescriptor engineTestDescriptor) {
+	private void executeAllChildren(RunnerExecutor runnerExecutor, TestDescriptor engineDescriptor) {
 		// @formatter:off
-		engineTestDescriptor.getChildren()
+		engineDescriptor.getChildren()
 				.stream()
 				.map(RunnerTestDescriptor.class::cast)
 				.forEach(runnerExecutor::execute);

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/TestSourceProvider.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/TestSourceProvider.java
@@ -17,12 +17,13 @@ import static org.junit.platform.commons.util.FunctionUtils.where;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethods;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.support.ModifierSupport;
+import org.junit.platform.commons.util.LruCache;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
@@ -34,7 +35,7 @@ import org.junit.runner.Description;
 @API(status = INTERNAL, since = "5.6")
 public class TestSourceProvider {
 
-	private final Map<Class<?>, List<Method>> methodsCache = new ConcurrentHashMap<>();
+	private final Map<Class<?>, List<Method>> methodsCache = Collections.synchronizedMap(new LruCache<>(32));
 
 	public TestSource findTestSource(Description description) {
 		Class<?> testClass = description.getTestClass();

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/TestSourceProvider.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/TestSourceProvider.java
@@ -42,7 +42,7 @@ public class TestSourceProvider {
 		if (testClass != null) {
 			String methodName = description.getMethodName();
 			if (methodName != null) {
-				Method method = findMethod(testClass, methodName);
+				Method method = findMethod(testClass, sanitizeMethodName(methodName));
 				if (method != null) {
 					return MethodSource.from(testClass, method);
 				}
@@ -52,11 +52,15 @@ public class TestSourceProvider {
 		return null;
 	}
 
-	private Method findMethod(Class<?> testClass, String methodName) {
+	private String sanitizeMethodName(String methodName) {
 		if (methodName.contains("[") && methodName.endsWith("]")) {
 			// special case for parameterized tests
-			return findMethod(testClass, methodName.substring(0, methodName.indexOf("[")));
+			return methodName.substring(0, methodName.indexOf("["));
 		}
+		return methodName;
+	}
+
+	private Method findMethod(Class<?> testClass, String methodName) {
 		List<Method> methods = methodsCache.computeIfAbsent(testClass, clazz -> findMethods(clazz, m -> true)).stream() //
 				.filter(where(Method::getName, isEqual(methodName))) //
 				.collect(toList());

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/TestSourceProvider.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/TestSourceProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.descriptor;
+
+import static java.util.function.Predicate.isEqual;
+import static java.util.stream.Collectors.toList;
+import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.junit.platform.commons.util.FunctionUtils.where;
+import static org.junit.platform.commons.util.ReflectionUtils.findMethods;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.support.ModifierSupport;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.runner.Description;
+
+/**
+ * @since 5.6
+ */
+@API(status = INTERNAL, since = "5.6")
+public class TestSourceProvider {
+
+	private final Map<Class<?>, List<Method>> methodsCache = new ConcurrentHashMap<>();
+
+	public TestSource findTestSource(Description description) {
+		Class<?> testClass = description.getTestClass();
+		if (testClass != null) {
+			String methodName = description.getMethodName();
+			if (methodName != null) {
+				Method method = findMethod(testClass, methodName);
+				if (method != null) {
+					return MethodSource.from(testClass, method);
+				}
+			}
+			return ClassSource.from(testClass);
+		}
+		return null;
+	}
+
+	private Method findMethod(Class<?> testClass, String methodName) {
+		if (methodName.contains("[") && methodName.endsWith("]")) {
+			// special case for parameterized tests
+			return findMethod(testClass, methodName.substring(0, methodName.indexOf("[")));
+		}
+		List<Method> methods = methodsCache.computeIfAbsent(testClass, clazz -> findMethods(clazz, m -> true)).stream() //
+				.filter(where(Method::getName, isEqual(methodName))) //
+				.collect(toList());
+		if (methods.isEmpty()) {
+			return null;
+		}
+		if (methods.size() == 1) {
+			return methods.get(0);
+		}
+		methods = methods.stream().filter(ModifierSupport::isPublic).collect(toList());
+		if (methods.size() == 1) {
+			return methods.get(0);
+		}
+		return null;
+	}
+
+}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/TestSourceProvider.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/TestSourceProvider.java
@@ -35,7 +35,7 @@ import org.junit.runner.Description;
 @API(status = INTERNAL, since = "5.6")
 public class TestSourceProvider {
 
-	private final Map<Class<?>, List<Method>> methodsCache = Collections.synchronizedMap(new LruCache<>(32));
+	private final Map<Class<?>, List<Method>> methodsCache = Collections.synchronizedMap(new LruCache<>(31));
 
 	public TestSource findTestSource(Description description) {
 		Class<?> testClass = description.getTestClass();

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageEngineDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageEngineDescriptor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.descriptor;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import org.apiguardian.api.API;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+
+/**
+ * @since 5.6
+ */
+@API(status = INTERNAL, since = "5.6")
+public class VintageEngineDescriptor extends EngineDescriptor {
+
+	private final TestSourceProvider testSourceProvider;
+
+	public VintageEngineDescriptor(UniqueId uniqueId, TestSourceProvider testSourceProvider) {
+		super(uniqueId, "JUnit Vintage");
+		this.testSourceProvider = testSourceProvider;
+	}
+
+	public TestSourceProvider getTestSourceProvider() {
+		return testSourceProvider;
+	}
+
+}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -12,13 +12,9 @@ package org.junit.vintage.engine.descriptor;
 
 import static java.util.Arrays.stream;
 import static java.util.function.Predicate.isEqual;
-import static java.util.stream.Collectors.toList;
 import static org.apiguardian.api.API.Status.INTERNAL;
-import static org.junit.platform.commons.util.FunctionUtils.where;
-import static org.junit.platform.commons.util.ReflectionUtils.findMethods;
 import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -28,15 +24,12 @@ import java.util.Set;
 
 import org.apiguardian.api.API;
 import org.junit.experimental.categories.Category;
-import org.junit.platform.commons.support.ModifierSupport;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
-import org.junit.platform.engine.support.descriptor.ClassSource;
-import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.runner.Description;
 
 /**
@@ -52,8 +45,8 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 
 	protected Description description;
 
-	public VintageTestDescriptor(UniqueId uniqueId, Description description) {
-		this(uniqueId, description, generateDisplayName(description), toTestSource(description));
+	public VintageTestDescriptor(UniqueId uniqueId, Description description, TestSource source) {
+		this(uniqueId, description, generateDisplayName(description), source);
 	}
 
 	VintageTestDescriptor(UniqueId uniqueId, Description description, String displayName, TestSource source) {
@@ -142,40 +135,6 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 					.forEachOrdered(tags::add);
 			// @formatter:on
 		}
-	}
-
-	private static TestSource toTestSource(Description description) {
-		Class<?> testClass = description.getTestClass();
-		if (testClass != null) {
-			String methodName = description.getMethodName();
-			if (methodName != null) {
-				Method method = findMethod(testClass, methodName);
-				if (method != null) {
-					return MethodSource.from(testClass, method);
-				}
-			}
-			return ClassSource.from(testClass);
-		}
-		return null;
-	}
-
-	private static Method findMethod(Class<?> testClass, String methodName) {
-		if (methodName.contains("[") && methodName.endsWith("]")) {
-			// special case for parameterized tests
-			return findMethod(testClass, methodName.substring(0, methodName.indexOf("[")));
-		}
-		List<Method> methods = findMethods(testClass, where(Method::getName, isEqual(methodName)));
-		if (methods.isEmpty()) {
-			return null;
-		}
-		if (methods.size() == 1) {
-			return methods.get(0);
-		}
-		methods = methods.stream().filter(ModifierSupport::isPublic).collect(toList());
-		if (methods.size() == 1) {
-			return methods.get(0);
-		}
-		return null;
 	}
 
 }

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessor.java
@@ -23,6 +23,7 @@ import java.util.function.IntFunction;
 import org.junit.platform.engine.UniqueId;
 import org.junit.runner.Description;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
+import org.junit.vintage.engine.descriptor.TestSourceProvider;
 import org.junit.vintage.engine.descriptor.VintageTestDescriptor;
 import org.junit.vintage.engine.support.UniqueIdReader;
 import org.junit.vintage.engine.support.UniqueIdStringifier;
@@ -34,6 +35,11 @@ class RunnerTestDescriptorPostProcessor {
 
 	private final UniqueIdReader uniqueIdReader = new UniqueIdReader();
 	private final UniqueIdStringifier uniqueIdStringifier = new UniqueIdStringifier();
+	private final TestSourceProvider testSourceProvider;
+
+	public RunnerTestDescriptorPostProcessor(TestSourceProvider testSourceProvider) {
+		this.testSourceProvider = testSourceProvider;
+	}
 
 	void applyFiltersAndCreateDescendants(RunnerTestDescriptor runnerTestDescriptor) {
 		addChildrenRecursively(runnerTestDescriptor);
@@ -53,7 +59,8 @@ class RunnerTestDescriptorPostProcessor {
 				String reallyUniqueId = uniqueIdGenerator.apply(index);
 				Description description = childrenWithSameUniqueId.get(index);
 				UniqueId id = parent.getUniqueId().append(VintageTestDescriptor.SEGMENT_TYPE_TEST, reallyUniqueId);
-				VintageTestDescriptor child = new VintageTestDescriptor(id, description);
+				VintageTestDescriptor child = new VintageTestDescriptor(id, description,
+					testSourceProvider.findTestSource(description));
 				parent.addChild(child);
 				addChildrenRecursively(child);
 			}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
@@ -17,9 +17,10 @@ import org.junit.platform.commons.util.ClassFilter;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
+import org.junit.vintage.engine.descriptor.TestSourceProvider;
+import org.junit.vintage.engine.descriptor.VintageEngineDescriptor;
 
 /**
  * @since 4.12
@@ -37,10 +38,11 @@ public class VintageDiscoverer {
 			.build();
 	// @formatter:on
 
-	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
-		EngineDescriptor engineDescriptor = new EngineDescriptor(uniqueId, "JUnit Vintage");
+	public VintageEngineDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+		TestSourceProvider testSourceProvider = new TestSourceProvider();
+		VintageEngineDescriptor engineDescriptor = new VintageEngineDescriptor(uniqueId, testSourceProvider);
 		resolver.resolve(discoveryRequest, engineDescriptor);
-		RunnerTestDescriptorPostProcessor postProcessor = new RunnerTestDescriptorPostProcessor();
+		RunnerTestDescriptorPostProcessor postProcessor = new RunnerTestDescriptorPostProcessor(testSourceProvider);
 		// @formatter:off
 		engineDescriptor.getChildren().stream()
 				.filter(RunnerTestDescriptor.class::isInstance)

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunListenerAdapter.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunListenerAdapter.java
@@ -25,6 +25,7 @@ import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
+import org.junit.vintage.engine.descriptor.TestSourceProvider;
 import org.junit.vintage.engine.descriptor.VintageTestDescriptor;
 import org.junit.vintage.engine.support.UniqueIdReader;
 import org.junit.vintage.engine.support.UniqueIdStringifier;
@@ -36,11 +37,13 @@ class RunListenerAdapter extends RunListener {
 
 	private final TestRun testRun;
 	private final EngineExecutionListener listener;
+	private TestSourceProvider testSourceProvider;
 	private final Function<Description, String> uniqueIdExtractor;
 
-	RunListenerAdapter(TestRun testRun, EngineExecutionListener listener) {
+	RunListenerAdapter(TestRun testRun, EngineExecutionListener listener, TestSourceProvider testSourceProvider) {
 		this.testRun = testRun;
 		this.listener = listener;
+		this.testSourceProvider = testSourceProvider;
 		this.uniqueIdExtractor = new UniqueIdReader().andThen(new UniqueIdStringifier());
 	}
 
@@ -100,7 +103,8 @@ class RunListenerAdapter extends RunListener {
 		// workaround for dynamic children as used by Spock's Runner
 		TestDescriptor parent = findParent(description);
 		UniqueId uniqueId = parent.getUniqueId().append(SEGMENT_TYPE_DYNAMIC, uniqueIdExtractor.apply(description));
-		VintageTestDescriptor dynamicDescriptor = new VintageTestDescriptor(uniqueId, description);
+		VintageTestDescriptor dynamicDescriptor = new VintageTestDescriptor(uniqueId, description,
+			testSourceProvider.findTestSource(description));
 		parent.addChild(dynamicDescriptor);
 		testRun.registerDynamicTest(dynamicDescriptor);
 		dynamicTestRegistered(dynamicDescriptor);

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunListenerAdapter.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunListenerAdapter.java
@@ -37,7 +37,7 @@ class RunListenerAdapter extends RunListener {
 
 	private final TestRun testRun;
 	private final EngineExecutionListener listener;
-	private TestSourceProvider testSourceProvider;
+	private final TestSourceProvider testSourceProvider;
 	private final Function<Description, String> uniqueIdExtractor;
 
 	RunListenerAdapter(TestRun testRun, EngineExecutionListener listener, TestSourceProvider testSourceProvider) {

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunnerExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunnerExecutor.java
@@ -19,6 +19,7 @@ import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.runner.JUnitCore;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
+import org.junit.vintage.engine.descriptor.TestSourceProvider;
 
 /**
  * @since 4.12
@@ -27,15 +28,17 @@ import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
 public class RunnerExecutor {
 
 	private final EngineExecutionListener engineExecutionListener;
+	private TestSourceProvider testSourceProvider;
 
-	public RunnerExecutor(EngineExecutionListener engineExecutionListener) {
+	public RunnerExecutor(EngineExecutionListener engineExecutionListener, TestSourceProvider testSourceProvider) {
 		this.engineExecutionListener = engineExecutionListener;
+		this.testSourceProvider = testSourceProvider;
 	}
 
 	public void execute(RunnerTestDescriptor runnerTestDescriptor) {
 		TestRun testRun = new TestRun(runnerTestDescriptor);
 		JUnitCore core = new JUnitCore();
-		core.addListener(new RunListenerAdapter(testRun, engineExecutionListener));
+		core.addListener(new RunListenerAdapter(testRun, engineExecutionListener, testSourceProvider));
 		try {
 			core.run(runnerTestDescriptor.toRequest());
 		}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunnerExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunnerExecutor.java
@@ -28,7 +28,7 @@ import org.junit.vintage.engine.descriptor.TestSourceProvider;
 public class RunnerExecutor {
 
 	private final EngineExecutionListener engineExecutionListener;
-	private TestSourceProvider testSourceProvider;
+	private final TestSourceProvider testSourceProvider;
 
 	public RunnerExecutor(EngineExecutionListener engineExecutionListener, TestSourceProvider testSourceProvider) {
 		this.engineExecutionListener = engineExecutionListener;

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/descriptor/TestSourceProviderTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/descriptor/TestSourceProviderTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.descriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.runner.Description;
+import org.junit.vintage.engine.samples.junit4.ConcreteJUnit4TestCase;
+
+/**
+ * @since 5.6
+ */
+class TestSourceProviderTests {
+
+	@Test
+	void findsInheritedMethod() {
+		Description description = Description.createTestDescription(ConcreteJUnit4TestCase.class, "theTest");
+
+		TestSource source = new TestSourceProvider().findTestSource(description);
+		assertThat(source).isInstanceOf(MethodSource.class);
+
+		MethodSource methodSource = (MethodSource) source;
+		assertEquals(ConcreteJUnit4TestCase.class.getName(), methodSource.getClassName());
+		assertEquals("theTest", methodSource.getMethodName());
+	}
+
+}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/descriptor/VintageTestDescriptorTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/descriptor/VintageTestDescriptorTests.java
@@ -10,47 +10,30 @@
 
 package org.junit.vintage.engine.descriptor;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
-import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.runner.Description;
+import org.junit.vintage.engine.samples.junit4.ConcreteJUnit4TestCase;
 
 class VintageTestDescriptorTests {
 
 	private static final UniqueId uniqueId = UniqueId.forEngine("vintage");
 
 	@Test
-	void constructFromInheritedMethod() {
-		Description description = Description.createTestDescription(ConcreteTest.class, "theTest");
-		VintageTestDescriptor descriptor = new VintageTestDescriptor(uniqueId, description);
-
-		Optional<TestSource> sourceOptional = descriptor.getSource();
-		assertThat(sourceOptional).containsInstanceOf(MethodSource.class);
-
-		MethodSource methodSource = (MethodSource) sourceOptional.get();
-		assertEquals(ConcreteTest.class.getName(), methodSource.getClassName());
-		assertEquals("theTest", methodSource.getMethodName());
-	}
-
-	@Test
 	void legacyReportingNameUsesClassName() {
-		Description description = Description.createSuiteDescription(ConcreteTest.class);
-		VintageTestDescriptor testDescriptor = new VintageTestDescriptor(uniqueId, description);
+		Description description = Description.createSuiteDescription(ConcreteJUnit4TestCase.class);
+		VintageTestDescriptor testDescriptor = new VintageTestDescriptor(uniqueId, description, null);
 
-		assertEquals("org.junit.vintage.engine.descriptor.VintageTestDescriptorTests$ConcreteTest",
+		assertEquals("org.junit.vintage.engine.samples.junit4.ConcreteJUnit4TestCase",
 			testDescriptor.getLegacyReportingName());
 	}
 
 	@Test
 	void legacyReportingNameUsesMethodName() {
-		Description description = Description.createTestDescription(ConcreteTest.class, "legacyTest");
-		VintageTestDescriptor testDescriptor = new VintageTestDescriptor(uniqueId, description);
+		Description description = Description.createTestDescription(ConcreteJUnit4TestCase.class, "legacyTest");
+		VintageTestDescriptor testDescriptor = new VintageTestDescriptor(uniqueId, description, null);
 
 		assertEquals("legacyTest", testDescriptor.getLegacyReportingName());
 	}
@@ -59,19 +42,10 @@ class VintageTestDescriptorTests {
 	void legacyReportingNameFallbackToDisplayName() {
 		String suiteName = "Legacy Suite";
 		Description description = Description.createSuiteDescription(suiteName);
-		VintageTestDescriptor testDescriptor = new VintageTestDescriptor(uniqueId, description);
+		VintageTestDescriptor testDescriptor = new VintageTestDescriptor(uniqueId, description, null);
 
 		assertEquals(testDescriptor.getDisplayName(), testDescriptor.getLegacyReportingName());
 		assertEquals(suiteName, testDescriptor.getLegacyReportingName());
 	}
 
-	private abstract static class AbstractTestBase {
-
-		@Test
-		public void theTest() {
-		}
-	}
-
-	private static class ConcreteTest extends AbstractTestBase {
-	}
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessorTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessorTests.java
@@ -27,6 +27,7 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.vintage.engine.VintageUniqueIdBuilder;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
+import org.junit.vintage.engine.descriptor.TestSourceProvider;
 import org.junit.vintage.engine.samples.junit4.IgnoredJUnit4TestCase;
 import org.junit.vintage.engine.samples.junit4.IgnoredJUnit4TestCaseWithNotFilterableRunner;
 import org.junit.vintage.engine.samples.junit4.NotFilterableRunner;
@@ -73,7 +74,8 @@ class RunnerTestDescriptorPostProcessorTests {
 		TestDescriptor engineDescriptor = new VintageDiscoverer().discover(request, VintageUniqueIdBuilder.engineId());
 		RunnerTestDescriptor runnerTestDescriptor = (RunnerTestDescriptor) getOnlyElement(
 			engineDescriptor.getChildren());
-		new RunnerTestDescriptorPostProcessor().applyFiltersAndCreateDescendants(runnerTestDescriptor);
+		new RunnerTestDescriptorPostProcessor(new TestSourceProvider()).applyFiltersAndCreateDescendants(
+			runnerTestDescriptor);
 	}
 
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/execution/TestRunTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/execution/TestRunTests.java
@@ -54,7 +54,8 @@ class TestRunTests {
 			new BlockJUnit4ClassRunner(testClass));
 		UniqueId dynamicTestId = runnerId.append(SEGMENT_TYPE_DYNAMIC, "dynamicTest");
 		Description dynamicDescription = createTestDescription(testClass, "dynamicTest");
-		VintageTestDescriptor dynamicTestDescriptor = new VintageTestDescriptor(dynamicTestId, dynamicDescription);
+		VintageTestDescriptor dynamicTestDescriptor = new VintageTestDescriptor(dynamicTestId, dynamicDescription,
+			null);
 
 		TestRun testRun = new TestRun(runnerTestDescriptor);
 		testRun.registerDynamicTest(dynamicTestDescriptor);

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/AbstractJUnit4TestCase.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/AbstractJUnit4TestCase.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractJUnit4TestCase {
+
+	@Test
+	public void theTest() {
+	}
+
+}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/ConcreteJUnit4TestCase.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/ConcreteJUnit4TestCase.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+public class ConcreteJUnit4TestCase extends AbstractJUnit4TestCase {
+}

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/LruCacheTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/LruCacheTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @since 1.6
+ */
+class LruCacheTests {
+
+	@Test
+	void evictsEldestEntryWhenMaxSizeIsReached() {
+		var cache = new LruCache<String, String>(1);
+
+		cache.put("foo", "bar");
+		cache.put("bar", "baz");
+
+		assertThat(cache) //
+				.containsExactly(entry("bar", "baz")) //
+				.hasSize(1);
+	}
+
+}


### PR DESCRIPTION
Prior to this commit, we scanned the hierarchy of a test class for
methods once for every test method. This lead to quadratic runtime
behavior and was problematic for large test classes. Now, the new
`TestSourceProvider` caches the methods of a class so that we only need
to filter that list once for every test method.

## Before

<img width="799" alt="Screenshot 2019-09-14 at 20 53 07" src="https://user-images.githubusercontent.com/214207/64912589-d9dcb400-d731-11e9-9231-7a154cfe3ecb.png">

## After

<img width="799" alt="Screenshot 2019-09-15 at 11 13 18" src="https://user-images.githubusercontent.com/214207/64919337-f288b080-d7a9-11e9-982c-6279b27878cf.png">


Resolves #1965.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
