### PR TITLE
Include parameter names in default name of @ParameterizedTest

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
@@ -47,8 +47,8 @@ on GitHub.
 * `InvocationInterceptor` extensions may now explicitly `skip()` an intercepted
   invocation. This allows executing it by other means, e.g. in a forked JVM.
 * Parameter names are now included in the default display name of a `@ParameterizedTest`
-  invocation (if they can be found). The `{argumentsWithNames}` pattern can also be used
-  in custom names.
+  invocation (if they are present in the bytecode). The `{argumentsWithNames}` pattern
+  can also be used in custom names.
 
 [[release-notes-5.6.0-M2️-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
@@ -47,7 +47,7 @@ on GitHub.
 * `InvocationInterceptor` extensions may now explicitly `skip()` an intercepted
   invocation. This allows executing it by other means, e.g. in a forked JVM.
 * Parameter names are now included in the default display name of a `@ParameterizedTest`
-  invocation (if they can be found). The `{arguments_with_names}` pattern can also be used
+  invocation (if they can be found). The `{argumentsWithNames}` pattern can also be used
   in custom names.
 
 [[release-notes-5.6.0-M2️-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
@@ -46,7 +46,9 @@ on GitHub.
   annotations multiple times on a test interface, test class, or test method.
 * `InvocationInterceptor` extensions may now explicitly `skip()` an intercepted
   invocation. This allows executing it by other means, e.g. in a forked JVM.
-
+* Parameter names are now included in the default display name of a `@ParameterizedTest`
+  invocation (if they can be found). The `{arguments_with_names}` pattern can also be used
+  in custom names.
 
 [[release-notes-5.6.0-M2️-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1451,8 +1451,10 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsAggregator_w
 ==== Customizing Display Names
 
 By default, the display name of a parameterized test invocation contains the invocation
-index and the `String` representation of all arguments for that specific invocation,
-each of them preceded by the parameter name if it exists and can be found.
+index and the `String` representation of all arguments for that specific invocation.
+Each of them is preceded by the parameter name (unless the argument is only available via
+an `ArgumentsAccessor` or `ArgumentAggregator`), if present in the bytecode (for Java,
+test code must be compiled with the `-parameters` compiler flag).
 
 However, you can customize invocation display names via the `name` attribute of the
 `@ParameterizedTest` annotation like in the following example.

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1476,12 +1476,12 @@ The following placeholders are supported within custom display names.
 
 [cols="20,80"]
 |===
-| Placeholder       | Description
+| Placeholder              | Description
 
 | `{displayName}`          | the display name of the method
 | `{index}`                | the current invocation index (1-based)
 | `{arguments}`            | the complete, comma-separated arguments list
-| `{arguments_with_names}` | the complete, comma-separated arguments list with parameter names
+| `{argumentsWithNames}`   | the complete, comma-separated arguments list with parameter names
 | `{0}`, `{1}`, ...        | an individual argument
 |===
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -924,9 +924,9 @@ following.
 
 ....
 palindromes(String) ✔
-├─ [1] racecar ✔
-├─ [2] radar ✔
-└─ [3] able was I ere I saw elba ✔
+├─ [1] candidate=racecar ✔
+├─ [2] candidate=radar ✔
+└─ [3] candidate=able was I ere I saw elba ✔
 ....
 
 WARNING: Parameterized tests are currently an _experimental_ feature. Consult the table
@@ -1451,7 +1451,9 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsAggregator_w
 ==== Customizing Display Names
 
 By default, the display name of a parameterized test invocation contains the invocation
-index and the `String` representation of all arguments for that specific invocation.
+index and the `String` representation of all arguments for that specific invocation,
+each of them preceded by the parameter name if it exists and can be found.
+
 However, you can customize invocation display names via the `name` attribute of the
 `@ParameterizedTest` annotation like in the following example.
 
@@ -1465,9 +1467,9 @@ the following.
 
 ....
 Display name of container ✔
-├─ 1 ==> fruit='apple', rank=1 ✔
-├─ 2 ==> fruit='banana', rank=2 ✔
-└─ 3 ==> fruit='lemon, lime', rank=3 ✔
+├─ 1 ==> the rank of 'apple' is 1 ✔
+├─ 2 ==> the rank of 'banana' is 2 ✔
+└─ 3 ==> the rank of 'lemon, lime' is 3 ✔
 ....
 
 The following placeholders are supported within custom display names.
@@ -1476,9 +1478,11 @@ The following placeholders are supported within custom display names.
 |===
 | Placeholder       | Description
 
-| `{index}`         | the current invocation index (1-based)
-| `{arguments}`     | the complete, comma-separated arguments list
-| `{0}`, `{1}`, ... | an individual argument
+| `{displayName}`          | the display name of the method
+| `{index}`                | the current invocation index (1-based)
+| `{arguments}`            | the complete, comma-separated arguments list
+| `{arguments_with_names}` | the complete, comma-separated arguments list with parameter names
+| `{0}`, `{1}`, ...        | an individual argument
 |===
 
 

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -411,7 +411,7 @@ class ParameterizedTestDemo {
 
 	// tag::custom_display_names[]
 	@DisplayName("Display name of container")
-	@ParameterizedTest(name = "{index} ==> fruit=''{0}'', rank={1}")
+	@ParameterizedTest(name = "{index} ==> the rank of ''{0}'' is {1}")
 	@CsvSource({ "apple, 1", "banana, 2", "'lemon, lime', 3" })
 	void testWithCustomDisplayNames(String fruit, int rank) {
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -158,13 +158,13 @@ public @interface ParameterizedTest {
 	/**
 	 * Placeholder for the complete, comma-separated named arguments list
 	 * of the current invocation of a {@code @ParameterizedTest} method:
-	 * <code>{arguments_with_names}</code>
+	 * <code>{argumentsWithNames}</code>
 	 *
 	 * @see #name
 	 * @since 5.6
 	 */
 	@API(status = EXPERIMENTAL, since = "5.6")
-	String ARGUMENTS_WITH_NAMES_PLACEHOLDER = "{arguments_with_names}";
+	String ARGUMENTS_WITH_NAMES_PLACEHOLDER = "{argumentsWithNames}";
 
 	/**
 	 * Default display name pattern for the current invocation of a

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -156,6 +156,17 @@ public @interface ParameterizedTest {
 	String ARGUMENTS_PLACEHOLDER = "{arguments}";
 
 	/**
+	 * Placeholder for the complete, comma-separated named arguments list
+	 * of the current invocation of a {@code @ParameterizedTest} method:
+	 * <code>{arguments_with_names}</code>
+	 *
+	 * @see #name
+	 * @since 5.6
+	 */
+	@API(status = EXPERIMENTAL, since = "5.6")
+	String ARGUMENTS_WITH_NAMES_PLACEHOLDER = "{arguments_with_names}";
+
+	/**
 	 * Default display name pattern for the current invocation of a
 	 * {@code @ParameterizedTest} method: {@value}
 	 *
@@ -166,11 +177,11 @@ public @interface ParameterizedTest {
 	 * @see #name
 	 * @see #DISPLAY_NAME_PLACEHOLDER
 	 * @see #INDEX_PLACEHOLDER
-	 * @see #ARGUMENTS_PLACEHOLDER
+	 * @see #ARGUMENTS_WITH_NAMES_PLACEHOLDER
 	 * @since 5.3
 	 */
 	@API(status = EXPERIMENTAL, since = "5.3")
-	String DEFAULT_DISPLAY_NAME = "[" + INDEX_PLACEHOLDER + "] " + ARGUMENTS_PLACEHOLDER;
+	String DEFAULT_DISPLAY_NAME = "[" + INDEX_PLACEHOLDER + "] " + ARGUMENTS_WITH_NAMES_PLACEHOLDER;
 
 	/**
 	 * The display name to be used for individual invocations of the

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -15,7 +15,6 @@ import static org.junit.platform.commons.util.AnnotationUtils.findRepeatableAnno
 import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -126,9 +125,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 			() -> String.format(
 				"Configuration error: @ParameterizedTest on method [%s] must be declared with a non-empty name.",
 				templateMethod));
-		Parameter[] parameters = templateMethod.getParameters();
-		boolean hasAggregator = methodContext != null && methodContext.hasAggregator();
-		return new ParameterizedTestNameFormatter(pattern, displayName, parameters, hasAggregator);
+		return new ParameterizedTestNameFormatter(pattern, displayName, methodContext);
 	}
 
 	protected static Stream<? extends Arguments> arguments(ArgumentsProvider provider, ExtensionContext context) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.util.AnnotationUtils.findRepeatableAnno
 import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -72,7 +73,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 		String displayName = extensionContext.getDisplayName();
 		ParameterizedTestMethodContext methodContext = getStore(extensionContext)//
 				.get(METHOD_CONTEXT_KEY, ParameterizedTestMethodContext.class);
-		ParameterizedTestNameFormatter formatter = createNameFormatter(templateMethod, displayName);
+		ParameterizedTestNameFormatter formatter = createNameFormatter(templateMethod, methodContext, displayName);
 		AtomicLong invocationCount = new AtomicLong(0);
 
 		// @formatter:off
@@ -118,13 +119,16 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 		return new ParameterizedTestInvocationContext(formatter, methodContext, arguments);
 	}
 
-	private ParameterizedTestNameFormatter createNameFormatter(Method templateMethod, String displayName) {
+	private ParameterizedTestNameFormatter createNameFormatter(Method templateMethod,
+			ParameterizedTestMethodContext methodContext, String displayName) {
 		ParameterizedTest parameterizedTest = findAnnotation(templateMethod, ParameterizedTest.class).get();
 		String pattern = Preconditions.notBlank(parameterizedTest.name().trim(),
 			() -> String.format(
 				"Configuration error: @ParameterizedTest on method [%s] must be declared with a non-empty name.",
 				templateMethod));
-		return new ParameterizedTestNameFormatter(pattern, displayName);
+		Parameter[] parameters = templateMethod.getParameters();
+		boolean hasAggregator = methodContext != null && methodContext.hasAggregator();
+		return new ParameterizedTestNameFormatter(pattern, displayName, parameters, hasAggregator);
 	}
 
 	protected static Stream<? extends Arguments> arguments(ArgumentsProvider provider, ExtensionContext context) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
@@ -35,6 +35,7 @@ class ParameterizedTestParameterResolver implements ParameterResolver {
 	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
 		Executable declaringExecutable = parameterContext.getDeclaringExecutable();
 		Method testMethod = extensionContext.getTestMethod().orElse(null);
+		int parameterIndex = parameterContext.getIndex();
 
 		// Not a @ParameterizedTest method?
 		if (!declaringExecutable.equals(testMethod)) {
@@ -42,18 +43,18 @@ class ParameterizedTestParameterResolver implements ParameterResolver {
 		}
 
 		// Current parameter is an aggregator?
-		if (this.methodContext.isAggregator(parameterContext.getIndex())) {
+		if (this.methodContext.isAggregator(parameterIndex)) {
 			return true;
 		}
 
 		// Ensure that the current parameter is declared before aggregators.
 		// Otherwise, a different ParameterResolver should handle it.
-		if (this.methodContext.indexOfFirstAggregator() != -1) {
-			return parameterContext.getIndex() < this.methodContext.indexOfFirstAggregator();
+		if (this.methodContext.hasAggregator()) {
+			return parameterIndex < this.methodContext.indexOfFirstAggregator();
 		}
 
 		// Else fallback to behavior for parameterized test methods without aggregators.
-		return parameterContext.getIndex() < this.arguments.length;
+		return parameterIndex < this.arguments.length;
 	}
 
 	@Override

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -54,6 +54,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.engine.JupiterTestEngine;
+import org.junit.jupiter.params.aggregator.AggregateWith;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregationException;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregator;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
 import org.junit.jupiter.params.converter.ArgumentConverter;
 import org.junit.jupiter.params.converter.ConvertWith;
@@ -85,16 +89,16 @@ class ParameterizedTestIntegrationTests {
 	void executesWithSingleArgumentsProviderWithMultipleInvocations() {
 		var results = execute("testWithTwoSingleStringArgumentsProvider", String.class);
 		results.allEvents().assertThatEvents() //
-				.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
-				.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
+				.haveExactly(1, event(test(), displayName("[1] argument=foo"), finishedWithFailure(message("foo")))) //
+				.haveExactly(1, event(test(), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));
 	}
 
 	@Test
 	void executesWithCsvSource() {
 		var results = execute("testWithCsvSource", String.class);
 		results.allEvents().assertThatEvents() //
-				.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
-				.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
+				.haveExactly(1, event(test(), displayName("[1] argument=foo"), finishedWithFailure(message("foo")))) //
+				.haveExactly(1, event(test(), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));
 	}
 
 	@Test
@@ -112,8 +116,8 @@ class ParameterizedTestIntegrationTests {
 	void executesWithPrimitiveWideningConversion() {
 		var results = execute("testWithPrimitiveWideningConversion", double.class);
 		results.allEvents().assertThatEvents() //
-				.haveExactly(1, event(test(), displayName("[1] 1"), finishedWithFailure(message("num: 1.0")))) //
-				.haveExactly(1, event(test(), displayName("[2] 2"), finishedWithFailure(message("num: 2.0"))));
+				.haveExactly(1, event(test(), displayName("[1] num=1"), finishedWithFailure(message("num: 1.0")))) //
+				.haveExactly(1, event(test(), displayName("[2] num=2"), finishedWithFailure(message("num: 2.0"))));
 	}
 
 	/**
@@ -123,8 +127,8 @@ class ParameterizedTestIntegrationTests {
 	void executesWithImplicitGenericConverter() {
 		var results = execute("testWithImplicitGenericConverter", Book.class);
 		results.allEvents().assertThatEvents() //
-				.haveExactly(1, event(test(), displayName("[1] book 1"), finishedWithFailure(message("book 1")))) //
-				.haveExactly(1, event(test(), displayName("[2] book 2"), finishedWithFailure(message("book 2"))));
+				.haveExactly(1, event(test(), displayName("[1] book=book 1"), finishedWithFailure(message("book 1")))) //
+				.haveExactly(1, event(test(), displayName("[2] book=book 2"), finishedWithFailure(message("book 2"))));
 	}
 
 	@Test
@@ -144,8 +148,19 @@ class ParameterizedTestIntegrationTests {
 	void executesWithExplicitConverter() {
 		var results = execute("testWithExplicitConverter", int.class);
 		results.allEvents().assertThatEvents() //
-				.haveExactly(1, event(test(), displayName("[1] O"), finishedWithFailure(message("length: 1")))) //
-				.haveExactly(1, event(test(), displayName("[2] XXX"), finishedWithFailure(message("length: 3"))));
+				.haveExactly(1, event(test(), displayName("[1] length=O"), finishedWithFailure(message("length: 1")))) //
+				.haveExactly(1,
+					event(test(), displayName("[2] length=XXX"), finishedWithFailure(message("length: 3"))));
+	}
+
+	@Test
+	void executesWithAggregator() {
+		var results = execute("testWithAggregator", String.class);
+		results.allEvents().assertThatEvents() //
+				.haveExactly(1,
+					event(test(), displayName("[1] ab, cd"), finishedWithFailure(message("concatenation: abcd")))) //
+				.haveExactly(1,
+					event(test(), displayName("[2] ef, gh"), finishedWithFailure(message("concatenation: efgh"))));
 	}
 
 	@Test
@@ -172,8 +187,10 @@ class ParameterizedTestIntegrationTests {
 
 		var results = execute(selectClass(LifecycleTestCase.class));
 		results.allEvents().assertThatEvents() //
-				.haveExactly(1, event(test("test1"), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
-				.haveExactly(1, event(test("test1"), displayName("[2] bar"), finishedWithFailure(message("bar"))));
+				.haveExactly(1,
+					event(test("test1"), displayName("[1] argument=foo"), finishedWithFailure(message("foo")))) //
+				.haveExactly(1,
+					event(test("test1"), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));
 
 		List<String> testMethods = new ArrayList<>(LifecycleTestCase.testMethods);
 
@@ -182,22 +199,22 @@ class ParameterizedTestIntegrationTests {
 			"beforeAll:ParameterizedTestIntegrationTests$LifecycleTestCase",
 				"providerMethod",
 					"constructor:ParameterizedTestIntegrationTests$LifecycleTestCase",
-					"beforeEach:[1] foo",
-						testMethods.get(0) + ":[1] foo",
-					"afterEach:[1] foo",
+					"beforeEach:[1] argument=foo",
+						testMethods.get(0) + ":[1] argument=foo",
+					"afterEach:[1] argument=foo",
 					"constructor:ParameterizedTestIntegrationTests$LifecycleTestCase",
-					"beforeEach:[2] bar",
-						testMethods.get(0) + ":[2] bar",
-					"afterEach:[2] bar",
+					"beforeEach:[2] argument=bar",
+						testMethods.get(0) + ":[2] argument=bar",
+					"afterEach:[2] argument=bar",
 				"providerMethod",
 					"constructor:ParameterizedTestIntegrationTests$LifecycleTestCase",
-					"beforeEach:[1] foo",
-						testMethods.get(1) + ":[1] foo",
-					"afterEach:[1] foo",
+					"beforeEach:[1] argument=foo",
+						testMethods.get(1) + ":[1] argument=foo",
+					"afterEach:[1] argument=foo",
 					"constructor:ParameterizedTestIntegrationTests$LifecycleTestCase",
-					"beforeEach:[2] bar",
-						testMethods.get(1) + ":[2] bar",
-					"afterEach:[2] bar",
+					"beforeEach:[2] argument=bar",
+						testMethods.get(1) + ":[2] argument=bar",
+					"afterEach:[2] argument=bar",
 			"afterAll:ParameterizedTestIntegrationTests$LifecycleTestCase");
 		// @formatter:on
 	}
@@ -224,21 +241,21 @@ class ParameterizedTestIntegrationTests {
 		void executesWithNullSourceForString() {
 			var results = execute("testWithNullSourceForString", String.class);
 			results.testEvents().failed().assertEventsMatchExactly(
-				event(test(), displayName("[1] null"), finishedWithFailure(message("null"))));
+				event(test(), displayName("[1] argument=null"), finishedWithFailure(message("null"))));
 		}
 
 		@Test
 		void executesWithNullSourceForStringAndTestInfo() {
 			var results = execute("testWithNullSourceForStringAndTestInfo", String.class, TestInfo.class);
 			results.testEvents().failed().assertEventsMatchExactly(
-				event(test(), displayName("[1] null"), finishedWithFailure(message("null"))));
+				event(test(), displayName("[1] argument=null"), finishedWithFailure(message("null"))));
 		}
 
 		@Test
 		void executesWithNullSourceForNumber() {
 			var results = execute("testWithNullSourceForNumber", Number.class);
 			results.testEvents().failed().assertEventsMatchExactly(
-				event(test(), displayName("[1] null"), finishedWithFailure(message("null"))));
+				event(test(), displayName("[1] argument=null"), finishedWithFailure(message("null"))));
 		}
 
 		@Test
@@ -255,7 +272,7 @@ class ParameterizedTestIntegrationTests {
 		@Test
 		void failsWithNullSourceForPrimitive() {
 			var results = execute("testWithNullSourceForPrimitive", int.class);
-			results.testEvents().failed().assertEventsMatchExactly(event(test(), displayName("[1] null"),
+			results.testEvents().failed().assertEventsMatchExactly(event(test(), displayName("[1] argument=null"),
 				finishedWithFailure(instanceOf(ParameterResolutionException.class), message(
 					"Error converting parameter at index 0: Cannot convert null to primitive value of type int"))));
 		}
@@ -276,55 +293,55 @@ class ParameterizedTestIntegrationTests {
 		@Test
 		void executesWithEmptySourceForString() {
 			var results = execute("testWithEmptySourceForString", String.class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] ")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=")));
 		}
 
 		@Test
 		void executesWithEmptySourceForStringAndTestInfo() {
 			var results = execute("testWithEmptySourceForStringAndTestInfo", String.class, TestInfo.class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] ")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=")));
 		}
 
 		@Test
 		void executesWithEmptySourceForList() {
 			var results = execute("testWithEmptySourceForList", List.class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] []")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
 		}
 
 		@Test
 		void executesWithEmptySourceForSet() {
 			var results = execute("testWithEmptySourceForSet", Set.class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] []")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
 		}
 
 		@Test
 		void executesWithEmptySourceForMap() {
 			var results = execute("testWithEmptySourceForMap", Map.class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] {}")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument={}")));
 		}
 
 		@Test
 		void executesWithEmptySourceForOneDimensionalPrimitiveArray() {
 			var results = execute("testWithEmptySourceForOneDimensionalPrimitiveArray", int[].class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] []")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
 		}
 
 		@Test
 		void executesWithEmptySourceForOneDimensionalStringArray() {
 			var results = execute("testWithEmptySourceForOneDimensionalStringArray", String[].class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] []")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
 		}
 
 		@Test
 		void executesWithEmptySourceForTwoDimensionalPrimitiveArray() {
 			var results = execute("testWithEmptySourceForTwoDimensionalPrimitiveArray", int[][].class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] []")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
 		}
 
 		@Test
 		void executesWithEmptySourceForTwoDimensionalStringArray() {
 			var results = execute("testWithEmptySourceForTwoDimensionalStringArray", String[][].class);
-			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] []")));
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
 		}
 
 		@Test
@@ -406,15 +423,15 @@ class ParameterizedTestIntegrationTests {
 
 		private void assertNullAndEmptyString(EngineExecutionResults results) {
 			results.testEvents().succeeded().assertEventsMatchExactly(//
-				event(test(), displayName("[1] null")), //
-				event(test(), displayName("[2] "))//
+				event(test(), displayName("[1] argument=null")), //
+				event(test(), displayName("[2] argument="))//
 			);
 		}
 
 		private void assertNullAndEmpty(EngineExecutionResults results) {
 			results.testEvents().succeeded().assertEventsMatchExactly(//
-				event(test(), displayName("[1] null")), //
-				event(test(), displayName("[2] []"))//
+				event(test(), displayName("[1] argument=null")), //
+				event(test(), displayName("[2] argument=[]"))//
 			);
 		}
 
@@ -569,32 +586,36 @@ class ParameterizedTestIntegrationTests {
 		void executesWithArgumentsSourceProvidingUnusedArguments() {
 			var results = execute("testWithTwoUnusedStringArgumentsProvider", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
-					.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
+					.haveExactly(1, event(test(), displayName("[1] argument=foo"), finishedWithFailure(message("foo")))) //
+					.haveExactly(1,
+						event(test(), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));
 		}
 
 		@Test
 		void executesWithCsvSourceContainingUnusedArguments() {
 			var results = execute("testWithCsvSourceContainingUnusedArguments", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
-					.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
+					.haveExactly(1, event(test(), displayName("[1] argument=foo"), finishedWithFailure(message("foo")))) //
+					.haveExactly(1,
+						event(test(), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));
 		}
 
 		@Test
 		void executesWithCsvFileSourceContainingUnusedArguments() {
 			var results = execute("testWithCsvFileSourceContainingUnusedArguments", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
-					.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
+					.haveExactly(1, event(test(), displayName("[1] argument=foo"), finishedWithFailure(message("foo")))) //
+					.haveExactly(1,
+						event(test(), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));
 		}
 
 		@Test
 		void executesWithMethodSourceProvidingUnusedArguments() {
 			var results = execute("testWithMethodSourceProvidingUnusedArguments", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(test(), displayName("[1] foo"), finishedWithFailure(message("foo")))) //
-					.haveExactly(1, event(test(), displayName("[2] bar"), finishedWithFailure(message("bar"))));
+					.haveExactly(1, event(test(), displayName("[1] argument=foo"), finishedWithFailure(message("foo")))) //
+					.haveExactly(1,
+						event(test(), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));
 		}
 
 		private EngineExecutionResults execute(String methodName, Class<?>... methodParameterTypes) {
@@ -654,6 +675,12 @@ class ParameterizedTestIntegrationTests {
 		@ValueSource(ints = 42)
 		void testWithErroneousConverter(@ConvertWith(ErroneousConverter.class) Object ignored) {
 			fail("this should never be called");
+		}
+
+		@ParameterizedTest
+		@CsvSource({ "ab, cd", "ef, gh" })
+		void testWithAggregator(@AggregateWith(StringAggregator.class) String concatenation) {
+			fail("concatenation: " + concatenation);
 		}
 
 	}
@@ -1088,6 +1115,15 @@ class ParameterizedTestIntegrationTests {
 		@Override
 		public Object convert(Object source, ParameterContext context) throws ArgumentConversionException {
 			return String.valueOf(source).length();
+		}
+	}
+
+	private static class StringAggregator implements ArgumentsAggregator {
+
+		@Override
+		public Object aggregateArguments(ArgumentsAccessor accessor, ParameterContext context)
+				throws ArgumentsAggregationException {
+			return accessor.getString(0) + accessor.getString(1);
 		}
 	}
 


### PR DESCRIPTION
## Overview

Introduced a new `{arguments_with_names}` pattern in `@ParameterizedTest`, which is now used in the default name pattern. The parameter names are included only if they are present in the bytecode and if the parameter types are known (`ArgumentsAccessor` and `ArgumentsAggregator` are therefore ignored).

Closes #2040.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
