### PR TITLE
Change Devoxx Belgium talk date

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -684,7 +684,7 @@
   {
     "title": "JUnit: time to shift into 5th gear!",
     "event": "Devoxx Belgium",
-    "date": "2019-11-05",
+    "date": "2019-11-07",
     "location": "Antwerp, Belgium",
     "link": "https://devoxx.be/talk/?id=17601",
     "speakers": [


### PR DESCRIPTION
Changing Devoxx "Junit: time to shift into 5th gear" event date since the schedule has been released.
