### PR TITLE
Use Gradle Enterprise server to upload scans and as remote build cache

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - '*'
 
+env:
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  ORG_GRADLE_PROJECT_junitBuildCacheUsername: ${{ secrets.BUILD_CACHE_USERNAME }}
+  ORG_GRADLE_PROJECT_junitBuildCachePassword: ${{ secrets.BUILD_CACHE_PASSWORD }}
+
 jobs:
   openjdk:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - '*'
 
+env:
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  ORG_GRADLE_PROJECT_junitBuildCacheUsername: ${{ secrets.BUILD_CACHE_USERNAME }}
+  ORG_GRADLE_PROJECT_junitBuildCachePassword: ${{ secrets.BUILD_CACHE_PASSWORD }}
+
 jobs:
   linux:
     name: 'Linux'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,12 +9,6 @@ plugins {
 }
 
 buildScan {
-	if (System.getenv("CI") != null || System.getenv("GITHUB_WORKFLOW") != null) {
-		tag("CI")
-	} else {
-		tag("LOCAL")
-	}
-
 	value("Git Branch", versioning.info.branch)
 	value("Git Commit", versioning.info.commit)
 	link("Commit", "https://github.com/junit-team/junit5/commit/${versioning.info.commit}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,14 +8,9 @@ plugins {
 	id("io.spring.nohttp")
 }
 
-buildScan {
-	value("Git Branch", versioning.info.branch)
-	value("Git Commit", versioning.info.commit)
-	link("Commit", "https://github.com/junit-team/junit5/commit/${versioning.info.commit}")
-	if (versioning.info.dirty) {
-		tag("DIRTY")
-	}
+apply(from = "gradle/build-scan-user-data.gradle")
 
+buildScan {
 	if (project.hasProperty("javaHome")) {
 		value("Custom Java home", project.property("javaHome") as String)
 	}

--- a/gradle/build-scan-user-data.gradle
+++ b/gradle/build-scan-user-data.gradle
@@ -1,0 +1,247 @@
+// Source: https://github.com/gradle/gradle-build-scan-snippets/blob/master/guided-trials-default-custom-user-data/default-custom-user-data.gradle
+
+tagOs()
+tagIde()
+tagCiOrLocal()
+addCiMetadata()
+addGitMetadata()
+addTestParallelization()
+
+// Add here other scripts, if needed
+//apply from:"${rootProject.projectDir}/<<other-script.gradle>>"
+
+void tagOs() {
+	buildScan.tag System.getProperty('os.name')
+}
+
+void tagIde() {
+	if (project.hasProperty('android.injected.invoked.from.ide')) {
+		buildScan.tag 'Android Studio'
+	} else if (System.getProperty('idea.version')) {
+		buildScan.tag 'IntelliJ IDEA'
+	} else if (System.getProperty('eclipse.buildId')) {
+		buildScan.tag 'Eclipse'
+	} else if (!isCi()) {
+		buildScan.tag 'Cmd Line'
+	}
+}
+
+void tagCiOrLocal() {
+	buildScan.tag(isCi() ? 'CI' : 'LOCAL')
+}
+
+void addCiMetadata() {
+	if (isJenkins()) {
+		if (System.getenv('BUILD_URL')) {
+			buildScan.link 'Jenkins build', System.getenv('BUILD_URL')
+		}
+		if (System.getenv('BUILD_NUMBER')) {
+			buildScan.value 'CI build number', System.getenv('BUILD_NUMBER')
+		}
+		if (System.getenv('NODE_NAME')) {
+			def agentName = System.getenv('NODE_NAME') == 'master' ? 'master-node' : System.getenv('NODE_NAME')
+			buildScan.tag agentName
+			buildScan.value 'CI node name', agentName
+		}
+		if (System.getenv('JOB_NAME')) {
+			def jobNameLabel = 'CI job'
+			def jobName = System.getenv('JOB_NAME')
+			buildScan.value jobNameLabel, jobName
+			addCustomValueSearchLink 'CI job build scans', [(jobNameLabel): jobName]
+		}
+		if (System.getenv('STAGE_NAME')) {
+			def stageNameLabel = 'CI stage'
+			def stageName = System.getenv('STAGE_NAME')
+			buildScan.value stageNameLabel, stageName
+			addCustomValueSearchLink 'CI stage build scans', [(stageNameLabel): stageName]
+		}
+	}
+
+	if (isTeamCity()) {
+		def teamCityConfigurationFileProp = 'teamcity.configuration.properties.file'
+		if (project.hasProperty(teamCityConfigurationFileProp)) {
+			def properties = new Properties()
+			properties.load(new FileInputStream("${project.property(teamCityConfigurationFileProp)}"))
+			def teamCityServerUrl = properties.getProperty("teamcity.serverUrl")
+			if (teamCityServerUrl && project.hasProperty('build.number') && project.hasProperty('teamcity.buildType.id')) {
+				def teamCityBuildNumber = project.property('build.number')
+				def teamCityBuildTypeId = project.property('teamcity.buildType.id')
+				buildScan.link 'TeamCity build', "${appendIfMissing(teamCityServerUrl, '/')}viewLog.html?buildNumber=${teamCityBuildNumber}&buildTypeId=${teamCityBuildTypeId}"
+			}
+		}
+		if (project.hasProperty('build.number')) {
+			buildScan.value 'CI build number', project.property('build.number')
+		}
+		if (project.hasProperty('agent.name')) {
+			def agentName = project.property('agent.name')
+			buildScan.tag agentName
+			buildScan.value 'CI agent name', agentName
+		}
+	}
+
+	if (isCircleCI()) {
+		if (System.getenv('CIRCLE_BUILD_URL')) {
+			buildScan.link 'CircleCI build', System.getenv('CIRCLE_BUILD_URL')
+		}
+		if (System.getenv('CIRCLE_BUILD_NUM')) {
+			buildScan.value 'CI build number', System.getenv('CIRCLE_BUILD_NUM')
+		}
+		if (System.getenv('CIRCLE_JOB')) {
+			def jobLabel = 'CI job'
+			def job = System.getenv('CIRCLE_JOB')
+			buildScan.value jobLabel, job
+			addCustomValueSearchLink 'CI job build scans', [(jobLabel): job]
+		}
+		if (System.getenv('CIRCLE_WORKFLOW_ID')) {
+			def workflowIdLabel = 'CI workflow'
+			def workflowId = System.getenv('CIRCLE_WORKFLOW_ID')
+			buildScan.value workflowIdLabel, workflowId
+			addCustomValueSearchLink 'CI workflow build scans', [(workflowIdLabel): workflowId]
+		}
+	}
+
+	if (isBamboo()) {
+		if (System.getenv('bamboo_resultsUrl')) {
+			buildScan.link 'Bamboo build', System.getenv('bamboo_resultsUrl')
+		}
+		if (System.getenv('bamboo_buildNumber')) {
+			buildScan.value 'CI build number', System.getenv('bamboo_buildNumber')
+		}
+		if (System.getenv('bamboo_planName')) {
+			def planNameLabel = 'CI plan'
+			def planName = System.getenv('bamboo_planName')
+			buildScan.value planNameLabel, planName
+			addCustomValueSearchLink 'CI plan build scans', [(planNameLabel): planName]
+		}
+		if (System.getenv('bamboo_buildPlanName')) {
+			def jobNameLabel = 'CI job'
+			def jobName = System.getenv('bamboo_buildPlanName')
+			buildScan.value jobNameLabel, jobName
+			addCustomValueSearchLink 'CI job build scans', [(jobNameLabel): jobName]
+		}
+		if (System.getenv('bamboo_agentId')) {
+			def agentId = System.getenv('bamboo_agentId')
+			buildScan.tag agentId
+			buildScan.value 'CI agent ID', agentId
+		}
+	}
+
+	if (isGitHubActions()) {
+		def repo = System.getenv('GITHUB_REPOSITORY')
+		def runId = System.getenv('GITHUB_RUN_ID')
+		if (repo && runId) {
+			buildScan.link 'GitHub Actions run', "https://github.com/$repo/actions/runs/$runId"
+		}
+		if (System.getenv('GITHUB_WORKFLOW')) {
+			def ghActionWorkflowLabel = 'GitHub workflow'
+			def ghActionWorkflowName = System.getenv('GITHUB_WORKFLOW')
+			buildScan.value ghActionWorkflowLabel, ghActionWorkflowName
+			addCustomValueSearchLink 'GitHub workflow build scans', [(ghActionWorkflowLabel): ghActionWorkflowName]
+		}
+	}
+}
+
+void addGitMetadata() {
+	buildScan.background {
+		if (!isGitInstalled()) {
+			return
+		}
+		def gitCommitId = execAndGetStdout('git', 'rev-parse', '--short=8', '--verify', 'HEAD')
+		def gitBranchName = execAndGetStdout('git', 'rev-parse', '--abbrev-ref', 'HEAD')
+		def gitStatus = execAndGetStdout('git', 'status', '--porcelain')
+
+		if (gitCommitId) {
+			def commitIdLabel = 'Git commit id'
+			value commitIdLabel, gitCommitId
+			addCustomValueSearchLink 'Git commit id build scans', [(commitIdLabel): gitCommitId]
+			def originUrl = execAndGetStdout('git', 'config', '--get', 'remote.origin.url')
+			if (originUrl.contains('github.com')) { // only for GitHub
+				def repoPath = (originUrl =~ /(.*)github\.com[\/|:](.*)/)[0][2]
+				if (repoPath.endsWith('.git')) {
+					repoPath = repoPath.substring(0, repoPath.length() - 4)
+				}
+				link 'Github Source', "https://github.com/$repoPath/tree/" + gitCommitId
+			}
+		}
+		if (gitBranchName) {
+			tag gitBranchName
+			value 'Git branch', gitBranchName
+		}
+		if (gitStatus) {
+			tag 'Dirty'
+			value 'Git status', gitStatus
+		}
+	}
+}
+
+void addTestParallelization() {
+	allprojects { p ->
+		p.tasks.withType(Test).configureEach { t -> doFirst { buildScan.value "${t.identityPath}#maxParallelForks", t.maxParallelForks.toString() } }
+	}
+}
+
+static boolean isCi() {
+	isJenkins() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions()
+}
+
+static boolean isJenkins() {
+	System.getenv('JENKINS_URL')
+}
+
+static boolean isTeamCity() {
+	System.getenv('TEAMCITY_VERSION')
+}
+
+static boolean isCircleCI() {
+	System.getenv('CIRCLECI')
+}
+
+static boolean isBamboo() {
+	System.getenv('bamboo_resultsUrl')
+}
+
+static boolean isGitHubActions() {
+	System.getenv('GITHUB_ACTIONS')
+}
+
+String execAndGetStdout(String... args) {
+	def stdout = new ByteArrayOutputStream()
+	exec {
+		commandLine(args)
+		standardOutput = stdout
+	}
+	trimAtEnd(stdout.toString())
+}
+
+void addCustomValueSearchLink(String title, Map<String, String> search) {
+	if (buildScan.server) {
+		buildScan.link title, customValueSearchUrl(search)
+	}
+}
+
+String customValueSearchUrl(Map<String, String> search) {
+	def query = search.collect { name, value ->
+		"search.names=${encodeURL(name)}&search.values=${encodeURL(value)}"
+	}.join('&')
+	"${appendIfMissing(buildScan.server, '/')}scans?$query#selection.buildScanB=%7BSCAN_ID%7D"
+}
+
+static String encodeURL(String url) {
+	URLEncoder.encode(url, 'UTF-8')
+}
+
+static boolean isGitInstalled() {
+	try {
+		"git --version".execute().waitFor() == 0
+	} catch (IOException ignored) {
+		false
+	}
+}
+
+static String appendIfMissing(String str, String suffix) {
+	str.endsWith(suffix) ? str : str + suffix
+}
+
+static String trimAtEnd(String str) {
+	('x' + str).trim().substring(1)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,14 @@ gradleEnterprise {
 		tag(if (isCiServer) "CI" else "LOCAL")
 		this as BuildScanExtensionWithHiddenFeatures
 		publishIfAuthenticated()
+		obfuscation {
+			if (isCiServer) {
+				username { "github" }
+			} else {
+				hostname { null }
+				ipAddresses { emptyList() }
+			}
+		}
 	}
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 val gradleEnterpriseServer = "https://ge.junit.org"
-val isCiServer = System.getenv("CI") != null || System.getenv("GITHUB_WORKFLOW") != null
+val isCiServer = System.getenv("CI") != null || System.getenv("GITHUB_ACTIONS") != null
 val junitBuildCacheUsername: String? by extra
 val junitBuildCachePassword: String? by extra
 
@@ -30,7 +30,6 @@ gradleEnterprise {
 		server = gradleEnterpriseServer
 		isCaptureTaskInputFiles = true
 		publishAlways()
-		tag(if (isCiServer) "CI" else "LOCAL")
 		this as BuildScanExtensionWithHiddenFeatures
 		publishIfAuthenticated()
 		obfuscation {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,8 @@
+import com.gradle.scan.plugin.internal.api.BuildScanExtensionWithHiddenFeatures
+
 pluginManagement {
 	plugins {
-		id("com.gradle.enterprise") version "3.1"
+		id("com.gradle.enterprise") version "3.1.1"
 		id("net.nemerosa.versioning") version "2.10.0"
 		id("com.github.ben-manes.versions") version "0.27.0"
 		id("com.diffplug.gradle.spotless") version "3.27.0"
@@ -18,10 +20,15 @@ plugins {
 	id("com.gradle.enterprise")
 }
 
+val gradleEnterpriseServer = "https://ge.junit.org"
+
 gradleEnterprise {
 	buildScan {
-		termsOfServiceUrl = "https://gradle.com/terms-of-service"
-		termsOfServiceAgree = "yes"
+		server = gradleEnterpriseServer
+		isCaptureTaskInputFiles = true
+		publishAlways()
+		this as BuildScanExtensionWithHiddenFeatures
+		publishIfAuthenticated()
 	}
 }
 


### PR DESCRIPTION
This PR configures the Gradle Enterprise plugin to use the https://ge.junit.org Gradle Enterprise server to publish build scans. Build scans are now always published if the user is [authenticated](https://docs.gradle.com/enterprise/gradle-plugin/#authenticating_with_gradle_enterprise). I will create individual users for all core team members so you can create your own access keys for publishing.

The hostname and IP addresses of local builds are now cleared before the build is being published and CI builds always use "github" as their user name to make the [scans list](https://ge.junit.org/scans) more consistent.

Moreover, the build is now configured to use the remote build cache that is built-in to the Gradle Enterprise server so that local builds can reuse task outputs of that have been stored in the remote build cache. Only CI builds are configured to push entries to the remote cache. Since our CI agents are ephemeral, the local build cache is now deactivated for them.

The [default custom user data script](https://github.com/gradle/gradle-build-scan-snippets/blob/master/guided-trials-default-custom-user-data/default-custom-user-data.gradle) for build scans is applied. It adds tags for the operating system, IDE, CI/LOCAL as well as custom links from the build scan to the commit on GitHub and the GitHub Actions that executed it (if any).