### PR TITLE
Add JRE.currentVersion() for accessing the current JRE version

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/JRE.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/JRE.java
@@ -165,6 +165,16 @@ public enum JRE {
 		return this == CURRENT_VERSION;
 	}
 
+	/**
+	 * @return the {@link JRE} for the currently executing JVM
+	 *
+	 * @since 5.7
+	 */
+	@API(status = STABLE, since = "5.7")
+	public static JRE currentVersion() {
+		return CURRENT_VERSION;
+	}
+
 	static boolean isCurrentVersionWithinRange(JRE min, JRE max) {
 		return EnumSet.range(min, max).contains(CURRENT_VERSION);
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/JRETests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/JRETests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.condition.JRE.JAVA_10;
+import static org.junit.jupiter.api.condition.JRE.JAVA_11;
+import static org.junit.jupiter.api.condition.JRE.JAVA_12;
+import static org.junit.jupiter.api.condition.JRE.JAVA_13;
+import static org.junit.jupiter.api.condition.JRE.JAVA_14;
+import static org.junit.jupiter.api.condition.JRE.JAVA_15;
+import static org.junit.jupiter.api.condition.JRE.JAVA_8;
+import static org.junit.jupiter.api.condition.JRE.JAVA_9;
+import static org.junit.jupiter.api.condition.JRE.OTHER;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link JRE}
+ *
+ * @since 5.7
+ */
+public class JRETests {
+
+	@Test
+	@EnabledOnJre(JAVA_8)
+	void java8() {
+		assertEquals(JAVA_8, JRE.currentVersion());
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_9)
+	void java9() {
+		assertEquals(JAVA_9, JRE.currentVersion());
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_10)
+	void java10() {
+		assertEquals(JAVA_10, JRE.currentVersion());
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_11)
+	void java11() {
+		assertEquals(JAVA_11, JRE.currentVersion());
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_12)
+	void java12() {
+		assertEquals(JAVA_12, JRE.currentVersion());
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_13)
+	void java13() {
+		assertEquals(JAVA_13, JRE.currentVersion());
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_14)
+	void java14() {
+		assertEquals(JAVA_14, JRE.currentVersion());
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_15)
+	void java15() {
+		assertEquals(JAVA_15, JRE.currentVersion());
+	}
+
+	@Test
+	@EnabledOnJre(OTHER)
+	void other() {
+		assertEquals(OTHER, JRE.currentVersion());
+	}
+}


### PR DESCRIPTION
Issue: #2176

Expose public static method for accessing the current `JRE`.

I was not sure whether I need to add something to the release notes about this or not. 

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
