### PR TITLE
Add support for WildCardType and type hierarchy for TypeBasedParameterResolver

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -10,6 +10,7 @@ object Versions {
     val ota4j = "1.2.0"
     val picocli = "4.0.4"
     val univocity = "2.8.3"
+    val commonsLang3 = "3.9"
 
     // Test Dependencies
     val archunit = "0.12.0"

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0-M2.adoc
@@ -64,7 +64,7 @@ on GitHub.
   they are destroyed.
 * `InvocationInterceptor` extensions may now explicitly `skip()` an intercepted
   invocation. This allows executing it by other means, e.g. in a forked JVM.
-
+* Adding supports for WildCardType and type hierarchy for `TypeBasedParameterResolver<T>`.
 
 [[release-notes-5.6.0-M2️-junit-vintage]]
 === JUnit Vintage

--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
 	api(project(":junit-platform-commons"))
 
 	compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
+	implementation("org.apache.commons:commons-lang3:${Versions.commonsLang3}")
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolver.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolver.java
@@ -15,6 +15,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
+import org.apache.commons.lang3.reflect.TypeUtils;
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -23,7 +24,8 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
- * {@link ParameterResolver} adapter which resolves a parameter based on its exact type.
+ * {@link ParameterResolver} adapter which resolves a parameter based on its type.
+ * It supports parameterized and wildcard types and the type hierarchy.
  *
  * @param <T> the type of the parameter supported by this {@code ParameterResolver}
  * @since 5.6
@@ -39,7 +41,7 @@ public abstract class TypeBasedParameterResolver<T> implements ParameterResolver
 
 	@Override
 	public final boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		return this.supportedParameterType.equals(getParameterType(parameterContext));
+		return TypeUtils.isAssignable(supportedParameterType, getParameterType(parameterContext));
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/MapOfListsTypeBasedParameterResolver.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/injection/sample/MapOfListsTypeBasedParameterResolver.java
@@ -28,5 +28,4 @@ public class MapOfListsTypeBasedParameterResolver extends TypeBasedParameterReso
 
 		return Map.of("ids", List.of(1, 42));
 	}
-
 }


### PR DESCRIPTION
## Overview

This new implementation supports WildCardType and type hierarchy thanks to the usage of  `TypeUtils.isAssignable` provided by apache commons lang3. 

Drawback : it adds a new dependency to JUnit Jupiter.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
