### PR TITLE
Improve handling of duplicate Descriptions

### DIFF
--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -10,17 +10,19 @@
 
 package org.junit.vintage.engine.execution;
 
-import static java.util.stream.Collectors.groupingBy;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Stream.concat;
-import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.TestExecutionResult.failed;
 import static org.junit.platform.engine.TestExecutionResult.successful;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -30,7 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.junit.platform.engine.TestDescriptor;
@@ -47,12 +49,14 @@ class TestRun {
 
 	private final RunnerTestDescriptor runnerTestDescriptor;
 	private final Set<TestDescriptor> runnerDescendants;
-	private final Map<Description, List<VintageTestDescriptor>> descriptionToDescriptors;
+	private final Map<Description, VintageDescriptors> descriptionToDescriptors;
 	private final Map<TestDescriptor, List<TestExecutionResult>> executionResults = new LinkedHashMap<>();
 	private final Set<TestDescriptor> skippedDescriptors = new LinkedHashSet<>();
 	private final Set<TestDescriptor> startedDescriptors = new HashSet<>();
 	private final Map<TestDescriptor, EventType> inProgressDescriptors = new LinkedHashMap<>();
 	private final Set<TestDescriptor> finishedDescriptors = new LinkedHashSet<>();
+	private final ThreadLocal<Deque<VintageTestDescriptor>> inProgressDescriptorsByStartingThread = ThreadLocal.withInitial(
+		ArrayDeque::new);
 
 	TestRun(RunnerTestDescriptor runnerTestDescriptor) {
 		this.runnerTestDescriptor = runnerTestDescriptor;
@@ -60,14 +64,13 @@ class TestRun {
 		// @formatter:off
 		descriptionToDescriptors = concat(Stream.of(runnerTestDescriptor), runnerDescendants.stream())
 				.map(VintageTestDescriptor.class::cast)
-				.collect(groupingBy(
-						VintageTestDescriptor::getDescription, HashMap::new, toCollection(ArrayList::new)));
+				.collect(toMap(VintageTestDescriptor::getDescription, VintageDescriptors::new, VintageDescriptors::merge, HashMap::new));
 		// @formatter:on
 	}
 
 	void registerDynamicTest(VintageTestDescriptor testDescriptor) {
-		descriptionToDescriptors.computeIfAbsent(testDescriptor.getDescription(),
-			key -> new CopyOnWriteArrayList<>()).add(testDescriptor);
+		descriptionToDescriptors.computeIfAbsent(testDescriptor.getDescription(), __ -> new VintageDescriptors()).add(
+			testDescriptor);
 		runnerDescendants.add(testDescriptor);
 	}
 
@@ -88,35 +91,37 @@ class TestRun {
 		return runnerDescendants.contains(testDescriptor);
 	}
 
-	/**
-	 * Returns the {@link TestDescriptor} that represents the specified
-	 * {@link Description}.
-	 *
-	 * <p>There are edge cases where multiple {@link Description Descriptions}
-	 * with the same {@code uniqueId} exist, e.g. when using overloaded methods
-	 * to define {@linkplain org.junit.experimental.theories.Theory theories}.
-	 * In this case, we try to find the correct {@link TestDescriptor} by
-	 * checking for object identity on the {@link Description} it represents.
-	 *
-	 * @param description the {@code Description} to look up
-	 */
-	Optional<VintageTestDescriptor> lookupTestDescriptor(Description description) {
-		List<VintageTestDescriptor> descriptors = descriptionToDescriptors.get(description);
-		if (descriptors == null) {
+	Optional<VintageTestDescriptor> lookupNextTestDescriptor(Description description) {
+		return lookupUnambiguouslyOrApplyFallback(description, VintageDescriptors::getNextUnstarted);
+	}
+
+	Optional<VintageTestDescriptor> lookupCurrentTestDescriptor(Description description) {
+		return lookupUnambiguouslyOrApplyFallback(description, __ -> {
+			VintageTestDescriptor lastStarted = inProgressDescriptorsByStartingThread.get().peekLast();
+			if (lastStarted != null && description.equals(lastStarted.getDescription())) {
+				return Optional.of(lastStarted);
+			}
 			return Optional.empty();
+		});
+	}
+
+	private Optional<VintageTestDescriptor> lookupUnambiguouslyOrApplyFallback(Description description,
+			Function<VintageDescriptors, Optional<VintageTestDescriptor>> fallback) {
+		VintageDescriptors vintageDescriptors = descriptionToDescriptors.getOrDefault(description,
+			VintageDescriptors.NONE);
+		Optional<VintageTestDescriptor> result = vintageDescriptors.getUnambiguously(description);
+		if (!result.isPresent()) {
+			result = fallback.apply(vintageDescriptors);
 		}
-		if (descriptors.size() == 1) {
-			return Optional.of(getOnlyElement(descriptors));
-		}
-		// @formatter:off
-		return descriptors.stream()
-				.filter(testDescriptor -> description == testDescriptor.getDescription())
-				.findFirst();
-		// @formatter:on
+		return result;
 	}
 
 	void markSkipped(TestDescriptor testDescriptor) {
 		skippedDescriptors.add(testDescriptor);
+		if (testDescriptor instanceof VintageTestDescriptor) {
+			VintageTestDescriptor vintageDescriptor = (VintageTestDescriptor) testDescriptor;
+			descriptionToDescriptors.get(vintageDescriptor.getDescription()).incrementSkippedOrStarted();
+		}
 	}
 
 	boolean isNotSkipped(TestDescriptor testDescriptor) {
@@ -130,6 +135,11 @@ class TestRun {
 	void markStarted(TestDescriptor testDescriptor, EventType eventType) {
 		inProgressDescriptors.put(testDescriptor, eventType);
 		startedDescriptors.add(testDescriptor);
+		if (testDescriptor instanceof VintageTestDescriptor) {
+			VintageTestDescriptor vintageDescriptor = (VintageTestDescriptor) testDescriptor;
+			inProgressDescriptorsByStartingThread.get().addLast(vintageDescriptor);
+			descriptionToDescriptors.get(vintageDescriptor.getDescription()).incrementSkippedOrStarted();
+		}
 	}
 
 	boolean isNotStarted(TestDescriptor testDescriptor) {
@@ -139,6 +149,10 @@ class TestRun {
 	void markFinished(TestDescriptor testDescriptor) {
 		inProgressDescriptors.remove(testDescriptor);
 		finishedDescriptors.add(testDescriptor);
+		if (testDescriptor instanceof VintageTestDescriptor) {
+			VintageTestDescriptor descriptor = (VintageTestDescriptor) testDescriptor;
+			inProgressDescriptorsByStartingThread.get().removeLastOccurrence(descriptor);
+		}
 	}
 
 	boolean isNotFinished(TestDescriptor testDescriptor) {
@@ -181,4 +195,76 @@ class TestRun {
 		// @formatter:on
 		return failed(new MultipleFailuresError("", failures));
 	}
+
+	private static class VintageDescriptors {
+
+		private static final VintageDescriptors NONE = new VintageDescriptors(emptyList());
+
+		private final List<VintageTestDescriptor> descriptors;
+		private int skippedOrStartedCount;
+
+		static VintageDescriptors merge(VintageDescriptors a, VintageDescriptors b) {
+			List<VintageTestDescriptor> mergedDescriptors = new ArrayList<>(
+				a.descriptors.size() + b.descriptors.size());
+			mergedDescriptors.addAll(a.descriptors);
+			mergedDescriptors.addAll(b.descriptors);
+			return new VintageDescriptors(mergedDescriptors);
+		}
+
+		VintageDescriptors(VintageTestDescriptor vintageTestDescriptor) {
+			this();
+			add(vintageTestDescriptor);
+		}
+
+		VintageDescriptors() {
+			this(new ArrayList<>(1));
+		}
+
+		VintageDescriptors(List<VintageTestDescriptor> descriptors) {
+			this.descriptors = descriptors;
+		}
+
+		void add(VintageTestDescriptor descriptor) {
+			descriptors.add(descriptor);
+		}
+
+		/**
+		 * Returns the {@link TestDescriptor} that represents the specified
+		 * {@link Description}.
+		 *
+		 * <p>There are edge cases where multiple {@link Description Descriptions}
+		 * with the same {@code uniqueId} exist, e.g. when using overloaded methods
+		 * to define {@linkplain org.junit.experimental.theories.Theory theories}.
+		 * In this case, we try to find the correct {@link TestDescriptor} by
+		 * checking for object identity on the {@link Description} it represents.
+		 *
+		 * @param description the {@code Description} to look up
+		 */
+		Optional<VintageTestDescriptor> getUnambiguously(Description description) {
+			if (descriptors.isEmpty()) {
+				return Optional.empty();
+			}
+			if (descriptors.size() == 1) {
+				return Optional.of(descriptors.get(0));
+			}
+			// @formatter:off
+			return descriptors.stream()
+					.filter(testDescriptor -> description == testDescriptor.getDescription())
+					.findFirst();
+			// @formatter:on
+		}
+
+		public void incrementSkippedOrStarted() {
+			skippedOrStartedCount++;
+		}
+
+		public Optional<VintageTestDescriptor> getNextUnstarted() {
+			if (skippedOrStartedCount < descriptors.size()) {
+				return Optional.of(descriptors.get(skippedOrStartedCount));
+			}
+			return Optional.empty();
+		}
+
+	}
+
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
@@ -42,14 +42,15 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
-import org.junit.platform.testkit.engine.Events;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.junit.vintage.engine.samples.junit3.JUnit3ParallelSuiteWithSubsuites;
 import org.junit.vintage.engine.samples.junit3.PlainJUnit3TestCaseWithSingleTestWhichFails;
 import org.junit.vintage.engine.samples.junit4.CompletelyDynamicTestCase;
 import org.junit.vintage.engine.samples.junit4.EmptyIgnoredTestCase;
@@ -74,6 +75,7 @@ import org.junit.vintage.engine.samples.junit4.JUnit4TestCaseWithExceptionThrowi
 import org.junit.vintage.engine.samples.junit4.JUnit4TestCaseWithFailingDescriptionThatIsNotReportedAsFinished;
 import org.junit.vintage.engine.samples.junit4.JUnit4TestCaseWithIndistinguishableOverloadedMethod;
 import org.junit.vintage.engine.samples.junit4.JUnit4TestCaseWithRunnerWithCustomUniqueIds;
+import org.junit.vintage.engine.samples.junit4.JUnit4TestCaseWithRunnerWithDuplicateChangingChildDescriptions;
 import org.junit.vintage.engine.samples.junit4.MalformedJUnit4TestCase;
 import org.junit.vintage.engine.samples.junit4.ParameterizedTestCase;
 import org.junit.vintage.engine.samples.junit4.PlainJUnit4TestCaseWithFiveTestMethods;
@@ -92,7 +94,7 @@ class VintageTestEngineExecutionTests {
 	void executesPlainJUnit4TestCaseWithSingleTestWhichFails() {
 		Class<?> testClass = PlainJUnit4TestCaseWithSingleTestWhichFails.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(test("failingTest"), started()), //
@@ -106,7 +108,7 @@ class VintageTestEngineExecutionTests {
 	void executesPlainJUnit4TestCaseWithTwoTests() {
 		Class<?> testClass = PlainJUnit4TestCaseWithTwoTestMethods.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(test("failingTest"), started()), //
@@ -122,7 +124,7 @@ class VintageTestEngineExecutionTests {
 	void executesPlainJUnit4TestCaseWithFiveTests() {
 		Class<?> testClass = PlainJUnit4TestCaseWithFiveTestMethods.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(test("abortedTest"), started()), //
@@ -145,7 +147,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> testClass = EnclosedJUnit4TestCase.class;
 		Class<?> nestedClass = EnclosedJUnit4TestCase.NestedClass.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(container(nestedClass), started()), //
@@ -164,7 +166,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> junit4SuiteClass = JUnit4SuiteWithJUnit3SuiteWithSingleTestCase.class;
 		Class<?> testClass = PlainJUnit3TestCaseWithSingleTestWhichFails.class;
 
-		execute(junit4SuiteClass).assertEventsMatchExactly( //
+		execute(junit4SuiteClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(junit4SuiteClass), started()), //
 			event(container("TestSuite with 1 tests"), started()), //
@@ -182,7 +184,7 @@ class VintageTestEngineExecutionTests {
 	void executesMalformedJUnit4TestCase() {
 		Class<?> testClass = MalformedJUnit4TestCase.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(test("initializationError"), started()), //
@@ -195,7 +197,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4TestCaseWithErrorInBeforeClass() {
 		Class<?> testClass = JUnit4TestCaseWithErrorInBeforeClass.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(container(testClass),
@@ -208,7 +210,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> suiteClass = JUnit4SuiteWithJUnit4TestCaseWithErrorInBeforeClass.class;
 		Class<?> testClass = JUnit4TestCaseWithErrorInBeforeClass.class;
 
-		execute(suiteClass).assertEventsMatchExactly( //
+		execute(suiteClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(suiteClass), started()), //
 			event(container(testClass), started()), //
@@ -224,7 +226,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> suiteClass = JUnit4SuiteWithJUnit4TestCaseWithErrorInBeforeClass.class;
 		Class<?> testClass = JUnit4TestCaseWithErrorInBeforeClass.class;
 
-		execute(suiteOfSuiteClass).assertEventsMatchExactly( //
+		execute(suiteOfSuiteClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(suiteOfSuiteClass), started()), //
 			event(container(suiteClass), started()), //
@@ -240,7 +242,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4TestCaseWithAssumptionFailureInBeforeClass() {
 		Class<?> testClass = JUnit4TestCaseWithAssumptionFailureInBeforeClass.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(container(testClass),
@@ -254,7 +256,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> suiteClass = JUnit4SuiteWithJUnit4TestCaseWithAssumptionFailureInBeforeClass.class;
 		Class<?> testClass = JUnit4TestCaseWithAssumptionFailureInBeforeClass.class;
 
-		execute(suiteOfSuiteClass).assertEventsMatchExactly( //
+		execute(suiteOfSuiteClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(suiteOfSuiteClass), started()), //
 			event(container(suiteClass), started()), //
@@ -270,7 +272,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4TestCaseWithErrorInAfterClass() {
 		Class<?> testClass = JUnit4TestCaseWithErrorInAfterClass.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(test("failingTest"), started()), //
@@ -287,7 +289,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4TestCaseWithOverloadedMethod() {
 		Class<?> testClass = JUnit4TestCaseWithIndistinguishableOverloadedMethod.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(test("theory(" + JUnit4TestCaseWithIndistinguishableOverloadedMethod.class.getName() + ")[0]"),
@@ -306,7 +308,7 @@ class VintageTestEngineExecutionTests {
 	void executesIgnoredJUnit4TestCase() {
 		Class<?> testClass = IgnoredJUnit4TestCase.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), skippedWithReason("complete class is ignored")), //
 			event(engine(), finishedSuccessfully()));
@@ -316,7 +318,7 @@ class VintageTestEngineExecutionTests {
 	void executesEmptyIgnoredTestClass() {
 		Class<?> testClass = EmptyIgnoredTestCase.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(test(testClass.getName()), skippedWithReason("empty")), //
 			event(engine(), finishedSuccessfully()));
@@ -386,7 +388,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> suiteClass = JUnit4SuiteWithPlainJUnit4TestCaseWithSingleTestWhichIsIgnored.class;
 		Class<?> testClass = PlainJUnit4TestCaseWithSingleTestWhichIsIgnored.class;
 
-		execute(suiteClass).assertEventsMatchExactly( //
+		execute(suiteClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(suiteClass), started()), //
 			event(container(testClass), started()), //
@@ -402,7 +404,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> suiteClass = JUnit4SuiteWithIgnoredJUnit4TestCase.class;
 		Class<?> testClass = IgnoredJUnit4TestCase.class;
 
-		execute(suiteOfSuiteClass).assertEventsMatchExactly( //
+		execute(suiteOfSuiteClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(suiteOfSuiteClass), started()), //
 			event(container(suiteClass), started()), //
@@ -416,7 +418,7 @@ class VintageTestEngineExecutionTests {
 	void executesParameterizedTestCase() {
 		Class<?> testClass = ParameterizedTestCase.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(container("[foo]"), started()), //
@@ -436,7 +438,7 @@ class VintageTestEngineExecutionTests {
 	void executesIgnoredParameterizedTestCase() {
 		Class<?> testClass = IgnoredParameterizedTestCase.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(container("[foo]"), started()), //
@@ -453,7 +455,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4TestCaseWithExceptionThrowingRunner() {
 		Class<?> testClass = JUnit4TestCaseWithExceptionThrowingRunner.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(test(testClass.getName()), started()), //
 			event(test(testClass.getName()), finishedWithFailure()), //
@@ -464,7 +466,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4SuiteWithExceptionThrowingRunner() {
 		Class<?> testClass = JUnit4SuiteWithExceptionThrowingRunner.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(container(testClass), finishedWithFailure()), //
@@ -501,7 +503,7 @@ class VintageTestEngineExecutionTests {
 	void reportsDynamicTestsForUnknownDescriptions() {
 		Class<?> testClass = DynamicTestClass.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(test(testClass.getName()), started()), //
 			event(dynamicTestRegistered("dynamicTest")), //
@@ -552,7 +554,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> suiteClass = SuiteWithDynamicAndStaticTestClass.class;
 		Class<?> testClass = DynamicAndStaticTestClass.class;
 
-		execute(suiteClass).assertEventsMatchExactly( //
+		execute(suiteClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(suiteClass.getName()), started()), //
 			event(container(testClass.getName()), started()), //
@@ -595,7 +597,7 @@ class VintageTestEngineExecutionTests {
 	void ignoreEventsForUnknownDescriptionsByMisbehavingChildlessRunner() {
 		Class<?> testClass = MisbehavingChildTestClass.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(test(testClass.getName()), started()), //
 			event(dynamicTestRegistered("doesNotExist")), //
@@ -608,7 +610,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4TestCaseWithRunnerWithCustomUniqueIds() {
 		Class<?> testClass = JUnit4TestCaseWithRunnerWithCustomUniqueIds.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(uniqueIdSubstring(testClass.getName()), started()), //
@@ -621,7 +623,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4TestCaseWithErrorCollectorStoringMultipleFailures() {
 		Class<?> testClass = JUnit4TestCaseWithErrorCollectorStoringMultipleFailures.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(test("example"), started()), //
@@ -637,7 +639,7 @@ class VintageTestEngineExecutionTests {
 	void executesJUnit4TestCaseWithFailingDescriptionThatIsNotReportedAsFinished() {
 		Class<?> testClass = JUnit4TestCaseWithFailingDescriptionThatIsNotReportedAsFinished.class;
 
-		execute(testClass).assertEventsMatchExactly( //
+		execute(testClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
 			event(test("testWithMissingEvents"), started()), //
@@ -652,7 +654,7 @@ class VintageTestEngineExecutionTests {
 		Class<?> firstTestClass = JUnit4TestCaseWithFailingDescriptionThatIsNotReportedAsFinished.class;
 		Class<?> secondTestClass = PlainJUnit4TestCaseWithSingleTestWhichFails.class;
 
-		execute(suiteClass).assertEventsMatchExactly( //
+		execute(suiteClass).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(suiteClass), started()), //
 			event(container(firstTestClass), started()), //
@@ -673,7 +675,7 @@ class VintageTestEngineExecutionTests {
 		var request = LauncherDiscoveryRequestBuilder.request().selectors(
 			selectUniqueId(VintageUniqueIdBuilder.uniqueIdForClass(testClass))).build();
 
-		execute(request).assertEventsMatchExactly( //
+		execute(request).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(displayName(testClass.getSimpleName()), started()), //
 			event(dynamicTestRegistered("Test #0")), //
@@ -683,12 +685,56 @@ class VintageTestEngineExecutionTests {
 			event(engine(), finishedSuccessfully()));
 	}
 
-	private static Events execute(Class<?> testClass) {
+	@Test
+	void executesJUnit3ParallelSuiteWithSubsuites() {
+		var suiteClass = JUnit3ParallelSuiteWithSubsuites.class;
+		var results = execute(suiteClass);
+		results.containerEvents() //
+				.assertStatistics(stats -> stats.started(4).dynamicallyRegistered(0).finished(4).succeeded(4)) //
+				.assertEventsMatchExactly( //
+					event(engine(), started()), //
+					event(container(suiteClass), started()), //
+					event(container("Case"), started()), //
+					event(container("Case")), //
+					event(container("Case")), //
+					event(container("Case"), finishedSuccessfully()), //
+					event(container(suiteClass), finishedSuccessfully()), //
+					event(engine(), finishedSuccessfully()));
+		results.testEvents() //
+				.assertStatistics(stats -> stats.started(2).dynamicallyRegistered(0).finished(2).succeeded(2)) //
+				.assertEventsMatchExactly( //
+					event(test("hello"), started()), //
+					event(test("hello")), //
+					event(test("hello")), //
+					event(test("hello"), finishedSuccessfully()));
+	}
+
+	@Test
+	void executesJUnit4TestCaseWithRunnerWithDuplicateChangingChildDescriptions() {
+		Class<?> testClass = JUnit4TestCaseWithRunnerWithDuplicateChangingChildDescriptions.class;
+		execute(testClass).allEvents().assertEventsMatchExactly( //
+			event(engine(), started()), //
+			event(container(testClass), started()), //
+			event(container("1st"), started()), //
+			event(test("0"), skippedWithReason(__ -> true)), //
+			event(test("1"), started()), //
+			event(test("1"), finishedSuccessfully()), //
+			event(container("1st"), finishedSuccessfully()), //
+			event(container("2nd"), started()), //
+			event(test("0"), skippedWithReason(__ -> true)), //
+			event(test("1"), started()), //
+			event(test("1"), finishedSuccessfully()), //
+			event(container("2nd"), finishedSuccessfully()), //
+			event(container(testClass), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	private static EngineExecutionResults execute(Class<?> testClass) {
 		return execute(request(testClass));
 	}
 
-	private static Events execute(LauncherDiscoveryRequest request) {
-		return EngineTestKit.execute(new VintageTestEngine(), request).allEvents();
+	private static EngineExecutionResults execute(LauncherDiscoveryRequest request) {
+		return EngineTestKit.execute(new VintageTestEngine(), request);
 	}
 
 	private static void execute(Class<?> testClass, EngineExecutionListener listener) {

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/execution/TestRunTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/execution/TestRunTests.java
@@ -41,7 +41,7 @@ class TestRunTests {
 		Description unknownDescription = createTestDescription(testClass, "dynamicTest");
 
 		TestRun testRun = new TestRun(runnerTestDescriptor);
-		Optional<VintageTestDescriptor> testDescriptor = testRun.lookupTestDescriptor(unknownDescription);
+		Optional<VintageTestDescriptor> testDescriptor = testRun.lookupNextTestDescriptor(unknownDescription);
 
 		assertThat(testDescriptor).isEmpty();
 	}
@@ -60,7 +60,7 @@ class TestRunTests {
 		TestRun testRun = new TestRun(runnerTestDescriptor);
 		testRun.registerDynamicTest(dynamicTestDescriptor);
 
-		assertThat(testRun.lookupTestDescriptor(dynamicDescription)).contains(dynamicTestDescriptor);
+		assertThat(testRun.lookupNextTestDescriptor(dynamicDescription)).contains(dynamicTestDescriptor);
 		assertTrue(testRun.isDescendantOfRunnerTestDescriptor(dynamicTestDescriptor));
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit3/JUnit3ParallelSuiteWithSubsuites.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit3/JUnit3ParallelSuiteWithSubsuites.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit3;
+
+import junit.extensions.ActiveTestSuite;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+public class JUnit3ParallelSuiteWithSubsuites extends TestCase {
+	private final String arg;
+
+	public JUnit3ParallelSuiteWithSubsuites(String name, String arg) {
+		super(name);
+		this.arg = arg;
+	}
+
+	public void hello() {
+		assertNotNull(arg);
+	}
+
+	public static TestSuite suite() {
+		TestSuite root = new ActiveTestSuite("allTests");
+		TestSuite case1 = new TestSuite("Case1");
+		case1.addTest(new JUnit3ParallelSuiteWithSubsuites("hello", "world"));
+		root.addTest(case1);
+		TestSuite case2 = new TestSuite("Case2");
+		case2.addTest(new JUnit3ParallelSuiteWithSubsuites("hello", "WORLD"));
+		root.addTest(case2);
+		return root;
+	}
+}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/JUnit4TestCaseWithRunnerWithDuplicateChangingChildDescriptions.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/samples/junit4/JUnit4TestCaseWithRunnerWithDuplicateChangingChildDescriptions.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.RunNotifier;
+
+@RunWith(JUnit4TestCaseWithRunnerWithDuplicateChangingChildDescriptions.Runner.class)
+public class JUnit4TestCaseWithRunnerWithDuplicateChangingChildDescriptions {
+	public static class Runner extends org.junit.runner.Runner {
+
+		private Class<?> testClass;
+
+		public Runner(Class<?> testClass) {
+			this.testClass = testClass;
+		}
+
+		@Override
+		public Description getDescription() {
+			var suiteDescription = Description.createSuiteDescription(testClass);
+			suiteDescription.addChild(getContainerDescription("1st"));
+			suiteDescription.addChild(getContainerDescription("2nd"));
+			return suiteDescription;
+		}
+
+		private Description getContainerDescription(String name) {
+			var parent = Description.createSuiteDescription(name);
+			parent.addChild(getLeafDescription());
+			parent.addChild(getLeafDescription());
+			return parent;
+		}
+
+		private Description getLeafDescription() {
+			return Description.createTestDescription(testClass, "leaf");
+		}
+
+		@Override
+		public void run(RunNotifier notifier) {
+			for (int i = 0; i < 2; i++) {
+				notifier.fireTestIgnored(getLeafDescription());
+				notifier.fireTestStarted(getLeafDescription());
+				notifier.fireTestFinished(getLeafDescription());
+			}
+		}
+	}
+}


### PR DESCRIPTION
Some runners don't memoize Description instances and even pass different
instances when invoking testStarted and testFinished. This makes it
particularly difficult when there are multiple equal Description
instances in a Runner.

Prior to this commit, such cases were deemed unresolvable which lead to
multiple dynamic TestDescriptors with the same unique ID being reported
which is a violation of the contract of TestExecutionListener.

Now, we assume the testStarted/testSkipped event for a Description with
multiple equal Descriptions is referring to the first Description that
hasn't yet been started or skipped. The corresponding TestDescriptor is
then reported as started/skipped. When testFinished is called for such
a Description, we check whether the same thread has previously reported
an equal Description as started. If so, we report the corresponding
TestDescriptor as finished.

Fixes #2021.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
