### PR TITLE
Improve performance of Vintage engine

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -82,6 +82,10 @@ public class UniqueId implements Cloneable, Serializable {
 
 	private final UniqueIdFormat uniqueIdFormat;
 	private final List<Segment> segments;
+	// lazily computed
+	private transient int hashCode;
+	// lazily computed
+	private transient String toString;
 
 	private UniqueId(UniqueIdFormat uniqueIdFormat, Segment segment) {
 		this.uniqueIdFormat = uniqueIdFormat;
@@ -221,7 +225,23 @@ public class UniqueId implements Cloneable, Serializable {
 
 	@Override
 	public int hashCode() {
-		return this.segments.hashCode();
+		int value = this.hashCode;
+		if (value == 0) {
+			value = this.segments.hashCode();
+			if (value == 0) {
+				// handle the edge case of the computed hashCode being 0
+				value = 1;
+			}
+			// this is a benign race like String#hash
+			// we potentially read and write values from multiple threads
+			// without a happens-before relationship
+			// however the JMM guarantees us that we only ever see values
+			// that were valid at one point, either 0 or the hash code
+			// so we might end up not seeing a value that a different thread
+			// has computed or multiple threads writing the same value
+			this.hashCode = value;
+		}
+		return value;
 	}
 
 	/**
@@ -230,7 +250,19 @@ public class UniqueId implements Cloneable, Serializable {
 	 */
 	@Override
 	public String toString() {
-		return this.uniqueIdFormat.format(this);
+		String s = this.toString;
+		if (s == null) {
+			s = this.uniqueIdFormat.format(this);
+			// this is a benign race like String#hash
+			// we potentially read and write values from multiple threads
+			// without a happens-before relationship
+			// however the JMM guarantees us that we only ever see values
+			// that were valid at one point, either null or the toString value
+			// so we might end up not seeing a value that a different thread
+			// has computed or multiple threads writing the same value
+			this.toString = s;
+		}
+		return s;
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
@@ -19,9 +19,9 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -63,7 +63,7 @@ class UniqueIdFormat implements Serializable {
 	private final char segmentDelimiter;
 	private final char typeValueSeparator;
 	private final Pattern segmentPattern;
-	private final Map<Character, String> encodedCharacterMap = new TreeMap<>();
+	private final Map<Character, String> encodedCharacterMap = new HashMap<>();
 
 	UniqueIdFormat(char openSegment, char typeValueSeparator, char closeSegment, char segmentDelimiter) {
 		this.openSegment = openSegment;
@@ -137,8 +137,9 @@ class UniqueIdFormat implements Serializable {
 	}
 
 	private String encode(String s) {
-		StringBuilder builder = new StringBuilder();
-		for (char c : s.toCharArray()) {
+		StringBuilder builder = new StringBuilder(s.length());
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
 			String value = encodedCharacterMap.get(c);
 			if (value == null) {
 				builder.append(c);


### PR DESCRIPTION
## Overview

Improves performance Parameterized vintage engine with the following
changes:

- add map to TestRun to track in progress TestDescriptors
- memoize UniqueId#hashCode
- memoize UniqueId#toString
- avoid intermediate char[] allocation when formatting UniqueId

Issue: #2030

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
