### PR TITLE
Evaluate @TempDir in enclosing classes of the test class as well.

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -89,6 +89,13 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 				.assertStatistics(stats -> stats.started(1).succeeded(1));
 	}
 
+	@Test
+	@DisplayName("can be used in nested test class")
+	void canBeUsedInNestedTestClass() {
+		executeTestsForClass(TempDirCanBeUsedInNestedTestClass.class).testEvents()//
+				.assertStatistics(stats -> stats.started(2).succeeded(2));
+	}
+
 	@Nested
 	@DisplayName("resolves shared temp dir")
 	@TestMethodOrder(OrderAnnotation.class)
@@ -766,4 +773,30 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 
 	}
 
+	// https://github.com/junit-team/junit5/issues/2079
+	static class TempDirCanBeUsedInNestedTestClass {
+
+		@TempDir
+		File tempDir;
+
+		@Nested
+		class NestedTestClass {
+
+			@Test
+			void testNested() {
+				assertNotNull(tempDir);
+				assertTrue(tempDir.exists());
+			}
+
+			@Nested
+			class EvenDeeperNestedTestClass {
+
+				@Test
+				void testDeepNested() {
+					assertNotNull(tempDir);
+					assertTrue(tempDir.exists());
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fixes: #2079

## Overview

`@TempDir` annotation are now evaluated in the test class and all enclosing classes of the test class.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
