### PR TITLE
Support repeatable annotations for built-in conditions

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
@@ -40,6 +40,10 @@ on GitHub.
 
 ==== New Features and Improvements
 
+* `@EnabledIfEnvironmentVariable`, `@DisabledIfEnvironmentVariable`,
+  `@EnabledIfSystemProperty`, and `@DisabledIfSystemProperty` may now be used as
+  _repeatable_ annotations. In other words, it is now possible to declare each of those
+  annotations multiple times on a test interface, test class, or test method.
 * `InvocationInterceptor` extensions may now explicitly `skip()` an intercepted
   invocation. This allows executing it by other means, e.g. in a forked JVM.
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -358,13 +358,13 @@ combine `@Test` and `@EnabledOnOs` in a single, reusable annotation.
 
 [WARNING]
 ====
-Each of the _conditional_ annotations listed in the following sections can only be
-declared once on a given test interface, test class, or test method. If a conditional
-annotation is directly present, indirectly present, or meta-present multiple times on a
-given element, only the first such annotation discovered by JUnit will be used; any
-additional declarations will be silently ignored. Note, however, that each conditional
-annotation may be used in conjunction with other conditional annotations in the
-`org.junit.jupiter.api.condition` package.
+Unless otherwise stated, each of the _conditional_ annotations listed in the following
+sections can only be declared once on a given test interface, test class, or test method.
+If a conditional annotation is directly present, indirectly present, or meta-present
+multiple times on a given element, only the first such annotation discovered by JUnit will
+be used; any additional declarations will be silently ignored. Note, however, that each
+conditional annotation may be used in conjunction with other conditional annotations in
+the `org.junit.jupiter.api.condition` package.
 ====
 
 [[writing-tests-conditional-execution-os]]
@@ -407,6 +407,14 @@ regular expression.
 include::{testDir}/example/ConditionalTestExecutionDemo.java[tags=user_guide_system_property]
 ----
 
+[TIP]
+====
+As of JUnit Jupiter 5.6, `{EnabledIfSystemProperty}` and `{DisabledIfSystemProperty}` are
+_repeatable annotations_. Consequently, these annotations may be declared multiple times
+on a test interface, test class, or test method. Specifically, these annotations will be
+found if they are directly present, indirectly present, or meta-present on a given element.
+====
+
 [[writing-tests-conditional-execution-environment-variables]]
 ==== Environment Variable Conditions
 
@@ -419,6 +427,15 @@ value supplied via the `matches` attribute will be interpreted as a regular expr
 ----
 include::{testDir}/example/ConditionalTestExecutionDemo.java[tags=user_guide_environment_variable]
 ----
