### PR TITLE
Simplified Kotlin Assertions

### DIFF
--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -14,4 +14,11 @@ dependencies {
 	api(project(":junit-platform-commons"))
 
 	compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
+
+	testImplementation("org.jetbrains.kotlin:kotlin-stdlib")
+	testRuntimeOnly(project(":junit-jupiter-engine"))
+}
+
+tasks.test {
+	useJUnitPlatform()
 }

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
@@ -12,13 +12,13 @@
 package org.junit.jupiter.api
 
 import java.time.Duration
+import java.util.Arrays
 import java.util.function.Supplier
 import java.util.stream.Stream
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.EXPERIMENTAL
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.api.function.ThrowingSupplier
-import java.util.Arrays
 
 /**
  * @see Assertions.fail

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
@@ -18,119 +18,85 @@ import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.EXPERIMENTAL
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.api.function.ThrowingSupplier
+import java.util.Arrays
 
 /**
  * @see Assertions.fail
  */
 fun fail(message: String?, throwable: Throwable? = null): Nothing =
-    Assertions.fail<Nothing>(message, throwable)
+    Assertions.fail(message, throwable)
 
 /**
  * @see Assertions.fail
  */
 fun fail(message: (() -> String)?): Nothing =
-    Assertions.fail<Nothing>(message)
+    Assertions.fail(message)
 
 /**
  * @see Assertions.fail
  */
 fun fail(throwable: Throwable?): Nothing =
-    Assertions.fail<Nothing>(throwable)
-
-/**
- * [Stream] of functions to be executed.
- */
-private typealias ExecutableStream = Stream<() -> Unit>
-private fun ExecutableStream.convert() = map { Executable(it) }
+    Assertions.fail(throwable)
 
 /**
  * @see Assertions.assertAll
  */
-fun assertAll(executables: ExecutableStream) =
-    Assertions.assertAll(executables.convert())
+fun assertAll(executables: Stream<() -> Unit>) =
+    assertAll(null, executables)
 
 /**
  * @see Assertions.assertAll
  */
-fun assertAll(heading: String?, executables: ExecutableStream) =
-    Assertions.assertAll(heading, executables.convert())
-
-/**
- * [Collection] of functions to be executed.
- */
-private typealias ExecutableCollection = Collection<() -> Unit>
-private fun ExecutableCollection.convert() = map { Executable(it) }
+fun assertAll(heading: String?, executables: Stream<() -> Unit>) =
+    Assertions.assertAll(heading, executables.map { Executable(it) })
 
 /**
  * @see Assertions.assertAll
  */
-fun assertAll(executables: ExecutableCollection) =
-    Assertions.assertAll(executables.convert())
+fun assertAll(executables: Collection<() -> Unit>) =
+    assertAll(executables.stream())
 
 /**
  * @see Assertions.assertAll
  */
-fun assertAll(heading: String?, executables: ExecutableCollection) =
-    Assertions.assertAll(heading, executables.convert())
+fun assertAll(heading: String?, executables: Collection<() -> Unit>) =
+    assertAll(heading, executables.stream())
 
 /**
  * @see Assertions.assertAll
  */
 fun assertAll(vararg executables: () -> Unit) =
-    assertAll(executables.toList().stream())
+    assertAll(Arrays.stream(executables))
 
 /**
  * @see Assertions.assertAll
  */
 fun assertAll(heading: String?, vararg executables: () -> Unit) =
