### PR TITLE
Make ThrowableCollector.toTestExecutionResult() public

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ThrowableCollector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ThrowableCollector.java
@@ -170,8 +170,10 @@ public class ThrowableCollector {
 	 * {@linkplain TestExecutionResult#failed failed} if it <em>failed</em>
 	 * execution; and {@linkplain TestExecutionResult#successful successful}
 	 * otherwise
+	 * @since 1.6
 	 */
-	TestExecutionResult toTestExecutionResult() {
+	@API(status = MAINTAINED, since = "1.6")
+	public TestExecutionResult toTestExecutionResult() {
 		if (isEmpty()) {
 			return successful();
 		}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ThrowableCollectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ThrowableCollectorTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.hierarchical;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
+import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
+import static org.junit.platform.engine.TestExecutionResult.Status.SUCCESSFUL;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestExecutionResult;
+
+/**
+ * @since 1.6
+ */
+class ThrowableCollectorTests {
+
+	@Test
+	void successfulExecution() {
+		ThrowableCollector collector = new ThrowableCollector(x -> true);
+		collector.execute(() -> {
+		});
+		TestExecutionResult result = collector.toTestExecutionResult();
+
+		assertEquals(SUCCESSFUL, result.getStatus());
+		assertEquals(Optional.empty(), result.getThrowable());
+	}
+
+	@Test
+	void abortedExecution() {
+		CustomAbort customAbort = new CustomAbort();
+
+		ThrowableCollector collector = new ThrowableCollector(CustomAbort.class::isInstance);
+		collector.execute(() -> {
+			throw customAbort;
+		});
+		TestExecutionResult result = collector.toTestExecutionResult();
+
+		assertEquals(ABORTED, result.getStatus());
+		assertSame(customAbort, result.getThrowable().get());
+	}
+
+	@Test
+	void failedExecution() {
+		AssertionError assertionError = new AssertionError("assumption violated");
+
+		ThrowableCollector collector = new ThrowableCollector(CustomAbort.class::isInstance);
+		collector.execute(() -> {
+			throw assertionError;
+		});
+		TestExecutionResult result = collector.toTestExecutionResult();
+
+		assertEquals(FAILED, result.getStatus());
+		assertSame(assertionError, result.getThrowable().get());
+	}
+
+	static private class CustomAbort extends Error {
+		private static final long serialVersionUID = 1L;
+	}
+}


### PR DESCRIPTION
Fixes #2113.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
