### PR TITLE
Allow to skip a test invocation from an extension

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/InvocationInterceptor.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/InvocationInterceptor.java
@@ -31,9 +31,8 @@ import org.junit.jupiter.api.TestTemplate;
  *
  * <h3>Invocation Contract</h3>
  *
- * <p>Each method in this class must execute the supplied {@linkplain Invocation
- * invocation} exactly once. Otherwise, the enclosing test or container will be
- * reported as failed.
+ * <p>Each method in this class must call {@link Invocation#proceed()} or {@link Invocation#skip()} exactly once
+ * on the supplied invocation. Otherwise, the enclosing test or container will be reported as failed.
  *
  * <p>The default implementation simply calls {@link Invocation#proceed()
  * proceed()} on the supplied {@linkplain Invocation invocation}.
@@ -207,6 +206,13 @@ public interface InvocationInterceptor extends Extension {
 		 */
 		T proceed() throws Throwable;
 
+		/**
+		 * Skip this invocation.
+		 * By default: do nothing.
+		 */
+		default void skip() {
+			//do nothing
+		}
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InvocationInterceptorChain.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InvocationInterceptorChain.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.ExceptionUtils;
 
 @API(status = INTERNAL, since = "5.5")
@@ -104,11 +106,17 @@ public class InvocationInterceptorChain {
 			return call.apply(interceptor, invocation);
 		}
 
+		@Override
+		public void skip() {
+			invocation.skip();
+		}
 	}
 
 	private static class ValidatingInvocation<T> implements Invocation<T> {
 
-		private final AtomicBoolean invoked = new AtomicBoolean();
+		private static final Logger LOG = LoggerFactory.getLogger(ValidatingInvocation.class);
+
+		private final AtomicBoolean invokedOrSkipped = new AtomicBoolean();
 		private final Invocation<T> delegate;
 		private final List<InvocationInterceptor> interceptors;
 
@@ -119,14 +127,14 @@ public class InvocationInterceptorChain {
 
 		@Override
 		public T proceed() throws Throwable {
-			if (!invoked.compareAndSet(false, true)) {
+			if (!invokedOrSkipped.compareAndSet(false, true)) {
 				fail("Chain of InvocationInterceptors called invocation multiple times instead of just once");
 			}
 			return delegate.proceed();
 		}
 
 		void verifyInvokedAtLeastOnce() {
-			if (!invoked.get()) {
+			if (!invokedOrSkipped.get()) {
 				fail("Chain of InvocationInterceptors never called invocation");
 			}
 		}
@@ -137,6 +145,14 @@ public class InvocationInterceptorChain {
 			throw new JUnitException(prefix + ": " + commaSeparatedInterceptorClasses);
 		}
 
+		@Override
+		public void skip() {
+			LOG.debug(() -> "The invocation is skipped");
+			if (!invokedOrSkipped.compareAndSet(false, true)) {
+				fail("Chain of InvocationInterceptors called invocation multiple times instead of just once");
+			}
+			delegate.skip();
+		}
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.extension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
@@ -70,6 +71,29 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 		@Test
 		void test() {
 			// never called
+		}
+	}
+
+	@Test
+	void successTestWhenInterceptorChainSkippedInvocation() {
+		var results = executeTestsForClass(InvocationSkippedTestCase.class);
+
+		results.testEvents().assertStatistics(stats -> stats.failed(0).succeeded(1));
+	}
+
+	static class InvocationSkippedTestCase {
+		@RegisterExtension
+		Extension interceptor = new InvocationInterceptor() {
+			@Override
+			public void interceptTestMethod(Invocation<Void> invocation,
+					ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) {
+				invocation.skip();
+			}
+		};
+
+		@Test
+		void test() {
+			fail("should not be called");
 		}
 	}
 


### PR DESCRIPTION
## Overview

Allow to skip a test invocation from an extension

Fixes #2083

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