-    assertAll(heading, executables.toList().stream())
+    assertAll(heading, Arrays.stream(executables))
 
 /**
- * Example usage:
- * ```kotlin
- * val exception = assertThrows<IllegalArgumentException> {
- *     throw IllegalArgumentException("Talk to a duck")
- * }
- * assertEquals("Talk to a duck", exception.message)
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertThrowsSample
  * @see Assertions.assertThrows
  */
 inline fun <reified T : Throwable> assertThrows(noinline executable: () -> Unit): T =
     Assertions.assertThrows(T::class.java, Executable(executable))
 
 /**
- * Example usage:
- * ```kotlin
- * val exception = assertThrows<IllegalArgumentException>("Should throw an Exception") {
- *     throw IllegalArgumentException("Talk to a duck")
- * }
- * assertEquals("Talk to a duck", exception.message)
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertThrowsWithMessageSample
  * @see Assertions.assertThrows
  */
 inline fun <reified T : Throwable> assertThrows(message: String, noinline executable: () -> Unit): T =
     assertThrows({ message }, executable)
 
 /**
- * Example usage:
- * ```kotlin
- * val exception = assertThrows<IllegalArgumentException>({ "Should throw an Exception" }) {
- *     throw IllegalArgumentException("Talk to a duck")
- * }
- * assertEquals("Talk to a duck", exception.message)
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertThrowsWithLazyMessageSample
  * @see Assertions.assertThrows
  */
 inline fun <reified T : Throwable> assertThrows(noinline message: () -> String, noinline executable: () -> Unit): T =
     Assertions.assertThrows(T::class.java, Executable(executable), Supplier(message))
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertDoesNotThrow {
- *     // Code block that is expected to not throw an exception
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertDoesNotThrowSample
  * @see Assertions.assertDoesNotThrow
  * @param R the result type of the [executable]
  */
@@ -139,12 +105,7 @@ fun <R> assertDoesNotThrow(executable: () -> R): R =
     Assertions.assertDoesNotThrow(ThrowingSupplier(executable))
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertDoesNotThrow("Should not throw an exception") {
- *     // Code block that is expected to not throw an exception
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertDoesNotThrowWithMessageSample
  * @see Assertions.assertDoesNotThrow
  * @param R the result type of the [executable]
  */
@@ -153,12 +114,7 @@ fun <R> assertDoesNotThrow(message: String, executable: () -> R): R =
     assertDoesNotThrow({ message }, executable)
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertDoesNotThrow({ "Should not throw an exception" }) {
- *     // Code block that is expected to not throw an exception
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertDoesNotThrowWithLazyMessageSample
  * @see Assertions.assertDoesNotThrow
  * @param R the result type of the [executable]
  */
@@ -167,84 +123,54 @@ fun <R> assertDoesNotThrow(message: () -> String, executable: () -> R): R =
     Assertions.assertDoesNotThrow(ThrowingSupplier(executable), Supplier(message))
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertTimeout(Duration.seconds(1)) {
- *     // Code block that is being timed.
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertTimeoutSample
  * @see Assertions.assertTimeout
- * @paramR the result of the [executable].
+ * @param R the result of the [executable].
  */
 @API(status = EXPERIMENTAL, since = "5.5")
 fun <R> assertTimeout(timeout: Duration, executable: () -> R): R =
     Assertions.assertTimeout(timeout, executable)
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertTimeout(Duration.seconds(1), "Should only take one second") {
- *     // Code block that is being timed.
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertTimeoutWithMessageSample
  * @see Assertions.assertTimeout
- * @paramR the result of the [executable].
+ * @param R the result of the [executable].
  */
 @API(status = EXPERIMENTAL, since = "5.5")
 fun <R> assertTimeout(timeout: Duration, message: String, executable: () -> R): R =
     Assertions.assertTimeout(timeout, executable, message)
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertTimeout(Duration.seconds(1), { "Should only take one second" }) {
- *     // Code block that is being timed.
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertTimeoutWithLazyMessageSample
  * @see Assertions.assertTimeout
- * @paramR the result of the [executable].
+ * @param R the result of the [executable].
  */
 @API(status = EXPERIMENTAL, since = "5.5")
 fun <R> assertTimeout(timeout: Duration, message: () -> String, executable: () -> R): R =
     Assertions.assertTimeout(timeout, executable, message)
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertTimeoutPreemptively(Duration.seconds(1)) {
- *     // Code block that is being timed.
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertTimeoutPreemptivelySample
  * @see Assertions.assertTimeoutPreemptively
- * @paramR the result of the [executable].
+ * @param R the result of the [executable].
  */
 @API(status = EXPERIMENTAL, since = "5.5")
 fun <R> assertTimeoutPreemptively(timeout: Duration, executable: () -> R): R =
     Assertions.assertTimeoutPreemptively(timeout, executable)
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertTimeoutPreemptively(Duration.seconds(1), "Should only take one second") {
- *     // Code block that is being timed.
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertTimeoutPreemptivelyWithMessageSample
  * @see Assertions.assertTimeoutPreemptively
- * @paramR the result of the [executable].
+ * @param R the result of the [executable].
  */
 @API(status = EXPERIMENTAL, since = "5.5")
 fun <R> assertTimeoutPreemptively(timeout: Duration, message: String, executable: () -> R): R =
     Assertions.assertTimeoutPreemptively(timeout, executable, message)
 
 /**
- * Example usage:
- * ```kotlin
- * val result = assertTimeoutPreemptively(Duration.seconds(1), { "Should only take one second" }) {
- *     // Code block that is being timed.
- * }
- * ```
+ * @sample org.junit.jupiter.api.AssertionsSamples.assertTimeoutPreemptivelyWithLazyMessageSample
  * @see Assertions.assertTimeoutPreemptively
- * @paramR the result of the [executable].
+ * @param R the result of the [executable].
  */
 @API(status = EXPERIMENTAL, since = "5.5")
 fun <R> assertTimeoutPreemptively(timeout: Duration, message: () -> String, executable: () -> R): R =

--- a/junit-jupiter-api/src/test/kotlin/org/junit/jupiter/api/AssertionsSamples.kt
+++ b/junit-jupiter-api/src/test/kotlin/org/junit/jupiter/api/AssertionsSamples.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import java.time.Duration
+
+@Suppress("UNUSED_VARIABLE")
+class AssertionsSamples {
+    @Test fun assertThrowsSample() {
+        val exception = assertThrows<IllegalArgumentException> {
+            throw IllegalArgumentException("Talk to a duck")
+        }
+        assertEquals("Talk to a duck", exception.message)
+    }
+
+    @Test fun assertThrowsWithMessageSample() {
+        val exception = assertThrows<IllegalArgumentException>("Should throw an Exception") {
+            throw IllegalArgumentException("Talk to a duck")
+        }
+        assertEquals("Talk to a duck", exception.message)
+    }
+
+    @Test fun assertThrowsWithLazyMessageSample() {
+        val exception = assertThrows<IllegalArgumentException>({ "Should throw an Exception" }) {
+            throw IllegalArgumentException("Talk to a duck")
+        }
+        assertEquals("Talk to a duck", exception.message)
+    }
+
+    @Test fun assertDoesNotThrowSample() {
+        val result = assertDoesNotThrow {
+            // Code block that is expected to not throw an exception
+        }
+    }
+
+    @Test fun assertDoesNotThrowWithMessageSample() {
+        val result = assertDoesNotThrow("Should not throw an exception") {
+            // Code block that is expected to not throw an exception
+        }
+    }
+
+    @Test fun assertDoesNotThrowWithLazyMessageSample() {
+        val result = assertDoesNotThrow({ "Should not throw an exception" }) {
+            // Code block that is expected to not throw an exception
+        }
+    }
+
+    @Test fun assertTimeoutSample() {
+        val result = assertTimeout(Duration.ofSeconds(1)) {
+            // Code block that is being timed.
+        }
+    }
+
+    @Test fun assertTimeoutWithMessageSample() {
+        val result = assertTimeout(Duration.ofSeconds(1), "Should only take one second") {
+            // Code block that is being timed.
+        }
+    }
+
+    @Test fun assertTimeoutWithLazyMessageSample() {
+        val result = assertTimeout(Duration.ofSeconds(1), { "Should only take one second" }) {
+            // Code block that is being timed.
+        }
+    }
+
+    @Test fun assertTimeoutPreemptivelySample() {
+        val result = assertTimeoutPreemptively(Duration.ofSeconds(1)) {
+            // Code block that is being timed.
+        }
+    }
+
+    @Test fun assertTimeoutPreemptivelyWithMessageSample() {
+        val result = assertTimeoutPreemptively(Duration.ofSeconds(1), "Should only take one second") {
+            // Code block that is being timed.
+        }
+    }
+
+    @Test fun assertTimeoutPreemptivelyWithLazyMessageSample() {
+        val result = assertTimeoutPreemptively(Duration.ofSeconds(1), { "Should only take one second" }) {
+            // Code block that is being timed.
+        }
+    }
+}

--- a/junit-jupiter-api/src/test/kotlin/org/junit/jupiter/api/AssertionsSamples.kt
+++ b/junit-jupiter-api/src/test/kotlin/org/junit/jupiter/api/AssertionsSamples.kt
@@ -9,8 +9,8 @@
  */
 package org.junit.jupiter.api
 
-import org.junit.jupiter.api.Assertions.assertEquals
 import java.time.Duration
+import org.junit.jupiter.api.Assertions.assertEquals
 
 @Suppress("UNUSED_VARIABLE")
 class AssertionsSamples {


### PR DESCRIPTION
## Overview

- Inlined `ExecutableStream` and `ExecutableCollection` type aliases since each is only used in two places that don‘t warrant dedicated type aliases. There is also [KT-24700](https://youtrack.jetbrains.com/issue/KT-24700) that makes private type aliases kind of dangerous.
- Removed the two map extension functions and instead inlined it at a single spot, all other functions are now calling that function and there is no need for the additional symbols anymore.
- Removed the `toList()` calls and exchanged them with `Arrays.stream()`, there is really no need to construct a list first.
- Moved the examples to Kotlin files and made them actual tests. This ensures that the code from the examples stays up-to-date and is correct since they are treated like normal tests. In fact, I fixed some samples that where using `Duration.seconds` which actually needs to be `Duration.ofSeconds`.

We could make every trivial, forwarding function `inline` but I didn‘t do it right away because I would first like to know if there are any good reasons not to. I will leave a comment on every function that I believe should be inlined. Instead of making them `inline` we could also drop them altogether since some of them are just forwarding to their corresponding Java functions. Instead of redeclaring the whole Java API in Kotlin we could just start annotating the Java code with the [JetBrains annotations](https://github.com/JetBrains/java-annotations), the result would be the same but the experience would not only be improved for Kotlin users but for Java users as well (given they use IntelliJ).

Moving the samples to actual tests means that I had to enable tests in the API module. I am not sure if this is a good thing. Let me know what you think.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass