### PR TITLE
Add support for LGTM scanner

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  java:
+    index:
+      java_version: "12"


### PR DESCRIPTION
## Overview

Fix lgtm build due to requiring JDK 12
https://lgtm.com/projects/g/junit-team/junit5

GitHub has acquired Semmle (creators of LGTM).

https://blog.semmle.com/secure-software-github-semmle/?utm_content=101286158&utm_medium=social&utm_source=twitter&hss_channel=tw-4896799426

I wanted to see if Semmle caught any errors against JUnit5 but the build fails because it attempts to use the wrong JDK version. Also, it's currently not possible to use the QL language to query the Java source of Junit5 due to not being able to build properly.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
