### PR TITLE
Remove read-only files under TempDir

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 
@@ -208,15 +209,10 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 					}
 				}
 
-				private void makeWritable(Path path) throws IOException {
+				private void makeWritable(Path path) {
 					boolean writable = path.toFile().setWritable(true);
 					if (!writable) {
-						throw new IOException("Attempt to make file '" + path + "' writable failed") {
-							@Override
-							public synchronized Throwable fillInStackTrace() {
-								return this; // Make the output smaller by omitting the stacktrace
-							}
-						};
+						throw new UndeletableFileException("Attempt to make file '" + path + "' writable failed");
 					}
 				}
 			});
@@ -254,6 +250,21 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				return path;
 			}
 		}
+	}
+
+	private static class UndeletableFileException extends JUnitException {
+
+		private static final long serialVersionUID = 1L;
+
+		UndeletableFileException(String message) {
+			super(message);
+		}
+
+		@Override
+		public Throwable fillInStackTrace() {
+			return this; // Make the output smaller by omitting the stacktrace
+		}
+
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -195,6 +196,9 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 					}
 					catch (NoSuchFileException ignore) {
 						// ignore
+					}
+					catch (DirectoryNotEmptyException exception) {
+						failures.put(path, exception);
 					}
 					catch (IOException exception) {
 						makeWritableAndTryToDeleteAgain(path, exception);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -191,6 +192,9 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				private FileVisitResult deleteAndContinue(Path path) {
 					try {
 						Files.delete(path);
+					}
+					catch (NoSuchFileException ignore) {
+						// ignore
 					}
 					catch (IOException exception) {
 						makeWritableAndTryToDeleteAgain(path, exception);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.cause;
@@ -78,6 +79,13 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 	@DisplayName("does not prevent user from deleting the temp dir within a test")
 	void tempDirectoryDoesNotPreventUserFromDeletingTempDir() {
 		executeTestsForClass(UserTempDirectoryDeletionDoesNotCauseFailureTestCase.class).testEvents()//
+				.assertStatistics(stats -> stats.started(1).succeeded(1));
+	}
+
+	@Test
+	@DisplayName("is capable of removal of a read-only file")
+	void nonWritableFileDoesNotCauseFailureTestCase() {
+		executeTestsForClass(NonWritableFileDoesNotCauseFailureTestCase.class).testEvents()//
 				.assertStatistics(stats -> stats.started(1).succeeded(1));
 	}
 
@@ -740,6 +748,20 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 		void deleteTempDir(@TempDir Path tempDir) throws IOException {
 			Files.delete(tempDir);
 			assertThat(tempDir).doesNotExist();
+		}
+
+	}
+
+	// https://github.com/junit-team/junit5/issues/2046
+	static class NonWritableFileDoesNotCauseFailureTestCase {
+
+		@Test
+		void createReadonlyFile(@TempDir Path tempDir) throws IOException {
+			// Removal of setWritable(false) files might fail (e.g. for Windows)
+			// The test verifies that @TempDir is capable of removal of such files
+			Path filePath = Files.write(tempDir.resolve("test.txt"), new byte[0]);
+			assumeTrue(filePath.toFile().setWritable(false),
+				() -> "Unable to set file " + filePath + " readonly via .toFile().setWritable(false)");
 		}
 
 	}


### PR DESCRIPTION
Removal of read-only files fails (e.g. for Windows),
so the engine should try making the file writable first.

see #2046

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
