### PR TITLE
Make TestExecutionSummary.Failure serializable

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
@@ -279,6 +279,8 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 
 	private static class DefaultFailure implements Failure {
 
+		private static final long serialVersionUID = 1L;
+
 		private final TestIdentifier testIdentifier;
 		private final Throwable exception;
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/TestExecutionSummary.java
@@ -13,6 +13,7 @@ package org.junit.platform.launcher.listeners;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.util.List;
 
 import org.apiguardian.api.API;
@@ -163,7 +164,7 @@ public interface TestExecutionSummary {
 	/**
 	 * Failure of a test or container.
 	 */
-	interface Failure {
+	interface Failure extends Serializable {
 
 		/**
 		 * Get the identifier of the failed test or container.


### PR DESCRIPTION
## Overview

Make the `TestExecutionSummary.Failure` interface serializable.

The `Throwable` and `TestIdentifier` classes that are used by this interface are serializable, so it is safe to make it serializable also.

The default implementation `org.junit.platform.launcher.listeners.MutableTestExecutionSummary.DefaultFailure` is also safe to make serializable as it's a simple Java Bean with these two serializable fields.

I need to be able to serialize to disk the failures of a test for [QuickPerf](https://github.com/quick-perf), a tool that I works on a JUnit5 implementation that allows to make rapid performance test with JUnit4 and soon 5. 

As QuickPerf needs to launch a test in a separate JVM we need a way to pass the failures from one JVM to the other, and serializing them to disk is the easiest way to do it.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
