### PR TITLE
Provide JARs with OSGi metadata

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,4 +10,5 @@ repositories {
 dependencies {
 	implementation(kotlin("gradle-plugin"))
 	implementation("de.marcphilipp.gradle:nexus-publish-plugin:0.4.0")
+	implementation("biz.aQute.bnd:biz.aQute.bnd.gradle:4.3.1")
 }

--- a/buildSrc/src/main/kotlin/APIGuardianAnnotations.kt
+++ b/buildSrc/src/main/kotlin/APIGuardianAnnotations.kt
@@ -1,0 +1,91 @@
+import aQute.bnd.header.Attrs
+import aQute.bnd.header.OSGiHeader
+import aQute.bnd.header.Parameters
+import aQute.bnd.osgi.Analyzer
+import aQute.bnd.osgi.Clazz
+import aQute.bnd.osgi.Descriptors.TypeRef
+import aQute.bnd.osgi.Instruction
+import aQute.bnd.osgi.Instructions
+import aQute.bnd.service.AnalyzerPlugin
+
+/*
+This is a plugin for bnd which helps analyze the usages of
+org.apiguardian.api.API found in the project bytecode. You can read more
+about this here: https://bnd.bndtools.org/instructions/export-apiguardian.html
+
+Once the next version of bnd releases (likely 5.0.0) this plugin will be
+included in bnd and this class can be removed.
+
+Please ping @rotty3000 to cleanup when that happens.
+*/
+open class APIGuardianAnnotations : AnalyzerPlugin {
+
+	companion object {
+		const val API_ANNOTATION: String = "org/apiguardian/api/API"
+		const val INTERNAL_STATUS: String	= "INTERNAL"
+		const val STATUS_PROPERTY: String	= "status"
+		const val EXPORT_APIGUARDIAN: String = "-export-apiguardian"
+		const val MANDATORY_DIRECTIVE: String = "mandatory:"
+		const val NO_IMPORT_DIRECTIVE: String = "-noimport:"
+	}
+
+	internal enum class Status {
+		INTERNAL,
+		DEPRECATED,
+		EXPERIMENTAL,
+		MAINTAINED,
+		STABLE
+	}
+
+	@Throws(Exception::class)
+	override fun analyzeJar(analyzer:Analyzer):Boolean {
+		// Opt-in is required.
+		val header = OSGiHeader.parseHeader(analyzer.getProperty(EXPORT_APIGUARDIAN))
+		if (header.isEmpty()) return false
+		val exportPackages = analyzer.getExportPackage()
+		val instructions = Instructions(header)
+		val apiGuardianPackages = Parameters(false)
+		for ((_, c:Clazz) in analyzer.getClassspace()) {
+			if (c.isModule() || c.isInnerClass() || c.isSynthetic()) continue
+			for ((k:Instruction, v:Attrs) in instructions) {
+				if (k.matches(c.getFQN())) {
+					if (k.isNegated()) break
+
+					c.annotations(API_ANNOTATION)
+						.map({ ann-> Status.valueOf(ann.get(STATUS_PROPERTY)) })
+						.max(Status::compareTo)
+						.ifPresent({ status->
+							val attrs = apiGuardianPackages.computeIfAbsent(
+								c.getClassName().getPackageRef().getFQN(), { _->
+									Attrs(v)
+								}
+							)
+
+							attrs.compute(
+								STATUS_PROPERTY, { _, v->
+									if ((v == null))
+										status.name
+									else
+										if ((Status.valueOf(v).compareTo(status) > 0))
+											v
+										else
+											status.name
+								}
+							)
+						}
+					)
+				}
+			}
+		}
+
+		apiGuardianPackages.values.stream()
+			.filter({ a-> Status.valueOf(a.get(STATUS_PROPERTY)) === Status.INTERNAL })
+			.forEach({ a->
+				a.put(MANDATORY_DIRECTIVE, STATUS_PROPERTY)
+				a.put(NO_IMPORT_DIRECTIVE, "true")
+			})
+		exportPackages.mergeWith(apiGuardianPackages, false)
+		analyzer.setExportPackage(exportPackages.toString())
+		return false
+	}
+}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -34,5 +34,6 @@ object Versions {
     val jmh = "1.21"
     val ktlint = "0.35.0"
     val surefire = "2.22.2"
+    var bnd = "4.3.1"
 
 }

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -1,3 +1,7 @@
+import aQute.bnd.gradle.BundleTaskConvention
+import aQute.bnd.gradle.FileSetRepositoryConvention
+import aQute.bnd.gradle.Resolve
+
 plugins {
 	`java-library`
 	eclipse
@@ -136,6 +140,105 @@ if (project in mavenizedProjects) {
 					description.set(provider { "Module \"${project.name}\" of JUnit 5." })
 				}
 			}
+		}
+	}
+
+	// This task enances `jar` and `shadowJar` tasks with the bnd
+	// `BundleTaskConvention` convention which allows for generating OSGi
+	// metadata into the jar
+	tasks.withType<Jar>().matching {
+		task: Jar -> task.name == "jar" || task.name == "shadowJar"
+	}.configureEach {
+		val btc = BundleTaskConvention(this)
+
+		// These are bnd instructions necessary for generating OSGi metadata.
+		// We've generalized these so that they are widely applicable limiting
+		// module configurations to special cases.
+		btc.setBnd("""
+			# These are the general rules for package imports.
+			Import-Package: \
+				!org.apiguardian.api,\
+				org.junit.platform.commons.logging;status=INTERNAL,\
+				kotlin.*;resolution:="optional",\
+				*
+
+			# This tells bnd not to complain if a module doesn't actually import
+			# the kotlin packages, but enough modules do to make it a default.
+			-fixupmessages.kotlin.import: "Unused Import-Package instructions: \\[kotlin.*\\]";is:=ignore
+
+			# This tells bnd to ignore classes it files in `META-INF/versions/`
+			# because bnd doesn't yet support multi-release jars.
+			-fixupmessages.wrong.dir: "Classes found in the wrong directory: \\{META-INF/versions/...";is:=ignore
+
+			# Don't scan for Class.forName package imports.
+			# See https://bnd.bndtools.org/instructions/noclassforname.html
+			-noclassforname: true
+
+			# Don't add all the extra headers bnd normally adds.
+			# See https://bnd.bndtools.org/instructions/noextraheaders.html
+			-noextraheaders: true
+
+			# Don't add the Private-Package header.
+			# See https://bnd.bndtools.org/instructions/removeheaders.html
+			-removeheaders: Private-Package
+
+			# Add the custom buildSrc/src/main/kotlin/APIGuardianAnnotations.kt
+			# plugin to bnd
+			-plugin.apiguardian.annotations: ${APIGuardianAnnotations::class.qualifiedName}
+
+			# Instruct the APIGuardianAnnotations how to operate.
+			# See https://bnd.bndtools.org/instructions/export-apiguardian.html
+			-export-apiguardian: *;version=${project.version}
+		""")
+
+		// Add the convention to the jar task
+		convention.plugins.put("bundle", btc)
+
+		doLast {
+			// Do the actual work putting OSGi stuff in the jar.
+			btc.buildBundle()
+		}
+
+		finalizedBy("verifyOSGi")
+	}
+
+	// Bnd's Resolve task uses a properties file for it's configuration. This
+	// task writes out the properties necessary for it to verify the OSGi
+	// metadata.
+	tasks.register<WriteProperties>("verifyOSGiProperties") {
+		setOutputFile("${buildDir}/verifyOSGiProperties.bndrun")
+		property("-standalone", "true")
+		property("-runee", "JavaSE-${Versions.jvmTarget}")
+		property("-runrequires", "osgi.identity;filter:='(osgi.identity=${project.name})'")
+		property("-runsystempackages", "jdk.internal.misc,sun.misc")
+	}
+
+	// Bnd's Resolve task is what verifies that a jar can be used in OSGi and
+	// that it's metadata is valid. If the metadata is invalid this task will
+	// fail.
+	tasks.register<Resolve>("verifyOSGi") {
+		dependsOn("verifyOSGiProperties")
+		setBndrun("${buildDir}/verifyOSGiProperties.bndrun")
+		setReportOptional(false)
+		withConvention(FileSetRepositoryConvention::class) {
+
+			// By default bnd will use jars found in:
+			// 1. project.sourceSets.main.runtimeClasspath
+			// 2. project.configurations.archives.artifacts.files
+			// to validate the metadata.
+			// This adds jars defined in `testRuntimeClasses` also so that bnd
+			// can use them to validate the metadata without causing those to
+			// end up in the dependencies of those projects.
+			bundles(sourceSets["test"].runtimeClasspath)
+		}
+	}
+
+	// The ${project.description}, for some odd reason, is only available
+	// afterEvaluate.
+	afterEvaluate {
+		tasks.withType<Jar>().configureEach {
+			convention.findPlugin(BundleTaskConvention::class.java)
+				?.bnd("Bundle-Name: ${project.description}")
 		}
 	}
 

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
@@ -24,6 +24,7 @@ on GitHub.
 
 ==== New Features and Improvements
 
