### PR TITLE
Issue/1596 indicative sentences

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -146,8 +146,8 @@ public interface DisplayNameGenerator {
 	 * {@code DisplayNameGenerator} that supports {@code ReplaceUnderscores} to generate complete sentences.
 	 *
 	 * <p>This generator extends the functionality of {@link ReplaceUnderscores} by
-	 * replacing all underscores ({@code '_'}) found in class and method names
-	 * with spaces ({@code ' '}).
+	 * generating a human-readable display names that form complete sentences divided each
+	 * class, nested class and test by a ({@code ','}).
 	 */
 	class IndicativeSentencesGenerator extends ReplaceUnderscores {
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.DisplayNameGenerator.IndicativeSentencesGenerator;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.DisplayNameGenerator.Standard;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
@@ -50,6 +51,11 @@ final class DisplayNameUtils {
 	 * Pre-defined display name generator instance replacing underscores.
 	 */
 	private static final DisplayNameGenerator replaceUnderscoresGenerator = new ReplaceUnderscores();
+
+	/**
+	 * Pre-defined display name generator instance with indicative sentences.
+	 */
+	private static final DisplayNameGenerator indicativeSentencesGenerator = new IndicativeSentencesGenerator();
 
 	static String determineDisplayName(AnnotatedElement element, Supplier<String> displayNameSupplier) {
 		Preconditions.notNull(element, "Annotated element must not be null");
@@ -98,6 +104,9 @@ final class DisplayNameUtils {
 					}
 					if (displayNameGeneratorClass == ReplaceUnderscores.class) {
 						return replaceUnderscoresGenerator;
+					}
+					if (displayNameGeneratorClass == IndicativeSentencesGenerator.class) {
+						return indicativeSentencesGenerator;
 					}
 					return ReflectionUtils.newInstance(displayNameGeneratorClass);
 				}) //

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -68,6 +68,22 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	void indicativeSentencesGenerator() {
+		var expectedDisplayNames = List.of( //
+						"CONTAINER: IndicativeStyleTestCase", //
+						"TEST: @DisplayName prevails", //
+						"TEST: IndicativeStyleTestCase, test", //
+						"TEST: IndicativeStyleTestCase, test (TestInfo)", //
+						"TEST: IndicativeStyleTestCase, test with underscores", //
+						"TEST: IndicativeStyleTestCase, testUsingCamelCase and also UnderScores", //
+						"TEST: IndicativeStyleTestCase, testUsingCamelCase and also UnderScores keepingParameterTypeNamesIntact (TestInfo)", //
+						"TEST: IndicativeStyleTestCase, testUsingCamelCaseStyle" //
+		);
+		check(IndicativeStyleTestCase.class, expectedDisplayNames);
+		//check(IndicativeSentencesInheritedFromSuperClassTestCase.class, expectedDisplayNames);
+	}
+
+	@Test
 	void noNameGenerator() {
 		check(NoNameStyleTestCase.class, List.of( //
 			"CONTAINER: nn", //
@@ -94,6 +110,19 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 			"TEST: the stack is no longer empty", //
 			"TEST: throws an EmptyStackException when peeked", //
 			"TEST: throws an EmptyStackException when popped" //
+		));
+	}
+
+	@Test
+	void checkDisplayNameGeneratedForIndicativeGeneratorTestCase() {
+		check(IndicativeGeneratorTestCase.class, List.of( //
+			"CONTAINER: A stack", //
+			"CONTAINER: A stack, when is new", //
+			"CONTAINER: A stack, when is new, after pushing an element to an empty stack", //
+			"TEST: A stack, is instantiated with new constructor", //
+			"TEST: A stack, when is new, after pushing an element to an empty stack, is no longer empty", //
+			"TEST: A stack, when is new, throws EmptyStackException when peeked", //
+			"TEST: A stack, when is new, throws EmptyStackException when popped" //
 		));
 	}
 
@@ -170,6 +199,10 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	static class UnderscoreStyleTestCase extends AbstractTestCase {
 	}
 
+	@DisplayNameGeneration(DisplayNameGenerator.IndicativeSentencesGenerator.class)
+	static class IndicativeStyleTestCase extends AbstractTestCase {
+	}
+
 	@DisplayNameGeneration(NoNameGenerator.class)
 	static class NoNameStyleTestCase extends AbstractTestCase {
 	}
@@ -177,7 +210,6 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	// No annotation here! @DisplayNameGeneration is inherited from super class
 	static class UnderscoreStyleInheritedFromSuperClassTestCase extends UnderscoreStyleTestCase {
 	}
-
 	// -------------------------------------------------------------------
 
 	@DisplayName("A stack")
@@ -238,6 +270,55 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 				@Test
 				void peek_returns_that_element_without_removing_it_from_the_stack() {
 					assertEquals(anElement, stack.peek());
+					assertFalse(stack.isEmpty());
+				}
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------
+
+	@DisplayName("A stack")
+	@DisplayNameGeneration(DisplayNameGenerator.IndicativeSentencesGenerator.class)
+	static class IndicativeGeneratorTestCase {
+
+		Stack<Object> stack;
+
+		@Test
+		void is_Instantiated_With_New_Constructor() {
+			new Stack<>();
+		}
+
+		@Nested
+		class When_Is_New {
+
+			@BeforeEach
+			void create_With_New_Stack() {
+				stack = new Stack<>();
+			}
+
+			@Test
+			void throws_EmptyStackException_When_Peeked() {
+				assertThrows(EmptyStackException.class, () -> stack.peek());
+			}
+
+			@Test
+			void throws_EmptyStackException_When_Popped() {
+				assertThrows(EmptyStackException.class, () -> stack.pop());
+			}
+
+			@Nested
+			class After_pushing_an_element_to_an_empty_stack {
+
+				String anElement = "an element";
+
+				@BeforeEach
+				void push_An_Element() {
+					stack.push(anElement);
+				}
+
+				@Test
+				void is_no_longer_empty() {
 					assertFalse(stack.isEmpty());
 				}
 			}


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
Hi!, as followed up in the issue #1596, this is the pull request of the implementation of a IndicativeSentencesGenerator supporting the RemplaceUnderscores class and with DisplayName's.

I have a open question: https://github.com/junit-team/junit5/issues/1596#issuecomment-562296145 Here I proposed that might be better to use a variable string to separate the result of the nodes of the test tree, instead of a fixed comma, but I am not sure how to pass that variable.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---
### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass