### PR TITLE
Introduce new `DisplayNameGenerator` named `Simple`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -49,8 +49,10 @@ on GitHub.
 * The `JRE` enum now provides a static `currentVersion()` method that returns the enum
   constant for the currently executing JRE, e.g. for use in custom execution conditions
   and other extensions.
-* Clearly document that `name` attribute of `@ParameterizedTest` is a `MessageFormat`
-  pattern.
+* The `name` attribute of `@ParameterizedTest` is now clearly documented to be a
+  `MessageFormat` pattern.
+* Introduce a new `DisplayNameGenerator` named `Simple` (based on `Standard`) that
+  removes trailing parentheses for methods with no parameters.
 
 
 [[release-notes-5.7.0-M1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -105,13 +105,38 @@ public interface DisplayNameGenerator {
 	}
 
 	/**
-	 * {@code DisplayNameGenerator} that replaces underscores with spaces.
+	 * Simple {@code DisplayNameGenerator} that removes trailing parentheses
+	 * for methods with no parameters.
 	 *
 	 * <p>This generator extends the functionality of {@link Standard} by
+	 * removing parentheses ({@code '()'}) found at the end of method names
+	 * with no parameters.
+	 */
+	class Simple extends Standard {
+
+		@Override
+		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+			String displayName = testMethod.getName();
+			if (hasParameters(testMethod)) {
+				displayName += ' ' + parameterTypesAsString(testMethod);
+			}
+			return displayName;
+		}
+
+		private static boolean hasParameters(Method method) {
+			return method.getParameterCount() > 0;
+		}
+
+	}
+
+	/**
+	 * {@code DisplayNameGenerator} that replaces underscores with spaces.
+	 *
+	 * <p>This generator extends the functionality of {@link Simple} by
 	 * replacing all underscores ({@code '_'}) found in class and method names
 	 * with spaces ({@code ' '}).
 	 */
-	class ReplaceUnderscores extends Standard {
+	class ReplaceUnderscores extends Simple {
 
 		@Override
 		public String generateDisplayNameForClass(Class<?> testClass) {
@@ -125,20 +150,13 @@ public interface DisplayNameGenerator {
 
 		@Override
 		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
-			String displayName = replaceUnderscores(testMethod.getName());
-			if (hasParameters(testMethod)) {
-				displayName += ' ' + parameterTypesAsString(testMethod);
-			}
-			return displayName;
+			return replaceUnderscores(super.generateDisplayNameForMethod(testClass, testMethod));
 		}
 
 		private static String replaceUnderscores(String name) {
 			return name.replace('_', ' ');
 		}
 
-		private static boolean hasParameters(Method method) {
-			return method.getParameterCount() > 0;
-		}
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.DisplayNameGenerator.Simple;
 import org.junit.jupiter.api.DisplayNameGenerator.Standard;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.commons.logging.Logger;
@@ -45,6 +46,11 @@ final class DisplayNameUtils {
 	 * Pre-defined standard display name generator instance.
 	 */
 	private static final DisplayNameGenerator standardGenerator = new Standard();
+
+	/**
+	 * Pre-defined simple display name generator instance.
+	 */
+	private static final DisplayNameGenerator simpleGenerator = new Simple();
 
 	/**
 	 * Pre-defined display name generator instance replacing underscores.
@@ -95,6 +101,9 @@ final class DisplayNameUtils {
 				.map(displayNameGeneratorClass -> {
 					if (displayNameGeneratorClass == Standard.class) {
 						return standardGenerator;
+					}
+					if (displayNameGeneratorClass == Simple.class) {
+						return simpleGenerator;
 					}
 					if (displayNameGeneratorClass == ReplaceUnderscores.class) {
 						return replaceUnderscoresGenerator;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -52,6 +52,20 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	void simpleGenerator() {
+		check(SimpleStyleTestCase.class, List.of( //
+			"CONTAINER: DisplayNameGenerationTests$SimpleStyleTestCase", //
+			"TEST: @DisplayName prevails", //
+			"TEST: test", //
+			"TEST: test (TestInfo)", //
+			"TEST: testUsingCamelCaseStyle", //
+			"TEST: testUsingCamelCase_and_also_UnderScores", //
+			"TEST: testUsingCamelCase_and_also_UnderScores_keepingParameterTypeNamesIntact (TestInfo)", //
+			"TEST: test_with_underscores" //
+		));
+	}
+
+	@Test
 	void underscoreGenerator() {
 		var expectedDisplayNames = List.of( //
 			"CONTAINER: DisplayNameGenerationTests\\$UnderscoreStyle.*", //
@@ -164,6 +178,10 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 
 	@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 	static class DefaultStyleTestCase extends AbstractTestCase {
+	}
+
+	@DisplayNameGeneration(DisplayNameGenerator.Simple.class)
+	static class SimpleStyleTestCase extends AbstractTestCase {
 	}
 
 	@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)


### PR DESCRIPTION
This new generator extends `Standard` and removes parenthesis
at the end of method names if they have no parameters.

Resolves #1961.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
