### PR TITLE
[ReflectionUtils] Use class' classloader to load method params

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -248,6 +248,9 @@ public final class ReflectionSupport {
 	 *
 	 * <p>The algorithm does not search for methods in {@link java.lang.Object}.
 	 *
+	 * <p>The algorithm will use {@code clazz}'s class loader to attempt to
+	 * resolve the elements of {@code parameterTypeNames} into a {@link Class} object.
+	 *
 	 * @param clazz the class or interface in which to find the method; never {@code null}
 	 * @param methodName the name of the method to find; never {@code null} or empty
 	 * @param parameterTypeNames the fully qualified names of the types of parameters

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassLoaderUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassLoaderUtils.java
@@ -12,9 +12,15 @@ package org.junit.platform.commons.util;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
+import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
 import java.security.CodeSource;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 
@@ -48,6 +54,43 @@ public final class ClassLoaderUtils {
 			/* otherwise ignore */
 		}
 		return ClassLoader.getSystemClassLoader();
+	}
+
+	static URL toURL(String filePath) {
+		try {
+			return Paths.get(filePath).toUri().toURL();
+		}
+		catch (MalformedURLException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Returns a classloader that has visibility to the current classpath, but won't delegate to the parent for classes that
+	 * match the supplied filter. If you attempt to load a class using this loader that matches the filter, then
+	 * it will be loaded directly from the classpath and a new {@link Class} object created.
+	 *
+	 * <p>This is sometimes useful for testing if you have a class in your JVM that's already visible to the current
+	 * class loader, but for testing purposes you need to load it from the context of another class loader. This allows
+	 * you to emulate environments that have multiple classloaders (eg, OSGi).
+	 *
+	 * <p>For an example, see {@link ReflectionUtilsTest#findMethodByParameterTypesFromForeignClassLoader}.
+	 *
+	 * @param filter predicate to match on the type names. If the predicate returns true, then the classloader won't
+	 * delegate to the parent classloader but will load the class directly from the classpath.
+	 * @return The excluding class loader.
+	 */
+	public static URLClassLoader excludingClassLoader(Predicate<String> filter) {
+		return new URLClassLoader(Stream.of(System.getProperty("java.class.path").split(File.pathSeparator)).map(
+			ClassLoaderUtils::toURL).toArray(URL[]::new), new ClassLoader() {
+				@Override
+				protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+					if (filter.test(name)) {
+						throw new ClassNotFoundException("Skipping " + name + " for testing");
+					}
+					return super.loadClass(name, resolve);
+				}
+			});
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -1207,7 +1207,7 @@ public final class ReflectionUtils {
 
 	private static Class<?> loadRequiredParameterType(Class<?> clazz, String methodName, String typeName) {
 		// @formatter:off
-		return tryToLoadClass(typeName)
+		return tryToLoadClass(typeName, clazz.getClassLoader() == null ? ClassLoaderUtils.getDefaultClassLoader() : clazz.getClassLoader())
 				.getOrThrow(cause -> new JUnitException(
 						String.format("Failed to load parameter type [%s] for method [%s] in class [%s].",
 								typeName, methodName, clazz.getName()), cause));


### PR DESCRIPTION
Fixes #2104, along with corresponding test case.

## Overview

`ReflectionUtils.loadRequiredParameterType()` will now use class' classloader to resolve parameter type names into `Class` objects.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
