### PR TITLE
Added programmatic test builder API

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/ThrowingConsumers.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/ThrowingConsumers.java
@@ -7,11 +7,12 @@
  *
  * https://www.eclipse.org/legal/epl-v20.html
  */
+
 package org.junit.jupiter.api.function;
 
-import org.apiguardian.api.API;
-
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
 
 /**
  * {@code ThrowingConsumers} contains additional {@link ThrowingConsumer}
@@ -22,213 +23,224 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
  */
 @API(status = EXPERIMENTAL, since = "5.7")
 public interface ThrowingConsumers {
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer2<P1, P2> {
-        void accept(P1 p1, P2 p2) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer2<P1, P2> {
+		void accept(P1 p1, P2 p2) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer3<P1, P2, P3> {
-        void accept(P1 p1, P2 p2, P3 p3) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer3<P1, P2, P3> {
+		void accept(P1 p1, P2 p2, P3 p3) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer4<P1, P2, P3, P4> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer4<P1, P2, P3, P4> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer5<P1, P2, P3, P4, P5> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer5<P1, P2, P3, P4, P5> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer6<P1, P2, P3, P4, P5, P6> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer6<P1, P2, P3, P4, P5, P6> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer7<P1, P2, P3, P4, P5, P6, P7> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer7<P1, P2, P3, P4, P5, P6, P7> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer8<P1, P2, P3, P4, P5, P6, P7, P8> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer8<P1, P2, P3, P4, P5, P6, P7, P8> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer9<P1, P2, P3, P4, P5, P6, P7, P8, P9> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer9<P1, P2, P3, P4, P5, P6, P7, P8, P9> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12)
+				throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13)
+				throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14, P15 p15) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14, P15 p15, P16 p16) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14, P15 p15, P16 p16, P17 p17) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14, P15 p15, P16 p16, P17 p17, P18 p18) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20, P21 p21) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20, P21 p21) throws Throwable;
+	}
 
-    /**
-     * @since 5.7
-     * @see ThrowingConsumer
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    @FunctionalInterface
-    interface ThrowingConsumer22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22> {
-        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20, P21 p21, P22 p22) throws Throwable;
-    }
+	/**
+	 * @since 5.7
+	 * @see ThrowingConsumer
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	@FunctionalInterface
+	interface ThrowingConsumer22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22> {
+		void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13,
+				P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20, P21 p21, P22 p22) throws Throwable;
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/ThrowingConsumers.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/ThrowingConsumers.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api.function;
+
+import org.apiguardian.api.API;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+/**
+ * {@code ThrowingConsumers} contains additional {@link ThrowingConsumer}
+ * functional interfaces that take from 2 to up to 22 arguments.
+ *
+ * @since 5.7
+ * @see ThrowingConsumer
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+public interface ThrowingConsumers {
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer2<P1, P2> {
+        void accept(P1 p1, P2 p2) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer3<P1, P2, P3> {
+        void accept(P1 p1, P2 p2, P3 p3) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer4<P1, P2, P3, P4> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer5<P1, P2, P3, P4, P5> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer6<P1, P2, P3, P4, P5, P6> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer7<P1, P2, P3, P4, P5, P6, P7> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer8<P1, P2, P3, P4, P5, P6, P7, P8> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer9<P1, P2, P3, P4, P5, P6, P7, P8, P9> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20, P21 p21) throws Throwable;
+    }
+
+    /**
+     * @since 5.7
+     * @see ThrowingConsumer
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    @FunctionalInterface
+    interface ThrowingConsumer22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22> {
+        void accept(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20, P21 p21, P22 p22) throws Throwable;
+    }
+}

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/JavaOnly.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/JavaOnly.kt
@@ -7,7 +7,12 @@
  *
  * https://www.eclipse.org/legal/epl-v20.html
  */
+@file:API(status = EXPERIMENTAL, since = "5.7")
+
 package org.junit.jupiter.api
+
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status.EXPERIMENTAL
 
 /**
  * Value that can be used with [@SinceKotlin][SinceKotlin] to hide symbols from

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/JavaOnly.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/JavaOnly.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api
+
+/**
+ * Value that can be used with [@SinceKotlin][SinceKotlin] to hide symbols from
+ * Kotlin users. There is a dedicated annotation ([@JvmSynthetic][JvmSynthetic])
+ * to hide Kotlin symbols from Java, however, there is none for the opposite.
+ * [KT-36439](https://youtrack.jetbrains.com/issue/KT-36439) was created to ask
+ * for exactly that feature, until then this workaround is what leads to the
+ * same desired result.
+ *
+ * Note that files using this workaround must add [@file:Suppress][Suppress]
+ * containing [JAVA_ONLY_HACK] to disable the warning about symbols that require
+ * a newer Kotlin version than the one the module is compiled against.
+ */
+internal const val JAVA_ONLY = "999999.999999"
+
+/** @see JAVA_ONLY */
+internal const val JAVA_ONLY_HACK = "NEWER_VERSION_IN_SINCE_KOTLIN"

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCase.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCase.kt
@@ -12,9 +12,9 @@
 
 package org.junit.jupiter.api
 
