### PR TITLE
Fix link to LICENSE.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 ### Project Licenses
 
-- All modules use [Eclipse Public License v2.0](junit-jupiter-api/LICENSE.md).
+- All modules use [Eclipse Public License v2.0](LICENSE.md).
 
 ## Commit Messages
 


### PR DESCRIPTION
I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).