+
+[TIP]
+====
+As of JUnit Jupiter 5.6, `{EnabledIfEnvironmentVariable}` and
+`{DisabledIfEnvironmentVariable}` are _repeatable annotations_. Consequently, these
+annotations may be declared multiple times on a test interface, test class, or test
+method. Specifically, these annotations will be found if they are directly present,
+indirectly present, or meta-present on a given element.
+====
 
 
 [[writing-tests-tagging-and-filtering]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractRepeatableAnnotationCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractRepeatableAnnotationCondition.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static java.lang.String.format;
+import static org.junit.platform.commons.util.AnnotationUtils.findRepeatableAnnotations;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Repeatable;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+
+/**
+ * Abstract base class for {@link ExecutionCondition} implementations that support
+ * {@linkplain Repeatable repeatable} annotations.
+ *
+ * @param <A> the type of repeatable annotation supported by this {@code ExecutionCondition}
+ * @since 5.6
+ */
+abstract class AbstractRepeatableAnnotationCondition<A extends Annotation> implements ExecutionCondition {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	private final Class<A> annotationType;
+
+	AbstractRepeatableAnnotationCondition(Class<A> annotationType) {
+		this.annotationType = annotationType;
+	}
+
+	@Override
+	public final ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		Optional<AnnotatedElement> optionalElement = context.getElement();
+		if (optionalElement.isPresent()) {
+			AnnotatedElement annotatedElement = optionalElement.get();
+			// @formatter:off
+			return findRepeatableAnnotations(annotatedElement, this.annotationType).stream()
+					.map(annotation -> {
+						ConditionEvaluationResult result = evaluate(annotation);
+						logResult(annotation, annotatedElement, result);
+						return result;
+					})
+					.filter(ConditionEvaluationResult::isDisabled)
+					.findFirst()
+					.orElse(getNoDisabledConditionsEncounteredResult());
+			// @formatter:on
+		}
+		return getNoDisabledConditionsEncounteredResult();
+	}
+
+	protected abstract ConditionEvaluationResult evaluate(A annotation);
+
+	protected abstract ConditionEvaluationResult getNoDisabledConditionsEncounteredResult();
+
+	private void logResult(A annotation, AnnotatedElement annotatedElement, ConditionEvaluationResult result) {
+		logger.trace(() -> format("Evaluation of %s on [%s] resulted in: %s", annotation, annotatedElement, result));
+	}
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -43,16 +44,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * custom <em>composed annotation</em> that inherits the semantics of this
  * annotation.
  *
- * <h4>Warning</h4>
- *
- * <p>As of JUnit Jupiter 5.1, this annotation can only be declared once on an
- * {@link java.lang.reflect.AnnotatedElement AnnotatedElement} (i.e., test
- * interface, test class, or test method). If this annotation is directly
- * present, indirectly present, or meta-present multiple times on a given
- * element, only the first such annotation discovered by JUnit will be used;
- * any additional declarations will be silently ignored. Note, however, that
- * this annotation may be used in conjunction with other {@code @Enabled*} or
- * {@code @Disabled*} annotations in this package.
+ * <p>As of JUnit Jupiter 5.6, this annotation is a {@linkplain Repeatable
+ * repeatable} annotation. Consequently, this annotation may be declared multiple
+ * times on an {@link java.lang.reflect.AnnotatedElement AnnotatedElement} (i.e.,
+ * test interface, test class, or test method). Specifically, this annotation will
+ * be found if it is directly present, indirectly present, or meta-present on a
+ * given element.
  *
  * @since 5.1
  * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
@@ -69,6 +66,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(DisabledIfEnvironmentVariables.class)
 @ExtendWith(DisabledIfEnvironmentVariableCondition.class)
 @API(status = STABLE, since = "5.1")
 public @interface DisabledIfEnvironmentVariable {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableCondition.java
@@ -13,13 +13,9 @@ package org.junit.jupiter.api.condition;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
-
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -28,21 +24,23 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see DisabledIfEnvironmentVariable
  */
-class DisabledIfEnvironmentVariableCondition implements ExecutionCondition {
+class DisabledIfEnvironmentVariableCondition
+		extends AbstractRepeatableAnnotationCondition<DisabledIfEnvironmentVariable> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled(
-		"@DisabledIfEnvironmentVariable is not present");
+	private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
+		"No @DisabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+
+	DisabledIfEnvironmentVariableCondition() {
+		super(DisabledIfEnvironmentVariable.class);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<DisabledIfEnvironmentVariable> optional = findAnnotation(context.getElement(),
-			DisabledIfEnvironmentVariable.class);
+	protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
+		return ENABLED;
+	}
 
-		if (!optional.isPresent()) {
-			return ENABLED_BY_DEFAULT;
-		}
-
-		DisabledIfEnvironmentVariable annotation = optional.get();
+	@Override
+	protected ConditionEvaluationResult evaluate(DisabledIfEnvironmentVariable annotation) {
 		String name = annotation.named().trim();
 		String regex = annotation.matches();
 		Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariables.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariables.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code @DisabledIfEnvironmentVariables} is a container for one or more
+ * {@link DisabledIfEnvironmentVariable @DisabledIfEnvironmentVariable} declarations.
+ *
+ * <p>Note, however, that use of the {@code @DisabledIfEnvironmentVariables} container
+ * is completely optional since {@code @DisabledIfEnvironmentVariable} is a {@linkplain
+ * java.lang.annotation.Repeatable repeatable} annotation.
+ *
+ * @since 5.6
+ * @see DisabledIfEnvironmentVariable
+ * @see java.lang.annotation.Repeatable
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = STABLE, since = "5.6")
+public @interface DisabledIfEnvironmentVariables {
+
+	/**
+	 * An array of one or more {@link DisabledIfEnvironmentVariable @DisabledIfEnvironmentVariable}
+	 * declarations.
+	 */
+	DisabledIfEnvironmentVariable[] value();
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperties.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code @DisabledIfSystemProperties} is a container for one or more
+ * {@link DisabledIfSystemProperty @DisabledIfSystemProperty} declarations.
+ *
+ * <p>Note, however, that use of the {@code @DisabledIfSystemProperties} container
+ * is completely optional since {@code @DisabledIfSystemProperty} is a {@linkplain
+ * java.lang.annotation.Repeatable repeatable} annotation.
+ *
+ * @since 5.6
+ * @see DisabledIfSystemProperty
+ * @see java.lang.annotation.Repeatable
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = STABLE, since = "5.6")
+public @interface DisabledIfSystemProperties {
+
+	/**
+	 * An array of one or more {@link DisabledIfSystemProperty @DisabledIfSystemProperty}
+	 * declarations.
+	 */
+	DisabledIfSystemProperty[] value();
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -43,16 +44,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * custom <em>composed annotation</em> that inherits the semantics of this
  * annotation.
  *
- * <h4>Warning</h4>
- *
- * <p>As of JUnit Jupiter 5.1, this annotation can only be declared once on an
- * {@link java.lang.reflect.AnnotatedElement AnnotatedElement} (i.e., test
- * interface, test class, or test method). If this annotation is directly
- * present, indirectly present, or meta-present multiple times on a given
- * element, only the first such annotation discovered by JUnit will be used;
- * any additional declarations will be silently ignored. Note, however, that
- * this annotation may be used in conjunction with other {@code @Enabled*} or
- * {@code @Disabled*} annotations in this package.
+ * <p>As of JUnit Jupiter 5.6, this annotation is a {@linkplain Repeatable
+ * repeatable} annotation. Consequently, this annotation may be declared multiple
+ * times on an {@link java.lang.reflect.AnnotatedElement AnnotatedElement} (i.e.,
+ * test interface, test class, or test method). Specifically, this annotation will
+ * be found if it is directly present, indirectly present, or meta-present on a
+ * given element.
  *
  * @since 5.1
  * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
@@ -69,6 +66,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(DisabledIfSystemProperties.class)
 @ExtendWith(DisabledIfSystemPropertyCondition.class)
 @API(status = STABLE, since = "5.1")
 public @interface DisabledIfSystemProperty {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyCondition.java
@@ -13,13 +13,9 @@ package org.junit.jupiter.api.condition;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
-
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -28,21 +24,22 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see DisabledIfSystemProperty
  */
-class DisabledIfSystemPropertyCondition implements ExecutionCondition {
+class DisabledIfSystemPropertyCondition extends AbstractRepeatableAnnotationCondition<DisabledIfSystemProperty> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled(
-		"@DisabledIfSystemProperty is not present");
+	private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
+		"No @DisabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
+
+	DisabledIfSystemPropertyCondition() {
+		super(DisabledIfSystemProperty.class);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<DisabledIfSystemProperty> optional = findAnnotation(context.getElement(),
-			DisabledIfSystemProperty.class);
+	protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
+		return ENABLED;
+	}
 
-		if (!optional.isPresent()) {
-			return ENABLED_BY_DEFAULT;
-		}
-
-		DisabledIfSystemProperty annotation = optional.get();
+	@Override
+	protected ConditionEvaluationResult evaluate(DisabledIfSystemProperty annotation) {
 		String name = annotation.named().trim();
 		String regex = annotation.matches();
 		Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -42,16 +43,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * custom <em>composed annotation</em> that inherits the semantics of this
  * annotation.
  *
- * <h4>Warning</h4>
- *
- * <p>As of JUnit Jupiter 5.1, this annotation can only be declared once on an
- * {@link java.lang.reflect.AnnotatedElement AnnotatedElement} (i.e., test
- * interface, test class, or test method). If this annotation is directly
- * present, indirectly present, or meta-present multiple times on a given
- * element, only the first such annotation discovered by JUnit will be used;
- * any additional declarations will be silently ignored. Note, however, that
- * this annotation may be used in conjunction with other {@code @Enabled*} or
- * {@code @Disabled*} annotations in this package.
+ * <p>As of JUnit Jupiter 5.6, this annotation is a {@linkplain Repeatable
+ * repeatable} annotation. Consequently, this annotation may be declared multiple
+ * times on an {@link java.lang.reflect.AnnotatedElement AnnotatedElement} (i.e.,
+ * test interface, test class, or test method). Specifically, this annotation will
+ * be found if it is directly present, indirectly present, or meta-present on a
+ * given element.
  *
  * @since 5.1
  * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
@@ -68,6 +65,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(EnabledIfEnvironmentVariables.class)
 @ExtendWith(EnabledIfEnvironmentVariableCondition.class)
 @API(status = STABLE, since = "5.1")
 public @interface EnabledIfEnvironmentVariable {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableCondition.java
@@ -13,13 +13,9 @@ package org.junit.jupiter.api.condition;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
-
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -28,21 +24,24 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see EnabledIfEnvironmentVariable
  */
-class EnabledIfEnvironmentVariableCondition implements ExecutionCondition {
+class EnabledIfEnvironmentVariableCondition
+		extends AbstractRepeatableAnnotationCondition<EnabledIfEnvironmentVariable> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled(
-		"@EnabledIfEnvironmentVariable is not present");
+	private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
+		"No @EnabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+
+	EnabledIfEnvironmentVariableCondition() {
+		super(EnabledIfEnvironmentVariable.class);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<EnabledIfEnvironmentVariable> optional = findAnnotation(context.getElement(),
-			EnabledIfEnvironmentVariable.class);
+	protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
+		return ENABLED;
+	}
 
-		if (!optional.isPresent()) {
-			return ENABLED_BY_DEFAULT;
-		}
+	@Override
+	protected ConditionEvaluationResult evaluate(EnabledIfEnvironmentVariable annotation) {
 
-		EnabledIfEnvironmentVariable annotation = optional.get();
 		String name = annotation.named().trim();
 		String regex = annotation.matches();
 		Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariables.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariables.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code @EnabledIfEnvironmentVariables} is a container for one or more
+ * {@link EnabledIfEnvironmentVariable @EnabledIfEnvironmentVariable} declarations.
+ *
+ * <p>Note, however, that use of the {@code @EnabledIfEnvironmentVariables} container
+ * is completely optional since {@code @EnabledIfEnvironmentVariable} is a {@linkplain
+ * java.lang.annotation.Repeatable repeatable} annotation.
+ *
+ * @since 5.6
+ * @see EnabledIfEnvironmentVariable
+ * @see java.lang.annotation.Repeatable
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = STABLE, since = "5.6")
+public @interface EnabledIfEnvironmentVariables {
+
+	/**
+	 * An array of one or more {@link EnabledIfEnvironmentVariable @EnabledIfEnvironmentVariable}
+	 * declarations.
+	 */
+	EnabledIfEnvironmentVariable[] value();
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperties.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code @EnabledIfSystemProperties} is a container for one or more
+ * {@link EnabledIfSystemProperty @EnabledIfSystemProperty} declarations.
+ *
+ * <p>Note, however, that use of the {@code @EnabledIfSystemProperties} container
+ * is completely optional since {@code @EnabledIfSystemProperty} is a {@linkplain
+ * java.lang.annotation.Repeatable repeatable} annotation.
+ *
+ * @since 5.6
+ * @see EnabledIfSystemProperty
+ * @see java.lang.annotation.Repeatable
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = STABLE, since = "5.6")
+public @interface EnabledIfSystemProperties {
+
+	/**
+	 * An array of one or more {@link EnabledIfSystemProperty @EnabledIfSystemProperty}
+	 * declarations.
+	 */
+	EnabledIfSystemProperty[] value();
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -42,16 +43,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * custom <em>composed annotation</em> that inherits the semantics of this
  * annotation.
  *
- * <h4>Warning</h4>
- *
- * <p>As of JUnit Jupiter 5.1, this annotation can only be declared once on an
- * {@link java.lang.reflect.AnnotatedElement AnnotatedElement} (i.e., test
- * interface, test class, or test method). If this annotation is directly
- * present, indirectly present, or meta-present multiple times on a given
- * element, only the first such annotation discovered by JUnit will be used;
- * any additional declarations will be silently ignored. Note, however, that
- * this annotation may be used in conjunction with other {@code @Enabled*} or
- * {@code @Disabled*} annotations in this package.
+ * <p>As of JUnit Jupiter 5.6, this annotation is a {@linkplain Repeatable
+ * repeatable} annotation. Consequently, this annotation may be declared multiple
+ * times on an {@link java.lang.reflect.AnnotatedElement AnnotatedElement} (i.e.,
+ * test interface, test class, or test method). Specifically, this annotation will
+ * be found if it is directly present, indirectly present, or meta-present on a
+ * given element.
  *
  * @since 5.1
  * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
@@ -68,6 +65,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(EnabledIfSystemProperties.class)
 @ExtendWith(EnabledIfSystemPropertyCondition.class)
 @API(status = STABLE, since = "5.1")
 public @interface EnabledIfSystemProperty {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyCondition.java
@@ -13,13 +13,9 @@ package org.junit.jupiter.api.condition;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
-
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -28,21 +24,23 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see EnabledIfSystemProperty
  */
-class EnabledIfSystemPropertyCondition implements ExecutionCondition {
+class EnabledIfSystemPropertyCondition extends AbstractRepeatableAnnotationCondition<EnabledIfSystemProperty> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled(
-		"@EnabledIfSystemProperty is not present");
+	private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
+		"No @EnabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
+
+	EnabledIfSystemPropertyCondition() {
+		super(EnabledIfSystemProperty.class);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<EnabledIfSystemProperty> optional = findAnnotation(context.getElement(),
-			EnabledIfSystemProperty.class);
+	protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
+		return ENABLED;
+	}
 
-		if (!optional.isPresent()) {
-			return ENABLED_BY_DEFAULT;
-		}
+	@Override
+	protected ConditionEvaluationResult evaluate(EnabledIfSystemProperty annotation) {
 
-		EnabledIfSystemProperty annotation = optional.get();
 		String name = annotation.named().trim();
 		String regex = annotation.matches();
 		Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableConditionTests.java
@@ -13,7 +13,8 @@ package org.junit.jupiter.api.condition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.condition.DisabledIfEnvironmentVariableIntegrationTests.ENIGMA;
-import static org.junit.jupiter.api.condition.DisabledIfEnvironmentVariableIntegrationTests.KEY;
+import static org.junit.jupiter.api.condition.DisabledIfEnvironmentVariableIntegrationTests.KEY1;
+import static org.junit.jupiter.api.condition.DisabledIfEnvironmentVariableIntegrationTests.KEY2;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExecutionCondition;
@@ -32,17 +33,17 @@ class DisabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondi
 	/**
 	 * Stubbed subclass of {@link DisabledIfEnvironmentVariableCondition}.
 	 */
-	private static final ExecutionCondition condition = new DisabledIfEnvironmentVariableCondition() {
+	private ExecutionCondition condition = new DisabledIfEnvironmentVariableCondition() {
 
 		@Override
 		protected String getEnvironmentVariable(String name) {
-			return KEY.equals(name) ? ENIGMA : null;
+			return KEY1.equals(name) ? ENIGMA : null;
 		}
 	};
 
 	@Override
 	protected ExecutionCondition getExecutionCondition() {
-		return condition;
+		return this.condition;
 	}
 
 	@Override
@@ -57,7 +58,8 @@ class DisabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondi
 	void enabledBecauseAnnotationIsNotPresent() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("@DisabledIfEnvironmentVariable is not present");
+		assertReasonContains(
+			"No @DisabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -89,6 +91,24 @@ class DisabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondi
 	}
 
 	/**
+	 * @see DisabledIfEnvironmentVariableIntegrationTests#disabledBecauseEnvironmentVariableForComposedAnnotationMatchesExactly()
+	 */
+	@Test
+	void disabledBecauseEnvironmentVariableForComposedAnnotationMatchesExactly() {
+		this.condition = new DisabledIfEnvironmentVariableCondition() {
+
+			@Override
+			protected String getEnvironmentVariable(String name) {
+				return KEY1.equals(name) || KEY2.equals(name) ? ENIGMA : null;
+			}
+		};
+
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("matches regular expression");
+	}
+
+	/**
 	 * @see DisabledIfEnvironmentVariableIntegrationTests#disabledBecauseEnvironmentVariableMatchesPattern()
 	 */
 	@Test
@@ -105,7 +125,8 @@ class DisabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondi
 	void enabledBecauseEnvironmentVariableDoesNotMatch() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("does not match regular expression");
+		assertReasonContains(
+			"No @DisabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -115,7 +136,8 @@ class DisabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondi
 	void enabledBecauseEnvironmentVariableDoesNotExist() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("does not exist");
+		assertReasonContains(
+			"No @DisabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableIntegrationTests.java
@@ -14,6 +14,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -22,54 +27,67 @@ import org.junit.jupiter.api.Test;
  *
  * @since 5.1
  */
-@Disabled("Disabled since the required environment variable is not set")
-// Tests will pass if you set the following environment variable:
-// DisabledIfEnvironmentVariableTests.key = DisabledIfEnvironmentVariableTests.enigma
+@Disabled("Disabled since the required environment variables are not set")
+// Tests (except those with intentional configuration errors) will pass if you set
+// the following environment variables:
+// DisabledIfEnvironmentVariableTests.key1 = enigma
+// DisabledIfEnvironmentVariableTests.key2 = enigma
 class DisabledIfEnvironmentVariableIntegrationTests {
 
-	static final String KEY = "DisabledIfEnvironmentVariableTests.key";
-	static final String ENIGMA = "DisabledIfEnvironmentVariableTests.enigma";
-	static final String BOGUS = "DisabledIfEnvironmentVariableTests.bogus";
+	static final String KEY1 = "DisabledIfEnvironmentVariableTests.key1";
+	static final String KEY2 = "DisabledIfEnvironmentVariableTests.key2";
+	static final String ENIGMA = "enigma";
+	static final String BOGUS = "bogus";
 
 	@Test
-	@Disabled("Only used in a unit test via reflection")
 	void enabledBecauseAnnotationIsNotPresent() {
 	}
 
 	@Test
-	@Disabled("Only used in a unit test via reflection")
 	@DisabledIfEnvironmentVariable(named = "  ", matches = ENIGMA)
 	void blankNamedAttribute() {
 	}
 
 	@Test
-	@Disabled("Only used in a unit test via reflection")
-	@DisabledIfEnvironmentVariable(named = KEY, matches = "  ")
+	@DisabledIfEnvironmentVariable(named = KEY1, matches = "  ")
 	void blankMatchesAttribute() {
 	}
 
 	@Test
-	@DisabledIfEnvironmentVariable(named = KEY, matches = ENIGMA)
+	@DisabledIfEnvironmentVariable(named = KEY1, matches = ENIGMA)
 	void disabledBecauseEnvironmentVariableMatchesExactly() {
 		fail("should be disabled");
 	}
 
 	@Test
-	@DisabledIfEnvironmentVariable(named = KEY, matches = ".+enigma$")
+	@DisabledIfEnvironmentVariable(named = KEY1, matches = BOGUS)
+	@CustomDisabled
+	void disabledBecauseEnvironmentVariableForComposedAnnotationMatchesExactly() {
+		fail("should be disabled");
+	}
+
+	@Test
+	@DisabledIfEnvironmentVariable(named = KEY1, matches = ".*e.+gma$")
 	void disabledBecauseEnvironmentVariableMatchesPattern() {
 		fail("should be disabled");
 	}
 
 	@Test
-	@DisabledIfEnvironmentVariable(named = KEY, matches = BOGUS)
+	@DisabledIfEnvironmentVariable(named = KEY1, matches = BOGUS)
 	void enabledBecauseEnvironmentVariableDoesNotMatch() {
-		assertNotEquals(BOGUS, System.getenv(KEY));
+		assertNotEquals(BOGUS, System.getenv(KEY1));
 	}
 
 	@Test
 	@DisabledIfEnvironmentVariable(named = BOGUS, matches = "doesn't matter")
 	void enabledBecauseEnvironmentVariableDoesNotExist() {
 		assertNull(System.getenv(BOGUS));
+	}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@DisabledIfEnvironmentVariable(named = KEY2, matches = ENIGMA)
+	@interface CustomDisabled {
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyConditionTests.java
@@ -40,13 +40,13 @@ class DisabledIfSystemPropertyConditionTests extends AbstractExecutionConditionT
 	}
 
 	@BeforeAll
-	static void setSystemProperty() {
-		DisabledIfSystemPropertyIntegrationTests.setSystemProperty();
+	static void setSystemProperties() {
+		DisabledIfSystemPropertyIntegrationTests.setSystemProperties();
 	}
 
 	@AfterAll
-	static void clearSystemProperty() {
-		DisabledIfSystemPropertyIntegrationTests.clearSystemProperty();
+	static void clearSystemProperties() {
+		DisabledIfSystemPropertyIntegrationTests.clearSystemProperties();
 	}
 
 	/**
@@ -56,7 +56,7 @@ class DisabledIfSystemPropertyConditionTests extends AbstractExecutionConditionT
 	void enabledBecauseAnnotationIsNotPresent() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("@DisabledIfSystemProperty is not present");
+		assertReasonContains("No @DisabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -88,6 +88,16 @@ class DisabledIfSystemPropertyConditionTests extends AbstractExecutionConditionT
 	}
 
 	/**
+	 * @see DisabledIfSystemPropertyIntegrationTests#disabledBecauseSystemPropertyForComposedAnnotationMatchesExactly()
+	 */
+	@Test
+	void disabledBecauseSystemPropertyForComposedAnnotationMatchesExactly() {
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("matches regular expression");
+	}
+
+	/**
 	 * @see DisabledIfSystemPropertyIntegrationTests#disabledBecauseSystemPropertyMatchesPattern()
 	 */
 	@Test
@@ -104,7 +114,7 @@ class DisabledIfSystemPropertyConditionTests extends AbstractExecutionConditionT
 	void enabledBecauseSystemPropertyDoesNotMatch() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("does not match regular expression");
+		assertReasonContains("No @DisabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -114,7 +124,7 @@ class DisabledIfSystemPropertyConditionTests extends AbstractExecutionConditionT
 	void enabledBecauseSystemPropertyDoesNotExist() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("does not exist");
+		assertReasonContains("No @DisabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyIntegrationTests.java
@@ -14,6 +14,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -26,59 +31,77 @@ import org.junit.jupiter.api.Test;
  */
 class DisabledIfSystemPropertyIntegrationTests {
 
-	private static final String KEY = "DisabledIfSystemPropertyTests.key";
-	private static final String ENIGMA = "DisabledIfSystemPropertyTests.enigma";
-	private static final String BOGUS = "DisabledIfSystemPropertyTests.bogus";
+	private static final String KEY1 = "DisabledIfSystemPropertyTests.key1";
+	private static final String KEY2 = "DisabledIfSystemPropertyTests.key2";
+	private static final String ENIGMA = "enigma";
+	private static final String BOGUS = "bogus";
 
 	@BeforeAll
-	static void setSystemProperty() {
-		System.setProperty(KEY, ENIGMA);
+	static void setSystemProperties() {
+		System.setProperty(KEY1, ENIGMA);
+		System.setProperty(KEY2, ENIGMA);
 	}
 
 	@AfterAll
-	static void clearSystemProperty() {
-		System.clearProperty(KEY);
+	static void clearSystemProperties() {
+		System.clearProperty(KEY1);
+		System.clearProperty(KEY2);
 	}
 
 	@Test
-	@Disabled("Only used in a unit test via reflection")
 	void enabledBecauseAnnotationIsNotPresent() {
+		// no-op
 	}
 
 	@Test
 	@Disabled("Only used in a unit test via reflection")
 	@DisabledIfSystemProperty(named = "  ", matches = ENIGMA)
 	void blankNamedAttribute() {
+		fail("should be disabled");
 	}
 
 	@Test
 	@Disabled("Only used in a unit test via reflection")
-	@DisabledIfSystemProperty(named = KEY, matches = "  ")
+	@DisabledIfSystemProperty(named = KEY1, matches = "  ")
 	void blankMatchesAttribute() {
+		fail("should be disabled");
 	}
 
 	@Test
-	@DisabledIfSystemProperty(named = KEY, matches = ENIGMA)
+	@DisabledIfSystemProperty(named = KEY1, matches = ENIGMA)
 	void disabledBecauseSystemPropertyMatchesExactly() {
 		fail("should be disabled");
 	}
 
 	@Test
-	@DisabledIfSystemProperty(named = KEY, matches = ".+enigma$")
+	@DisabledIfSystemProperty(named = KEY1, matches = BOGUS)
+	@CustomDisabled
+	void disabledBecauseSystemPropertyForComposedAnnotationMatchesExactly() {
+		fail("should be disabled");
+	}
+
+	@Test
+	@DisabledIfSystemProperty(named = KEY1, matches = ".*e.+gma$")
 	void disabledBecauseSystemPropertyMatchesPattern() {
 		fail("should be disabled");
 	}
 
 	@Test
-	@DisabledIfSystemProperty(named = KEY, matches = BOGUS)
+	@DisabledIfSystemProperty(named = KEY1, matches = BOGUS)
 	void enabledBecauseSystemPropertyDoesNotMatch() {
-		assertNotEquals(BOGUS, System.getProperty(KEY));
+		assertNotEquals(BOGUS, System.getProperty(KEY1));
 	}
 
 	@Test
 	@DisabledIfSystemProperty(named = BOGUS, matches = "doesn't matter")
 	void enabledBecauseSystemPropertyDoesNotExist() {
 		assertNull(System.getProperty(BOGUS));
+	}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@DisabledIfSystemProperty(named = KEY2, matches = ENIGMA)
+	@interface CustomDisabled {
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableConditionTests.java
@@ -12,8 +12,10 @@ package org.junit.jupiter.api.condition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.condition.EnabledIfEnvironmentVariableIntegrationTests.BOGUS;
 import static org.junit.jupiter.api.condition.EnabledIfEnvironmentVariableIntegrationTests.ENIGMA;
-import static org.junit.jupiter.api.condition.EnabledIfEnvironmentVariableIntegrationTests.KEY;
+import static org.junit.jupiter.api.condition.EnabledIfEnvironmentVariableIntegrationTests.KEY1;
+import static org.junit.jupiter.api.condition.EnabledIfEnvironmentVariableIntegrationTests.KEY2;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExecutionCondition;
@@ -32,11 +34,11 @@ class EnabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondit
 	/**
 	 * Stubbed subclass of {@link EnabledIfEnvironmentVariableCondition}.
 	 */
-	private static final ExecutionCondition condition = new EnabledIfEnvironmentVariableCondition() {
+	private ExecutionCondition condition = new EnabledIfEnvironmentVariableCondition() {
 
 		@Override
 		protected String getEnvironmentVariable(String name) {
-			return KEY.equals(name) ? ENIGMA : null;
+			return KEY1.equals(name) ? ENIGMA : null;
 		}
 	};
 
@@ -57,7 +59,8 @@ class EnabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondit
 	void enabledBecauseAnnotationIsNotPresent() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("@EnabledIfEnvironmentVariable is not present");
+		assertReasonContains(
+			"No @EnabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -85,7 +88,27 @@ class EnabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondit
 	void enabledBecauseEnvironmentVariableMatchesExactly() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("matches regular expression");
+		assertReasonContains(
+			"No @EnabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+	}
+
+	/**
+	 * @see EnabledIfEnvironmentVariableIntegrationTests#enabledBecauseBothEnvironmentVariablesMatchExactly()
+	 */
+	@Test
+	void enabledBecauseBothEnvironmentVariablesMatchExactly() {
+		this.condition = new EnabledIfEnvironmentVariableCondition() {
+
+			@Override
+			protected String getEnvironmentVariable(String name) {
+				return KEY1.equals(name) || KEY2.equals(name) ? ENIGMA : null;
+			}
+		};
+
+		evaluateCondition();
+		assertEnabled();
+		assertReasonContains(
+			"No @EnabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -95,7 +118,8 @@ class EnabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondit
 	void enabledBecauseEnvironmentVariableMatchesPattern() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("matches regular expression");
+		assertReasonContains(
+			"No @EnabledIfEnvironmentVariable conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -103,6 +127,24 @@ class EnabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondit
 	 */
 	@Test
 	void disabledBecauseEnvironmentVariableDoesNotMatch() {
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("does not match regular expression");
+	}
+
+	/**
+	 * @see EnabledIfEnvironmentVariableIntegrationTests#disabledBecauseEnvironmentVariableForComposedAnnotationDoesNotMatch()
+	 */
+	@Test
+	void disabledBecauseEnvironmentVariableForComposedAnnotationDoesNotMatch() {
+		this.condition = new EnabledIfEnvironmentVariableCondition() {
+
+			@Override
+			protected String getEnvironmentVariable(String name) {
+				return KEY1.equals(name) ? ENIGMA : KEY2.equals(name) ? BOGUS : null;
+			}
+		};
+
 		evaluateCondition();
 		assertDisabled();
 		assertReasonContains("does not match regular expression");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableIntegrationTests.java
@@ -13,6 +13,11 @@ package org.junit.jupiter.api.condition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -21,47 +26,63 @@ import org.junit.jupiter.api.Test;
  *
  * @since 5.1
  */
-@Disabled("Disabled since the required environment variable is not set")
-// Tests will pass if you set the following environment variable:
-// EnabledIfEnvironmentVariableTests.key = EnabledIfEnvironmentVariableTests.enigma
+@Disabled("Disabled since the required environment variables are not set")
+// Tests (except those with intentional configuration errors) will pass if you set
+// the following environment variables:
+// EnabledIfEnvironmentVariableTests.key1 = enigma
+// EnabledIfEnvironmentVariableTests.key2 = enigma
 class EnabledIfEnvironmentVariableIntegrationTests {
 
-	static final String KEY = "EnabledIfEnvironmentVariableTests.key";
-	static final String ENIGMA = "EnabledIfEnvironmentVariableTests.enigma";
-	static final String BOGUS = "EnabledIfEnvironmentVariableTests.bogus";
+	static final String KEY1 = "EnabledIfEnvironmentVariableTests.key1";
+	static final String KEY2 = "EnabledIfEnvironmentVariableTests.key2";
+	static final String ENIGMA = "enigma";
+	static final String PUZZLE = "puzzle";
+	static final String BOGUS = "bogus";
 
 	@Test
-	@Disabled("Only used in a unit test via reflection")
 	void enabledBecauseAnnotationIsNotPresent() {
 	}
 
 	@Test
-	@Disabled("Only used in a unit test via reflection")
 	@EnabledIfEnvironmentVariable(named = "  ", matches = ENIGMA)
 	void blankNamedAttribute() {
 	}
 
 	@Test
-	@Disabled("Only used in a unit test via reflection")
-	@EnabledIfEnvironmentVariable(named = KEY, matches = "  ")
+	@EnabledIfEnvironmentVariable(named = KEY1, matches = "  ")
 	void blankMatchesAttribute() {
 	}
 
 	@Test
-	@EnabledIfEnvironmentVariable(named = KEY, matches = ENIGMA)
+	@EnabledIfEnvironmentVariable(named = KEY1, matches = ENIGMA)
 	void enabledBecauseEnvironmentVariableMatchesExactly() {
-		assertEquals(ENIGMA, System.getenv(KEY));
+		assertEquals(ENIGMA, System.getenv(KEY1));
 	}
 
 	@Test
-	@EnabledIfEnvironmentVariable(named = KEY, matches = ".+enigma$")
+	@EnabledIfEnvironmentVariable(named = KEY1, matches = ENIGMA)
+	@EnabledIfEnvironmentVariable(named = KEY2, matches = ENIGMA)
+	void enabledBecauseBothEnvironmentVariablesMatchExactly() {
+		assertEquals(ENIGMA, System.getenv(KEY1));
+		assertEquals(ENIGMA, System.getenv(KEY2));
+	}
+
+	@Test
+	@EnabledIfEnvironmentVariable(named = KEY1, matches = ".*e.+ma$")
 	void enabledBecauseEnvironmentVariableMatchesPattern() {
-		assertEquals(ENIGMA, System.getenv(KEY));
+		assertEquals(ENIGMA, System.getenv(KEY1));
 	}
 
 	@Test
-	@EnabledIfEnvironmentVariable(named = KEY, matches = BOGUS)
+	@EnabledIfEnvironmentVariable(named = KEY1, matches = BOGUS)
 	void disabledBecauseEnvironmentVariableDoesNotMatch() {
+		fail("should be disabled");
+	}
+
+	@Test
+	@EnabledIfEnvironmentVariable(named = KEY1, matches = ENIGMA)
+	@CustomEnabled
+	void disabledBecauseEnvironmentVariableForComposedAnnotationDoesNotMatch() {
 		fail("should be disabled");
 	}
 
@@ -69,6 +90,12 @@ class EnabledIfEnvironmentVariableIntegrationTests {
 	@EnabledIfEnvironmentVariable(named = BOGUS, matches = "doesn't matter")
 	void disabledBecauseEnvironmentVariableDoesNotExist() {
 		fail("should be disabled");
+	}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@EnabledIfEnvironmentVariable(named = KEY2, matches = PUZZLE)
+	@interface CustomEnabled {
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyConditionTests.java
@@ -40,13 +40,13 @@ class EnabledIfSystemPropertyConditionTests extends AbstractExecutionConditionTe
 	}
 
 	@BeforeAll
-	static void setSystemProperty() {
-		EnabledIfSystemPropertyIntegrationTests.setSystemProperty();
+	static void setSystemProperties() {
+		EnabledIfSystemPropertyIntegrationTests.setSystemProperties();
 	}
 
 	@AfterAll
-	static void clearSystemProperty() {
-		EnabledIfSystemPropertyIntegrationTests.clearSystemProperty();
+	static void clearSystemProperties() {
+		EnabledIfSystemPropertyIntegrationTests.clearSystemProperties();
 	}
 
 	/**
@@ -56,7 +56,7 @@ class EnabledIfSystemPropertyConditionTests extends AbstractExecutionConditionTe
 	void enabledBecauseAnnotationIsNotPresent() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("@EnabledIfSystemProperty is not present");
+		assertReasonContains("No @EnabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -84,7 +84,17 @@ class EnabledIfSystemPropertyConditionTests extends AbstractExecutionConditionTe
 	void enabledBecauseSystemPropertyMatchesExactly() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("matches regular expression");
+		assertReasonContains("No @EnabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
+	}
+
+	/**
+	 * @see EnabledIfSystemPropertyIntegrationTests#enabledBecauseBothSystemPropertiesMatchExactly()
+	 */
+	@Test
+	void enabledBecauseBothSystemPropertiesMatchExactly() {
+		evaluateCondition();
+		assertEnabled();
+		assertReasonContains("No @EnabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -94,7 +104,7 @@ class EnabledIfSystemPropertyConditionTests extends AbstractExecutionConditionTe
 	void enabledBecauseSystemPropertyMatchesPattern() {
 		evaluateCondition();
 		assertEnabled();
-		assertReasonContains("matches regular expression");
+		assertReasonContains("No @EnabledIfSystemProperty conditions resulting in 'disabled' execution encountered");
 	}
 
 	/**
@@ -102,6 +112,13 @@ class EnabledIfSystemPropertyConditionTests extends AbstractExecutionConditionTe
 	 */
 	@Test
 	void disabledBecauseSystemPropertyDoesNotMatch() {
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("does not match regular expression");
+	}
+
+	@Test
+	void disabledBecauseSystemPropertyForComposedAnnotationDoesNotMatch() {
 		evaluateCondition();
 		assertDisabled();
 		assertReasonContains("does not match regular expression");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyIntegrationTests.java
@@ -13,6 +13,11 @@ package org.junit.jupiter.api.condition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -25,22 +30,24 @@ import org.junit.jupiter.api.Test;
  */
 class EnabledIfSystemPropertyIntegrationTests {
 
-	private static final String KEY = "EnabledIfSystemPropertyTests.key";
-	private static final String ENIGMA = "EnabledIfSystemPropertyTests.enigma";
-	private static final String BOGUS = "EnabledIfSystemPropertyTests.bogus";
+	private static final String KEY1 = "EnabledIfSystemPropertyTests.key1";
+	private static final String KEY2 = "EnabledIfSystemPropertyTests.key2";
+	private static final String ENIGMA = "enigma";
+	private static final String BOGUS = "bogus";
 
 	@BeforeAll
-	static void setSystemProperty() {
-		System.setProperty(KEY, ENIGMA);
+	static void setSystemProperties() {
+		System.setProperty(KEY1, ENIGMA);
+		System.setProperty(KEY2, ENIGMA);
 	}
 
 	@AfterAll
-	static void clearSystemProperty() {
-		System.clearProperty(KEY);
+	static void clearSystemProperties() {
+		System.clearProperty(KEY1);
+		System.clearProperty(KEY2);
 	}
 
 	@Test
-	@Disabled("Only used in a unit test via reflection")
 	void enabledBecauseAnnotationIsNotPresent() {
 	}
 
@@ -48,29 +55,46 @@ class EnabledIfSystemPropertyIntegrationTests {
 	@Disabled("Only used in a unit test via reflection")
 	@EnabledIfSystemProperty(named = "  ", matches = ENIGMA)
 	void blankNamedAttribute() {
+		fail("should be disabled");
 	}
 
 	@Test
 	@Disabled("Only used in a unit test via reflection")
-	@EnabledIfSystemProperty(named = KEY, matches = "  ")
+	@EnabledIfSystemProperty(named = KEY1, matches = "  ")
 	void blankMatchesAttribute() {
+		fail("should be disabled");
 	}
 
 	@Test
-	@EnabledIfSystemProperty(named = KEY, matches = ENIGMA)
+	@EnabledIfSystemProperty(named = KEY1, matches = ENIGMA)
 	void enabledBecauseSystemPropertyMatchesExactly() {
-		assertEquals(ENIGMA, System.getProperty(KEY));
+		assertEquals(ENIGMA, System.getProperty(KEY1));
 	}
 
 	@Test
-	@EnabledIfSystemProperty(named = KEY, matches = ".+enigma$")
+	@EnabledIfSystemProperty(named = KEY1, matches = ENIGMA)
+	@EnabledIfSystemProperty(named = KEY2, matches = ENIGMA)
+	void enabledBecauseBothSystemPropertiesMatchExactly() {
+		assertEquals(ENIGMA, System.getProperty(KEY1));
+		assertEquals(ENIGMA, System.getProperty(KEY2));
+	}
+
+	@Test
+	@EnabledIfSystemProperty(named = KEY1, matches = ".*en.+gma$")
 	void enabledBecauseSystemPropertyMatchesPattern() {
-		assertEquals(ENIGMA, System.getProperty(KEY));
+		assertEquals(ENIGMA, System.getProperty(KEY1));
 	}
 
 	@Test
-	@EnabledIfSystemProperty(named = KEY, matches = BOGUS)
+	@EnabledIfSystemProperty(named = KEY1, matches = BOGUS)
 	void disabledBecauseSystemPropertyDoesNotMatch() {
+		fail("should be disabled");
+	}
+
+	@Test
+	@EnabledIfSystemProperty(named = KEY1, matches = ENIGMA)
+	@CustomEnabled
+	void disabledBecauseSystemPropertyForComposedAnnotationDoesNotMatch() {
 		fail("should be disabled");
 	}
 
@@ -78,6 +102,12 @@ class EnabledIfSystemPropertyIntegrationTests {
 	@EnabledIfSystemProperty(named = BOGUS, matches = "doesn't matter")
 	void disabledBecauseSystemPropertyDoesNotExist() {
 		fail("should be disabled");
+	}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@EnabledIfSystemProperty(named = KEY2, matches = BOGUS)
+	@interface CustomEnabled {
 	}
 
 }


### PR DESCRIPTION
Prior to this commit, built-in conditions could not be declared
multiple times for a given annotated element (i.e., class or method).
This prevents users from specifying multiple system properties or
environment variables for which an element should be enabled or
disabled.

This commit introduces repeatable annotation support for
@EnabledIfEnvironmentVariable, @DisabledIfEnvironmentVariable,
@EnabledIfSystemProperty, and @DisabledIfSystemProperty.

Closes: #1793

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
