### PR TITLE
Inject Gradle Enterprise access key via file to fix builds from forks

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -10,7 +10,6 @@ on:
       - '*'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
   ORG_GRADLE_PROJECT_junitBuildCacheUsername: ${{ secrets.BUILD_CACHE_USERNAME }}
   ORG_GRADLE_PROJECT_junitBuildCachePassword: ${{ secrets.BUILD_CACHE_PASSWORD }}
 
@@ -24,6 +23,9 @@ jobs:
     container: "junitteam/build:${{ matrix.jdk }}"
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare Gradle Enterprise credentials
+        if: github.repository == 'junit-team/junit5'
+        run: echo "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}" > ~/.gradle/enterprise/keys.properties
       - name: Test
         run: |
           ./gradlew --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ on:
       - '*'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
   ORG_GRADLE_PROJECT_junitBuildCacheUsername: ${{ secrets.BUILD_CACHE_USERNAME }}
   ORG_GRADLE_PROJECT_junitBuildCachePassword: ${{ secrets.BUILD_CACHE_PASSWORD }}
 
@@ -21,6 +20,9 @@ jobs:
     container: junitteam/build:latest
     steps:
     - uses: actions/checkout@v2
+    - name: Prepare Gradle Enterprise credentials
+      if: github.repository == 'junit-team/junit5'
+      run: echo "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}" > ~/.gradle/enterprise/keys.properties
     - name: 'Test'
       run: |
         ./gradlew --version
@@ -35,6 +37,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Prepare Gradle Enterprise credentials
+      if: github.repository == 'junit-team/junit5'
+      shell: bash
+      run: echo "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}" > ~/.gradle/enterprise/keys.properties
     - name: 'Test'
       shell: bash
       run: |
@@ -50,6 +56,9 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Prepare Gradle Enterprise credentials
+      if: github.repository == 'junit-team/junit5'
+      run: echo "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}" > ~/.gradle/enterprise/keys.properties
     - name: 'Test'
       run: |
         ./gradlew --version
@@ -66,6 +75,9 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Prepare Gradle Enterprise credentials
+      if: github.repository == 'junit-team/junit5'
+      run: echo "${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}" > ~/.gradle/enterprise/keys.properties
     - name: 'Run tests with JaCoCo'
       shell: bash
       run: |
@@ -93,6 +105,7 @@ jobs:
       env:
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
         ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       run: ./gradlew --scan publish -x check
 
   update_documentation:
@@ -109,6 +122,7 @@ jobs:
     - name: 'Upload Documentation'
       env:
         GRGIT_USER: ${{ secrets.GH_TOKEN }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       run: |
         sudo apt-get install graphviz
         ./src/publishDocumentationSnapshotOnlyIfNecessary.sh


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
