### PR TITLE
Introduce discovery listeners and abort discovery on failures by default

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -27,6 +27,8 @@ endif::[]
 // Platform Launcher API
 :junit-platform-launcher:                    {javadoc-root}/org/junit/platform/launcher/package-summary.html[junit-platform-launcher]
 :Launcher:                                   {javadoc-root}/org/junit/platform/launcher/Launcher.html[Launcher]
+:LauncherDiscoveryListener:                  {javadoc-root}/org/junit/platform/launcher/LauncherDiscoveryListener.html[LauncherDiscoveryListener]
+:LauncherDiscoveryRequestBuilder:            {javadoc-root}/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.html[LauncherDiscoveryRequestBuilder]
 :LoggingListener:                            {javadoc-root}/org/junit/platform/launcher/listeners/LoggingListener.html[LoggingListener]
 :SummaryGeneratingListener:                  {javadoc-root}/org/junit/platform/launcher/listeners/SummaryGeneratingListener.html[SummaryGeneratingListener]
 :TestExecutionListener:                      {javadoc-root}/org/junit/platform/launcher/TestExecutionListener.html[TestExecutionListener]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M1.adoc
@@ -35,6 +35,15 @@ on GitHub.
 
 ==== Deprecations and Breaking Changes
 
+* The `Launcher` now propagates errors during test discovery by default instead of only
+  logging and thereby potentially hiding them. In order to restore the old, lenient
+  behavior, you can set the `junit.platform.discovery.listener.default` configuration
+  parameter to `logging`.
+* To support the above feature consistently, a new `EngineDiscoveryListener` interface was
+  introduced. `TestEngine` implementations should now notify the listener that can be
+  accessed via the `EngineDiscoveryRequest.getDiscoveryListener()` method about each
+  processed `DiscoverySelector`. Test engines that use `EngineDiscoveryRequestResolver` do
+  not have to make any changes.
 * In the `EngineTestKit` API, the `all()`, `containers()`, and `tests()` methods in
   `EngineExecutionResults` have been deprecated in favor of the new `allEvents()`,
   `containerEvents()`, and `testEvents()` methods, respectively. The deprecated methods

--- a/documentation/src/docs/asciidoc/user-guide/launcher-api.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/launcher-api.adoc
@@ -45,6 +45,13 @@ traverse the tree, retrieve details about a node, and get a link to the original
 (like class, method, or file position). Every node in the test plan has a _unique ID_
 that can be used to invoke a particular test or group of tests.
 
+Clients can register one or more `{LauncherDiscoveryListener}` implementations to get
+insights into events that occur during test discovery via the
+`{LauncherDiscoveryRequestBuilder}`. The builder registers a default listener that can be
+changed via the `junit.platform.discovery.listener.default` configuration parameter. If
+the parameter is not set, test discovery will be aborted after the first failure is
+encountered.
+
 [[launcher-api-execution]]
 ==== Executing Tests
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -36,6 +36,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPacka
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.engine.discovery.PackageNameFilter.excludePackageNames;
 import static org.junit.platform.engine.discovery.PackageNameFilter.includePackageNames;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -84,7 +85,6 @@ import org.junit.platform.engine.discovery.PackageSelector;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
-import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 import org.mockito.ArgumentCaptor;
 
 /**
@@ -756,8 +756,7 @@ class DiscoverySelectorResolverTests {
 
 	private LauncherDiscoveryRequestBuilder request() {
 		return LauncherDiscoveryRequestBuilder.request() //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.listeners(discoveryListener);
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -84,6 +84,7 @@ import org.junit.platform.engine.discovery.PackageSelector;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 import org.mockito.ArgumentCaptor;
 
 /**
@@ -754,7 +755,10 @@ class DiscoverySelectorResolverTests {
 	}
 
 	private LauncherDiscoveryRequestBuilder request() {
-		return LauncherDiscoveryRequestBuilder.request().listeners(discoveryListener);
+		return LauncherDiscoveryRequestBuilder.request() //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.listeners(discoveryListener);
 	}
 
 	private void assertAllSelectorsResolved() {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -60,7 +60,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.descriptor.DynamicDescendantFilter;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -135,7 +135,7 @@ class DiscoverySelectorResolverTests {
 		assertTrue(engineDescriptor.getDescendants().isEmpty());
 		var result = verifySelectorProcessed(selector);
 		assertThat(result.getStatus()).isEqualTo(FAILED);
-		assertThat(result.getThrowable()).hasMessageContaining("Could not load class with name");
+		assertThat(result.getThrowable().get()).hasMessageContaining("Could not load class with name");
 	}
 
 	@Test
@@ -230,7 +230,7 @@ class DiscoverySelectorResolverTests {
 		assertTrue(engineDescriptor.getDescendants().isEmpty());
 		var result = verifySelectorProcessed(selector);
 		assertThat(result.getStatus()).isEqualTo(FAILED);
-		assertThat(result.getThrowable())//
+		assertThat(result.getThrowable().get())//
 				.isInstanceOf(PreconditionViolationException.class)//
 				.hasMessageStartingWith("Could not load class with name: " + className);
 	}
@@ -244,7 +244,7 @@ class DiscoverySelectorResolverTests {
 		assertTrue(engineDescriptor.getDescendants().isEmpty());
 		var result = verifySelectorProcessed(selector);
 		assertThat(result.getStatus()).isEqualTo(FAILED);
-		assertThat(result.getThrowable()).hasMessageContaining("Could not find method");
+		assertThat(result.getThrowable().get()).hasMessageContaining("Could not find method");
 	}
 
 	@Test
@@ -314,7 +314,7 @@ class DiscoverySelectorResolverTests {
 		assertTrue(engineDescriptor.getDescendants().isEmpty());
 		var result = verifySelectorProcessed(selectUniqueId(uniqueId));
 		assertThat(result.getStatus()).isEqualTo(FAILED);
-		assertThat(result.getThrowable())//
+		assertThat(result.getThrowable().get())//
 				.isInstanceOf(PreconditionViolationException.class)//
 				.hasMessageStartingWith("Method [()] does not match pattern");
 	}
@@ -328,7 +328,7 @@ class DiscoverySelectorResolverTests {
 		assertThat(engineDescriptor.getDescendants()).isEmpty();
 		var result = verifySelectorProcessed(selectUniqueId(uniqueId));
 		assertThat(result.getStatus()).isEqualTo(FAILED);
-		assertThat(result.getThrowable())//
+		assertThat(result.getThrowable().get())//
 				.isInstanceOf(PreconditionViolationException.class)//
 				.hasMessageStartingWith("Method [methodName] does not match pattern");
 	}
@@ -342,7 +342,7 @@ class DiscoverySelectorResolverTests {
 		assertTrue(engineDescriptor.getDescendants().isEmpty());
 		var result = verifySelectorProcessed(selectUniqueId(uniqueId));
 		assertThat(result.getStatus()).isEqualTo(FAILED);
-		assertThat(result.getThrowable())//
+		assertThat(result.getThrowable().get())//
 				.isInstanceOf(JUnitException.class)//
 				.hasMessage("Failed to load parameter type [%s] for method [%s] in class [%s].", "junit.foo.Enigma",
 					"methodName", getClass().getName());

--- a/junit-jupiter-engine/src/test/resources/log4j2-test.xml
+++ b/junit-jupiter-engine/src/test/resources/log4j2-test.xml
@@ -9,7 +9,6 @@
 		<Logger name="org.junit" level="warn" />
 		<Logger name="org.junit.jupiter.api" level="off" />
 		<Logger name="org.junit.jupiter.engine" level="off" />
-		<Logger name="org.junit.platform.engine.support.discovery" level="off" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>

--- a/junit-jupiter-engine/src/test/resources/log4j2-test.xml
+++ b/junit-jupiter-engine/src/test/resources/log4j2-test.xml
@@ -9,6 +9,7 @@
 		<Logger name="org.junit" level="warn" />
 		<Logger name="org.junit.jupiter.api" level="off" />
 		<Logger name="org.junit.jupiter.engine" level="off" />
+		<Logger name="org.junit.platform.launcher.listeners.discovery.LoggingLauncherDiscoveryListener" level="off" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
@@ -10,7 +10,13 @@
 
 package org.junit.platform.engine;
 
+import org.apiguardian.api.API;
+
+@API(status = API.Status.EXPERIMENTAL, since = "1.6")
 public interface EngineDiscoveryListener {
+
+	EngineDiscoveryListener NOOP = new EngineDiscoveryListener() {
+	};
 
 	default void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine;
+
+public interface EngineDiscoveryListener {
+
+	default void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
@@ -10,14 +10,43 @@
 
 package org.junit.platform.engine;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
 import org.apiguardian.api.API;
 
-@API(status = API.Status.EXPERIMENTAL, since = "1.6")
+/**
+ * {@code EngineDiscoveryListener} contains {@link TestEngine} access to the
+ * information necessary to discover tests and containers.
+ *
+ * <p>All methods in this interface have empty <em>default</em> implementations.
+ * Concrete implementations may therefore override one or more of these methods
+ * to be notified of the selected events.
+ *
+ * <p>The methods declared in this interface <em>should</em> be called by
+ * each {@link TestEngine} during test discovery. However, since this interface
+ * was only added in 1.6, older engines might not yet do so.
+ *
+ * @see EngineDiscoveryRequest#getDiscoveryListener()
+ * @since 1.6
+ */
+@API(status = EXPERIMENTAL, since = "1.6")
 public interface EngineDiscoveryListener {
 
+	/**
+	 * No-op implementation of {@code EngineDiscoveryListener}
+	 */
 	EngineDiscoveryListener NOOP = new EngineDiscoveryListener() {
 	};
 
+	/**
+	 * Must be called after a discovery selector has been processed by a test
+	 * engine.
+	 *
+	 * @param engineId the unique ID of the engine descriptor
+	 * @param selector the processed selector
+	 * @param result the resolution result of the supplied engine and selector
+	 * @see SelectorResolutionResult
+	 */
 	default void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryListener.java
@@ -42,6 +42,9 @@ public interface EngineDiscoveryListener {
 	 * Must be called after a discovery selector has been processed by a test
 	 * engine.
 	 *
+	 * <p>Exceptions thrown by implementations of this method will cause test
+	 * discovery of the current engine to be aborted.
+	 *
 	 * @param engineId the unique ID of the engine descriptor
 	 * @param selector the processed selector
 	 * @param result the resolution result of the supplied engine and selector

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.List;
@@ -44,28 +45,42 @@ public interface EngineDiscoveryRequest {
 	 * filtered by a particular type.
 	 *
 	 * @param selectorType the type of {@link DiscoverySelector} to filter by
-	 * @return all selectors of this request that are instances of {@code selectorType}
+	 * @return all selectors of this request that are instances of
+	 * {@code selectorType}; never {@code null} but potentially empty
 	 */
 	<T extends DiscoverySelector> List<T> getSelectorsByType(Class<T> selectorType);
 
 	/**
-	 * Get the {@link DiscoveryFilter DiscoveryFilters} for this request, filtered
-	 * by a particular type.
+	 * Get the {@link DiscoveryFilter DiscoveryFilters} for this request,
+	 * filtered by a particular type.
 	 *
-	 * <p>The returned filters are to be combined using AND semantics, i.e. all of
-	 * them have to include a resource for it to end up in the test plan.
+	 * <p>The returned filters are to be combined using AND semantics, i.e. all
+	 * of them have to include a resource for it to end up in the test plan.
 	 *
 	 * @param filterType the type of {@link DiscoveryFilter} to filter by
-	 * @return all filters of this request that are instances of {@code filterType}
+	 * @return all filters of this request that are instances of
+	 * {@code filterType}; never {@code null} but potentially empty
 	 */
 	<T extends DiscoveryFilter<?>> List<T> getFiltersByType(Class<T> filterType);
 
 	/**
 	 * Get the {@link ConfigurationParameters} for this request.
+	 *
+	 * @return the configuration parameters; never {@code null}
 	 */
 	ConfigurationParameters getConfigurationParameters();
 
-	@API(status = API.Status.EXPERIMENTAL, since = "1.6")
+	/**
+	 * Get the {@link EngineDiscoveryListener} for this request.
+	 *
+	 * <p>The default implementation returns a no-op listener that ignores all
+	 * calls so that engines that call this methods can be used with an earlier
+	 * version of the JUnit Platform that did not yet include it.
+	 *
+	 * @return the discovery listener; never {@code null}
+	 * @since 1.6
+	 */
+	@API(status = EXPERIMENTAL, since = "1.6")
 	default EngineDiscoveryListener getDiscoveryListener() {
 		return EngineDiscoveryListener.NOOP;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
@@ -65,4 +65,6 @@ public interface EngineDiscoveryRequest {
 	 */
 	ConfigurationParameters getConfigurationParameters();
 
+	EngineDiscoveryListener getDiscoveryListener();
+
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
@@ -65,6 +65,9 @@ public interface EngineDiscoveryRequest {
 	 */
 	ConfigurationParameters getConfigurationParameters();
 
-	EngineDiscoveryListener getDiscoveryListener();
+	@API(status = API.Status.EXPERIMENTAL, since = "1.6")
+	default EngineDiscoveryListener getDiscoveryListener() {
+		return EngineDiscoveryListener.NOOP;
+	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
@@ -75,7 +75,7 @@ public interface EngineDiscoveryRequest {
 	 *
 	 * <p>The default implementation returns a no-op listener that ignores all
 	 * calls so that engines that call this methods can be used with an earlier
-	 * version of the JUnit Platform that did not yet include it.
+	 * version of the JUnit Platform that did not yet include this API.
 	 *
 	 * @return the discovery listener; never {@code null}
 	 * @since 1.6

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/SelectorResolutionResult.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/SelectorResolutionResult.java
@@ -12,8 +12,10 @@ package org.junit.platform.engine;
 
 import java.util.Optional;
 
+import org.apiguardian.api.API;
 import org.junit.platform.commons.util.ToStringBuilder;
 
+@API(status = API.Status.EXPERIMENTAL, since = "1.6")
 public class SelectorResolutionResult {
 
 	public enum Status {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/SelectorResolutionResult.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/SelectorResolutionResult.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine;
+
+import org.junit.platform.commons.util.ToStringBuilder;
+
+public class SelectorResolutionResult {
+
+	public enum Status {
+		RESOLVED, UNRESOLVED, FAILED
+	}
+
+	private static final SelectorResolutionResult RESOLVED_RESULT = new SelectorResolutionResult(Status.RESOLVED, null);
+	private static final SelectorResolutionResult UNRESOLVED_RESULT = new SelectorResolutionResult(Status.UNRESOLVED,
+		null);
+
+	public static SelectorResolutionResult resolved() {
+		return RESOLVED_RESULT;
+	}
+
+	public static SelectorResolutionResult unresolved() {
+		return UNRESOLVED_RESULT;
+	}
+
+	public static SelectorResolutionResult failed(Throwable throwable) {
+		return new SelectorResolutionResult(Status.FAILED, throwable);
+	}
+
+	private final Status status;
+	private final Throwable throwable;
+
+	public SelectorResolutionResult(Status status, Throwable throwable) {
+		this.status = status;
+		this.throwable = throwable;
+	}
+
+	public Status getStatus() {
+		return status;
+	}
+
+	public Throwable getThrowable() {
+		return throwable;
+	}
+
+	@Override
+	public String toString() {
+		// @formatter:off
+        return new ToStringBuilder(this)
+                .append("status", status)
+                .append("throwable", throwable)
+                .toString();
+        // @formatter:on
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/SelectorResolutionResult.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/SelectorResolutionResult.java
@@ -10,30 +10,77 @@
 
 package org.junit.platform.engine;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
 import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.ToStringBuilder;
 
-@API(status = API.Status.EXPERIMENTAL, since = "1.6")
+/**
+ * {@code SelectorResolutionResult} encapsulates the result of resolving a
+ * {@link DiscoverySelector} by a {@link TestEngine}.
+ *
+ * <p>A {@code SelectorResolutionResult} consists of a mandatory
+ * {@link #getStatus() Status} and an optional {@link #getThrowable() Throwable}.
+ *
+ * @since 1.6
+ */
+@API(status = EXPERIMENTAL, since = "1.6")
 public class SelectorResolutionResult {
 
+	/**
+	 * Status of resolving a {@link DiscoverySelector}.
+	 */
 	public enum Status {
-		RESOLVED, UNRESOLVED, FAILED
+
+		/**
+		 * Indicates that the {@link TestEngine} has successfully resolved the
+		 * selector.
+		 */
+		RESOLVED,
+
+		/**
+		 * Indicates that the {@link TestEngine} was unable to resolve the
+		 * selector.
+		 */
+		UNRESOLVED,
+
+		/**
+		 * Indicates that the {@link TestEngine} has encountered an error while
+		 * resolving the selector.
+		 */
+		FAILED
+
 	}
 
 	private static final SelectorResolutionResult RESOLVED_RESULT = new SelectorResolutionResult(Status.RESOLVED, null);
 	private static final SelectorResolutionResult UNRESOLVED_RESULT = new SelectorResolutionResult(Status.UNRESOLVED,
 		null);
 
+	/**
+	 * Create a {@code SelectorResolutionResult} for a <em>resolved</em>
+	 * selector.
+	 * @return the {@code SelectorResolutionResult}; never {@code null}
+	 */
 	public static SelectorResolutionResult resolved() {
 		return RESOLVED_RESULT;
 	}
 
+	/**
+	 * Create a {@code SelectorResolutionResult} for an <em>unresolved</em>
+	 * selector.
+	 * @return the {@code SelectorResolutionResult}; never {@code null}
+	 */
 	public static SelectorResolutionResult unresolved() {
 		return UNRESOLVED_RESULT;
 	}
 
+	/**
+	 * Create a {@code SelectorResolutionResult} for a <em>failed</em>
+	 * selector resolution.
+	 * @return the {@code SelectorResolutionResult}; never {@code null}
+	 */
 	public static SelectorResolutionResult failed(Throwable throwable) {
 		return new SelectorResolutionResult(Status.FAILED, throwable);
 	}
@@ -46,10 +93,21 @@ public class SelectorResolutionResult {
 		this.throwable = throwable;
 	}
 
+	/**
+	 * Get the {@linkplain Status status} of this result.
+	 *
+	 * @return the status; never {@code null}
+	 */
 	public Status getStatus() {
 		return status;
 	}
 
+	/**
+	 * Get the throwable that caused this result, if available.
+	 *
+	 * @return an {@code Optional} containing the throwable; never {@code null}
+	 * but potentially empty
+	 */
 	public Optional<Throwable> getThrowable() {
 		return Optional.ofNullable(throwable);
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/ClassContainerSelectorResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/ClassContainerSelectorResolver.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.support.ReflectionSupport.findAllClasse
 import static org.junit.platform.commons.support.ReflectionSupport.findAllClassesInModule;
 import static org.junit.platform.commons.support.ReflectionSupport.findAllClassesInPackage;
 import static org.junit.platform.engine.support.discovery.SelectorResolver.Resolution.selectors;
+import static org.junit.platform.engine.support.discovery.SelectorResolver.Resolution.unresolved;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -53,6 +54,9 @@ class ClassContainerSelectorResolver implements SelectorResolver {
 	}
 
 	private Resolution classSelectors(List<Class<?>> classes) {
+		if (classes.isEmpty()) {
+			return unresolved();
+		}
 		return selectors(classes.stream().map(DiscoverySelectors::selectClass).collect(toSet()));
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
@@ -38,6 +38,11 @@ import org.junit.platform.engine.support.discovery.SelectorResolver.Resolution;
  * and {@link TestDescriptor.Visitor} that can be reused by different
  * {@link org.junit.platform.engine.TestEngine TestEngines}.
  *
+ * <p>This resolver takes care of notifying registered
+ * {@link org.junit.platform.engine.EngineDiscoveryListener
+ * EngineDiscoveryListeners} about the results of processed
+ * {@link org.junit.platform.engine.DiscoverySelector DiscoverySelectors}.
+ *
  * @param <T> the type of the engine's descriptor
  * @see #builder()
  * @see #resolve(EngineDiscoveryRequest, TestDescriptor)

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
@@ -19,8 +19,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -47,8 +45,6 @@ import org.junit.platform.engine.support.discovery.SelectorResolver.Resolution;
  */
 @API(status = EXPERIMENTAL, since = "1.5")
 public class EngineDiscoveryRequestResolver<T extends TestDescriptor> {
-
-	private static final Logger logger = LoggerFactory.getLogger(EngineDiscoveryRequestResolver.class);
 
 	private final List<Function<InitializationContext<T>, SelectorResolver>> resolverCreators;
 	private final List<Function<InitializationContext<T>, TestDescriptor.Visitor>> visitorCreators;
@@ -109,7 +105,7 @@ public class EngineDiscoveryRequestResolver<T extends TestDescriptor> {
 		InitializationContext<T> initializationContext = new DefaultInitializationContext<>(request, engineDescriptor);
 		List<SelectorResolver> resolvers = instantiate(resolverCreators, initializationContext);
 		List<TestDescriptor.Visitor> visitors = instantiate(visitorCreators, initializationContext);
-		new EngineDiscoveryRequestResolution(logger, request, engineDescriptor, resolvers, visitors).run();
+		new EngineDiscoveryRequestResolution(request, engineDescriptor, resolvers, visitors).run();
 	}
 
 	private <R> List<R> instantiate(List<Function<InitializationContext<T>, R>> creators,

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineDiscoveryResult.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineDiscoveryResult.java
@@ -8,38 +8,32 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.engine;
+package org.junit.platform.launcher;
 
 import java.util.Optional;
 
 import org.junit.platform.commons.util.ToStringBuilder;
 
-public class SelectorResolutionResult {
+public class EngineDiscoveryResult {
 
 	public enum Status {
-		RESOLVED, UNRESOLVED, FAILED
+		SUCCESSFUL, FAILED
 	}
 
-	private static final SelectorResolutionResult RESOLVED_RESULT = new SelectorResolutionResult(Status.RESOLVED, null);
-	private static final SelectorResolutionResult UNRESOLVED_RESULT = new SelectorResolutionResult(Status.UNRESOLVED,
-		null);
+	private static final EngineDiscoveryResult SUCCESSFUL_RESULT = new EngineDiscoveryResult(Status.SUCCESSFUL, null);
 
-	public static SelectorResolutionResult resolved() {
-		return RESOLVED_RESULT;
+	public static EngineDiscoveryResult successful() {
+		return SUCCESSFUL_RESULT;
 	}
 
-	public static SelectorResolutionResult unresolved() {
-		return UNRESOLVED_RESULT;
-	}
-
-	public static SelectorResolutionResult failed(Throwable throwable) {
-		return new SelectorResolutionResult(Status.FAILED, throwable);
+	public static EngineDiscoveryResult failed(Throwable throwable) {
+		return new EngineDiscoveryResult(Status.FAILED, throwable);
 	}
 
 	private final Status status;
 	private final Throwable throwable;
 
-	private SelectorResolutionResult(Status status, Throwable throwable) {
+	private EngineDiscoveryResult(Status status, Throwable throwable) {
 		this.status = status;
 		this.throwable = throwable;
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineDiscoveryResult.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineDiscoveryResult.java
@@ -10,24 +10,62 @@
 
 package org.junit.platform.launcher;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
 import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.ToStringBuilder;
 
-@API(status = API.Status.EXPERIMENTAL, since = "1.6")
+/**
+ * {@code EngineDiscoveryResult} encapsulates the result of test discovery by a
+ * {@link org.junit.platform.engine.TestEngine}.
+ *
+ * <p>A {@code EngineDiscoveryResult} consists of a mandatory
+ * {@link #getStatus() Status} and an optional {@link #getThrowable() Throwable}.
+ *
+ * @since 1.6
+ */
+@API(status = EXPERIMENTAL, since = "1.6")
 public class EngineDiscoveryResult {
 
+	/**
+	 * Status of test discovery by a
+	 * {@link org.junit.platform.engine.TestEngine}.
+	 */
 	public enum Status {
-		SUCCESSFUL, FAILED
+
+		/**
+		 * Indicates that test discovery was <em>successful</em>.
+		 */
+		SUCCESSFUL,
+
+		/**
+		 * Indicates that test discovery has <em>failed</em>.
+		 */
+		FAILED
+
 	}
 
 	private static final EngineDiscoveryResult SUCCESSFUL_RESULT = new EngineDiscoveryResult(Status.SUCCESSFUL, null);
 
+	/**
+	 * Create a {@code EngineDiscoveryResult} for a <em>successful</em> test
+	 * discovery.
+	 * @return the {@code EngineDiscoveryResult}; never {@code null}
+	 */
 	public static EngineDiscoveryResult successful() {
 		return SUCCESSFUL_RESULT;
 	}
 
+	/**
+	 * Create a {@code EngineDiscoveryResult} for a <em>failed</em> test
+	 * discovery.
+	 *
+	 * @param throwable the throwable that caused the failed discovery; may be
+	 * {@code null}
+	 * @return the {@code EngineDiscoveryResult}; never {@code null}
+	 */
 	public static EngineDiscoveryResult failed(Throwable throwable) {
 		return new EngineDiscoveryResult(Status.FAILED, throwable);
 	}
@@ -40,10 +78,21 @@ public class EngineDiscoveryResult {
 		this.throwable = throwable;
 	}
 
+	/**
+	 * Get the {@linkplain Status status} of this result.
+	 *
+	 * @return the status; never {@code null}
+	 */
 	public Status getStatus() {
 		return status;
 	}
 
+	/**
+	 * Get the throwable that caused this result, if available.
+	 *
+	 * @return an {@code Optional} containing the throwable; never {@code null}
+	 * but potentially empty
+	 */
 	public Optional<Throwable> getThrowable() {
 		return Optional.ofNullable(throwable);
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineDiscoveryResult.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineDiscoveryResult.java
@@ -12,8 +12,10 @@ package org.junit.platform.launcher;
 
 import java.util.Optional;
 
+import org.apiguardian.api.API;
 import org.junit.platform.commons.util.ToStringBuilder;
 
+@API(status = API.Status.EXPERIMENTAL, since = "1.6")
 public class EngineDiscoveryResult {
 
 	public enum Status {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher;
+
+import java.util.Optional;
+
+import org.junit.platform.engine.EngineDiscoveryListener;
+import org.junit.platform.engine.UniqueId;
+
+public interface LauncherDiscoveryListener extends EngineDiscoveryListener {
+
+	default void engineDiscoveryStarted(UniqueId engineId) {
+	}
+
+	default void engineDiscoveryFinished(UniqueId engineId, Optional<Throwable> failure) {
+	}
+
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
@@ -10,20 +10,58 @@
 
 package org.junit.platform.launcher;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
 import org.apiguardian.api.API;
 import org.junit.platform.engine.EngineDiscoveryListener;
 import org.junit.platform.engine.UniqueId;
 
-@API(status = API.Status.EXPERIMENTAL, since = "1.6")
-public interface LauncherDiscoveryListener extends EngineDiscoveryListener {
+/**
+ * Register a concrete implementation of this interface with a
+ * {@link org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder}
+ * to be notified of events that occur during test discovery.
+ *
+ * <p>All methods in this interface have empty <em>default</em> implementations.
+ * Concrete implementations may therefore override one or more of these methods
+ * to be notified of the selected events.
+ *
+ * <p>JUnit provides default implementations that are created via the factory
+ * methods in
+ * {@link org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners}.
+ *
+ * <p>The methods declared in this interface are called by the {@link Launcher}
+ * created via the {@link org.junit.platform.launcher.core.LauncherFactory}
+ * during test discovery.
+ *
+ * @see org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners
+ * @see LauncherDiscoveryRequest#getDiscoveryListener()
+ * @since 1.6
+ */
+@API(status = EXPERIMENTAL, since = "1.6")
+public abstract class LauncherDiscoveryListener implements EngineDiscoveryListener {
 
-	LauncherDiscoveryListener NOOP = new LauncherDiscoveryListener() {
+	/**
+	 * No-op implementation of {@code LauncherDiscoveryListener}
+	 */
+	public static final LauncherDiscoveryListener NOOP = new LauncherDiscoveryListener() {
 	};
 
-	default void engineDiscoveryStarted(UniqueId engineId) {
+	/**
+	 * Called when test discovery is about to be started for an engine.
+	 *
+	 * @param engineId the unique ID of the engine descriptor
+	 */
+	public void engineDiscoveryStarted(UniqueId engineId) {
 	}
 
-	default void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
+	/**
+	 * Called when test discovery has finished for an engine.
+	 *
+	 * @param engineId the unique ID of the engine descriptor
+	 * @param result the discovery result of the supplied engine
+	 * @see EngineDiscoveryResult
+	 */
+	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
@@ -10,8 +10,6 @@
 
 package org.junit.platform.launcher;
 
-import java.util.Optional;
-
 import org.junit.platform.engine.EngineDiscoveryListener;
 import org.junit.platform.engine.UniqueId;
 
@@ -20,7 +18,7 @@ public interface LauncherDiscoveryListener extends EngineDiscoveryListener {
 	default void engineDiscoveryStarted(UniqueId engineId) {
 	}
 
-	default void engineDiscoveryFinished(UniqueId engineId, Optional<Throwable> failure) {
+	default void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
@@ -10,10 +10,15 @@
 
 package org.junit.platform.launcher;
 
+import org.apiguardian.api.API;
 import org.junit.platform.engine.EngineDiscoveryListener;
 import org.junit.platform.engine.UniqueId;
 
+@API(status = API.Status.EXPERIMENTAL, since = "1.6")
 public interface LauncherDiscoveryListener extends EngineDiscoveryListener {
+
+	LauncherDiscoveryListener NOOP = new LauncherDiscoveryListener() {
+	};
 
 	default void engineDiscoveryStarted(UniqueId engineId) {
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
@@ -57,6 +57,9 @@ public abstract class LauncherDiscoveryListener implements EngineDiscoveryListen
 	/**
 	 * Called when test discovery has finished for an engine.
 	 *
+	 * <p>Exceptions thrown by implementations of this method will cause the
+	 * complete test discovery to be aborted.
+	 *
 	 * @param engineId the unique ID of the engine descriptor
 	 * @param result the discovery result of the supplied engine
 	 * @see EngineDiscoveryResult

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
@@ -80,7 +80,10 @@ public interface LauncherDiscoveryRequest extends EngineDiscoveryRequest {
 	 */
 	List<PostDiscoveryFilter> getPostDiscoveryFilters();
 
+	@API(status = API.Status.EXPERIMENTAL, since = "1.6")
 	@Override
-	LauncherDiscoveryListener getDiscoveryListener();
+	default LauncherDiscoveryListener getDiscoveryListener() {
+		return LauncherDiscoveryListener.NOOP;
+	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.launcher;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.List;
@@ -80,7 +81,17 @@ public interface LauncherDiscoveryRequest extends EngineDiscoveryRequest {
 	 */
 	List<PostDiscoveryFilter> getPostDiscoveryFilters();
 
-	@API(status = API.Status.EXPERIMENTAL, since = "1.6")
+	/**
+	 * Get the {@link LauncherDiscoveryListener} for this request.
+	 *
+	 * <p>The default implementation returns a no-op listener that ignores all
+	 * calls so that engines that call this methods can be used with an earlier
+	 * version of the JUnit Platform that did not yet include it.
+	 *
+	 * @return the discovery listener; never {@code null}
+	 * @since 1.6
+	 */
+	@API(status = EXPERIMENTAL, since = "1.6")
 	@Override
 	default LauncherDiscoveryListener getDiscoveryListener() {
 		return LauncherDiscoveryListener.NOOP;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryRequest.java
@@ -80,4 +80,7 @@ public interface LauncherDiscoveryRequest extends EngineDiscoveryRequest {
 	 */
 	List<PostDiscoveryFilter> getPostDiscoveryFilters();
 
+	@Override
+	LauncherDiscoveryListener getDiscoveryListener();
+
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultDiscoveryRequest.java
@@ -21,6 +21,7 @@ import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.launcher.EngineFilter;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
 
@@ -47,14 +48,18 @@ final class DefaultDiscoveryRequest implements LauncherDiscoveryRequest {
 	// Configuration parameters can be used to provide custom configuration to engines, e.g. for extensions
 	private final LauncherConfigurationParameters configurationParameters;
 
+	// Listener for test discovery that may abort on errors.
+	private final LauncherDiscoveryListener discoveryListener;
+
 	DefaultDiscoveryRequest(List<DiscoverySelector> selectors, List<EngineFilter> engineFilters,
 			List<DiscoveryFilter<?>> discoveryFilters, List<PostDiscoveryFilter> postDiscoveryFilters,
-			LauncherConfigurationParameters configurationParameters) {
+			LauncherConfigurationParameters configurationParameters, LauncherDiscoveryListener discoveryListener) {
 		this.selectors = selectors;
 		this.engineFilters = engineFilters;
 		this.discoveryFilters = discoveryFilters;
 		this.postDiscoveryFilters = postDiscoveryFilters;
 		this.configurationParameters = configurationParameters;
+		this.discoveryListener = discoveryListener;
 	}
 
 	@Override
@@ -82,6 +87,11 @@ final class DefaultDiscoveryRequest implements LauncherDiscoveryRequest {
 	@Override
 	public ConfigurationParameters getConfigurationParameters() {
 		return this.configurationParameters;
+	}
+
+	@Override
+	public LauncherDiscoveryListener getDiscoveryListener() {
+		return discoveryListener;
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -28,6 +28,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.launcher.EngineDiscoveryResult;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -179,14 +180,14 @@ class DefaultLauncher implements Launcher {
 			discoveryListener.engineDiscoveryStarted(uniqueEngineId);
 			TestDescriptor engineRoot = testEngine.discover(discoveryRequest, uniqueEngineId);
 			discoveryResultValidator.validate(testEngine, engineRoot);
-			discoveryListener.engineDiscoveryFinished(uniqueEngineId, Optional.empty());
+			discoveryListener.engineDiscoveryFinished(uniqueEngineId, EngineDiscoveryResult.successful());
 			return engineRoot;
 		}
 		catch (Throwable throwable) {
 			BlacklistedExceptions.rethrowIfBlacklisted(throwable);
 			String message = String.format("TestEngine with ID '%s' failed to discover tests", testEngine.getId());
 			JUnitException cause = new JUnitException(message, throwable);
-			discoveryListener.engineDiscoveryFinished(uniqueEngineId, Optional.of(cause));
+			discoveryListener.engineDiscoveryFinished(uniqueEngineId, EngineDiscoveryResult.failed(cause));
 			return new EngineDiscoveryErrorDescriptor(uniqueEngineId, testEngine, cause);
 		}
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -82,6 +82,17 @@ import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListener
 @API(status = STABLE, since = "1.0")
 public final class LauncherDiscoveryRequestBuilder {
 
+	/**
+	 * Property name used to set the default discovery listener that is added to all : {@value}
+	 *
+	 * <h3>Supported Values</h3>
+	 *
+	 * <p>Supported values are {@code "logging"} and {@code "abortOnFailure"}.
+	 *
+	 * <p>If not specified, the default is {@code "logging"}.
+	 */
+	public static final String DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME = "junit.platform.discovery.listener.default";
+
 	private List<DiscoverySelector> selectors = new ArrayList<>();
 	private List<EngineFilter> engineFilters = new ArrayList<>();
 	private List<DiscoveryFilter<?>> discoveryFilters = new ArrayList<>();
@@ -173,6 +184,22 @@ public final class LauncherDiscoveryRequestBuilder {
 		return this;
 	}
 
+	/**
+	 * Add all of the supplied discovery listeners to the request.
+	 *
+	 * <p>In addition to the {@linkplain LauncherDiscoveryListener listeners}
+	 * registered using this method, this builder will add a default listener
+	 * to this request that can be specified using the
+	 * {@value LauncherDiscoveryRequestBuilder#DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME}
+	 * configuration parameter.
+	 *
+	 * @param listeners the {@code LauncherDiscoveryListeners} to add; never
+	 * {@code null}
+	 * @return this builder for method chaining
+	 * @see LauncherDiscoveryListener
+	 * @see LauncherDiscoveryListeners
+	 * @see LauncherDiscoveryRequestBuilder#DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME
+	 */
 	@API(status = API.Status.EXPERIMENTAL, since = "1.6")
 	public LauncherDiscoveryRequestBuilder listeners(LauncherDiscoveryListener... listeners) {
 		Preconditions.notNull(listeners, "discovery listener array must not be null");
@@ -211,8 +238,11 @@ public final class LauncherDiscoveryRequestBuilder {
 	}
 
 	private LauncherDiscoveryListener getLauncherDiscoveryListener(ConfigurationParameters configurationParameters) {
-		LauncherDiscoveryListener defaultDiscoveryListener = LauncherDiscoveryListeners.fromConfigurationParameter(
-			configurationParameters);
+		LauncherDiscoveryListener defaultDiscoveryListener = configurationParameters.get(
+			DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME) //
+				.map(value -> LauncherDiscoveryListeners.fromConfigurationParameter(
+					DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, value)) //
+				.orElseGet(LauncherDiscoveryListeners::abortOnFailure);
 		if (discoveryListeners.isEmpty()) {
 			return defaultDiscoveryListener;
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -172,6 +172,7 @@ public final class LauncherDiscoveryRequestBuilder {
 		return this;
 	}
 
+	@API(status = API.Status.EXPERIMENTAL, since = "1.6")
 	public LauncherDiscoveryRequestBuilder listeners(LauncherDiscoveryListener... listeners) {
 		Preconditions.notNull(listeners, "discovery listener array must not be null");
 		Preconditions.containsNoNullElements(listeners, "individual discovery listeners must not be null");

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
@@ -39,4 +39,20 @@ class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListen
 		}
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		return getClass() == obj.getClass();
+	}
+
+	@Override
+	public int hashCode() {
+		return 0;
+	}
+
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.discovery;
+
+import java.util.Optional;
+
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.SelectorResolutionResult;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+
+class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListener {
+
+	@Override
+	public void engineDiscoveryFinished(UniqueId engineId, Optional<Throwable> failure) {
+		failure.ifPresent(ExceptionUtils::throwAsUncheckedException);
+	}
+
+	@Override
+	public void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
+		if (result.getStatus() == SelectorResolutionResult.Status.FAILED) {
+			throw new JUnitException(selector + " resolution failed", result.getThrowable());
+		}
+		if (result.getStatus() == SelectorResolutionResult.Status.UNRESOLVED && selector instanceof UniqueIdSelector) {
+			UniqueId uniqueId = ((UniqueIdSelector) selector).getUniqueId();
+			if (uniqueId.hasPrefix(engineId)) {
+				throw new JUnitException(selector + " could not be resolved");
+			}
+		}
+	}
+
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
@@ -10,6 +10,9 @@
 
 package org.junit.platform.launcher.listeners.discovery;
 
+import static org.junit.platform.engine.SelectorResolutionResult.Status.FAILED;
+import static org.junit.platform.engine.SelectorResolutionResult.Status.UNRESOLVED;
+
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.DiscoverySelector;
@@ -19,7 +22,11 @@ import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.launcher.EngineDiscoveryResult;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
-class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListener {
+/**
+ * @since 1.6
+ * @see LauncherDiscoveryListeners#abortOnFailure()
+ */
+class AbortOnFailureLauncherDiscoveryListener extends LauncherDiscoveryListener {
 
 	@Override
 	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
@@ -28,10 +35,10 @@ class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListen
 
 	@Override
 	public void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
-		if (result.getStatus() == SelectorResolutionResult.Status.FAILED) {
+		if (result.getStatus() == FAILED) {
 			throw new JUnitException(selector + " resolution failed", result.getThrowable().orElse(null));
 		}
-		if (result.getStatus() == SelectorResolutionResult.Status.UNRESOLVED && selector instanceof UniqueIdSelector) {
+		if (result.getStatus() == UNRESOLVED && selector instanceof UniqueIdSelector) {
 			UniqueId uniqueId = ((UniqueIdSelector) selector).getUniqueId();
 			if (uniqueId.hasPrefix(engineId)) {
 				throw new JUnitException(selector + " could not be resolved");

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
@@ -10,27 +10,26 @@
 
 package org.junit.platform.launcher.listeners.discovery;
 
-import java.util.Optional;
-
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.SelectorResolutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
+import org.junit.platform.launcher.EngineDiscoveryResult;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
 class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	@Override
-	public void engineDiscoveryFinished(UniqueId engineId, Optional<Throwable> failure) {
-		failure.ifPresent(ExceptionUtils::throwAsUncheckedException);
+	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
+		result.getThrowable().ifPresent(ExceptionUtils::throwAsUncheckedException);
 	}
 
 	@Override
 	public void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
 		if (result.getStatus() == SelectorResolutionResult.Status.FAILED) {
-			throw new JUnitException(selector + " resolution failed", result.getThrowable());
+			throw new JUnitException(selector + " resolution failed", result.getThrowable().orElse(null));
 		}
 		if (result.getStatus() == SelectorResolutionResult.Status.UNRESOLVED && selector instanceof UniqueIdSelector) {
 			UniqueId uniqueId = ((UniqueIdSelector) selector).getUniqueId();

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
@@ -12,11 +12,11 @@ package org.junit.platform.launcher.listeners.discovery;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.SelectorResolutionResult;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.launcher.EngineDiscoveryResult;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
 class CompositeLauncherDiscoveryListener implements LauncherDiscoveryListener {
@@ -33,8 +33,8 @@ class CompositeLauncherDiscoveryListener implements LauncherDiscoveryListener {
 	}
 
 	@Override
-	public void engineDiscoveryFinished(UniqueId engineId, Optional<Throwable> failure) {
-		listeners.forEach(delegate -> delegate.engineDiscoveryFinished(engineId, failure));
+	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
+		listeners.forEach(delegate -> delegate.engineDiscoveryFinished(engineId, result));
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
@@ -11,6 +11,7 @@
 package org.junit.platform.launcher.listeners.discovery;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.platform.engine.DiscoverySelector;
@@ -24,7 +25,7 @@ class CompositeLauncherDiscoveryListener implements LauncherDiscoveryListener {
 	private final List<LauncherDiscoveryListener> listeners;
 
 	CompositeLauncherDiscoveryListener(List<LauncherDiscoveryListener> listeners) {
-		this.listeners = new ArrayList<>(listeners);
+		this.listeners = Collections.unmodifiableList(new ArrayList<>(listeners));
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.discovery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.SelectorResolutionResult;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+
+class CompositeLauncherDiscoveryListener implements LauncherDiscoveryListener {
+
+	private final List<LauncherDiscoveryListener> listeners;
+
+	CompositeLauncherDiscoveryListener(List<LauncherDiscoveryListener> listeners) {
+		this.listeners = new ArrayList<>(listeners);
+	}
+
+	@Override
+	public void engineDiscoveryStarted(UniqueId engineId) {
+		listeners.forEach(delegate -> delegate.engineDiscoveryStarted(engineId));
+	}
+
+	@Override
+	public void engineDiscoveryFinished(UniqueId engineId, Optional<Throwable> failure) {
+		listeners.forEach(delegate -> delegate.engineDiscoveryFinished(engineId, failure));
+	}
+
+	@Override
+	public void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
+		listeners.forEach(delegate -> delegate.selectorProcessed(engineId, selector, result));
+	}
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
@@ -20,7 +20,11 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.EngineDiscoveryResult;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
-class CompositeLauncherDiscoveryListener implements LauncherDiscoveryListener {
+/**
+ * @since 1.6
+ * @see LauncherDiscoveryListeners#composite(List)
+ */
+class CompositeLauncherDiscoveryListener extends LauncherDiscoveryListener {
 
 	private final List<LauncherDiscoveryListener> listeners;
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.discovery;
+
+import java.util.List;
+
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+
+public class LauncherDiscoveryListeners {
+
+	private LauncherDiscoveryListeners() {
+	}
+
+	public static LauncherDiscoveryListener abortOnFailure() {
+		return new AbortOnFailureLauncherDiscoveryListener();
+	}
+
+	public static LauncherDiscoveryListener logging() {
+		return new LoggingLauncherDiscoveryListener();
+	}
+
+	public static LauncherDiscoveryListener composite(List<LauncherDiscoveryListener> listeners) {
+		Preconditions.notEmpty(listeners, "listeners must not be empty");
+		if (listeners.size() == 1) {
+			return listeners.get(0);
+		}
+		return new CompositeLauncherDiscoveryListener(listeners);
+	}
+
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
@@ -12,9 +12,11 @@ package org.junit.platform.launcher.listeners.discovery;
 
 import java.util.List;
 
+import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
+@API(status = API.Status.EXPERIMENTAL, since = "1.6")
 public class LauncherDiscoveryListeners {
 
 	private LauncherDiscoveryListeners() {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
@@ -10,14 +10,22 @@
 
 package org.junit.platform.launcher.listeners.discovery;
 
+import static java.util.stream.Collectors.joining;
+
+import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
 @API(status = API.Status.EXPERIMENTAL, since = "1.6")
 public class LauncherDiscoveryListeners {
+
+	public static final String DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME = "junit.platform.discovery.listener.default";
 
 	private LauncherDiscoveryListeners() {
 	}
@@ -30,12 +38,50 @@ public class LauncherDiscoveryListeners {
 		return new LoggingLauncherDiscoveryListener();
 	}
 
+	@API(status = API.Status.INTERNAL, since = "1.6")
 	public static LauncherDiscoveryListener composite(List<LauncherDiscoveryListener> listeners) {
 		Preconditions.notEmpty(listeners, "listeners must not be empty");
+		Preconditions.containsNoNullElements(listeners, "listeners must not contain any null elements");
 		if (listeners.size() == 1) {
 			return listeners.get(0);
 		}
 		return new CompositeLauncherDiscoveryListener(listeners);
+	}
+
+	@API(status = API.Status.INTERNAL, since = "1.6")
+	public static LauncherDiscoveryListener fromConfigurationParameter(
+			ConfigurationParameters configurationParameters) {
+		return configurationParameters.get(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME,
+			defaultListenerType -> //
+			Arrays.stream(LauncherDiscoveryListenerType.values()) //
+					.filter(type -> type.parameterValue.equalsIgnoreCase(defaultListenerType)) //
+					.findFirst() //
+					.map(type -> type.creator.get()) //
+					.orElseThrow(() -> {
+						String allowedValues = Arrays.stream(LauncherDiscoveryListenerType.values()) //
+								.map(type -> type.parameterValue) //
+								.collect(joining("', '", "'", "'"));
+						return new JUnitException("Invalid value of configuration parameter '"
+								+ DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME + "': " //
+								+ defaultListenerType + " (allowed are " + allowedValues + ")");
+					})) //
+				.orElseGet(LauncherDiscoveryListeners::abortOnFailure);
+	}
+
+	private enum LauncherDiscoveryListenerType {
+
+		LOGGING("logging", LauncherDiscoveryListeners::logging),
+
+		ABORT_ON_FAILURE("abortOnFailure", LauncherDiscoveryListeners::abortOnFailure);
+
+		private final String parameterValue;
+		private final Supplier<LauncherDiscoveryListener> creator;
+
+		LauncherDiscoveryListenerType(String parameterValue, Supplier<LauncherDiscoveryListener> creator) {
+			this.parameterValue = parameterValue;
+			this.creator = creator;
+		}
+
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
@@ -88,13 +88,15 @@ public class LauncherDiscoveryListeners {
 				.filter(type -> type.parameterValue.equalsIgnoreCase(value)) //
 				.findFirst() //
 				.map(type -> type.creator.get()) //
-				.orElseThrow(() -> {
-					String allowedValues = Arrays.stream(LauncherDiscoveryListenerType.values()) //
-							.map(type -> type.parameterValue) //
-							.collect(joining("', '", "'", "'"));
-					return new JUnitException("Invalid value of configuration parameter '" + key + "': " //
-							+ value + " (allowed are " + allowedValues + ")");
-				});
+				.orElseThrow(() -> newInvalidConfigurationParameterException(key, value));
+	}
+
+	private static JUnitException newInvalidConfigurationParameterException(String key, String value) {
+		String allowedValues = Arrays.stream(LauncherDiscoveryListenerType.values()) //
+				.map(type -> type.parameterValue) //
+				.collect(joining("', '", "'", "'"));
+		return new JUnitException("Invalid value of configuration parameter '" + key + "': " //
+				+ value + " (allowed are " + allowedValues + ")");
 	}
 
 	private enum LauncherDiscoveryListenerType {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.discovery;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.SelectorResolutionResult;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+
+class LoggingLauncherDiscoveryListener implements LauncherDiscoveryListener {
+
+	private static final Logger logger = LoggerFactory.getLogger(LoggingLauncherDiscoveryListener.class);
+
+	@Override
+	public void engineDiscoveryStarted(UniqueId engineId) {
+		logger.trace(() -> "Engine " + engineId + " has started discovering tests");
+	}
+
+	@Override
+	public void engineDiscoveryFinished(UniqueId engineId, Optional<Throwable> failure) {
+		if (failure.isPresent()) {
+			logger.error(failure.get().getCause(), () -> failure.get().getMessage());
+		}
+		else {
+			logger.trace(() -> "Engine " + engineId + " has finished discovering tests");
+		}
+	}
+
+	@Override
+	public void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
+		switch (result.getStatus()) {
+			case RESOLVED:
+				logger.debug(() -> selector + " was resolved by " + engineId);
+				break;
+			case FAILED:
+				logger.error(result.getThrowable(), () -> "Resolution of " + selector + " by " + engineId + " failed");
+				break;
+			case UNRESOLVED:
+				Consumer<Supplier<String>> loggingConsumer = logger::debug;
+				if (selector instanceof UniqueIdSelector) {
+					UniqueId uniqueId = ((UniqueIdSelector) selector).getUniqueId();
+					if (uniqueId.hasPrefix(engineId)) {
+						loggingConsumer = logger::warn;
+					}
+				}
+				loggingConsumer.accept(() -> selector + " could not be resolved by " + engineId);
+				break;
+		}
+	}
+
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
@@ -71,4 +71,20 @@ class LoggingLauncherDiscoveryListener implements LauncherDiscoveryListener {
 		}
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		return getClass() == obj.getClass();
+	}
+
+	@Override
+	public int hashCode() {
+		return 1;
+	}
+
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
@@ -10,6 +10,8 @@
 
 package org.junit.platform.launcher.listeners.discovery;
 
+import static org.junit.platform.launcher.EngineDiscoveryResult.Status.FAILED;
+
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -23,7 +25,11 @@ import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.launcher.EngineDiscoveryResult;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
-class LoggingLauncherDiscoveryListener implements LauncherDiscoveryListener {
+/**
+ * @since 1.6
+ * @see LauncherDiscoveryListeners#logging()
+ */
+class LoggingLauncherDiscoveryListener extends LauncherDiscoveryListener {
 
 	private static final Logger logger = LoggerFactory.getLogger(LoggingLauncherDiscoveryListener.class);
 
@@ -34,7 +40,7 @@ class LoggingLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	@Override
 	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
-		if (result.getStatus() == EngineDiscoveryResult.Status.FAILED) {
+		if (result.getStatus() == FAILED) {
 			Optional<Throwable> failure = result.getThrowable();
 			if (failure.isPresent()) {
 				logger.error(failure.get().getCause(), () -> failure.get().getMessage());

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/package-info.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/package-info.java
@@ -1,0 +1,2 @@
+
+package org.junit.platform.launcher.listeners.discovery;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/package-info.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/package-info.java
@@ -1,2 +1,9 @@
+/**
+ * Common {@link org.junit.platform.launcher.LauncherDiscoveryListener}
+ * implementations and factory methods.
+ *
+ * @see org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners
+ * @since 1.6
+ */
 
 package org.junit.platform.launcher.listeners.discovery;

--- a/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
+++ b/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
@@ -16,6 +16,7 @@ module org.junit.platform.launcher {
 	exports org.junit.platform.launcher;
 	exports org.junit.platform.launcher.core;
 	exports org.junit.platform.launcher.listeners;
+	exports org.junit.platform.launcher.listeners.discovery;
 
 	uses org.junit.platform.engine.TestEngine;
 	uses org.junit.platform.launcher.TestExecutionListener;

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessorTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessorTests.java
@@ -45,7 +45,7 @@ class RunnerTestDescriptorPostProcessorTests {
 
 	@Test
 	void doesNotLogAnythingForFilterableRunner(LogRecordListener listener) {
-		resolve(selectMethod(PlainJUnit4TestCaseWithFiveTestMethods.class, "someTest"));
+		resolve(selectMethod(PlainJUnit4TestCaseWithFiveTestMethods.class, "successfulTest"));
 
 		assertThat(listener.stream(RunnerTestDescriptor.class)).isEmpty();
 	}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessorTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessorTests.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.mockito.Mockito.mock;
 
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.vintage.engine.VintageUniqueIdBuilder;
@@ -70,7 +72,8 @@ class RunnerTestDescriptorPostProcessorTests {
 	}
 
 	private void resolve(DiscoverySelector selector) {
-		LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selector).build();
+		LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selector).listeners(
+			mock(LauncherDiscoveryListener.class)).build();
 		TestDescriptor engineDescriptor = new VintageDiscoverer().discover(request, VintageUniqueIdBuilder.engineId());
 		RunnerTestDescriptor runnerTestDescriptor = (RunnerTestDescriptor) getOnlyElement(
 			engineDescriptor.getChildren());

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
@@ -34,6 +34,7 @@ import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.PackageNameFilter;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 import org.junit.vintage.engine.VintageUniqueIdBuilder;
 import org.junit.vintage.engine.samples.junit3.AbstractJUnit3TestCase;
 import org.junit.vintage.engine.samples.junit4.AbstractJunit4TestCaseWithConstructorParameter;
@@ -106,7 +107,12 @@ class VintageDiscovererTests {
 
 	private void doesNotResolve(DiscoverySelector selector, Consumer<SelectorResolutionResult> resultCheck) {
 		var discoveryListener = mock(LauncherDiscoveryListener.class);
-		LauncherDiscoveryRequest request = request().selectors(selector).listeners(discoveryListener).build();
+		LauncherDiscoveryRequest request = request() //
+				.selectors(selector) //
+				.listeners(discoveryListener) //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.build();
 
 		TestDescriptor testDescriptor = discover(request);
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
@@ -91,7 +91,7 @@ class VintageDiscovererTests {
 
 		doesNotResolve(selectUniqueId(uniqueId), result -> {
 			assertThat(result.getStatus()).isEqualTo(FAILED);
-			assertThat(result.getThrowable()).hasMessageContaining("Unknown class");
+			assertThat(result.getThrowable().get()).hasMessageContaining("Unknown class");
 		});
 	}
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
@@ -16,6 +16,7 @@ import static org.junit.platform.engine.SelectorResolutionResult.Status.FAILED;
 import static org.junit.platform.engine.SelectorResolutionResult.Status.UNRESOLVED;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.vintage.engine.VintageUniqueIdBuilder.engineId;
 import static org.mockito.ArgumentMatchers.eq;
@@ -34,7 +35,6 @@ import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.PackageNameFilter;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
-import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 import org.junit.vintage.engine.VintageUniqueIdBuilder;
 import org.junit.vintage.engine.samples.junit3.AbstractJUnit3TestCase;
 import org.junit.vintage.engine.samples.junit4.AbstractJunit4TestCaseWithConstructorParameter;
@@ -110,8 +110,7 @@ class VintageDiscovererTests {
 		LauncherDiscoveryRequest request = request() //
 				.selectors(selector) //
 				.listeners(discoveryListener) //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.build();
 
 		TestDescriptor testDescriptor = discover(request);

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/discovery/VintageDiscovererTests.java
@@ -12,35 +12,38 @@ package org.junit.vintage.engine.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
+import static org.junit.platform.engine.SelectorResolutionResult.Status.FAILED;
+import static org.junit.platform.engine.SelectorResolutionResult.Status.UNRESOLVED;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.vintage.engine.VintageUniqueIdBuilder.engineId;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.fixtures.TrackLogRecords;
-import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.SelectorResolutionResult;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.PackageNameFilter;
-import org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.vintage.engine.VintageUniqueIdBuilder;
 import org.junit.vintage.engine.samples.junit3.AbstractJUnit3TestCase;
 import org.junit.vintage.engine.samples.junit4.AbstractJunit4TestCaseWithConstructorParameter;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Tests for {@link VintageDiscoverer}.
  *
  * @since 4.12
  */
-@TrackLogRecords
 class VintageDiscovererTests {
 
 	@Test
@@ -73,38 +76,45 @@ class VintageDiscovererTests {
 	}
 
 	@Test
-	void doesNotResolveAbstractJUnit3Classes(LogRecordListener listener) {
-		doesNotResolve(listener, selectClass(AbstractJUnit3TestCase.class));
+	void doesNotResolveAbstractJUnit3Classes() {
+		doesNotResolve(selectClass(AbstractJUnit3TestCase.class));
 	}
 
 	@Test
-	void doesNotResolveAbstractJUnit4Classes(LogRecordListener listener) {
-		doesNotResolve(listener, selectClass(AbstractJunit4TestCaseWithConstructorParameter.class));
+	void doesNotResolveAbstractJUnit4Classes() {
+		doesNotResolve(selectClass(AbstractJunit4TestCaseWithConstructorParameter.class));
 	}
 
 	@Test
-	void logsWarningOnUnloadableTestClass(LogRecordListener listener) {
+	void failsToResolveUnloadableTestClass() {
 		UniqueId uniqueId = VintageUniqueIdBuilder.uniqueIdForClass("foo.bar.UnknownClass");
 
-		doesNotResolve(listener, selectUniqueId(uniqueId));
-
-		LogRecord logRecord = listener.stream(EngineDiscoveryRequestResolver.class, Level.WARNING).findFirst().get();
-		assertThat(logRecord.getMessage()).isEqualTo(
-			"UniqueIdSelector [uniqueId = " + uniqueId + "] could not be resolved.");
-		assertThat(logRecord.getThrown()).hasCauseInstanceOf(ClassNotFoundException.class);
+		doesNotResolve(selectUniqueId(uniqueId), result -> {
+			assertThat(result.getStatus()).isEqualTo(FAILED);
+			assertThat(result.getThrowable()).hasMessageContaining("Unknown class");
+		});
 	}
 
 	@Test
-	void ignoresUniqueIdsOfOtherEngines(LogRecordListener listener) {
-		doesNotResolve(listener, selectUniqueId(UniqueId.forEngine("someEngine")));
+	void ignoresUniqueIdsOfOtherEngines() {
+		doesNotResolve(selectUniqueId(UniqueId.forEngine("someEngine")));
 	}
 
-	private void doesNotResolve(LogRecordListener listener, DiscoverySelector selector) {
-		LauncherDiscoveryRequest request = request().selectors(selector).build();
+	private void doesNotResolve(DiscoverySelector selector) {
+		doesNotResolve(selector, result -> assertThat(result.getStatus()).isEqualTo(UNRESOLVED));
+	}
+
+	private void doesNotResolve(DiscoverySelector selector, Consumer<SelectorResolutionResult> resultCheck) {
+		var discoveryListener = mock(LauncherDiscoveryListener.class);
+		LauncherDiscoveryRequest request = request().selectors(selector).listeners(discoveryListener).build();
 
 		TestDescriptor testDescriptor = discover(request);
 
 		assertThat(testDescriptor.getChildren()).isEmpty();
+		ArgumentCaptor<SelectorResolutionResult> resultCaptor = ArgumentCaptor.forClass(SelectorResolutionResult.class);
+		verify(discoveryListener).selectorProcessed(eq(UniqueId.forEngine("junit-vintage")), eq(selector),
+			resultCaptor.capture());
+		resultCheck.accept(resultCaptor.getValue());
 	}
 
 	private TestDescriptor discover(EngineDiscoveryRequest request) {

--- a/junit-vintage-engine/src/test/resources/log4j2-test.xml
+++ b/junit-vintage-engine/src/test/resources/log4j2-test.xml
@@ -8,6 +8,7 @@
 	<Loggers>
 		<Logger name="org.junit" level="warn" />
 		<Logger name="org.junit.vintage.engine" level="error" />
+		<Logger name="org.junit.platform.launcher.listeners.discovery.LoggingLauncherDiscoveryListener" level="off" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>

--- a/junit-vintage-engine/src/test/resources/log4j2-test.xml
+++ b/junit-vintage-engine/src/test/resources/log4j2-test.xml
@@ -8,7 +8,6 @@
 	<Loggers>
 		<Logger name="org.junit" level="warn" />
 		<Logger name="org.junit.vintage.engine" level="error" />
-		<Logger name="org.junit.platform.engine.support.discovery" level="error" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -60,6 +60,7 @@ import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestEngine
 import org.junit.platform.fakes.TestDescriptorStub;
 import org.junit.platform.fakes.TestEngineSpy;
 import org.junit.platform.fakes.TestEngineStub;
+import org.junit.platform.launcher.EngineDiscoveryResult;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.PostDiscoveryFilter;
@@ -190,14 +191,15 @@ class DefaultLauncherTests {
 				.hasMessage("TestEngine with ID 'my-engine-id' failed to discover tests");
 	}
 
-	@SuppressWarnings({ "raw", "unchecked" })
 	private void assertDiscoveryFailed(TestEngine testEngine, LauncherDiscoveryListener discoveryListener) {
 		var engineId = testEngine.getId();
-		ArgumentCaptor<Optional<Throwable>> failureCaptor = ArgumentCaptor.forClass(Optional.class);
+		ArgumentCaptor<EngineDiscoveryResult> failureCaptor = ArgumentCaptor.forClass(EngineDiscoveryResult.class);
 		verify(discoveryListener).engineDiscoveryFinished(eq(UniqueId.forEngine(engineId)), failureCaptor.capture());
-		assertThat(failureCaptor.getValue()).isPresent();
-		assertThat(failureCaptor.getValue().get()) //
-				.hasMessage("TestEngine with ID '" + engineId + "' failed to discover tests");
+		var result = failureCaptor.getValue();
+		assertThat(result.getStatus()).isEqualTo(EngineDiscoveryResult.Status.FAILED);
+		assertThat(result.getThrowable()).isPresent();
+		assertThat(result.getThrowable().get()).hasMessage(
+			"TestEngine with ID '" + engineId + "' failed to discover tests");
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -69,6 +69,7 @@ import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -149,7 +150,11 @@ class DefaultLauncherTests {
 		};
 
 		var discoveryListener = mock(LauncherDiscoveryListener.class);
-		TestPlan testPlan = createLauncher(engine).discover(request().listeners(discoveryListener).build());
+		var testPlan = createLauncher(engine).discover(request() //
+				.listeners(discoveryListener) //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.build());
 		assertThat(testPlan.getRoots()).hasSize(1);
 		assertDiscoveryFailed(engine, discoveryListener);
 	}
@@ -173,7 +178,11 @@ class DefaultLauncherTests {
 
 		var launcher = createLauncher(engine);
 		var discoveryListener = mock(LauncherDiscoveryListener.class);
-		var testPlan = launcher.discover(request().listeners(discoveryListener).build());
+		var testPlan = launcher.discover(request() //
+				.listeners(discoveryListener) //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.build());
 
 		assertThat(testPlan.getRoots()).hasSize(1);
 		var engineIdentifier = getOnlyElement(testPlan.getRoots());

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -21,6 +21,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPacka
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.EngineFilter.excludeEngines;
 import static org.junit.platform.launcher.EngineFilter.includeEngines;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,7 +70,6 @@ import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
-import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -152,8 +152,7 @@ class DefaultLauncherTests {
 		var discoveryListener = mock(LauncherDiscoveryListener.class);
 		var testPlan = createLauncher(engine).discover(request() //
 				.listeners(discoveryListener) //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.build());
 		assertThat(testPlan.getRoots()).hasSize(1);
 		assertDiscoveryFailed(engine, discoveryListener);
@@ -180,8 +179,7 @@ class DefaultLauncherTests {
 		var discoveryListener = mock(LauncherDiscoveryListener.class);
 		var testPlan = launcher.discover(request() //
 				.listeners(discoveryListener) //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.build());
 
 		assertThat(testPlan.getRoots()).hasSize(1);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -60,6 +60,8 @@ import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestEngine
 import org.junit.platform.fakes.TestDescriptorStub;
 import org.junit.platform.fakes.TestEngineSpy;
 import org.junit.platform.fakes.TestEngineStub;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.PostDiscoveryFilterStub;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -72,7 +74,6 @@ import org.mockito.InOrder;
 /**
  * @since 1.0
  */
-@TrackLogRecords
 class DefaultLauncherTests {
 
 	private static final String FOO = DefaultLauncherTests.class.getSimpleName() + ".foo";
@@ -99,7 +100,7 @@ class DefaultLauncherTests {
 
 	@Test
 	void registerTestExecutionListenersWithNullArray() {
-		DefaultLauncher launcher = createLauncher(new DemoHierarchicalTestEngine("dummy id"));
+		var launcher = createLauncher(new DemoHierarchicalTestEngine("dummy id"));
 
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> launcher.registerTestExecutionListeners((TestExecutionListener[]) null));
@@ -109,7 +110,7 @@ class DefaultLauncherTests {
 
 	@Test
 	void registerTestExecutionListenersWithEmptyArray() {
-		DefaultLauncher launcher = createLauncher(new DemoHierarchicalTestEngine("dummy id"));
+		var launcher = createLauncher(new DemoHierarchicalTestEngine("dummy id"));
 
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> launcher.registerTestExecutionListeners(new TestExecutionListener[0]));
@@ -119,7 +120,7 @@ class DefaultLauncherTests {
 
 	@Test
 	void registerTestExecutionListenersWithArrayContainingNullElements() {
-		DefaultLauncher launcher = createLauncher(new DemoHierarchicalTestEngine("dummy id"));
+		var launcher = createLauncher(new DemoHierarchicalTestEngine("dummy id"));
 
 		PreconditionViolationException exception = assertThrows(PreconditionViolationException.class,
 			() -> launcher.registerTestExecutionListeners(new TestExecutionListener[] { null }));
@@ -129,7 +130,7 @@ class DefaultLauncherTests {
 
 	@Test
 	void discoverEmptyTestPlanWithEngineWithoutAnyTests() {
-		DefaultLauncher launcher = createLauncher(new DemoHierarchicalTestEngine());
+		Launcher launcher = createLauncher(new DemoHierarchicalTestEngine());
 
 		TestPlan testPlan = launcher.discover(request().build());
 
@@ -137,8 +138,8 @@ class DefaultLauncherTests {
 	}
 
 	@Test
-	void discoverTestPlanForEngineThatReturnsNullForItsRootDescriptor(LogRecordListener log) {
-		TestEngine engine = new TestEngineStub() {
+	void discoverTestPlanForEngineThatReturnsNullForItsRootDescriptor() {
+		TestEngine engine = new TestEngineStub("some-engine-id") {
 
 			@Override
 			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
@@ -146,16 +147,15 @@ class DefaultLauncherTests {
 			}
 		};
 
-		TestPlan testPlan = createLauncher(engine).discover(request().build());
+		var discoveryListener = mock(LauncherDiscoveryListener.class);
+		TestPlan testPlan = createLauncher(engine).discover(request().listeners(discoveryListener).build());
 		assertThat(testPlan.getRoots()).hasSize(1);
-		assertThat(log.stream(DefaultLauncher.class, Level.SEVERE).map(LogRecord::getMessage)) //
-				.containsExactly("TestEngine with ID 'TestEngineStub' failed to discover tests");
+		assertDiscoveryFailed(engine, discoveryListener);
 	}
 
 	@ParameterizedTest
 	@ValueSource(classes = { Error.class, RuntimeException.class })
-	void discoverErrorTestDescriptorForEngineThatThrowsInDiscoveryPhase(Class<? extends Throwable> throwableClass,
-			LogRecordListener log) {
+	void discoverErrorTestDescriptorForEngineThatThrowsInDiscoveryPhase(Class<? extends Throwable> throwableClass) {
 		TestEngine engine = new TestEngineStub("my-engine-id") {
 
 			@Override
@@ -171,23 +171,33 @@ class DefaultLauncherTests {
 		};
 
 		var launcher = createLauncher(engine);
-		var testPlan = launcher.discover(request().build());
+		var discoveryListener = mock(LauncherDiscoveryListener.class);
+		var testPlan = launcher.discover(request().listeners(discoveryListener).build());
 
 		assertThat(testPlan.getRoots()).hasSize(1);
+		var engineIdentifier = getOnlyElement(testPlan.getRoots());
 		assertThat(getOnlyElement(testPlan.getRoots()).getDisplayName()).isEqualTo("my-engine-id");
-		assertThat(log.stream(DefaultLauncher.class, Level.SEVERE).map(LogRecord::getMessage)) //
-				.containsExactly("TestEngine with ID 'my-engine-id' failed to discover tests");
+		assertDiscoveryFailed(engine, discoveryListener);
 
 		var listener = mock(TestExecutionListener.class);
 		launcher.execute(testPlan, listener);
 
-		var engineIdentifier = getOnlyElement(testPlan.getRoots());
 		var testExecutionResult = ArgumentCaptor.forClass(TestExecutionResult.class);
 		verify(listener).executionStarted(engineIdentifier);
 		verify(listener).executionFinished(eq(engineIdentifier), testExecutionResult.capture());
 		assertThat(testExecutionResult.getValue().getThrowable()).isPresent();
 		assertThat(testExecutionResult.getValue().getThrowable().get()) //
 				.hasMessage("TestEngine with ID 'my-engine-id' failed to discover tests");
+	}
+
+	@SuppressWarnings({ "raw", "unchecked" })
+	private void assertDiscoveryFailed(TestEngine testEngine, LauncherDiscoveryListener discoveryListener) {
+		var engineId = testEngine.getId();
+		ArgumentCaptor<Optional<Throwable>> failureCaptor = ArgumentCaptor.forClass(Optional.class);
+		verify(discoveryListener).engineDiscoveryFinished(eq(UniqueId.forEngine(engineId)), failureCaptor.capture());
+		assertThat(failureCaptor.getValue()).isPresent();
+		assertThat(failureCaptor.getValue().get()) //
+				.hasMessage("TestEngine with ID '" + engineId + "' failed to discover tests");
 	}
 
 	@Test
@@ -357,7 +367,7 @@ class DefaultLauncherTests {
 		engine.addTest("test1", noOp);
 		engine.addTest("test2", noOp);
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 
 		TestPlan testPlan = launcher.discover(request().selectors(selectPackage("any")).build());
 
@@ -374,7 +384,7 @@ class DefaultLauncherTests {
 		DemoHierarchicalTestEngine secondEngine = new DemoHierarchicalTestEngine("engine2");
 		TestDescriptor test2 = secondEngine.addTest("test2", noOp);
 
-		DefaultLauncher launcher = createLauncher(firstEngine, secondEngine);
+		var launcher = createLauncher(firstEngine, secondEngine);
 
 		TestPlan testPlan = launcher.discover(
 			request().selectors(selectUniqueId(test1.getUniqueId()), selectUniqueId(test2.getUniqueId())).build());
@@ -391,7 +401,7 @@ class DefaultLauncherTests {
 		DemoHierarchicalTestEngine secondEngine = new DemoHierarchicalTestEngine("second");
 		TestDescriptor test2 = secondEngine.addTest("test2", noOp);
 
-		DefaultLauncher launcher = createLauncher(firstEngine, secondEngine);
+		var launcher = createLauncher(firstEngine, secondEngine);
 
 		// @formatter:off
 		TestPlan testPlan = launcher.discover(
@@ -414,7 +424,7 @@ class DefaultLauncherTests {
 		DemoHierarchicalTestEngine secondEngine = new DemoHierarchicalTestEngine("second");
 		TestDescriptor test2 = secondEngine.addTest("test2", noOp);
 
-		DefaultLauncher launcher = createLauncher(firstEngine, secondEngine);
+		var launcher = createLauncher(firstEngine, secondEngine);
 
 		// @formatter:off
 		TestPlan testPlan = launcher.discover(
@@ -434,7 +444,7 @@ class DefaultLauncherTests {
 		DemoHierarchicalTestEngine secondEngine = new DemoHierarchicalTestEngine("second");
 		TestDescriptor test2 = secondEngine.addTest("test2", noOp);
 
-		DefaultLauncher launcher = createLauncher(firstEngine, secondEngine);
+		var launcher = createLauncher(firstEngine, secondEngine);
 
 		// @formatter:off
 		TestPlan testPlan = launcher.discover(
@@ -454,7 +464,7 @@ class DefaultLauncherTests {
 		DemoHierarchicalTestEngine secondEngine = new DemoHierarchicalTestEngine("second");
 		TestDescriptor test2 = secondEngine.addTest("test2", noOp);
 
-		DefaultLauncher launcher = createLauncher(firstEngine, secondEngine);
+		var launcher = createLauncher(firstEngine, secondEngine);
 
 		// @formatter:off
 		TestPlan testPlan = launcher.discover(
@@ -479,7 +489,7 @@ class DefaultLauncherTests {
 		DemoHierarchicalTestEngine thirdEngine = new DemoHierarchicalTestEngine("third");
 		TestDescriptor test3 = thirdEngine.addTest("test3", noOp);
 
-		DefaultLauncher launcher = createLauncher(firstEngine, secondEngine, thirdEngine);
+		var launcher = createLauncher(firstEngine, secondEngine, thirdEngine);
 
 		// @formatter:off
 		TestPlan testPlan = launcher.discover(
@@ -501,7 +511,7 @@ class DefaultLauncherTests {
 		DemoHierarchicalTestDescriptor test1 = engine.addTest("test1", noOp);
 		engine.addTest("test2", noOp);
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 
 		PostDiscoveryFilter includeWithUniqueIdContainsTest = new PostDiscoveryFilterStub(
 			descriptor -> FilterResult.includedIf(descriptor.getUniqueId().toString().contains("test")),
@@ -523,7 +533,7 @@ class DefaultLauncherTests {
 	void withoutConfigurationParameters_LauncherPassesEmptyConfigurationParametersIntoTheExecutionRequest() {
 		TestEngineSpy engine = new TestEngineSpy();
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		launcher.execute(request().build());
 
 		ConfigurationParameters configurationParameters = engine.requestForExecution.getConfigurationParameters();
@@ -535,7 +545,7 @@ class DefaultLauncherTests {
 	void withConfigurationParameters_LauncherPassesPopulatedConfigurationParametersIntoTheExecutionRequest() {
 		TestEngineSpy engine = new TestEngineSpy();
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		launcher.execute(request().configurationParameter("key", "value").build());
 
 		ConfigurationParameters configurationParameters = engine.requestForExecution.getConfigurationParameters();
@@ -551,7 +561,7 @@ class DefaultLauncherTests {
 		try {
 			TestEngineSpy engine = new TestEngineSpy();
 
-			DefaultLauncher launcher = createLauncher(engine);
+			var launcher = createLauncher(engine);
 			launcher.execute(request().build());
 
 			ConfigurationParameters configurationParameters = engine.requestForExecution.getConfigurationParameters();
@@ -570,7 +580,7 @@ class DefaultLauncherTests {
 		TestEngineSpy engine = new TestEngineSpy();
 		SummaryGeneratingListener listener = new SummaryGeneratingListener();
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		launcher.execute(request().build(), listener);
 
 		assertThat(listener.getSummary()).isNotNull();
@@ -601,7 +611,7 @@ class DefaultLauncherTests {
 			}
 		};
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		TestPlan testPlan = launcher.discover(request().filters(
 			(PostDiscoveryFilter) testDescriptor -> FilterResult.includedIf(testDescriptor.isContainer())).build());
 
@@ -652,7 +662,7 @@ class DefaultLauncherTests {
 			}
 		};
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		TestExecutionListener listener = mock(TestExecutionListener.class);
 		launcher.execute(request().build(), listener);
 
@@ -687,7 +697,7 @@ class DefaultLauncherTests {
 			return new EngineDescriptor(uniqueId, uniqueId.toString());
 		});
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		TestPlan testPlan = launcher.discover(request().build());
 		verify(engine, times(1)).discover(any(), any());
 
@@ -696,10 +706,11 @@ class DefaultLauncherTests {
 	}
 
 	@Test
+	@TrackLogRecords
 	@SuppressWarnings("deprecation")
 	void testPlanWarnsWhenModified(LogRecordListener listener) {
 		TestEngine engine = new TestEngineSpy();
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		TestPlan testPlan = launcher.discover(request().build());
 		TestIdentifier engineIdentifier = getOnlyElement(testPlan.getRoots());
 		UniqueId engineUniqueId = UniqueId.parse(engineIdentifier.getUniqueId());
@@ -718,6 +729,7 @@ class DefaultLauncherTests {
 	}
 
 	@Test
+	@TrackLogRecords
 	void thirdPartyEngineUsingReservedEngineIdPrefixEmitsWarning(LogRecordListener listener) {
 		String id = "junit-using-reserved-prefix";
 		createLauncher(new TestEngineStub(id));

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilderTests.java
@@ -23,6 +23,8 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPacka
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.EngineFilter.includeEngines;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+import static org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners.abortOnFailure;
+import static org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners.logging;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -46,6 +48,7 @@ import org.junit.platform.launcher.DiscoveryFilterStub;
 import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilterStub;
+import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 
 /**
  * @since 1.0
@@ -314,6 +317,50 @@ class LauncherDiscoveryRequestBuilderTests {
 			assertThat(configParams.get("key1")).contains("value1");
 			assertThat(configParams.get("key2")).contains("value2");
 		}
+	}
+
+	@Nested
+	class DisoveryListenerTests {
+
+		@Test
+		void usesAbortOnFailureByDefault() {
+			var request = request().build();
+
+			assertThat(request.getDiscoveryListener()).isEqualTo(abortOnFailure());
+		}
+
+		@Test
+		void onlyAddsAbortOnFailureOnce() {
+			var request = request() //
+					.listeners(abortOnFailure()) //
+					.configurationParameter(
+						LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME,
+						"abortOnFailure") //
+					.build();
+
+			assertThat(request.getDiscoveryListener()).isEqualTo(abortOnFailure());
+		}
+
+		@Test
+		void onlyAddsLoggingOnce() {
+			var request = request() //
+					.listeners(logging()) //
+					.configurationParameter(
+						LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+					.build();
+
+			assertThat(request.getDiscoveryListener()).isEqualTo(logging());
+		}
+
+		@Test
+		void createsCompositeForMultipleListeners() {
+			var request = request() //
+					.listeners(logging(), abortOnFailure()) //
+					.build();
+
+			assertThat(request.getDiscoveryListener().getClass().getSimpleName()).startsWith("Composite");
+		}
+
 	}
 
 	private static class SampleTestClass {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilderTests.java
@@ -22,6 +22,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectModul
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.EngineFilter.includeEngines;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners.abortOnFailure;
 import static org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners.logging;
@@ -48,7 +49,6 @@ import org.junit.platform.launcher.DiscoveryFilterStub;
 import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilterStub;
-import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 
 /**
  * @since 1.0
@@ -320,7 +320,7 @@ class LauncherDiscoveryRequestBuilderTests {
 	}
 
 	@Nested
-	class DisoveryListenerTests {
+	class DiscoveryListenerTests {
 
 		@Test
 		void usesAbortOnFailureByDefault() {
@@ -333,9 +333,7 @@ class LauncherDiscoveryRequestBuilderTests {
 		void onlyAddsAbortOnFailureOnce() {
 			var request = request() //
 					.listeners(abortOnFailure()) //
-					.configurationParameter(
-						LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME,
-						"abortOnFailure") //
+					.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "abortOnFailure") //
 					.build();
 
 			assertThat(request.getDiscoveryListener()).isEqualTo(abortOnFailure());
@@ -345,8 +343,7 @@ class LauncherDiscoveryRequestBuilderTests {
 		void onlyAddsLoggingOnce() {
 			var request = request() //
 					.listeners(logging()) //
-					.configurationParameter(
-						LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+					.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 					.build();
 
 			assertThat(request.getDiscoveryListener()).isEqualTo(logging());

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryForTestingPurposesOnly.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryForTestingPurposesOnly.java
@@ -10,17 +10,20 @@
 
 package org.junit.platform.launcher.core;
 
-import static java.util.Arrays.asList;
-
 import org.junit.platform.engine.TestEngine;
+import org.junit.platform.launcher.Launcher;
 
 /**
  * @since 1.0
  */
 public class LauncherFactoryForTestingPurposesOnly {
 
-	public static DefaultLauncher createLauncher(TestEngine... engines) {
-		return new DefaultLauncher(asList(engines));
+	public static Launcher createLauncher(TestEngine... engines) {
+		return LauncherFactory.create(LauncherConfig.builder() //
+				.enableTestEngineAutoRegistration(false) //
+				.addTestEngines(engines) //
+				.enableTestExecutionListenerAutoRegistration(false) //
+				.build());
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
@@ -73,7 +73,7 @@ class StreamInterceptingTestExecutionListenerIntegrationTests {
 			return null;
 		}).when(listener).executionStarted(any());
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		LauncherDiscoveryRequest discoveryRequest = request()//
 				.selectors(selectUniqueId(test.getUniqueId()))//
 				.configurationParameter(configParam, String.valueOf(true))//
@@ -106,7 +106,7 @@ class StreamInterceptingTestExecutionListenerIntegrationTests {
 		assertThat(StreamInterceptor.registerStdout(1)).isPresent();
 		assertThat(StreamInterceptor.registerStderr(1)).isPresent();
 
-		DefaultLauncher launcher = createLauncher(engine);
+		var launcher = createLauncher(engine);
 		LauncherDiscoveryRequest discoveryRequest = request()//
 				.selectors(selectUniqueId(test.getUniqueId()))//
 				.configurationParameter(configParam, String.valueOf(true))//

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListenerTests.java
@@ -21,15 +21,12 @@ import static org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryL
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.JUnitException;
-import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryRequest;
-import org.junit.platform.engine.SelectorResolutionResult;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.fakes.TestEngineStub;
 
-class AbortOnFailureLauncherDiscoveryListenerTests {
+class AbortOnFailureLauncherDiscoveryListenerTests extends AbstractLauncherDiscoveryListenerTests {
 
 	@Test
 	void abortsDiscoveryOnUnresolvedUniqueIdSelectorWithEnginePrefix() {
@@ -96,29 +93,4 @@ class AbortOnFailureLauncherDiscoveryListenerTests {
 				.hasCauseReference(rootCause);
 	}
 
-	private TestEngineStub createEngineThatCannotResolveAnything(String engineId) {
-		return new TestEngineStub(engineId) {
-			@Override
-			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
-				discoveryRequest.getSelectorsByType(DiscoverySelector.class).forEach(selector -> {
-					discoveryRequest.getDiscoveryListener().selectorProcessed(uniqueId, selector,
-						SelectorResolutionResult.unresolved());
-				});
-				return new EngineDescriptor(uniqueId, "Some Engine");
-			}
-		};
-	}
-
-	private TestEngineStub createEngineThatFailsToResolveAnything(String engineId, RuntimeException rootCause) {
-		return new TestEngineStub(engineId) {
-			@Override
-			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
-				discoveryRequest.getSelectorsByType(DiscoverySelector.class).forEach(selector -> {
-					discoveryRequest.getDiscoveryListener().selectorProcessed(uniqueId, selector,
-						SelectorResolutionResult.failed(rootCause));
-				});
-				return new EngineDescriptor(uniqueId, "Some Engine");
-			}
-		};
-	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListenerTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
+import static org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners.abortOnFailure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.SelectorResolutionResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+import org.junit.platform.fakes.TestEngineStub;
+
+class AbortOnFailureLauncherDiscoveryListenerTests {
+
+	@Test
+	void abortsDiscoveryOnUnresolvedUniqueIdSelectorWithEnginePrefix() {
+		var engine = createEngineThatCannotResolveAnything("some-engine");
+		var request = request() //
+				.listeners(abortOnFailure()) //
+				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		var exception = assertThrows(JUnitException.class, () -> launcher.discover(request));
+		assertThat(exception).hasMessage("TestEngine with ID 'some-engine' failed to discover tests");
+		assertThat(exception.getCause()).hasMessage(
+			"UniqueIdSelector [uniqueId = [engine:some-engine]] could not be resolved");
+	}
+
+	@Test
+	void doesNotAbortDiscoveryOnUnresolvedUniqueIdSelectorWithoutEnginePrefix() {
+		var engine = createEngineThatCannotResolveAnything("some-engine");
+		var request = request() //
+				.listeners(abortOnFailure()) //
+				.selectors(selectUniqueId(UniqueId.forEngine("some-other-engine"))) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		assertDoesNotThrow(() -> launcher.discover(request));
+	}
+
+	@Test
+	void abortsDiscoveryOnSelectorResolutionFailure() {
+		var rootCause = new RuntimeException();
+		var engine = createEngineThatFailsToResolveAnything("some-engine", rootCause);
+		var request = request() //
+				.listeners(abortOnFailure()) //
+				.selectors(selectClass(Object.class)) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		var exception = assertThrows(JUnitException.class, () -> launcher.discover(request));
+		assertThat(exception).hasMessage("TestEngine with ID 'some-engine' failed to discover tests");
+		assertThat(exception.getCause()) //
+				.hasMessageEndingWith("resolution failed") //
+				.hasCauseReference(rootCause);
+	}
+
+	@Test
+	void abortsDiscoveryOnEngineDiscoveryFailure() {
+		var rootCause = new RuntimeException();
+		var engine = new TestEngineStub("some-engine") {
+			@Override
+			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+				throw rootCause;
+			}
+		};
+		var request = request() //
+				.listeners(abortOnFailure()) //
+				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		var exception = assertThrows(JUnitException.class, () -> launcher.discover(request));
+		assertThat(exception) //
+				.hasMessage("TestEngine with ID 'some-engine' failed to discover tests") //
+				.hasCauseReference(rootCause);
+	}
+
+	private TestEngineStub createEngineThatCannotResolveAnything(String engineId) {
+		return new TestEngineStub(engineId) {
+			@Override
+			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+				discoveryRequest.getSelectorsByType(DiscoverySelector.class).forEach(selector -> {
+					discoveryRequest.getDiscoveryListener().selectorProcessed(uniqueId, selector,
+						SelectorResolutionResult.unresolved());
+				});
+				return new EngineDescriptor(uniqueId, "Some Engine");
+			}
+		};
+	}
+
+	private TestEngineStub createEngineThatFailsToResolveAnything(String engineId, RuntimeException rootCause) {
+		return new TestEngineStub(engineId) {
+			@Override
+			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+				discoveryRequest.getSelectorsByType(DiscoverySelector.class).forEach(selector -> {
+					discoveryRequest.getDiscoveryListener().selectorProcessed(uniqueId, selector,
+						SelectorResolutionResult.failed(rootCause));
+				});
+				return new EngineDescriptor(uniqueId, "Some Engine");
+			}
+		};
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/AbstractLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/AbstractLauncherDiscoveryListenerTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.discovery;
+
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.SelectorResolutionResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+import org.junit.platform.fakes.TestEngineStub;
+
+abstract class AbstractLauncherDiscoveryListenerTests {
+
+	protected TestEngineStub createEngineThatCannotResolveAnything(String engineId) {
+		return new TestEngineStub(engineId) {
+			@Override
+			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+				discoveryRequest.getSelectorsByType(DiscoverySelector.class).forEach(selector -> {
+					discoveryRequest.getDiscoveryListener().selectorProcessed(uniqueId, selector,
+						SelectorResolutionResult.unresolved());
+				});
+				return new EngineDescriptor(uniqueId, "Some Engine");
+			}
+		};
+	}
+
+	protected TestEngineStub createEngineThatFailsToResolveAnything(String engineId, RuntimeException rootCause) {
+		return new TestEngineStub(engineId) {
+			@Override
+			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+				discoveryRequest.getSelectorsByType(DiscoverySelector.class).forEach(selector -> {
+					discoveryRequest.getDiscoveryListener().selectorProcessed(uniqueId, selector,
+						SelectorResolutionResult.failed(rootCause));
+				});
+				return new EngineDescriptor(uniqueId, "Some Engine");
+			}
+		};
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.engine.TrackLogRecords;
+import org.junit.platform.commons.logging.LogRecordListener;
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.fakes.TestEngineStub;
+
+@TrackLogRecords
+public class LoggingLauncherDiscoveryListenerTests extends AbstractLauncherDiscoveryListenerTests {
+
+	@Test
+	void logsWarningOnUnresolvedUniqueIdSelectorWithEnginePrefix(LogRecordListener log) {
+		var engine = createEngineThatCannotResolveAnything("some-engine");
+		var request = request() //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		launcher.discover(request);
+
+		assertThat(log.stream(LoggingLauncherDiscoveryListener.class, Level.WARNING)) //
+				.extracting(LogRecord::getMessage) //
+				.containsExactly(
+					"UniqueIdSelector [uniqueId = [engine:some-engine]] could not be resolved by [engine:some-engine]");
+	}
+
+	@Test
+	void logsDebugMessageOnUnresolvedUniqueIdSelectorWithoutEnginePrefix(LogRecordListener log) {
+		var engine = createEngineThatCannotResolveAnything("some-engine");
+		var request = request() //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.selectors(selectUniqueId(UniqueId.forEngine("some-other-engine"))) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		launcher.discover(request);
+
+		assertThat(log.stream(LoggingLauncherDiscoveryListener.class, Level.FINE)) //
+				.extracting(LogRecord::getMessage) //
+				.containsExactly(
+					"UniqueIdSelector [uniqueId = [engine:some-other-engine]] could not be resolved by [engine:some-engine]");
+	}
+
+	@Test
+	void logsErrorOnSelectorResolutionFailure(LogRecordListener log) {
+		var rootCause = new RuntimeException();
+		var engine = createEngineThatFailsToResolveAnything("some-engine", rootCause);
+		var request = request() //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.selectors(selectClass(Object.class)) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		launcher.discover(request);
+
+		assertThat(log.stream(LoggingLauncherDiscoveryListener.class, Level.SEVERE)) //
+				.extracting(LogRecord::getMessage) //
+				.containsExactly(
+					"Resolution of ClassSelector [className = 'java.lang.Object'] by [engine:some-engine] failed");
+	}
+
+	@Test
+	void logsErrorOnEngineDiscoveryFailure(LogRecordListener log) {
+		var rootCause = new RuntimeException();
+		var engine = new TestEngineStub("some-engine") {
+			@Override
+			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+				throw rootCause;
+			}
+		};
+		var request = request() //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		launcher.discover(request);
+
+		var logRecord = log.stream(LoggingLauncherDiscoveryListener.class, Level.SEVERE).findFirst().get();
+		assertThat(logRecord.getMessage()).isEqualTo("TestEngine with ID 'some-engine' failed to discover tests");
+		assertThat(logRecord.getThrown()).isSameAs(rootCause);
+	}
+
+	@Test
+	void logsTraceMessageOnStartAndEnd(LogRecordListener log) {
+		var engine = new TestEngineStub("some-engine");
+		var request = request() //
+				.configurationParameter(
+					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.build();
+		var launcher = createLauncher(engine);
+
+		launcher.discover(request);
+
+		assertThat(log.stream(LoggingLauncherDiscoveryListener.class, Level.FINER)) //
+				.extracting(LogRecord::getMessage) //
+				.containsExactly( //
+					"Engine [engine:some-engine] has started discovering tests", //
+					"Engine [engine:some-engine] has finished discovering tests");
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
@@ -13,6 +13,7 @@ package org.junit.platform.launcher.listeners.discovery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
 
@@ -34,8 +35,7 @@ public class LoggingLauncherDiscoveryListenerTests extends AbstractLauncherDisco
 	void logsWarningOnUnresolvedUniqueIdSelectorWithEnginePrefix(LogRecordListener log) {
 		var engine = createEngineThatCannotResolveAnything("some-engine");
 		var request = request() //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
 				.build();
 		var launcher = createLauncher(engine);
@@ -52,8 +52,7 @@ public class LoggingLauncherDiscoveryListenerTests extends AbstractLauncherDisco
 	void logsDebugMessageOnUnresolvedUniqueIdSelectorWithoutEnginePrefix(LogRecordListener log) {
 		var engine = createEngineThatCannotResolveAnything("some-engine");
 		var request = request() //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine("some-other-engine"))) //
 				.build();
 		var launcher = createLauncher(engine);
@@ -71,8 +70,7 @@ public class LoggingLauncherDiscoveryListenerTests extends AbstractLauncherDisco
 		var rootCause = new RuntimeException();
 		var engine = createEngineThatFailsToResolveAnything("some-engine", rootCause);
 		var request = request() //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectClass(Object.class)) //
 				.build();
 		var launcher = createLauncher(engine);
@@ -95,8 +93,7 @@ public class LoggingLauncherDiscoveryListenerTests extends AbstractLauncherDisco
 			}
 		};
 		var request = request() //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
 				.build();
 		var launcher = createLauncher(engine);
@@ -112,8 +109,7 @@ public class LoggingLauncherDiscoveryListenerTests extends AbstractLauncherDisco
 	void logsTraceMessageOnStartAndEnd(LogRecordListener log) {
 		var engine = new TestEngineStub("some-engine");
 		var request = request() //
-				.configurationParameter(
-					LauncherDiscoveryListeners.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
+				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
 				.build();
 		var launcher = createLauncher(engine);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
@@ -21,7 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.engine.TrackLogRecords;
+import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.TestDescriptor;

--- a/platform-tests/src/test/resources/log4j2-test.xml
+++ b/platform-tests/src/test/resources/log4j2-test.xml
@@ -12,6 +12,7 @@
 		<Logger name="org.junit.platform.launcher.core.DefaultLauncher" level="fatal" />
 		<Logger name="org.junit.platform.launcher.core.InternalTestPlan" level="error" />
 		<Logger name="org.junit.platform.launcher.core.TestExecutionListenerRegistry" level="error" />
+		<Logger name="org.junit.platform.launcher.listeners.discovery.LoggingLauncherDiscoveryListener" level="off" />
 		<Logger name="org.junit.ApiReportGenerator" level="error" />
 		<Logger name="org.junit.vintage.engine" level="error" />
 		<Logger name="org.junit.jupiter.engine" level="error" />

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-launcher.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-launcher.expected.txt
@@ -2,6 +2,7 @@ org.junit.platform.launcher@${platformVersion} jar:file:.+junit-platform-launche
 exports org.junit.platform.launcher
 exports org.junit.platform.launcher.core
 exports org.junit.platform.launcher.listeners
+exports org.junit.platform.launcher.listeners.discovery
 requires java.base mandated
 requires java.logging
 requires org.apiguardian.api transitive


### PR DESCRIPTION
## Overview

This PR adds the ability to add `LauncherDiscoveryListeners` to `LauncherDiscoveryRequests`. Such listeners are notified when engines resolve or fail to resolve a `DiscoverySelector` and can decide how to handle this. The default listener (up for debate!), currently only logs messages. The new `abortOnFailure()` listener, however, throws exceptions thereby effectively aborting test discovery.

Resolves #2052.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
