### PR TITLE
Use platform subproject to manage dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -14,6 +14,12 @@ val buildRevision: Any by rootProject.extra
 val builtByValue: String by rootProject.extra
 
 val shadowed by configurations.creating
+val internal by configurations.creating {
+	isVisible = false
+	isCanBeConsumed = false
+	isCanBeResolved = false
+}
+
 val extension = extensions.create<JavaLibraryExtension>("javaLibrary")
 
 val moduleSourceDir = file("src/module/$javaModuleName")
@@ -37,12 +43,12 @@ sourceSets {
 }
 
 configurations {
-	named("mainRelease9CompileClasspath") {
-		extendsFrom(compileClasspath.get())
-	}
-	named("mainRelease9CompileClasspath") {
-		extendsFrom(runtimeClasspath.get())
-	}
+	compileClasspath.get().extendsFrom(internal)
+	runtimeClasspath.get().extendsFrom(internal)
+	testCompileClasspath.get().extendsFrom(internal)
+	testRuntimeClasspath.get().extendsFrom(internal)
+	shadowed.extendsFrom(internal)
+	getByName("mainRelease9CompileClasspath").extendsFrom(compileClasspath.get())
 }
 
 eclipse {
@@ -134,6 +140,8 @@ if (project in mavenizedProjects) {
 		val javaComponent = components["java"] as AdhocComponentWithVariants
 		javaComponent.withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
 		javaComponent.withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }
+		configurations["testFixturesCompileClasspath"].extendsFrom(internal)
+		configurations["testFixturesRuntimeClasspath"].extendsFrom(internal)
 	}
 
 	configure<PublishingExtension> {

--- a/buildSrc/src/main/kotlin/junit4-compatibility.gradle.kts
+++ b/buildSrc/src/main/kotlin/junit4-compatibility.gradle.kts
@@ -7,13 +7,6 @@ val junit_4_12 by configurations.creating {
 }
 
 dependencies {
-	constraints {
-		api("junit:junit:[${Versions.junit4Min},)") {
-			version {
-				prefer(Versions.junit4)
-			}
-		}
-	}
 	junit_4_12("junit:junit") {
 		version {
 			strictly("4.12")

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+	`java-platform`
+}
+
+dependencies {
+	constraints {
+		api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
+		api("org.opentest4j:opentest4j:${Versions.ota4j}")
+		api("org.apache.logging.log4j:log4j-core:${Versions.log4j}")
+		api("org.apache.logging.log4j:log4j-jul:${Versions.log4j}")
+		api("io.github.classgraph:classgraph:${Versions.classgraph}")
+		api("org.codehaus.groovy:groovy-all:${Versions.groovy}")
+		api("junit:junit:[${Versions.junit4Min},)") {
+			version {
+				prefer(Versions.junit4)
+			}
+		}
+		api("com.univocity:univocity-parsers:${Versions.univocity}")
+		api("info.picocli:picocli:${Versions.picocli}")
+		api("org.assertj:assertj-core:${Versions.assertJ}")
+		api("org.openjdk.jmh:jmh-core:${Versions.jmh}")
+		api("org.openjdk.jmh:jmh-generator-annprocess:${Versions.jmh}")
+		api("de.sormuras:bartholdy:${Versions.bartholdy}")
+		api("commons-io:commons-io:${Versions.commonsIo}")
+		api("com.tngtech.archunit:archunit-junit5-api:${Versions.archunit}")
+		api("com.tngtech.archunit:archunit-junit5-engine:${Versions.archunit}")
+		api("org.slf4j:slf4j-jdk14:${Versions.slf4j}")
+	}
+}

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -23,6 +23,8 @@ javaLibrary {
 }
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	// Jupiter API is used in src/main/java
 	implementation(project(":junit-jupiter-api"))
 
@@ -32,11 +34,11 @@ dependencies {
 
 	testImplementation("org.jetbrains.kotlin:kotlin-stdlib")
 
-	testRuntimeOnly("org.apache.logging.log4j:log4j-core:${Versions.log4j}")
-	testRuntimeOnly("org.apache.logging.log4j:log4j-jul:${Versions.log4j}")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-core")
+	testRuntimeOnly("org.apache.logging.log4j:log4j-jul")
 
 	// for ApiReportGenerator
-	testImplementation("io.github.classgraph:classgraph:${Versions.classgraph}")
+	testImplementation("io.github.classgraph:classgraph")
 }
 
 asciidoctorj {

--- a/junit-bom/junit-bom.gradle.kts
+++ b/junit-bom/junit-bom.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 	}
 }
 
-the<PublishingExtension>().publications.named<MavenPublication>("maven") {
+publishing.publications.named<MavenPublication>("maven") {
 	from(components["javaPlatform"])
 	pom {
 		description.set("This Bill of Materials POM can be used to ease dependency management " +

--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 description = "JUnit Jupiter API"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-	api("org.opentest4j:opentest4j:${Versions.ota4j}")
-
+	api("org.apiguardian:apiguardian-api")
+	api("org.opentest4j:opentest4j")
 	api(project(":junit-platform-commons"))
 
 	compileOnly("org.jetbrains.kotlin:kotlin-stdlib")

--- a/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
+++ b/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
@@ -8,10 +8,10 @@ apply(from = "$rootDir/gradle/testing.gradle.kts")
 description = "JUnit Jupiter Engine"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-
+	api("org.apiguardian:apiguardian-api")
 	api(project(":junit-platform-engine"))
 	api(project(":junit-jupiter-api"))
 
@@ -19,5 +19,5 @@ dependencies {
 	testImplementation(project(":junit-platform-runner"))
 	testImplementation(project(":junit-platform-testkit"))
 	testImplementation("org.jetbrains.kotlin:kotlin-stdlib")
-	testImplementation("org.codehaus.groovy:groovy-all:${Versions.groovy}")
+	testImplementation("org.codehaus.groovy:groovy-all")
 }

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -10,11 +10,11 @@ apply(from = "$rootDir/gradle/testing.gradle.kts")
 description = "JUnit Jupiter Migration Support"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
 	api("junit:junit")
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-
+	api("org.apiguardian:apiguardian-api")
 	api(project(":junit-jupiter-api"))
 
 	testImplementation(project(":junit-jupiter-engine"))

--- a/junit-jupiter-params/junit-jupiter-params.gradle.kts
+++ b/junit-jupiter-params/junit-jupiter-params.gradle.kts
@@ -8,13 +8,14 @@ apply(from = "$rootDir/gradle/testing.gradle.kts")
 description = "JUnit Jupiter Params"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-
+	api("org.apiguardian:apiguardian-api")
 	api(project(":junit-jupiter-api"))
 
-	shadowed("com.univocity:univocity-parsers:${Versions.univocity}")
+	shadowed(platform(project(":dependencies")))
+	shadowed("com.univocity:univocity-parsers")
 
 	testImplementation(project(":junit-platform-testkit"))
 	testImplementation(project(":junit-jupiter-engine"))

--- a/junit-jupiter/junit-jupiter.gradle.kts
+++ b/junit-jupiter/junit-jupiter.gradle.kts
@@ -5,9 +5,11 @@ plugins {
 description = "JUnit Jupiter (Aggregator)"
 
 dependencies {
-	api(platform(project(":junit-bom")))
+	internal(platform(project(":dependencies")))
 
+	api(platform(project(":junit-bom")))
 	api(project(":junit-jupiter-api"))
 	api(project(":junit-jupiter-params"))
+
 	runtimeOnly(project(":junit-jupiter-engine"))
 }

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -7,9 +7,9 @@ plugins {
 description = "JUnit Platform Commons"
 
 dependencies {
+	internal(platform(project(":dependencies")))
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
+	api("org.apiguardian:apiguardian-api")
 }
 
 tasks.jar {

--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 description = "JUnit Platform Console Standalone"
 
 dependencies {
+	internal(platform(project(":dependencies")))
 	shadowed(project(":junit-platform-reporting"))
 	shadowed(project(":junit-platform-console"))
 	shadowed(project(":junit-jupiter-engine"))

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -8,13 +8,14 @@ plugins {
 description = "JUnit Platform Console"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-
+	api("org.apiguardian:apiguardian-api")
 	api(project(":junit-platform-reporting"))
 
-	shadowed("info.picocli:picocli:${Versions.picocli}")
+	shadowed(platform(project(":dependencies")))
+	shadowed("info.picocli:picocli")
 }
 
 tasks {

--- a/junit-platform-engine/junit-platform-engine.gradle.kts
+++ b/junit-platform-engine/junit-platform-engine.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 description = "JUnit Platform Engine API"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-	api("org.opentest4j:opentest4j:${Versions.ota4j}")
-
+	api("org.apiguardian:apiguardian-api")
+	api("org.opentest4j:opentest4j")
 	api(project(":junit-platform-commons"))
 
-	testImplementation("org.assertj:assertj-core:${Versions.assertJ}")
+	testImplementation("org.assertj:assertj-core")
 }

--- a/junit-platform-launcher/junit-platform-launcher.gradle.kts
+++ b/junit-platform-launcher/junit-platform-launcher.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 description = "JUnit Platform Launcher"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-
+	api("org.apiguardian:apiguardian-api")
 	api(project(":junit-platform-engine"))
 }

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 description = "JUnit Platform Reporting"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-
+	api("org.apiguardian:apiguardian-api")
 	api(project(":junit-platform-launcher"))
 }

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -8,11 +8,11 @@ plugins {
 description = "JUnit Platform Runner"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
 	api("junit:junit")
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-
+	api("org.apiguardian:apiguardian-api")
 	api(project(":junit-platform-launcher"))
 	api(project(":junit-platform-suite-api"))
 

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
@@ -5,8 +5,9 @@ plugins {
 description = "JUnit Platform Suite API"
 
 dependencies {
-	api(platform(project(":junit-bom")))
+	internal(platform(project(":dependencies")))
 
+	api(platform(project(":junit-bom")))
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 
 	osgiVerification(project(":junit-platform-commons"))

--- a/junit-platform-testkit/junit-platform-testkit.gradle.kts
+++ b/junit-platform-testkit/junit-platform-testkit.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 description = "JUnit Platform Test Kit"
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	api(platform(project(":junit-bom")))
-
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-	api("org.assertj:assertj-core:${Versions.assertJ}")
-	api("org.opentest4j:opentest4j:${Versions.ota4j}")
-
+	api("org.apiguardian:apiguardian-api")
+	api("org.assertj:assertj-core")
+	api("org.opentest4j:opentest4j")
 	api(project(":junit-platform-launcher"))
 }

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -10,9 +10,10 @@ apply(from = "$rootDir/gradle/testing.gradle.kts")
 description = "JUnit Vintage Engine"
 
 dependencies {
-	api(platform(project(":junit-bom")))
+	internal(platform(project(":dependencies")))
 
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
+	api(platform(project(":junit-bom")))
+	api("org.apiguardian:apiguardian-api")
 	api(project(":junit-platform-engine"))
 	api("junit:junit")
 

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 apply(from = "$rootDir/gradle/testing.gradle.kts")
 
 dependencies {
+	internal(platform(project(":dependencies")))
+
 	// --- Things we are testing --------------------------------------------------
 	testImplementation(project(":junit-platform-commons"))
 	testImplementation(project(":junit-platform-console"))
@@ -19,21 +21,23 @@ dependencies {
 	testImplementation(testFixtures(project(":junit-platform-engine")))
 	testImplementation(testFixtures(project(":junit-platform-launcher")))
 	testImplementation(project(":junit-jupiter-engine"))
-	testImplementation("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
+	testImplementation("org.apiguardian:apiguardian-api")
 
 	// --- Test run-time dependencies ---------------------------------------------
 	testRuntimeOnly(project(":junit-vintage-engine"))
-	testRuntimeOnly("org.codehaus.groovy:groovy-all:${Versions.groovy}") {
+	testRuntimeOnly("org.codehaus.groovy:groovy-all") {
 		because("`ReflectionUtilsTests.findNestedClassesWithInvalidNestedClassFile` needs it")
 	}
 
 	// --- https://openjdk.java.net/projects/code-tools/jmh/ -----------------------
-	jmh("org.openjdk.jmh:jmh-core:${Versions.jmh}") {
+	jmh("org.openjdk.jmh:jmh-core") {
 		exclude(module = "jopt-simple")
 	}
-	jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:${Versions.jmh}")
+	jmhAnnotationProcessor(platform(project(":dependencies")))
+	jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess")
+	jmh(platform(project(":dependencies")))
 	jmh(project(":junit-jupiter-api"))
-	jmh("junit:junit:${Versions.junit4}")
+	jmh("junit:junit")
 }
 
 jmh {

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -9,30 +9,32 @@ javaLibrary {
 }
 
 dependencies {
-	implementation("de.sormuras:bartholdy:${Versions.bartholdy}") {
+	internal(platform(project(":dependencies")))
+
+	implementation("de.sormuras:bartholdy") {
 		because("manage external tool installations")
 	}
-	implementation("commons-io:commons-io:${Versions.commonsIo}") {
+	implementation("commons-io:commons-io") {
 		because("moving/deleting directory trees")
 	}
 
-	testImplementation("org.assertj:assertj-core:${Versions.assertJ}") {
+	testImplementation("org.assertj:assertj-core") {
 		because("more assertions")
 	}
-	testImplementation("com.tngtech.archunit:archunit-junit5-api:${Versions.archunit}") {
+	testImplementation("com.tngtech.archunit:archunit-junit5-api") {
 		because("checking the architecture of JUnit 5")
 	}
-	testImplementation("org.codehaus.groovy:groovy-all:${Versions.groovy}") {
+	testImplementation("org.codehaus.groovy:groovy-all") {
 		because("it provides convenience methods to handle process output")
 		exclude(group = "org.junit.platform", module = "junit-platform-launcher")
 	}
 	testImplementation("biz.aQute.bnd:biz.aQute.bndlib:${Versions.bnd}") {
 		because("parsing OSGi metadata")
 	}
-	testRuntimeOnly("com.tngtech.archunit:archunit-junit5-engine:${Versions.archunit}") {
+	testRuntimeOnly("com.tngtech.archunit:archunit-junit5-engine") {
 		because("contains the ArchUnit TestEngine implementation")
 	}
-	testRuntimeOnly("org.slf4j:slf4j-jdk14:${Versions.slf4j}") {
+	testRuntimeOnly("org.slf4j:slf4j-jdk14") {
 		because("provide appropriate SLF4J binding")
 	}
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,7 @@ require(javaVersion.isJava11Compatible) {
 
 rootProject.name = "junit5"
 
+include("dependencies")
 include("documentation")
 include("junit-jupiter")
 include("junit-jupiter-api")


### PR DESCRIPTION
The new `dependencies` subproject declares dependency contraints that
are imported in all other subprojects using an `internal` configuration
that is _not_ published in the dependency management section of the
generated POMs nor in Gradle Module Metadata.