### PR TITLE
Put final link to gradle metadata documentation

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.6.0.adoc
@@ -28,7 +28,7 @@ milestone pages in the JUnit repository on GitHub.
 [[release-notes-5.6.0-overall-improvements]]
 === Overall Improvements
 
-* https://docs.gradle.org/6.0-rc-1/userguide/publishing_gradle_module_metadata.html[Gradle
+* https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html[Gradle
   Module Metadata] is now published for all artifacts.
 * OSGi metadata is now published in all binary JARs.
 * Javadoc now contains a module API overview page.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 group           = org.junit
-version         = 5.6.0
+version         = 5.7.0-SNAPSHOT
 
 jupiterGroup    = org.junit.jupiter
 
 platformGroup   = org.junit.platform
-platformVersion = 1.6.0
+platformVersion = 1.7.0-SNAPSHOT
 
 vintageGroup    = org.junit.vintage
-vintageVersion  = 5.6.0
+vintageVersion  = 5.7.0-SNAPSHOT
 
 defaultBuiltBy  = JUnit Team
 releaseBranch   = master

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -49,7 +49,7 @@ tasks.test {
 	if (enabled) {
 		// All maven-aware projects must be installed, i.e. published to the local repository
 		val mavenizedProjects: List<Project> by rootProject.extra
-		mavenizedProjects
+		(mavenizedProjects + project(":junit-bom"))
 				.map { project -> project.tasks.named(MavenPublishPlugin.PUBLISH_LOCAL_LIFECYCLE_TASK_NAME)}
 				.forEach { dependsOn(it) }
 		// Pass "java.home.N" system properties from sources like "~/.gradle/gradle.properties".


### PR DESCRIPTION
## Overview

I just updated the link to the gradle metadata page in the 5.60 release notes in order to point to the _final_ version of the website instead of a RC version

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
