### PR TITLE
Fix stack overflow error in assertIterableEquals

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -64,11 +64,6 @@ class AssertIterableEquals {
 			Object expectedElement = expectedIterator.next();
 			Object actualElement = actualIterator.next();
 
-			if (expectedElement == actualElement) {
-				continue;
-			}
-			// Prevent stack overflow error.
-			// See https://github.com/junit-team/junit5/issues/2157 for details.
 			if (Objects.equals(expectedElement, actualElement)) {
 				continue;
 			}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -69,7 +69,7 @@ class AssertIterableEquals {
 			}
 			// Prevent stack overflow error.
 			// See https://github.com/junit-team/junit5/issues/2157 for details.
-			if (expectedElement != null && expectedElement.equals(actualElement)) {
+			if (Objects.equals(expectedElement, actualElement)) {
 				continue;
 			}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -67,6 +67,11 @@ class AssertIterableEquals {
 			if (expectedElement == actualElement) {
 				continue;
 			}
+			// Prevent stack overflow error.
+			// See https://github.com/junit-team/junit5/issues/2157 for details.
+			if (expectedElement != null && expectedElement.equals(actualElement)) {
+				continue;
+			}
 
 			indexes.addLast(processed - 1);
 			assertIterableElementsEqual(expectedElement, actualElement, indexes, messageOrSupplier);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
@@ -16,10 +16,12 @@ import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.IterableFactory.listOf;
 import static org.junit.jupiter.api.IterableFactory.setOf;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -447,6 +449,15 @@ class AssertIterableEqualsAssertionsTests {
 		var expected = listOf(Path.of("1"));
 		var actual = listOf(Path.of("1"));
 		assertDoesNotThrow(() -> assertIterableEquals(expected, actual));
+	}
+
+	@Test
+	void assertIterableEqualsThrowsStackOverflowErrorForInterlockedRecursiveStructures() {
+		var expected = new ArrayList<>();
+		var actual = new ArrayList<>();
+		actual.add(expected);
+		expected.add(actual);
+		assertThrows(StackOverflowError.class, () -> assertIterableEquals(expected, actual));
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
@@ -14,10 +14,12 @@ import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEndsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.IterableFactory.listOf;
 import static org.junit.jupiter.api.IterableFactory.setOf;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 
@@ -437,6 +439,14 @@ class AssertIterableEqualsAssertionsTests {
 			assertMessageStartsWith(ex, "message");
 			assertMessageEndsWith(ex, "iterable contents differ at index [4][1][0], expected: <3> but was: <5>");
 		}
+	}
+
+	@Test
+	// https://github.com/junit-team/junit5/issues/2157
+	void assertIterableEqualsWithListOfPath() {
+		var expected = listOf(Path.of("1"));
+		var actual = listOf(Path.of("1"));
+		assertDoesNotThrow(() -> assertIterableEquals(expected, actual));
 	}
 
 }


### PR DESCRIPTION
## Overview
Prior to this commit an iterable of iterables (here instances of java.nio.file.Path) passed to method `assertIterableEquals` in class `Assertions` of the JUnit Jupiter API yielded a `StackOverflowError`.

This commit prevent the eternal while-loop by leveraging the `equals()`-implementation of the non-null expected element.

Fixes #2157

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