+* Provide JARs with OSGi metadata.
 * `TestExecutionSummary.Failure` is now serializable.
 
 
@@ -40,6 +41,7 @@ on GitHub.
 
 ==== New Features and Improvements
 
+* Provide JARs with OSGi metadata.
 * `@EnabledIfEnvironmentVariable`, `@DisabledIfEnvironmentVariable`,
   `@EnabledIfSystemProperty`, and `@DisabledIfSystemProperty` may now be used as
   _repeatable_ annotations. In other words, it is now possible to declare each of those
@@ -61,4 +63,4 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* Provide JARs with OSGi metadata.

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,8 @@ org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
 org.gradle.caching=true
 org.gradle.parallel=true
 
+# Use this flag so that when compiling against project dependencies
+# the jar is created and used instead of using src/main/classes.
+#
+# See https://docs.gradle.org/current/userguide/java_library_plugin.html#sub:java_library_known_issues_windows_performance
+systemProp.org.gradle.java.compile-classpath-packaging=true

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -1,3 +1,5 @@
+import aQute.bnd.gradle.BundleTaskConvention;
+
 plugins {
 	`java-library-conventions`
 }
@@ -18,4 +20,20 @@ dependencies {
 	testImplementation(project(":junit-platform-launcher"))
 	testImplementation(project(":junit-platform-runner"))
 	testImplementation(project(":junit-platform-testkit"))
+
+	testRuntimeOnly("org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.12_1")
+}
+
+tasks.jar {
+	withConvention(BundleTaskConvention::class) {
+		bnd("""
+			# Import JUnit4 packages with a version
+			Import-Package: \
+				!org.apiguardian.api,\
+				org.junit;version="${Versions.junit4}",\
+				org.junit.platform.commons.logging;status=INTERNAL,\
+				org.junit.rules;version="${Versions.junit4}",\
+				*
+		""")
+	}
 }

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -42,4 +42,12 @@ tasks {
 			attributes("Main-Class" to "org.junit.platform.console.ConsoleLauncher")
 		}
 	}