+import java.util.function.Function
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.EXPERIMENTAL
-import java.util.function.Function
 
 // Implementation Notes
 //

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCase.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCase.kt
@@ -1,0 +1,492 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+@file:JvmName("TestCaseBuilder")
+@file:Suppress(JAVA_ONLY_HACK, "NOTHING_TO_INLINE")
+
+package org.junit.jupiter.api
+
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status.EXPERIMENTAL
+import java.util.function.Function
+
+// Implementation Notes
+//
+// - The name functions are annotated with @JvmSynthetic because Kotlin has
+//   different visibility rules than Java and they would be visible in Java if
+//   we would not mark them as such.
+// - The various component functions are also annotated with @JvmSynthetic since
+//   Java users cannot destructure the objects like Kotlin users can but instead
+//   shall use the fields directly. This minimized overhead for them but also
+//   minimized the public API we are exposing to Java, making it simpler to use.
+// - The whole Self business in Params is required for covariance and ensures
+//   that the concrete classes stay minimal.
+// - The arity of 22 was not chosen arbitrarily, it's the number Kotlin uses for
+//   its lambdas: https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/runtime/kotlin/jvm/functions/Functions.kt
+
+/**
+ * [TestCase] encapsulates the parameters for a parameterized test that can be
+ * constructed through one of the [testOf] static factory functions. It enables
+ * customization of the [name] of each individual case and (through its
+ * subclasses) provides compile-time type safety for them. Instances are created
+ * through one of the [case], or caseOf in Java, functions.
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.case
+ * @see org.junit.jupiter.api.testOf
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@Suppress("UNCHECKED_CAST") // covariance
+sealed class TestCase<Self : TestCase<Self>> {
+    private var name: (Self.() -> String)? = null
+
+    @JvmSynthetic
+    protected abstract fun name(): String
+
+    /**
+     * Generate a dynamic [name] for this case.
+     *
+     * @see TestCaseIterator.named
+     */
+    @JvmSynthetic
+    infix fun named(name: Self.() -> String) =
+        apply { this.name = name } as Self
+
+    /**
+     * Generate a dynamic [name] for this case.
+     *
+     * @see TestCaseIterator.named
+     */
+    @SinceKotlin(JAVA_ONLY)
+    fun named(name: Function<Self, String>) =
+        named(name::apply)
+
+    /**
+     * Use the given static [name] for this case.
+     *
+     * @see TestCaseIterator.named
+     */
+    inline infix fun named(name: String) =
+        named { name }
+
+    /** @see named */
+    final override fun toString() =
+        name?.invoke(this as Self) ?: name()
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase1<P1> @PublishedApi internal constructor(@JvmField val p1: P1) : TestCase<TestCase1<P1>>() {
+    @JvmSynthetic override fun name() = "$p1"
+    @JvmSynthetic operator fun component1() = p1
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase2<P1, P2> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2) : TestCase<TestCase2<P1, P2>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase3<P1, P2, P3> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3) : TestCase<TestCase3<P1, P2, P3>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase4<P1, P2, P3, P4> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4) : TestCase<TestCase4<P1, P2, P3, P4>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase5<P1, P2, P3, P4, P5> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5) : TestCase<TestCase5<P1, P2, P3, P4, P5>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase6<P1, P2, P3, P4, P5, P6> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6) : TestCase<TestCase6<P1, P2, P3, P4, P5, P6>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase7<P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7) : TestCase<TestCase7<P1, P2, P3, P4, P5, P6, P7>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase8<P1, P2, P3, P4, P5, P6, P7, P8> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8) : TestCase<TestCase8<P1, P2, P3, P4, P5, P6, P7, P8>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase9<P1, P2, P3, P4, P5, P6, P7, P8, P9> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9) : TestCase<TestCase9<P1, P2, P3, P4, P5, P6, P7, P8, P9>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10) : TestCase<TestCase10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11) : TestCase<TestCase11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12) : TestCase<TestCase12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13) : TestCase<TestCase13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14) : TestCase<TestCase14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15) : TestCase<TestCase15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+    @JvmSynthetic operator fun component15() = p15
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16) : TestCase<TestCase16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+    @JvmSynthetic operator fun component15() = p15
+    @JvmSynthetic operator fun component16() = p16
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17) : TestCase<TestCase17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+    @JvmSynthetic operator fun component15() = p15
+    @JvmSynthetic operator fun component16() = p16
+    @JvmSynthetic operator fun component17() = p17
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18) : TestCase<TestCase18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+    @JvmSynthetic operator fun component15() = p15
+    @JvmSynthetic operator fun component16() = p16
+    @JvmSynthetic operator fun component17() = p17
+    @JvmSynthetic operator fun component18() = p18
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18, @JvmField val p19: P19) : TestCase<TestCase19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+    @JvmSynthetic operator fun component15() = p15
+    @JvmSynthetic operator fun component16() = p16
+    @JvmSynthetic operator fun component17() = p17
+    @JvmSynthetic operator fun component18() = p18
+    @JvmSynthetic operator fun component19() = p19
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18, @JvmField val p19: P19, @JvmField val p20: P20) : TestCase<TestCase20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+    @JvmSynthetic operator fun component15() = p15
+    @JvmSynthetic operator fun component16() = p16
+    @JvmSynthetic operator fun component17() = p17
+    @JvmSynthetic operator fun component18() = p18
+    @JvmSynthetic operator fun component19() = p19
+    @JvmSynthetic operator fun component20() = p20
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18, @JvmField val p19: P19, @JvmField val p20: P20, @JvmField val p21: P21) : TestCase<TestCase21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20, $p21"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+    @JvmSynthetic operator fun component15() = p15
+    @JvmSynthetic operator fun component16() = p16
+    @JvmSynthetic operator fun component17() = p17
+    @JvmSynthetic operator fun component18() = p18
+    @JvmSynthetic operator fun component19() = p19
+    @JvmSynthetic operator fun component20() = p20
+    @JvmSynthetic operator fun component21() = p21
+}
+
+/** @see TestCase */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCase22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18, @JvmField val p19: P19, @JvmField val p20: P20, @JvmField val p21: P21, @JvmField val p22: P22) : TestCase<TestCase22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22>>() {
+    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20, $p21, $p22"
+    @JvmSynthetic operator fun component1() = p1
+    @JvmSynthetic operator fun component2() = p2
+    @JvmSynthetic operator fun component3() = p3
+    @JvmSynthetic operator fun component4() = p4
+    @JvmSynthetic operator fun component5() = p5
+    @JvmSynthetic operator fun component6() = p6
+    @JvmSynthetic operator fun component7() = p7
+    @JvmSynthetic operator fun component8() = p8
+    @JvmSynthetic operator fun component9() = p9
+    @JvmSynthetic operator fun component10() = p10
+    @JvmSynthetic operator fun component11() = p11
+    @JvmSynthetic operator fun component12() = p12
+    @JvmSynthetic operator fun component13() = p13
+    @JvmSynthetic operator fun component14() = p14
+    @JvmSynthetic operator fun component15() = p15
+    @JvmSynthetic operator fun component16() = p16
+    @JvmSynthetic operator fun component17() = p17
+    @JvmSynthetic operator fun component18() = p18
+    @JvmSynthetic operator fun component19() = p19
+    @JvmSynthetic operator fun component20() = p20
+    @JvmSynthetic operator fun component21() = p21
+    @JvmSynthetic operator fun component22() = p22
+}
+
+// @formatter:off
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1> case(p1: P1) = TestCase1(p1)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2> case(p1: P1, p2: P2) = TestCase2(p1, p2)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3> case(p1: P1, p2: P2, p3: P3) = TestCase3(p1, p2, p3)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4> case(p1: P1, p2: P2, p3: P3, p4: P4) = TestCase4(p1, p2, p3, p4)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) = TestCase5(p1, p2, p3, p4, p5)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) = TestCase6(p1, p2, p3, p4, p5, p6)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) = TestCase7(p1, p2, p3, p4, p5, p6, p7)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8) = TestCase8(p1, p2, p3, p4, p5, p6, p7, p8)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9) = TestCase9(p1, p2, p3, p4, p5, p6, p7, p8, p9)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10) = TestCase10(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11) = TestCase11(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12) = TestCase12(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13) = TestCase13(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14) = TestCase14(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15) = TestCase15(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16) = TestCase16(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17) = TestCase17(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18) = TestCase18(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18, p19: P19) = TestCase19(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18, p19: P19, p20: P20) = TestCase20(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18, p19: P19, p20: P20, p21: P21) = TestCase21(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
+/** @see TestCase */ @API(status = EXPERIMENTAL, since = "5.7") @JvmName("caseOf") inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22> case(p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16, p17: P17, p18: P18, p19: P19, p20: P20, p21: P21, p22: P22) = TestCase22(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22)
+// @formatter:on

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCase.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCase.kt
@@ -7,6 +7,7 @@
  *
  * https://www.eclipse.org/legal/epl-v20.html
  */
+@file:API(status = EXPERIMENTAL, since = "5.7")
 @file:JvmName("TestCaseBuilder")
 @file:Suppress(JAVA_ONLY_HACK, "NOTHING_TO_INLINE")
 
@@ -45,53 +46,51 @@ import org.apiguardian.api.API.Status.EXPERIMENTAL
 @API(status = EXPERIMENTAL, since = "5.7")
 @Suppress("UNCHECKED_CAST") // covariance
 sealed class TestCase<Self : TestCase<Self>> {
-    private var name: (Self.() -> String)? = null
-
-    @JvmSynthetic
-    protected abstract fun name(): String
+    @JvmSynthetic internal var name: String? = null
+        private set
 
     /**
-     * Generate a dynamic [name] for this case.
-     *
-     * @see TestCaseIterator.named
+     * Use the given [name] for this test case to display it.
      */
-    @JvmSynthetic
-    infix fun named(name: Self.() -> String) =
+    infix fun named(name: String) =
         apply { this.name = name } as Self
 
     /**
-     * Generate a dynamic [name] for this case.
-     *
-     * @see TestCaseIterator.named
+     * Use the given [formatter] to generate the name of this test case for
+     * displaying it.
      */
-    @SinceKotlin(JAVA_ONLY)
-    fun named(name: Function<Self, String>) =
-        named(name::apply)
+    @JvmSynthetic
+    inline infix fun named(formatter: Self.() -> String) =
+        named(formatter(this as Self))
 
     /**
-     * Use the given static [name] for this case.
-     *
-     * @see TestCaseIterator.named
+     * Use the given [formatter] to generate the name of this test case for
+     * displaying it.
      */
-    inline infix fun named(name: String) =
-        named { name }
+    @SinceKotlin(JAVA_ONLY)
+    fun named(formatter: Function<Self, String>) =
+        named(formatter::apply)
 
-    /** @see named */
-    final override fun toString() =
-        name?.invoke(this as Self) ?: name()
+    /**
+     * Do not use any name for this test case to display it.
+     */
+    inline fun unnamed() =
+        named("")
+
+    abstract override fun toString(): String
 }
 
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase1<P1> @PublishedApi internal constructor(@JvmField val p1: P1) : TestCase<TestCase1<P1>>() {
-    @JvmSynthetic override fun name() = "$p1"
+    override fun toString() = "$p1"
     @JvmSynthetic operator fun component1() = p1
 }
 
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase2<P1, P2> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2) : TestCase<TestCase2<P1, P2>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2"
+    override fun toString() = "$p1, $p2"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
 }
