### PR TITLE
Implement safer variant to ensure CDATA end markers result in valid XML

### DIFF
--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -51,8 +52,7 @@ import org.junit.platform.launcher.listeners.LegacyReportingUtils;
  */
 class XmlReportWriter {
 
-	private static final String CDATA_START = "<![CDATA[";
-	private static final String CDATA_END = "]]>";
+	private static final Pattern CDATA_SPLIT_PATTERN = Pattern.compile("(?<=]])(?=>)");
 
 	private final XmlReportData reportData;
 
@@ -296,7 +296,9 @@ class XmlReportWriter {
 	}
 
 	private void writeCDataSafely(XMLStreamWriter writer, String data) throws XMLStreamException {
-		writer.writeCData(data.replace(CDATA_END, "]]" + CDATA_END + CDATA_START + ">"));
+		for (String safeDataPart : CDATA_SPLIT_PATTERN.split(data)) {
+			writer.writeCData(safeDataPart);
+		}
 	}
 
 	private void newLine(XMLStreamWriter xmlWriter) throws XMLStreamException {

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -52,6 +52,8 @@ import org.junit.platform.launcher.listeners.LegacyReportingUtils;
  */
 class XmlReportWriter {
 
+	// Using zero-width assertions in the split pattern simplifies the splitting process: All split parts
+	// (including the first and last one) can be used directly, without having to re-add separator characters.
 	private static final Pattern CDATA_SPLIT_PATTERN = Pattern.compile("(?<=]])(?=>)");
 
 	private final XmlReportData reportData;

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
@@ -229,26 +229,15 @@ class XmlReportWriterTests {
 		XmlReportData reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		AssertionError assertionError = new AssertionError("<foo><![CDATA[bar]]></foo>");
 		reportData.markFinished(testPlan.getTestIdentifier(uniqueId.toString()), failed(assertionError));
-		Writer assertingNullWriter = new Writer() {
+		Writer assertingWriter = new StringWriter() {
 
 			@Override
 			public void write(char[] cbuf, int off, int len) {
-				//@formatter:off
-				assertThat(new String(cbuf, off, len))
-						.doesNotContain("]]><![CDATA[");
-				//@formatter:on
-			}
-
-			@Override
-			public void flush() {
-			}
-
-			@Override
-			public void close() {
+				assertThat(new String(cbuf, off, len)).doesNotContain("]]><![CDATA[");
 			}
 		};
 
-		writeXmlReport(testPlan, reportData, assertingNullWriter);
+		writeXmlReport(testPlan, reportData, assertingWriter);
 	}
 
 	private String writeXmlReport(TestPlan testPlan, XmlReportData reportData) throws Exception {


### PR DESCRIPTION
## Overview

This PR changes the implementation of `XmlReportWriter. writeCDataSafely(...)` to be even safer by always passing valid CDATA content to `javax.xml.stream.XMLStreamWriter.writeCData(...)`.

The current implementation passes a String to `javax.xml.stream.XMLStreamWriter.writeCData(...)` that might not be valid CDATA content, i.e. it might contain `]]>`. This causes issues if the implementation of that method validates its parameter value.

The PR does not change the produced XML, which is covered by `XmlReportWriterTests.writesValidXmlEvenIfExceptionMessageContainsCData()`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