+
+	// This jar contains some Java 9 code
+	// (org.junit.platform.console.ConsoleLauncherToolProvider which implements
+	// java.util.spi.ToolProvider which is @since 9).
+	// So in order to resolve this, it can only run on Java 9
+	verifyOSGiProperties {
+		property("-runee", "JavaSE-9")
+	}
 }

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -1,3 +1,5 @@
+import aQute.bnd.gradle.BundleTaskConvention;
+
 plugins {
 	`java-library-conventions`
 }
@@ -12,4 +14,19 @@ dependencies {
 
 	api(project(":junit-platform-launcher"))
 	api(project(":junit-platform-suite-api"))
+
+	testRuntimeOnly("org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.12_1")
+}
+
+tasks.jar {
+	withConvention(BundleTaskConvention::class) {
+		bnd("""
+			# Import JUnit4 packages with a version
+			Import-Package: \
+				!org.apiguardian.api,\
+				org.junit.platform.commons.logging;status=INTERNAL,\
+				org.junit.runner.*;version="${Versions.junit4}",\
+				*
+		""")
+	}
 }

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
@@ -8,4 +8,6 @@ dependencies {
 	api(platform(project(":junit-bom")))
 
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
+
+	testRuntimeOnly(project(":junit-platform-commons"))
 }

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -1,3 +1,5 @@
+import aQute.bnd.gradle.BundleTaskConvention;
+
 plugins {
 	`java-library-conventions`
 }
@@ -21,6 +23,8 @@ dependencies {
 	testImplementation(project(":junit-platform-runner"))
 	testImplementation(project(":junit-platform-testkit"))
 	junit_4_13("junit:junit:4.13-rc-1")
+
+	testRuntimeOnly("org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.12_1")
 }
 
 tasks {
@@ -30,5 +34,23 @@ tasks {
 	}
 	check {
 		dependsOn(test_4_13)
+	}
+}
+
+tasks.jar {
+	withConvention(BundleTaskConvention::class) {
+		bnd("""
+			# Import JUnit4 packages with a version
+			Import-Package: \
+				!org.apiguardian.api,\
+				junit.runner;version="${Versions.junit4}",\
+				org.junit;version="${Versions.junit4}",\
+				org.junit.experimental.categories;version="${Versions.junit4}",\
+				org.junit.internal.builders;version="${Versions.junit4}",\
+				org.junit.platform.commons.logging;status=INTERNAL,\
+				org.junit.runner.*;version="${Versions.junit4}",\
+				org.junit.runners.model;version="${Versions.junit4}",\
+				*
+		""")
 	}
 }

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
 		because("it provides convenience methods to handle process output")
 		exclude(group = "org.junit.platform", module = "junit-platform-launcher")
 	}
+	testImplementation("biz.aQute.bnd:biz.aQute.bndlib:${Versions.bnd}") {
+		because("parsing OSGi metadata")
+	}
 	testRuntimeOnly("com.tngtech.archunit:archunit-junit5-engine:${Versions.archunit}") {
 		because("contains the ArchUnit TestEngine implementation")
 	}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManifestTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManifestTests.java
@@ -44,6 +44,10 @@ class ManifestTests {
 			assertValue(attributes, "Implementation-Version", version);
 			assertValue(attributes, "Implementation-Vendor", "junit.org");
 			assertValue(attributes, "Automatic-Module-Name", null);
+			assertValue(attributes, "Bundle-ManifestVersion", "2");
+			assertValue(attributes, "Bundle-SymbolicName", module);
+			assertValue(attributes, "Bundle-Version",
+				aQute.bnd.version.MavenVersion.parseMavenString(version).getOSGiVersion().toString());
 			switch (module) {
 				case "junit-platform-commons":
 					assertValue(attributes, "Multi-Release", "true");


### PR DESCRIPTION
fixes  #195

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>

## Overview

Provide JARs with OSGi metadata

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
