### PR TITLE
Log containers and tests which are excluded by post discovery filters

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
@@ -90,11 +90,11 @@ public final class TagFilter {
 	}
 
 	private static String inclusionReasonExpressionSatisfy(List<String> tagExpressions) {
-		return String.format("Test included Because it satisfy expression(s): [%s]", formatToString(tagExpressions));
+		return String.format("included because tags match expression(s): [%s]", formatToString(tagExpressions));
 	}
 
 	private static String exclusionReasonExpressionNotSatisfy(List<String> tagExpressions) {
-		return String.format("Test excluded Because it does not satisfy expression(s): [%s]",
+		return String.format("excluded because tags do not match tag expression(s): [%s]",
 			formatToString(tagExpressions));
 
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -11,10 +11,8 @@
 package org.junit.platform.launcher.core;
 
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
@@ -168,7 +166,6 @@ class DefaultLauncher implements Launcher {
 			root.add(testEngine, rootDescriptor);
 		}
 		root.applyPostDiscoveryFilters(discoveryRequest);
-		printFilteredReason(root);
 		root.prune();
 		return root;
 	}
@@ -252,14 +249,4 @@ class DefaultLauncher implements Launcher {
 		}
 	}
 
-	/**
-	 * prints the reason for test cases that are excluded in post discovery filter phase.
-	 * @param root of the all engines.
-	 */
-	private void printFilteredReason(Root root) {
-		root.getExclusionReasonToDescriptorMap().forEach((key, value) -> {
-			String displayNames = value.stream().map(TestDescriptor::getDisplayName).collect(Collectors.joining(", "));
-			logger.debug(() -> String.format("Method names [%s] excluded, reason [%s]", displayNames, key));
-		});
-	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -13,6 +13,8 @@ package org.junit.platform.launcher.core;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.Optional;
+
 
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
@@ -167,6 +168,7 @@ class DefaultLauncher implements Launcher {
 			root.add(testEngine, rootDescriptor);
 		}
 		root.applyPostDiscoveryFilters(discoveryRequest);
+		printFilteredReason(root);
 		root.prune();
 		return root;
 	}
@@ -250,4 +252,14 @@ class DefaultLauncher implements Launcher {
 		}
 	}
 
+	/**
+	 * prints the reason for test cases that are excluded in post discovery filter phase.
+	 * @param root of the all engines.
+	 */
+	private void printFilteredReason(Root root) {
+		root.getExclusionReasonToDescriptorMap().forEach((key, value) -> {
+			String displayNames = value.stream().map(TestDescriptor::getDisplayName).collect(Collectors.joining(", "));
+			logger.debug(() -> String.format("Method names [%s] excluded, reason [%s]", displayNames, key));
+		});
+	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -11,10 +11,9 @@
 package org.junit.platform.launcher.core;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.Optional;
-
 
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
@@ -152,7 +152,7 @@ class TagFilterTests {
 
 		assertReason(filter.apply(classWithTag1), "Test included Because it satisfy expression(s): [tag1]");
 		assertReason(filter.apply(classWithTag1AndSurroundingWhitespace),
-				"Test included Because it satisfy expression(s): [tag1]");
+			"Test included Because it satisfy expression(s): [tag1]");
 		assertReason(filter.apply(classWithBothTags), "Test included Because it satisfy expression(s): [tag1]");
 
 		assertTrue(filter.apply(classWithTag2).excluded());
@@ -161,7 +161,7 @@ class TagFilterTests {
 
 		assertReason(filter.apply(classWithTag2), "Test excluded Because it does not satisfy expression(s): [tag1]");
 		assertReason(filter.apply(classWithDifferentTags),
-				"Test excluded Because it does not satisfy expression(s): [tag1]");
+			"Test excluded Because it does not satisfy expression(s): [tag1]");
 		assertReason(filter.apply(classWithNoTags), "Test excluded Because it does not satisfy expression(s): [tag1]");
 
 	}
@@ -173,7 +173,7 @@ class TagFilterTests {
 
 		assertReason(filter.apply(classWithTag1), "Test excluded Because it satisfy expression(s): [tag1]");
 		assertReason(filter.apply(classWithTag1AndSurroundingWhitespace),
-				"Test excluded Because it satisfy expression(s): [tag1]");
+			"Test excluded Because it satisfy expression(s): [tag1]");
 		assertReason(filter.apply(classWithBothTags), "Test excluded Because it satisfy expression(s): [tag1]");
 
 		assertTrue(filter.apply(classWithTag2).included());