@@ -99,7 +98,7 @@ class TestCase2<P1, P2> @PublishedApi internal constructor(@JvmField val p1: P1,
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase3<P1, P2, P3> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3) : TestCase<TestCase3<P1, P2, P3>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3"
+    override fun toString() = "$p1, $p2, $p3"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -108,7 +107,7 @@ class TestCase3<P1, P2, P3> @PublishedApi internal constructor(@JvmField val p1:
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase4<P1, P2, P3, P4> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4) : TestCase<TestCase4<P1, P2, P3, P4>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4"
+    override fun toString() = "$p1, $p2, $p3, $p4"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -118,7 +117,7 @@ class TestCase4<P1, P2, P3, P4> @PublishedApi internal constructor(@JvmField val
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase5<P1, P2, P3, P4, P5> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5) : TestCase<TestCase5<P1, P2, P3, P4, P5>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -129,7 +128,7 @@ class TestCase5<P1, P2, P3, P4, P5> @PublishedApi internal constructor(@JvmField
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase6<P1, P2, P3, P4, P5, P6> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6) : TestCase<TestCase6<P1, P2, P3, P4, P5, P6>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -141,7 +140,7 @@ class TestCase6<P1, P2, P3, P4, P5, P6> @PublishedApi internal constructor(@JvmF
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase7<P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7) : TestCase<TestCase7<P1, P2, P3, P4, P5, P6, P7>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -154,7 +153,7 @@ class TestCase7<P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal constructor(@
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase8<P1, P2, P3, P4, P5, P6, P7, P8> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8) : TestCase<TestCase8<P1, P2, P3, P4, P5, P6, P7, P8>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -168,7 +167,7 @@ class TestCase8<P1, P2, P3, P4, P5, P6, P7, P8> @PublishedApi internal construct
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase9<P1, P2, P3, P4, P5, P6, P7, P8, P9> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9) : TestCase<TestCase9<P1, P2, P3, P4, P5, P6, P7, P8, P9>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -183,7 +182,7 @@ class TestCase9<P1, P2, P3, P4, P5, P6, P7, P8, P9> @PublishedApi internal const
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10) : TestCase<TestCase10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -199,7 +198,7 @@ class TestCase10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @PublishedApi internal
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11) : TestCase<TestCase11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -216,7 +215,7 @@ class TestCase11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> @PublishedApi int
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12) : TestCase<TestCase12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -234,7 +233,7 @@ class TestCase12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> @PublishedAp
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13) : TestCase<TestCase13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -253,7 +252,7 @@ class TestCase13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> @Publis
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14) : TestCase<TestCase14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -273,7 +272,7 @@ class TestCase14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> @P
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15) : TestCase<TestCase15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -294,7 +293,7 @@ class TestCase15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P1
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16) : TestCase<TestCase16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -316,7 +315,7 @@ class TestCase16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P1
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17) : TestCase<TestCase17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -339,7 +338,7 @@ class TestCase17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P1
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18) : TestCase<TestCase18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -363,7 +362,7 @@ class TestCase18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P1
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18, @JvmField val p19: P19) : TestCase<TestCase19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -388,7 +387,7 @@ class TestCase19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P1
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18, @JvmField val p19: P19, @JvmField val p20: P20) : TestCase<TestCase20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -414,7 +413,7 @@ class TestCase20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P1
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18, @JvmField val p19: P19, @JvmField val p20: P20, @JvmField val p21: P21) : TestCase<TestCase21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20, $p21"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20, $p21"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3
@@ -441,7 +440,7 @@ class TestCase21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P1
 /** @see TestCase */
 @API(status = EXPERIMENTAL, since = "5.7")
 class TestCase22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22> @PublishedApi internal constructor(@JvmField val p1: P1, @JvmField val p2: P2, @JvmField val p3: P3, @JvmField val p4: P4, @JvmField val p5: P5, @JvmField val p6: P6, @JvmField val p7: P7, @JvmField val p8: P8, @JvmField val p9: P9, @JvmField val p10: P10, @JvmField val p11: P11, @JvmField val p12: P12, @JvmField val p13: P13, @JvmField val p14: P14, @JvmField val p15: P15, @JvmField val p16: P16, @JvmField val p17: P17, @JvmField val p18: P18, @JvmField val p19: P19, @JvmField val p20: P20, @JvmField val p21: P21, @JvmField val p22: P22) : TestCase<TestCase22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22>>() {
-    @JvmSynthetic override fun name() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20, $p21, $p22"
+    override fun toString() = "$p1, $p2, $p3, $p4, $p5, $p6, $p7, $p8, $p9, $p10, $p11, $p12, $p13, $p14, $p15, $p16, $p17, $p18, $p19, $p20, $p21, $p22"
     @JvmSynthetic operator fun component1() = p1
     @JvmSynthetic operator fun component2() = p2
     @JvmSynthetic operator fun component3() = p3

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCaseIterator.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCaseIterator.kt
@@ -1,0 +1,807 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+@file:JvmName("TestBuilder")
+@file:Suppress(JAVA_ONLY_HACK, "NOTHING_TO_INLINE")
+
+package org.junit.jupiter.api
+
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status.EXPERIMENTAL
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.function.ThrowingConsumer
+import org.junit.jupiter.api.function.ThrowingConsumers.*
+import java.util.function.BiFunction
+import java.util.stream.Stream
+
+/**
+ * The [TestCaseIterator] lazily builds a [DynamicTest] with the given [test]
+ * function for each of the supplied [cases] when iterated. It is to be used in
+ * conjunction with the [@TestFactory][TestFactory] annotation. Use the [testOf]
+ * family of static factory functions to build instances of this class.
+ *
+ * Use the [TestCases] interface as the return type for the test function that is
+ * annotated with [@TestFactory][TestFactory]. This avoids the unnecessary
+ * repetition of the actual [type][T] in the signature.
+ *
+ * Note that the [testOf] functions cannot use [TestCases] as their return type
+ * because it would make it impossible to provide a type-safe
+ * [display name generator][named] functionality then.
+ *
+ * ## Examples
+ *
+ * ### Java
+ * ```java
+ * import java.util.Arrays;
+ *
+ * import static org.junit.jupiter.api.Assertions.assertEquals;
+ * import static org.junit.jupiter.api.Assertions.assertTrue;
+ * import static org.junit.jupiter.api.TestBuilder.testOf;
+ * import static org.junit.jupiter.api.TestCaseBuilder.caseOf;
+ *
+ * final class JavaExamples {
+ *     @TestFactory
+ *     Tests collections() {
+ *         // There are overloads for many different collection types available
+ *         // that may act as the source for the cases of the test.
+ *         return testOf(
+ *             new int[]{1, 2, 3},
+ *             it -> assertTrue(it > 0)
+ *         );
+ *     }
+ *
+ *     enum CardinalDirection {
+ *         North(0), East(90), South(180), West(270);
+ *
+ *         public final int degree;
+ *
+ *         CardinalDirection(final int degree) {
+ *             this.degree = degree;
+ *         }
+ *     }
+ *
+ *     @TestFactory
+ *     Tests enums() {
+ *         return testOf(
+ *             CardinalDirection.class,
+ *             it -> assertTrue(it.degree >= 0 && it.degree <= 360)
+ *         );
+ *     }
+ *
+ *     @TestFactory
+ *     Tests parameterized() {
+ *         // There are type-safe overloads from 1 to 22 parameters.
+ *         return testOf(
+ *             (str, num, list) -> {
+ *                 assertEquals(5, str.length());
+ *                 assertTrue(num >= 1 && num <= 2);
+ *                 assertEquals(2, list.size());
+ *             },
+ *             caseOf("apple", 1, Arrays.asList('a', 'b')),
+ *             caseOf("lemon", 2, Arrays.asList('x', 'y'))
+ *         );
+ *     }
+ * }
+ * ```
+ *
+ * ### Kotlin
+ * ```kotlin
+ * import org.junit.jupiter.api.Assertions.assertEquals
+ * import org.junit.jupiter.api.Assertions.assertTrue
+ *
+ * private class KotlinExamples {
+ *     // There are overloads for many different collection types available that
+ *     // may act as the source for the cases of the test.
+ *     @TestFactory fun collections() =
+ *         testOf(sequence {
+ *             // Using a sequence as the source makes it completely async.
+ *             yield(1)
+ *             yield(2)
+ *             yield(3)
+ *         }) { assertTrue(it > 0) }
+ *
+ *     @TestFactory fun ranges() =
+ *         testOf(1..3) { assertTrue(it > 0) }
+ *
+ *     enum class CardinalDirection(val degree: Int) {
+ *         North(0), East(90), South(180), West(270)
+ *     }
+ *
+ *     @TestFactory fun enums() =
+ *         testOf<CardinalDirection> {
+ *             assertTrue(it.degree in 0..360)
+ *         }
+ *
+ *     // There are type-safe overloads from 1 to 22 parameters.
+ *     @TestFactory fun parameterized() =
+ *         testOf(
+ *             case("apple", 1, listOf('a', 'b')),
+ *             case("lemon", 2, listOf('x', 'y'))
+ *         ) { str, num, list ->
+ *             assertEquals(5, str.length)
+ *             assertTrue(num in 1..2)
+ *             assertEquals(2, list.size)
+ *         }
+ * }
+ * ```
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.case
+ * @see org.junit.jupiter.api.TestCase
+ * @see org.junit.jupiter.api.TestFactory
+ * @see org.junit.jupiter.api.testOf
+ * @see org.junit.jupiter.api.TestCases
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+class TestCaseIterator<T> @PublishedApi internal constructor(
+    private val cases: Iterator<T>,
+    private val test: (T) -> Unit
+) : TestCases {
+    private var i = 1
+    private var name: ((Int, T) -> String)? = null
+
+    override fun hasNext() =
+        cases.hasNext()
+
+    override fun next(): DynamicTest =
+        cases.next().let { case ->
+            dynamicTest(name?.invoke(i++, case) ?: "[${i++}] $case") {
+                test(case)
+            }
+        }
+
+    /**
+     * Use the given custom display name generator to all parameters that are to
+     * be tested with this parameterized test.
+     *
+     * The given function will receive the 1-based index of the parameters that
+     * are to be tested as the first argument and the actual parameters as the
+     * second argument. The formatting of individual parameters can be further
+     * customized through the [TestCase.named] function for each individual
+     * parameter collection.
+     *
+     * The default generator encloses the index in brackets and joins the
+     * parameters after calling their respective [toString][Any.toString] with
+     * a comma, e.g. `params("p1", "p2")` will result in `[1] p1, p2`.
+     *
+     * ## Examples
+     * ```kotlin
+     * @TestFactory fun isPalindrom() =
+     *     testOf(case("mum"), case("dad")) {
+     *         assertEquals(it.reversed(), it)
+     *     } named { _, case -> case }
+     * ```
+     *
+     * The above would result in the following output with the `ConsoleLauncher`
+     * and the Unicode theme:
+     *
+     * ```
+     * isPalindrom ✔
+     * ├─ mum ✔
+     * └─ dad ✔
+     * ```
+     *
+     * Instead of the default output that would be:
+     *
+     * ```
+     * isPalindrom ✔
+     * ├─ [1] mum ✔
+     * └─ [2] dad ✔
+     * ```
+     *
+     * The second argument passed to the [name] function provides access to each
+     * individual parameter of the case that is to be tested and thus allows for
+     * sophisticated customization since any library in the classpath is
+     * available for transforming the parameters. The various subclasses of
+     * [TestCase] all support destructuring that makes sure that the individual
+     * parameters can be named properly.
+     *
+     * ```kotlin
+     * @TestFactory fun `Magic constant`() =
+     *     testOf(
+     *         case("Pi", 3.1415926535897932384626433),
+     *         case("Euler‘s Number", 2.71828)
+     *     ) { assertTrue(true) } named { i, (name, x) ->
+     *         "#$i $name := %.2f".format(x)
+     *     }
+     * ```
+     *
+     * ```
+     * Magic constant ✔
+     * ├─ #1 Pi := 3.14 ✔
+     * └─ #2 Euler‘s Number := 2.71 ✔
+     * ```
+     *
+     * The above could be combined with [TestCase.named] if the name is not
+     * required for the actual test:
+     *
+     * ```kotlin
+     * @TestFactory fun `Magic constant`() =
+     *     testOf(
+     *         case(3.1415926535897932384626433) named "Pi",
+     *         case(2.71828) named "Euler‘s Number"
+     *     ) { assertTrue(true) } named { i, case ->
+     *         val (x) = case // or access it with case.p1
+     *         // The toString function of the case returns the name that was
+     *         // given to it.
+     *         "#$i $case := %.2f".format(x)
+     *     }
+     * ```
+     *
+     * @see org.junit.jupiter.api.TestCase.named
+     */
+    @JvmSynthetic
+    infix fun named(name: (i: Int, case: T) -> String) =
+        apply { this.name = name }
+
+    /**
+     * Use the given custom display name generator to all parameters that are to
+     * be tested with this parameterized test.
+     *
+     * The given function will receive the 1-based index of the parameters that
+     * are to be tested as the first argument and the actual parameters as the
+     * second argument. The formatting of individual parameters can be further
+     * customized through the [TestCase.named] function for each individual
+     * parameter collection.
+     *
+     * The default generator encloses the index in brackets and joins the
+     * parameters after calling their respective [toString][Any.toString] with
+     * a comma, e.g. `params("p1", "p2")` will result in `[1] p1, p2`.
+     *
+     * ### Examples
+     * ```java
+     * @TestFactory
+     * TestCases isPalindromTest() {
+     *     return testOf(
+     *         it -> assertTrue(isPalindrom(it)),
+     *         caseOf("mum"),
+     *         caseOf("dad")
+     *     ).named((i, case) -> case);
+     * }
+     * ```
+     *
+     * The above would result in the following output with the `ConsoleLauncher`
+     * and the Unicode theme:
+     *
+     * ```
+     * isPalindrom ✔
+     * ├─ mum ✔
+     * └─ dad ✔
+     * ```
+     *
+     * Instead of the default output that would be:
+     *
+     * ```
+     * isPalindrom ✔
+     * ├─ [1] mum ✔
+     * └─ [2] dad ✔
+     * ```
+     *
+     * The second argument passed to the [name] function provides access to each
+     * individual parameter of the case that is to be tested and thus allows for
+     * sophisticated customization since any library in the classpath is
+     * available for transforming the parameters.
+     *
+     * ```java
+     * @TestFactory
+     * TestCases magicConstants() {
+     *     return testOf(
+     *         (name, x) -> assertTrue(true),
+     *         caseOf("Pi", 3.1415926535897932384626433),
+     *         caseOf("Euler‘s Number", 2.71828)
+     *     ).named((i, case) -> format("#%d %s := %.2f", i, case.p1, case.p2));
+     * }
+     * ```
+     *
+     * ```
+     * Magic constant ✔
+     * ├─ #1 Pi := 3.14 ✔
+     * └─ #2 Euler‘s Number := 2.71 ✔
+     * ```
+     *
+     * The above could be combined with [TestCase.named] if the name is not
+     * required for the actual test:
+     *
+     * ```java
+     * @TestFactory
+     * TestCases magicConstants() {
+     *     return testOf(
+     *         (name, x) -> assertTrue(true),
+     *         caseOf(3.1415926535897932384626433).named("Pi"),
+     *         caseOf(2.71828).named("Euler‘s Number")
+     *     ).named((i, case) -> format("#%d %s := %.2f", i, case.toString(), case.p1));
+     * }
+     * ```
+     *
+     * @see org.junit.jupiter.api.TestCase.named
+     */
+    @SinceKotlin(JAVA_ONLY)
+    fun named(name: BiFunction<Int, T, String>) =
+        named(name::apply)
+}
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [sequence].
+ *
+ * Using a sequence as data provider makes the complete test factory lazy since
+ * yield is executed only if the iterator is advanced. This is ideal if the
+ * values require a lot of memory.
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun <E> testOf(sequence: Sequence<E>, noinline test: (E) -> Unit) =
+    TestCaseIterator(sequence.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [stream].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+fun <E> testOf(stream: Stream<E>, test: (E) -> Unit) =
+    TestCaseIterator(stream.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [stream].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun <E> testOf(stream: Stream<E>, test: ThrowingConsumer<E>) =
+    TestCaseIterator(stream.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun <E> testOf(array: Array<out E>, noinline test: (E) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun <E> testOf(array: Array<out E>, test: ThrowingConsumer<E>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(array: BooleanArray, noinline test: (Boolean) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun testOf(array: BooleanArray, test: ThrowingConsumer<Boolean>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(array: ByteArray, noinline test: (Byte) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun testOf(array: ByteArray, test: ThrowingConsumer<Byte>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(array: CharArray, noinline test: (Char) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun testOf(array: CharArray, test: ThrowingConsumer<Char>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(array: DoubleArray, noinline test: (Double) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun testOf(array: DoubleArray, test: ThrowingConsumer<Double>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(array: FloatArray, noinline test: (Float) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun testOf(array: FloatArray, test: ThrowingConsumer<Float>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(array: IntArray, noinline test: (Int) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun testOf(array: IntArray, test: ThrowingConsumer<Int>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(array: LongArray, noinline test: (Long) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun testOf(array: LongArray, test: ThrowingConsumer<Long>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(array: ShortArray, noinline test: (Short) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun testOf(array: ShortArray, test: ThrowingConsumer<Short>) =
+    TestCaseIterator(array.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@ExperimentalUnsignedTypes
+@JvmSynthetic
+inline fun testOf(array: UIntArray, noinline test: (UInt) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@ExperimentalUnsignedTypes
+@JvmSynthetic
+inline fun testOf(array: ULongArray, noinline test: (ULong) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each element of the given [array].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@ExperimentalUnsignedTypes
+@JvmSynthetic
+inline fun testOf(array: UShortArray, noinline test: (UShort) -> Unit) =
+    TestCaseIterator(array.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [iterable].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun <E> testOf(iterable: Iterable<E>, noinline test: (E) -> Unit) =
+    TestCaseIterator(iterable.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [iterable].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun <E> testOf(iterable: Iterable<E>, test: ThrowingConsumer<E>) =
+    TestCaseIterator(iterable.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [iterator].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun <E> testOf(iterator: Iterator<E>, noinline test: (E) -> Unit) =
+    TestCaseIterator(iterator, test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [element][E] of the given [iterator].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun <E> testOf(iterator: Iterator<E>, test: ThrowingConsumer<E>) =
+    TestCaseIterator(iterator, test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [value][enumValues] of the given [enum][E].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun <reified E : Enum<E>> testOf(noinline test: (E) -> Unit) =
+    TestCaseIterator(enumValues<E>().iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each [value][enumValues] of the given [enum][E].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@SinceKotlin(JAVA_ONLY)
+fun <E : Enum<E>> testOf(enum: Class<E>, test: ThrowingConsumer<E>) =
+    TestCaseIterator(enum.enumConstants.iterator(), test::accept)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each value in the given [range].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(range: CharRange, noinline test: (Char) -> Unit) =
+    TestCaseIterator(range.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each value in the given [range].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(range: IntRange, noinline test: (Int) -> Unit) =
+    TestCaseIterator(range.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each value in the given [range].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@JvmSynthetic
+inline fun testOf(range: LongRange, noinline test: (Long) -> Unit) =
+    TestCaseIterator(range.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each value in the given [range].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@ExperimentalUnsignedTypes
+@JvmSynthetic
+inline fun testOf(range: UIntRange, noinline test: (UInt) -> Unit) =
+    TestCaseIterator(range.iterator(), test)
+
+/**
+ * Build a [TestCaseIterator] that can be used with [@TestFactory][TestFactory]
+ * and [test] each value in the given [range].
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+@ExperimentalUnsignedTypes
+@JvmSynthetic
+inline fun testOf(range: ULongRange, noinline test: (ULong) -> Unit) =
+    TestCaseIterator(range.iterator(), test)
+
+// The arity of 22 was not chosen arbitrarily, it's the number Kotlin uses for
+// its lambdas: https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/runtime/kotlin/jvm/functions/Functions.kt
+//
+// @formatter:off
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1> testOf(vararg cases: TestCase1<P1>, crossinline test: (P1) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2> testOf(vararg cases: TestCase2<P1, P2>, crossinline test: (P1, P2) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3> testOf(vararg cases: TestCase3<P1, P2, P3>, crossinline test: (P1, P2, P3) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4> testOf(vararg cases: TestCase4<P1, P2, P3, P4>, crossinline test: (P1, P2, P3, P4) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5> testOf(vararg cases: TestCase5<P1, P2, P3, P4, P5>, crossinline test: (P1, P2, P3, P4, P5) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6> testOf(vararg cases: TestCase6<P1, P2, P3, P4, P5, P6>, crossinline test: (P1, P2, P3, P4, P5, P6) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7> testOf(vararg cases: TestCase7<P1, P2, P3, P4, P5, P6, P7>, crossinline test: (P1, P2, P3, P4, P5, P6, P7) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8> testOf(vararg cases: TestCase8<P1, P2, P3, P4, P5, P6, P7, P8>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9> testOf(vararg cases: TestCase9<P1, P2, P3, P4, P5, P6, P7, P8, P9>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> testOf(vararg cases: TestCase10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> testOf(vararg cases: TestCase11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> testOf(vararg cases: TestCase12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> testOf(vararg cases: TestCase13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> testOf(vararg cases: TestCase14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> testOf(vararg cases: TestCase15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> testOf(vararg cases: TestCase16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> testOf(vararg cases: TestCase17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> testOf(vararg cases: TestCase18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> testOf(vararg cases: TestCase19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18, it.p19) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> testOf(vararg cases: TestCase20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18, it.p19, it.p20) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21> testOf(vararg cases: TestCase21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18, it.p19, it.p20, it.p21) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @JvmSynthetic inline fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22> testOf(vararg cases: TestCase22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22>, crossinline test: (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22) -> Unit) = TestCaseIterator(cases.iterator()) { test(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18, it.p19, it.p20, it.p21, it.p22) }
+
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1> testOf(test: ThrowingConsumer<P1>, vararg cases: TestCase1<P1>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2> testOf(test: ThrowingConsumer2<P1, P2>, vararg cases: TestCase2<P1, P2>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3> testOf(test: ThrowingConsumer3<P1, P2, P3>, vararg cases: TestCase3<P1, P2, P3>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4> testOf(test: ThrowingConsumer4<P1, P2, P3, P4>, vararg cases: TestCase4<P1, P2, P3, P4>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5> testOf(test: ThrowingConsumer5<P1, P2, P3, P4, P5>, vararg cases: TestCase5<P1, P2, P3, P4, P5>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6> testOf(test: ThrowingConsumer6<P1, P2, P3, P4, P5, P6>, vararg cases: TestCase6<P1, P2, P3, P4, P5, P6>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7> testOf(test: ThrowingConsumer7<P1, P2, P3, P4, P5, P6, P7>, vararg cases: TestCase7<P1, P2, P3, P4, P5, P6, P7>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8> testOf(test: ThrowingConsumer8<P1, P2, P3, P4, P5, P6, P7, P8>, vararg cases: TestCase8<P1, P2, P3, P4, P5, P6, P7, P8>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9> testOf(test: ThrowingConsumer9<P1, P2, P3, P4, P5, P6, P7, P8, P9>, vararg cases: TestCase9<P1, P2, P3, P4, P5, P6, P7, P8, P9>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> testOf(test: ThrowingConsumer10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>, vararg cases: TestCase10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> testOf(test: ThrowingConsumer11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>, vararg cases: TestCase11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> testOf(test: ThrowingConsumer12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>, vararg cases: TestCase12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> testOf(test: ThrowingConsumer13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>, vararg cases: TestCase13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> testOf(test: ThrowingConsumer14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>, vararg cases: TestCase14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> testOf(test: ThrowingConsumer15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>, vararg cases: TestCase15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> testOf(test: ThrowingConsumer16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16>, vararg cases: TestCase16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> testOf(test: ThrowingConsumer17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17>, vararg cases: TestCase17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> testOf(test: ThrowingConsumer18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18>, vararg cases: TestCase18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> testOf(test: ThrowingConsumer19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19>, vararg cases: TestCase19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18, it.p19) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> testOf(test: ThrowingConsumer20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20>, vararg cases: TestCase20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18, it.p19, it.p20) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21> testOf(test: ThrowingConsumer21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21>, vararg cases: TestCase21<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18, it.p19, it.p20, it.p21) }
+/** @see TestCaseIterator */ @API(status = EXPERIMENTAL, since = "5.7") @SafeVarargs @SinceKotlin(JAVA_ONLY) fun <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22> testOf(test: ThrowingConsumer22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22>, vararg cases: TestCase22<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21, P22>) = TestCaseIterator(cases.iterator()) { test.accept(it.p1, it.p2, it.p3, it.p4, it.p5, it.p6, it.p7, it.p8, it.p9, it.p10, it.p11, it.p12, it.p13, it.p14, it.p15, it.p16, it.p17, it.p18, it.p19, it.p20, it.p21, it.p22) }
+// @formatter:on

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCaseIterator.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCaseIterator.kt
@@ -12,13 +12,33 @@
 
 package org.junit.jupiter.api
 
+import java.util.function.BiFunction
+import java.util.stream.Stream
 import org.apiguardian.api.API
 import org.apiguardian.api.API.Status.EXPERIMENTAL
 import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.function.ThrowingConsumer
-import org.junit.jupiter.api.function.ThrowingConsumers.*
-import java.util.function.BiFunction
-import java.util.stream.Stream
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer10
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer11
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer12
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer13
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer14
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer15
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer16
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer17
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer18
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer19
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer2
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer20
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer21
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer22
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer3
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer4
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer5
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer6
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer7
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer8
+import org.junit.jupiter.api.function.ThrowingConsumers.ThrowingConsumer9
 
 /**
  * The [TestCaseIterator] lazily builds a [DynamicTest] with the given [test]

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCases.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/TestCases.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api
+
+import org.apiguardian.api.API
+import org.apiguardian.api.API.Status.EXPERIMENTAL
+
+/**
+ * [TestCases] is an [Iterator] over one or more [DynamicTest]s. This is a
+ * convenience type alias that can be used as the return type for a
+ * [@TestFactory][TestFactory] that uses one of the [testOf] factory methods
+ * that have many type parameters. It ensures that the signature of such
+ * functions are not cluttered with a plethora of type information that is not
+ * relevant.
+ *
+ * This is defined as an interface and not as a Kotlin `typealias` for two
+ * reasons 1) we cannot use a Kotlin `typealias` in Java, and 2) we cannot
+ * annotate a Kotlin `typealias` with [@API][API]. It is not defined as a Java
+ * interface because this would require that Kotlin classes that implement this
+ * interface have to implement [MutableIterator] instead of [Iterator] because
+ * the [java.util.Iterator] has a [remove][java.util.Iterator.remove] function.
+ * But, removal is not supposed to be supported.
+ *
+ * ## Examples
+ * ```java
+ * class Example {
+ *     @TestFactory
+ *     void TestBuilder<TestCase4<Integer, Char, String, List<Integer>>> bad() {
+ *         return testOf(
+ *             i, c, s, l -> //...
+ *             caseOf(1, 'a', "a", Arrays.asList(10, 11, 12)),
+ *             caseOf(2, 'b', "a", Arrays.asList(20, 21, 22)),
+ *             caseOf(3, 'b', "a", Arrays.asList(30, 32, 33))
+ *         );
+ *     }
+ *
+ *     @TestFactory
+ *     void TestCases good() {
+ *         return testOf(
+ *             i, c, s, l -> //...
+ *             caseOf(1, 'a', "a", Arrays.asList(10, 11, 12)),
+ *             caseOf(2, 'b', "a", Arrays.asList(20, 21, 22)),
+ *             caseOf(3, 'b', "a", Arrays.asList(30, 32, 33))
+ *         );
+ *     }
+ * }
+ * ```
+ *
+ * In Kotlin the return type can usually be omitted:
+ *
+ * ```kotlin
+ * private class Example {
+ *     @TestFactory fun awesome() =
+ *         testOf(
+ *             case(1, 'a', "a", listOf(10, 11, 12)),
+ *             case(2, 'b', "b", listOf(20, 21, 22)),
+ *             case(3, 'c', "c", listOf(30, 31, 32))
+ *         ) //...
+ * }
+ * ```
+ *
+ * However, there are situations where a regular function body is desired, to
+ * e.g. set something up that is reused, and then [TestCases] comes into play:
+ *
+ * ```kotlin
+ * private class Example {
+ *     @TestFactory fun bad(): TestBuilder<TestCase4<Int, Char, String, List<Int>>> {
+ *         val service = mock<Service>()
+ *         return testOf(//...
+ *     }
+ *
+ *     @TestFactory fun good(): TestCases {
+ *         val service = mock<Service>()
+ *         return testOf(//...
+ *     }
+ * }
+ * ```
+ *
+ * @since 5.7
+ * @see org.junit.jupiter.api.TestCaseIterator
+ * @see org.junit.jupiter.api.testOf
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+interface TestCases : Iterator<DynamicTest>

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/JavaTestBuilderTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/JavaTestBuilderTests.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.TestBuilder.testOf;
+import static org.junit.jupiter.api.TestCaseBuilder.caseOf;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.function.ThrowingConsumer;
+
+// @formatter:off
+
+/**
+ * Java unit tests for {@link TestBuilder}.
+ */
+class JavaTestBuilderTests {
+	private static final ThrowingConsumer<Object> NOOP = it -> {};
+
+	@SuppressWarnings("unchecked")
+	private static <T> ThrowingConsumer<T> noop() {
+		return (ThrowingConsumer<T>) NOOP;
+	}
+
+	private static void check(final TestCases testCases, final String a, final String b) {
+		assertAll(
+			() -> assertTrue(testCases.hasNext()),
+			() -> assertEquals(a, testCases.next().getDisplayName()),
+			() -> assertTrue(testCases.hasNext()),
+			() -> assertEquals(b, testCases.next().getDisplayName()),
+			() -> assertFalse(testCases.hasNext()),
+			() -> assertThrows(NoSuchElementException.class, testCases::next)
+		);
+	}
+
+	private static void check(final TestCases testCases) {
+		check(testCases, "[1] a", "[2] b");
+	}
+
+	@Test
+	void testOfStream() {
+		check(testOf(Stream.of('a', 'b'), noop()));
+	}
+
+	@Test
+	void testOfArray() {
+		check(testOf(new String[] { "a", "b" }, noop()));
+	}
+
+	@Test
+	void testOfBooleanArray() {
+		check(testOf(new boolean[] { true, false }, noop()), "[1] true", "[2] false");
+	}
+
+	@Test
+	void testOfByteArray() {
+		check(testOf(new byte[] { 0b0, 0b1 }, noop()), "[1] 0", "[2] 1");
+	}
+
+	@Test
+	void testOfCharArray() {
+		check(testOf(new char[] { 'a', 'b' }, noop()));
+	}
+
+	@Test
+	void testOfDoubleArray() {
+		check(testOf(new double[] { 1.1, 2.2 }, noop()), "[1] 1.1", "[2] 2.2");
+	}
+
+	@Test
+	void testOfFloatArray() {
+		check(testOf(new float[] { 1.1F, 2.2F }, noop()), "[1] 1.1", "[2] 2.2");
+	}
+
+	@Test
+	void testOfIntArray() {
+		check(testOf(new int[] { 1, 2 }, noop()), "[1] 1", "[2] 2");
+	}
+
+	@Test
+	void testOfLongArray() {
+		check(testOf(new long[] { 1L, 2L }, noop()), "[1] 1", "[2] 2");
+	}
+
+	@Test
+	void testOfShortArray() {
+		check(testOf(new short[] { 1, 2 }, noop()), "[1] 1", "[2] 2");
+	}
+
+	@Test
+	void testOfIterable() {
+		check(testOf(Arrays.asList('a', 'b'), noop()));
+	}
+
+	@Test
+	void testOfIterator() {
+		check(testOf(Stream.of('a', 'b').iterator(), noop()));
+	}
+
+	enum E {
+		a, b
+	}
+
+	@Test
+	void testOfEnum() {
+		check(testOf(E.class, noop()));
+	}
+
+	@Test
+	void testOf1() {
+		check(testOf(noop(), caseOf('a'), caseOf('b')));
+	}
+
+	@Test
+	void testOf2() {
+		check(
+			testOf(
+				(p1, p2) -> {},
+				caseOf('a', 'a'),
+				caseOf('b', 'b')
+			),
+			"[1] a, a",
+			"[2] b, b"
+		);
+	}
+
+	@Test
+	void testOf3() {
+		check(
+			testOf(
+				(p1, p2, p3) -> {},
+				caseOf('a', 'a', 'a'),
+				caseOf('b', 'b', 'b')
+			),
+			"[1] a, a, a",
+			"[2] b, b, b"
+		);
+	}
+
+	@Test
+	void testOf4() {
+		check(
+			testOf(
+				(p1, p2, p3, p4) -> {},
+				caseOf('a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a",
+			"[2] b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf5() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a",
+			"[2] b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf6() {
+		check(testOf((p1, p2, p3, p4, p5, p6) -> {
+		}, caseOf('a', 'a', 'a', 'a', 'a', 'a'), caseOf('b', 'b', 'b', 'b', 'b', 'b')), "[1] a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b");
+	}
+
+	@Test
+	void testOf7() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf8() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf9() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf10() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf11() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf12() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf13() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf14() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf15() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf16() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf17() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf18() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf19() {
+		check(
+			testOf(
+				(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19) -> {},
+				caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')
+			),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b"
+		);
+	}
+
+	@Test
+	void testOf20() {
+		check(testOf((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20) -> {
+		}, caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'),
+			caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b')),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b");
+	}
+
+	@Test
+	void testOf21() {
+		check(
+			testOf((p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21) -> {
+			}, caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',
+				'a', 'a'),
+				caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b',
+					'b', 'b')),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b");
+	}
+
+	@Test
+	void testOf22() {
+		check(testOf(
+			(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22) -> {
+			},
+			caseOf('a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',
+				'a', 'a'),
+			caseOf('b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b',
+				'b', 'b')),
+			"[1] a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a",
+			"[2] b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b, b");
+	}
+
+	@Test
+	void testOfWithCustomCounter() {
+		check(testOf(noop(), caseOf('a'), caseOf('b')).counter(i -> "#" + i + " "), "#1 a", "#2 b");
+	}
+
+	@Test
+	void testOfWithFixedCounter() {
+		check(testOf(noop(), caseOf('a'), caseOf('b')).counter("… "), "… a", "… b");
+	}
+
+	@Test
+	void testOfWithoutCounter() {
+		check(testOf(noop(), caseOf('a'), caseOf('b')).uncounted(), "a", "b");
+	}
+
+	@Test
+	void testOfWithCustomNaming() {
+		check(testOf(noop(), caseOf('a'), caseOf('b')).named(it -> Character.toString(Character.toUpperCase(it.p1))),
+			"[1] A", "[2] B");
+	}
+
+	@Test
+	void testOfWithFixedNaming() {
+		check(testOf(noop(), caseOf('a'), caseOf('b')).named("…"), "[1] …", "[2] …");
+	}
+
+	@Test
+	void testOfWithoutName() {
+		check(testOf(noop(), caseOf('a'), caseOf('b')).unnamed(), "[1] ", "[2] ");
+	}
+
+	@Test
+	void testOfWithCustomCounterAndName() {
+		check(testOf(noop(), caseOf('a'), caseOf('b')).counter(i -> "#" + i).named(
+			it -> Character.toString(Character.toUpperCase(it.p1))), "#1A", "#2B");
+	}
+
+	@Test
+	void testOfWithCustomCaseNames() {
+		check(testOf(noop(), caseOf('a').named("AA"), caseOf('b').named("BB")), "[1] AA", "[2] BB");
+	}
+
+	@Test
+	void testOfWithCustomNameAndCustomCaseName() {
+		check(testOf(noop(), caseOf("").named("EMPTY"), caseOf(" ")).named(it -> Character.getName(it.p1.charAt(0))),
+			"[1] EMPTY", "[2] SPACE");
+	}
+}


### PR DESCRIPTION
## Overview

> This is a draft because the PR is still missing crucial parts like tests and documentation. However, the implementation itself is mostly finished and I would like to gather feedback. 😊

Using `junit-jupiter-params` in Kotlin is awkward for many reasons and why I propose the addition of a programmatic, functional API to JUnit that will make `junit-jupiter-params` obsolete for many use-cases.

```kotlin
private class JunitJupiterParamsKt {
    /** @see dataProvider */
    @ParameterizedTest
    @MethodSource("dataProvider")
    fun isPalindrom(candidate: String) {
        assertEquals(candidate.reversed(), candidate)
    }

    companion object {
        @JvmStatic
        fun dataProvider(): Stream<Arguments> =
            Stream.of(
                arguments("mum"),
                arguments("dad")
            )
    }
}
```

Above is an extremely simple test written in Kotlin that makes use of `junit-jupiter-params` but there are many issues with it (ordered from top to bottom as they occur in the file above):

- We have to add the kdoc block with an `@see` reference to the actual method source to please IntelliJ and stop insisting on `dataProvider` being unused (this is a total IDE issue that can be solved but it is a real issue).
- We need to add two annotations to our function to enable the parameterization.
- We need to add an annotation with a string value matching the name of the data provider function, keeping it up-to-date manually.
- We need to define the signature as we expect things to arrive, however, there are no compile-time checks that actually ensure that the arguments of the data provider are actually compatible with our signature. We might have been running tests for five minutes already until we run into the issue at runtime.
- We need to create a companion object where we collect all data providers. This means that the data providers will end up far away from the spot where they are actually being used. Forcing us to scroll and jump around to find everything that makes up a test case.
  
  There is the ability to change the test instance lifecycle to class that lifts this requirement. However, many users do not know about it and I also had to learn that tests can be written in ways that make it impossible to switch.
- We need to annotate each data provider with `@JvmStatic`.
- We need to add `Stream<Arguments>` as the return type (or add `!!` at the end of the stream construction and each `arguments` call) to disable warnings about missing nullability information.
- We need to use `Stream` which is not very idiomatic in Kotlin.

Here is the very same parameterized test written with the programmatic API that I am proposing:

```kotlin
private class JunitJupiterTestBuilderKt {
    @TestFactory fun isPalindrom() =
        testOf(case("mum"), case("dad")) { 
            assertEquals(it.reversed(), it)
        }
}
```

It solves all mentioned issues, better yet, it is also much faster than the version from above because there is no runtime discovery necessary and nothing needs to be wired by JUnit since its all done by the language. We can have all these benefits in Java too:

```java
class JunitJupiterTestBuilderJ {
    @TestFactory
    TestCases isPalindrom() {
        return testOf(
            it -> assertTrue(StringUtils.isPalindrom(it)),
            caseOf("mum"),
            caseOf("dad")
        );
    }
}
```

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
