### PR TITLE
Revert build to use Java 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   linux:
-    name: 'Linux (JDK 12)'
+    name: 'Linux'
     runs-on: ubuntu-latest
     container: junitteam/build:latest
     steps:
@@ -22,14 +22,14 @@ jobs:
         ./gradlew --scan --warning-mode=all -Dplatform.tooling.support.tests.enabled=true build
 
   windows:
-    name: 'Windows (JDK 12)'
+    name: 'Windows'
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@master
-    - name: 'Set up JDK 12'
+    - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
-        java-version: 12
+        java-version: 11
     - name: 'Test'
       shell: bash
       run: |
@@ -37,14 +37,14 @@ jobs:
         ./gradlew --scan --warning-mode=all -Dplatform.tooling.support.tests.enabled=true build
 
   mac:
-    name: 'Mac OS (JDK 12)'
+    name: 'Mac OS'
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@master
-    - name: 'Set up JDK 12'
+    - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
-        java-version: 12
+        java-version: 11
     - name: 'Test'
       run: |
         ./gradlew --version
@@ -57,10 +57,10 @@ jobs:
     container: junitteam/build:latest
     steps:
     - uses: actions/checkout@master
-    - name: 'Set up JDK 12'
+    - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
-        java-version: 12
+        java-version: 11
     - name: 'Run tests with JaCoCo'
       shell: bash
       run: |
@@ -80,10 +80,10 @@ jobs:
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/heads/releases/') || github.ref == 'refs/heads/master')
     steps:
     - uses: actions/checkout@master
-    - name: 'Set up JDK 12'
+    - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
-        java-version: 12
+        java-version: 11
     - name: 'Publish'
       env:
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -97,10 +97,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@master
-    - name: 'Set up JDK 12'
+    - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
-        java-version: 12
+        java-version: 11
     - name: 'Upload Documentation'
       env:
         GRGIT_USER: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ build scan for JUnit 5 can be viewed [here](https://scans.gradle.com/s/bl3pw4mrb
 
 ## Building from Source
 
-You need [JDK 12] to build JUnit 5.
+You need [JDK 11] to build JUnit 5.
 
 All modules can be _built_ with the [Gradle Wrapper] using the following command.
 
@@ -127,7 +127,7 @@ See also <https://repo1.maven.org/maven2/org/junit/> for releases and <https://o
 [Gradle Wrapper]: https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:using_wrapper
 [JaCoCo]: https://www.eclemma.org/jacoco/
 [Javadoc]: https://junit.org/junit5/docs/current/api/
-[JDK 12]: https://jdk.java.net/12/
+[JDK 11]: https://jdk.java.net/11/
 [Release Notes]: https://junit.org/junit5/docs/current/release-notes/
 [StackOverflow]: https://stackoverflow.com/questions/tagged/junit5
 [User Guide]: https://junit.org/junit5/docs/current/user-guide/

--- a/buildSrc/src/main/kotlin/JavaLibraryExtension.kt
+++ b/buildSrc/src/main/kotlin/JavaLibraryExtension.kt
@@ -3,5 +3,5 @@ import org.gradle.api.JavaVersion
 @Suppress("UnstableApiUsage")
 open class JavaLibraryExtension {
     var mainJavaVersion: JavaVersion = Versions.jvmTarget
-    var testJavaVersion: JavaVersion = JavaVersion.VERSION_12
+    var testJavaVersion: JavaVersion = JavaVersion.VERSION_11
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,8 +14,8 @@ pluginManagement {
 }
 
 val javaVersion = JavaVersion.current()
-require(javaVersion.isJava12Compatible) {
-	"The JUnit 5 build requires Java 12 or higher. Currently executing with Java ${javaVersion.majorVersion}."
+require(javaVersion.isJava11Compatible) {
+	"The JUnit 5 build requires Java 11 or higher. Currently executing with Java ${javaVersion.majorVersion}."
 }
 
 rootProject.name = "junit5"


### PR DESCRIPTION
We rely on tools such as Gradle, JaCoCo, Asciidoctor, and others and the
past few months have shown that's it's unrealistic to expect all of
them to be compatible with the latest JDK as soon as it's released. For
example, we're currently stuck on JDK 12 because Asciidoctor does not
yet support JDK 13. Since we don't want to compromise the safety of our
contributors, we should not rely on outdated non-LTS releases. Instead,
we now switch back the build to be compatible with the JDK 11 LTS
release which will get security patches until JDK 17 is released.

Closes #2018. Closes #2061. Closes #1906.