@@ -182,7 +182,7 @@ class TagFilterTests {
 
 		assertReason(filter.apply(classWithTag2), "Test included Because it does not satisfy expression(s): [tag1]");
 		assertReason(filter.apply(classWithDifferentTags),
-				"Test included Because it does not satisfy expression(s): [tag1]");
+			"Test included Because it does not satisfy expression(s): [tag1]");
 		assertReason(filter.apply(classWithNoTags), "Test included Because it does not satisfy expression(s): [tag1]");
 
 	}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
@@ -150,23 +150,19 @@ class TagFilterTests {
 		assertTrue(filter.apply(classWithTag1AndSurroundingWhitespace).included());
 		assertTrue(filter.apply(classWithBothTags).included());
 
-		assertThat(filter.apply(classWithTag1).getReason().get()).contains(
-			"Test included Because it contains tags: [tag1]");
-		assertThat(filter.apply(classWithTag1AndSurroundingWhitespace).getReason().get()).contains(
-			"Test included Because it contains tags: [tag1]");
-		assertThat(filter.apply(classWithBothTags).getReason().get()).contains(
-			"Test included Because it contains tags: [tag1,tag2]");
+		assertReason(filter.apply(classWithTag1), "Test included Because it satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithTag1AndSurroundingWhitespace),
+				"Test included Because it satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithBothTags), "Test included Because it satisfy expression(s): [tag1]");
 
 		assertTrue(filter.apply(classWithTag2).excluded());
 		assertTrue(filter.apply(classWithDifferentTags).excluded());
 		assertTrue(filter.apply(classWithNoTags).excluded());
 
-		assertThat(filter.apply(classWithTag2).getReason().get()).contains(
-			"Test excluded Because it contains tags: [tag2]");
-		assertThat(filter.apply(classWithDifferentTags).getReason().get()).contains(
-			"Test excluded Because it contains tags: [foo,bar]");
-		assertThat(filter.apply(classWithNoTags).getReason().get()).contains(
-			"Test excluded Because it contains tags: []");
+		assertReason(filter.apply(classWithTag2), "Test excluded Because it does not satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithDifferentTags),
+				"Test excluded Because it does not satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithNoTags), "Test excluded Because it does not satisfy expression(s): [tag1]");
 
 	}
 
@@ -175,24 +171,24 @@ class TagFilterTests {
 		assertTrue(filter.apply(classWithTag1AndSurroundingWhitespace).excluded());
 		assertTrue(filter.apply(classWithBothTags).excluded());
 
-		assertThat(filter.apply(classWithTag1).getReason().get()).contains(
-			"Test excluded Because it contains tags: [tag1]");
-		assertThat(filter.apply(classWithTag1AndSurroundingWhitespace).getReason().get()).contains(
-			"Test excluded Because it contains tags: [tag1]");
-		assertThat(filter.apply(classWithBothTags).getReason().get()).contains(
-			"Test excluded Because it contains tags: [tag1,tag2]");
+		assertReason(filter.apply(classWithTag1), "Test excluded Because it satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithTag1AndSurroundingWhitespace),
+				"Test excluded Because it satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithBothTags), "Test excluded Because it satisfy expression(s): [tag1]");
 
 		assertTrue(filter.apply(classWithTag2).included());
 		assertTrue(filter.apply(classWithDifferentTags).included());
 		assertTrue(filter.apply(classWithNoTags).included());
 
-		assertThat(filter.apply(classWithTag2).getReason().get()).contains(
-			"Test included Because it contains tags: [tag2]");
-		assertThat(filter.apply(classWithDifferentTags).getReason().get()).contains(
-			"Test included Because it contains tags: [foo,bar]");
-		assertThat(filter.apply(classWithNoTags).getReason().get()).contains(
-			"Test included Because it contains tags: []");
+		assertReason(filter.apply(classWithTag2), "Test included Because it does not satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithDifferentTags),
+				"Test included Because it does not satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithNoTags), "Test included Because it does not satisfy expression(s): [tag1]");
 
+	}
+
+	private void assertReason(FilterResult filterResult, String expectedReason) {
+		assertThat(filterResult.getReason()).isPresent().contains(expectedReason);
 	}
 
 	// -------------------------------------------------------------------------

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
@@ -151,19 +151,19 @@ class TagFilterTests {
 		assertTrue(filter.apply(classWithTag1AndSurroundingWhitespace).included());
 		assertTrue(filter.apply(classWithBothTags).included());
 
-		assertReason(filter.apply(classWithTag1), "Test included Because it satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithTag1), "included because tags match expression(s): [tag1]");
 		assertReason(filter.apply(classWithTag1AndSurroundingWhitespace),
-			"Test included Because it satisfy expression(s): [tag1]");
-		assertReason(filter.apply(classWithBothTags), "Test included Because it satisfy expression(s): [tag1]");
+			"included because tags match expression(s): [tag1]");
+		assertReason(filter.apply(classWithBothTags), "included because tags match expression(s): [tag1]");
 
 		assertTrue(filter.apply(classWithTag2).excluded());
 		assertTrue(filter.apply(classWithDifferentTags).excluded());
 		assertTrue(filter.apply(classWithNoTags).excluded());
 
-		assertReason(filter.apply(classWithTag2), "Test excluded Because it does not satisfy expression(s): [tag1]");
+		assertReason(filter.apply(classWithTag2), "excluded because tags do not match tag expression(s): [tag1]");
 		assertReason(filter.apply(classWithDifferentTags),
-			"Test excluded Because it does not satisfy expression(s): [tag1]");
-		assertReason(filter.apply(classWithNoTags), "Test excluded Because it does not satisfy expression(s): [tag1]");
+			"excluded because tags do not match tag expression(s): [tag1]");
+		assertReason(filter.apply(classWithNoTags), "excluded because tags do not match tag expression(s): [tag1]");
 
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.DemoClassTestDescriptor;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
@@ -150,9 +150,24 @@ class TagFilterTests {
 		assertTrue(filter.apply(classWithTag1AndSurroundingWhitespace).included());
 		assertTrue(filter.apply(classWithBothTags).included());
 
+		assertThat(filter.apply(classWithTag1).getReason().get()).contains(
+			"Test included Because it contains tags: [tag1]");
+		assertThat(filter.apply(classWithTag1AndSurroundingWhitespace).getReason().get()).contains(
+			"Test included Because it contains tags: [tag1]");
+		assertThat(filter.apply(classWithBothTags).getReason().get()).contains(
+			"Test included Because it contains tags: [tag1,tag2]");
+
 		assertTrue(filter.apply(classWithTag2).excluded());
 		assertTrue(filter.apply(classWithDifferentTags).excluded());
 		assertTrue(filter.apply(classWithNoTags).excluded());
+
+		assertThat(filter.apply(classWithTag2).getReason().get()).contains(
+			"Test excluded Because it contains tags: [tag2]");
+		assertThat(filter.apply(classWithDifferentTags).getReason().get()).contains(
+			"Test excluded Because it contains tags: [foo,bar]");
+		assertThat(filter.apply(classWithNoTags).getReason().get()).contains(
+			"Test excluded Because it contains tags: []");
+
 	}
 
 	private void excludeSingleTag(PostDiscoveryFilter filter) {
@@ -160,9 +175,24 @@ class TagFilterTests {
 		assertTrue(filter.apply(classWithTag1AndSurroundingWhitespace).excluded());
 		assertTrue(filter.apply(classWithBothTags).excluded());
 
+		assertThat(filter.apply(classWithTag1).getReason().get()).contains(
+			"Test excluded Because it contains tags: [tag1]");
+		assertThat(filter.apply(classWithTag1AndSurroundingWhitespace).getReason().get()).contains(
+			"Test excluded Because it contains tags: [tag1]");
+		assertThat(filter.apply(classWithBothTags).getReason().get()).contains(
+			"Test excluded Because it contains tags: [tag1,tag2]");
+
 		assertTrue(filter.apply(classWithTag2).included());
 		assertTrue(filter.apply(classWithDifferentTags).included());
 		assertTrue(filter.apply(classWithNoTags).included());
+
+		assertThat(filter.apply(classWithTag2).getReason().get()).contains(
+			"Test included Because it contains tags: [tag2]");
+		assertThat(filter.apply(classWithDifferentTags).getReason().get()).contains(
+			"Test included Because it contains tags: [foo,bar]");
+		assertThat(filter.apply(classWithNoTags).getReason().get()).contains(
+			"Test included Because it contains tags: []");
+
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Overview
Mention containers and tests that were ignored because of their tags or any other reason.

Current Behavior:
During the execution of post-discovery filters, tests which are excluded does not print any message/reason, which leaves developers to be unaware of the reason for exclusion. Also, No reason was passed from TagFilter class.

Solution:
Stores the Exclusion reason against the set of TestDescriptors and print this information after the discovery phase. Passed the inclusion or exclusion reason to FilterResult for TagFilter.

Closes #1514



---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
