### PR TITLE
Make JAR builds reproducible

### DIFF
--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,0 +1,25 @@
+name: Reproducible build
+
+on:
+  push:
+    branches:
+    - master
+    - 'releases/*'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  check_build_reproducibility:
+    name: 'Check build reproducibility'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'Set up JDK 11'
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Build and compare checksums
+      shell: bash
+      run: |
+        ./src/checkBuildReproducibility.sh

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ gradle-app.setting
 *.graphml
 coverage.db*
 .metadata
+
+checksums*

--- a/buildSrc/src/main/kotlin/java-repackage-jars.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-repackage-jars.gradle.kts
@@ -1,0 +1,42 @@
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarOutputStream
+import org.gradle.api.internal.file.archive.ZipCopyAction
+
+// This registers a `doLast` action to rewrite the timestamps of the project's output JAR
+afterEvaluate {
+	val jarTask = (tasks.findByName("shadowJar") ?: tasks["jar"]) as Jar
+
+	jarTask.doLast {
+
+		val newFile = createTempFile("rewrite-timestamp")
+		val originalOutput = jarTask.archiveFile.get().getAsFile()
+
+		newFile.outputStream().use { os ->
+
+			val newJarStream = JarOutputStream(os)
+			val oldJar = JarFile(originalOutput)
+
+			oldJar.entries()
+					.toList()
+					.distinctBy { it.name }
+					.sortedBy { it.name }
+					.forEach { entry ->
+						val jarEntry = JarEntry(entry.name)
+
+						// Use the same constant as the fixed timestamps in normal copy actions
+						jarEntry.time = ZipCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES
+
+						newJarStream.putNextEntry(jarEntry)
+
+						oldJar.getInputStream(entry).copyTo(newJarStream)
+					}
+
+			newJarStream.finish()
+		}
+
+		newFile.renameTo(originalOutput)
+	}
+}

--- a/documentation/src/docs/asciidoc/user-guide/appendix.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/appendix.adoc
@@ -1,6 +1,18 @@
 [[appendix]]
 == Appendix
 
+[[reproducible-builds]]
+=== Reproducible Builds
+
+Starting with version 5.7, JUnit 5 aims for its non-javadoc JARs to be https://reproducible-builds.org/[reproducible]
+
+Under identical build conditions, such as Java version, repeated builds should provide the
+same output byte-for-byte.
+
+This means that anyone can reproduce the build conditions of the artifacts on Maven
+Central/Sonatype and produce the same output artifact locally, confirming that the
+artifacts in the repositories were actually generated from this source code.
+
 [[dependency-metadata]]
 === Dependency Metadata
 

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -3,6 +3,7 @@ import java.util.spi.ToolProvider
 plugins {
 	`java-library-conventions`
 	`java-multi-release-sources`
+	`java-repackage-jars`
 }
 
 description = "JUnit Platform Commons"

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	`java-library-conventions`
 	`shadow-conventions`
 	`java-multi-release-sources`
+	`java-repackage-jars`
 }
 
 description = "JUnit Platform Console"

--- a/src/checkBuildReproducibility.sh
+++ b/src/checkBuildReproducibility.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+rm -rf checksums*
+
+export SOURCE_DATE_EPOCH=$(date +%s)
+
+function calculate_checksums() {
+    OUTPUT=$1
+
+    ./gradlew --no-build-cache clean assemble --parallel
+
+    find . -name '*.jar' \
+        | grep '/build/libs/' \
+        | grep --invert-match 'javadoc' \
+        | sort \
+        | xargs sha256sum > ${OUTPUT}
+}
+
+
+calculate_checksums checksums-1.txt
+calculate_checksums checksums-2.txt
+
+diff checksums-1.txt checksums-2.txt


### PR DESCRIPTION
## Overview

This PR makes the java bytecode generated by this project [reproducible](https://reproducible-builds.org/). This means that under identical builds condition (for example Java version), repeated builds should provide the same output byte-for-byte.

It achieves this by:

* supporting [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) as a way of fixing build-time-specific metadata added to JARs
* using Gradle's [reproducible archives](https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives) functionality to fix timestamps and file ordering within JARs
* re-archiving JARs that are non-deterministic because they use `jar` to rewrite their contents after build.

## Confirming the change

```shell
#!/bin/bash -e

rm -f checksums*

# Fix build time
export SOURCE_DATE_EPOCH=$(date +%s)

./gradlew clean build -x test --parallel --rerun-tasks

find . -name '*.jar' \
    | grep '/build/libs/' \
    | grep -v 'javadoc' \
    | sort \
    | xargs sha256sum > checksums-1.txt

./gradlew clean build -x test --parallel --rerun-tasks

find . -name '*.jar' \
    | grep '/build/libs/' \
    | grep -v 'javadoc' \
    | sort \
    | xargs sha256sum > checksums-2.txt

diff checksums-{1,2}.txt
```

The diff should be empty, that is to say, both independent runs of the build should have generated byte-for-byte identical outputs.

## Omitting Javadocs

The javadocs outputs remain non-deterministic - despite the inclusion of `noTimestamp(true)` in the project's javadoc configuration, the comment header is still being generated. It looks like the javadoc mechanism in Gradle isn't honouring this flag.

I wasn't able to solve this problem, but would be necessary to achieve full reproducibility.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement). ✅ 

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
