### PR TITLE
Improve error message for TestTemplateInvocationContextProvider

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -15,7 +15,7 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ?
+* ❓
 
 ==== Deprecations and Breaking Changes
 

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -15,7 +15,7 @@ on GitHub.
 
 ==== Bug Fixes
 
-* The javadoc of `TestTemplateInvocationContextProvider` has been fixed: it's allowed to return an empty stream. The error message when all provided streams are empty is now more helpful.
+* ?
 
 ==== Deprecations and Breaking Changes
 
@@ -40,7 +40,7 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* The javadoc of `TestTemplateInvocationContextProvider` has been aligned with the implementation (which was better): it's allowed to return an empty stream. And the error message when all provided streams are empty is now more helpful.
 
 
 [[release-notes-5.7.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -15,7 +15,7 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* The javadoc of `TestTemplateInvocationContextProvider` has been fixed: it's allowed to return an empty stream. The error message when all provided streams are empty is now more helpful.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -70,8 +70,8 @@ public interface TestTemplateInvocationContextProvider extends Extension {
 	 * for the test template method represented by the supplied {@code context}.
 	 *
 	 * <p>This method is only called by the framework if {@link #supportsTestTemplate}
-	 * previously returned {@code true} for the same {@link ExtensionContext}.
-	 * Thus, this method must not return an empty {@code Stream}.
+	 * previously returned {@code true} for the same {@link ExtensionContext};
+	 * this method is allowed to return an empty {@code Stream}, but not {@code null}.
 	 *
 	 * <p>The returned {@code Stream} will be properly closed by calling
 	 * {@link Stream#close()}, making it safe to use a resource such as
@@ -81,7 +81,6 @@ public interface TestTemplateInvocationContextProvider extends Extension {
 	 * to be invoked; never {@code null}
 	 * @return a {@code Stream} of {@code TestTemplateInvocationContext}
 	 * instances for the invocation of the test template method; never {@code null}
-	 * or empty
 	 * @see #supportsTestTemplate
 	 * @see ExtensionContext
 	 */

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.ExtensionUtils.populateNewExtensionRegistryFromExtendWithAnnotation;
@@ -105,7 +106,7 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 				.map(Optional::get)
 				.forEach(invocationTestDescriptor -> execute(dynamicTestExecutor, invocationTestDescriptor));
 		// @formatter:on
-		validateWasAtLeastInvokedOnce(invocationIndex.get());
+		validateWasAtLeastInvokedOnce(invocationIndex.get(), providers);
 		return context;
 	}
 
@@ -138,9 +139,13 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 		dynamicTestExecutor.execute(testDescriptor);
 	}
 
-	private void validateWasAtLeastInvokedOnce(int invocationIndex) {
-		Preconditions.condition(invocationIndex > 0, () -> "No supporting "
-				+ TestTemplateInvocationContextProvider.class.getSimpleName() + " provided an invocation context");
+	private void validateWasAtLeastInvokedOnce(int invocationIndex,
+			List<TestTemplateInvocationContextProvider> providers) {
+		Preconditions.condition(invocationIndex > 0,
+			() -> "None of the " + TestTemplateInvocationContextProvider.class.getSimpleName() + "s "
+					+ providers.stream().map(provider -> provider.getClass().getSimpleName()).collect(
+						joining(", ", "[", "]"))
+					+ " has provided a non-empty stream");
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -354,8 +354,10 @@ class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 		executionResults.allEvents().assertEventsMatchExactly( //
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithSupportingProviderButNoInvocations"), started()), //
-				event(container("templateWithSupportingProviderButNoInvocations"), finishedWithFailure(
-					message("No supporting TestTemplateInvocationContextProvider provided an invocation context")))));
+				event(container("templateWithSupportingProviderButNoInvocations"),
+					finishedWithFailure(message("None of the TestTemplateInvocationContextProviders ["
+							+ InvocationContextProviderThatSupportsEverythingButProvidesNothing.class.getSimpleName()
+							+ "] has provided a non-empty stream")))));
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

Fix javadoc about empty streams from template invocation context providers and produce more helpful error message.

Resolves #2166.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
  **This link is broken... probably should be [this](https://junit.org/junit5/docs/current/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html)**
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
