### PR TITLE
Added DisplayName MethodOrderer

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -53,7 +53,8 @@ on GitHub.
   `MessageFormat` pattern.
 * Introduce a new `DisplayNameGenerator` named `Simple` (based on `Standard`) that
   removes trailing parentheses for methods with no parameters.
-
+* New MethodOrderer annotation `@DisplayNameAnnotation` that allows controlling test
+  execution order based on the `@DisplayName` applied to a method 
 
 [[release-notes-5.7.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -55,8 +55,7 @@ on GitHub.
   removes trailing parentheses for methods with no parameters.
 * `assertThrows` for Kotlin can now be used with suspending functions and other lambda
   contexts that require inlining.
-
-* New MethodOrderer annotation `@DisplayNameAnnotation` that allows controlling test
+* New MethodOrderer annotation `@DisplayName` that allows controlling test
   execution order based on the generated test display name
 
 [[release-notes-5.7.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -54,7 +54,7 @@ on GitHub.
 * Introduce a new `DisplayNameGenerator` named `Simple` (based on `Standard`) that
   removes trailing parentheses for methods with no parameters.
 * New MethodOrderer annotation `@DisplayNameAnnotation` that allows controlling test
-  execution order based on the `@DisplayName` applied to a method 
+  execution order based on the generated test display name
 
 [[release-notes-5.7.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -492,8 +492,8 @@ following built-in `MethodOrderer` implementations.
 
 * `{Alphanumeric}`: sorts test methods _alphanumerically_ based on their names and formal
   parameter lists.
-* `{DisplayNameAnnotation}`: sorts test methods _alphanumerically_ based on values specified via the
-  `{DisplayName}` annotation.    
+* `{DisplayName}`: sorts test methods _alphanumerically_ based on the display name that has
+  been generated for the test, taking into account usage of the `{DisplayName}` annotation.
 * `{OrderAnnotation}`: sorts test methods _numerically_ based on values specified via the
   `{Order}` annotation.
 * `{Random}`: orders test methods _pseudo-randomly_ and supports configuration of a custom

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -492,6 +492,8 @@ following built-in `MethodOrderer` implementations.
 
 * `{Alphanumeric}`: sorts test methods _alphanumerically_ based on their names and formal
   parameter lists.
+* `{DisplayNameAnnotation}`: sorts test methods _alphanumerically_ based on values specified via the
+  `{DisplayName}` annotation.    
 * `{OrderAnnotation}`: sorts test methods _numerically_ based on values specified via the
   `{Order}` annotation.
 * `{Random}`: orders test methods _pseudo-randomly_ and supports configuration of a custom

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodDescriptor.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodDescriptor.java
@@ -36,6 +36,12 @@ public interface MethodDescriptor {
 	Method getMethod();
 
 	/**
+	 * Get the display name for this descriptor.
+	 * @return the method; never {@code null}
+	 */
+	String getDisplayName();
+
+	/**
 	 * Determine if an annotation of {@code annotationType} is either
 	 * <em>present</em> or <em>meta-present</em> on the {@link Method} for
 	 * this descriptor.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodDescriptor.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodDescriptor.java
@@ -37,7 +37,8 @@ public interface MethodDescriptor {
 
 	/**
 	 * Get the display name for this descriptor.
-	 * @return the method; never {@code null}
+	 *
+	 * @return the display name for this descriptor; never {@code null} or blank
 	 */
 	String getDisplayName();
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -246,4 +246,29 @@ public interface MethodOrderer {
 		}
 	}
 
+	/**
+	 * {@code MethodOrderer} that sorts methods alphanumerically based on the
+	 * the {@link DisplayName @DisplayName} names using {@link String#compareTo(String)}.
+	 *
+	 * <p>If no attribute is found for the method, the method name will be used as a fallback
+	 * for comparing the methods.
+	 */
+	class DisplayNameAnnotation implements MethodOrderer {
+
+		/**
+		 * Sort the methods encapsulated in the supplied
+		 * {@link MethodOrdererContext} alphanumerically based on the {@link DisplayName @DisplayName} names
+		 */
+		@Override
+		public void orderMethods(MethodOrdererContext context) {
+			context.getMethodDescriptors().sort(Comparator.comparing(DisplayNameAnnotation::getDisplayName));
+		}
+
+		private static String getDisplayName(MethodDescriptor descriptor) {
+			return descriptor
+				.findAnnotation(DisplayName.class)
+				.map(DisplayName::value)
+				.orElse(descriptor.getMethod().getName());
+		}
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -248,27 +248,20 @@ public interface MethodOrderer {
 
 	/**
 	 * {@code MethodOrderer} that sorts methods alphanumerically based on the
-	 * the {@link DisplayName @DisplayName} names using {@link String#compareTo(String)}.
-	 *
-	 * <p>If no attribute is found for the method, the method name will be used as a fallback
-	 * for comparing the methods.
+	 * the generated test display names using {@link String#compareTo(String)}
 	 */
-	class DisplayNameAnnotation implements MethodOrderer {
+	class DisplayName implements MethodOrderer {
 
 		/**
-		 * Sort the methods encapsulated in the supplied
-		 * {@link MethodOrdererContext} alphanumerically based on the {@link DisplayName @DisplayName} names
+		 * Sort the methods encapsulated in the supplied {@link MethodOrdererContext} alphanumerically
+		 * based on the test display names
 		 */
 		@Override
 		public void orderMethods(MethodOrdererContext context) {
-			context.getMethodDescriptors().sort(Comparator.comparing(DisplayNameAnnotation::getDisplayName));
+			context.getMethodDescriptors().sort(comparator);
 		}
 
-		private static String getDisplayName(MethodDescriptor descriptor) {
-			return descriptor
-				.findAnnotation(DisplayName.class)
-				.map(DisplayName::value)
-				.orElse(descriptor.getMethod().getName());
-		}
+		private static final Comparator<MethodDescriptor> comparator = Comparator.comparing(
+			MethodDescriptor::getDisplayName);
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestMethodOrder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestMethodOrder.java
@@ -73,6 +73,7 @@ public @interface TestMethodOrder {
 	 *
 	 * @see MethodOrderer
 	 * @see MethodOrderer.Alphanumeric
+	 * @see MethodOrderer.DisplayName
 	 * @see MethodOrderer.OrderAnnotation
 	 * @see MethodOrderer.Random
 	 */

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DefaultMethodDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DefaultMethodDescriptor.java
@@ -45,6 +45,11 @@ class DefaultMethodDescriptor implements MethodDescriptor {
 	}
 
 	@Override
+	public final String getDisplayName() {
+		return this.testDescriptor.getDisplayName();
+	}
+
+	@Override
 	public boolean isAnnotated(Class<? extends Annotation> annotationType) {
 		Preconditions.notNull(annotationType, "annotationType must not be null");
 		return AnnotationUtils.isAnnotated(getMethod(), annotationType);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.MethodDescriptor;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
+import org.junit.jupiter.api.MethodOrderer.DisplayNameAnnotation;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.MethodOrderer.Random;
 import org.junit.jupiter.api.MethodOrdererContext;
@@ -90,6 +91,19 @@ class OrderedMethodTests {
 
 		assertThat(callSequence).containsExactly("$()", "AAA()", "AAA(org.junit.jupiter.api.TestInfo)",
 			"AAA(org.junit.jupiter.api.TestReporter)", "ZZ_Top()", "___()", "a1()", "a2()", "b()", "c()", "zzz()");
+		assertThat(threadNames).hasSize(1);
+	}
+
+	@Test
+	void displayName() {
+		var tests = executeTestsInParallel(DisplayNameTestCase.class);
+
+		tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
+
+		assertThat(callSequence)//
+			.containsExactly("$", "AAA", "No_display_name_attribute_1_caps()", "No_display_name_attribute_2_caps()",
+				"ZZ_Top", "___", "a1", "a2", "b()", "no_display_name_attribute_1()",
+				"no_display_name_attribute_2()", "repetition 1 of 1");
 		assertThat(threadNames).hasSize(1);
 	}
 
@@ -353,6 +367,73 @@ class OrderedMethodTests {
 
 		@RepeatedTest(1)
 		void zzz() {
+		}
+	}
+
+	@TestMethodOrder(DisplayNameAnnotation.class)
+	static class DisplayNameTestCase {
+
+		@BeforeEach
+		void trackInvocations(TestInfo testInfo) {
+			callSequence.add(testInfo.getDisplayName());
+			threadNames.add(Thread.currentThread().getName());
+		}
+
+		@TestFactory
+		DynamicTest b() {
+			return dynamicTest("dynamic", () -> {
+			});
+		}
+
+		@DisplayName("$")
+		@Test
+		void $() {
+		}
+
+		@DisplayName("___")
+		@Test
+		void ___() {
+		}
+
+		@DisplayName("AAA")
+		@Test
+		void AAA() {
+		}
+
+		@DisplayName("ZZ_Top")
+		@Test
+		void ZZ_Top() {
+		}
+
+		@DisplayName("a1")
+		@Test
+		void a1() {
+		}
+
+		@DisplayName("a2")
+		@Test
+		void a2() {
+		}
+
+		@DisplayName("zzz")
+		@RepeatedTest(1)
+		void zzz() {
+		}
+
+		@Test
+		void no_display_name_attribute_1() {
+		}
+
+		@Test
+		void no_display_name_attribute_2() {
+		}
+
+		@Test
+		void No_display_name_attribute_1_caps() {
+		}
+
+		@Test
+		void No_display_name_attribute_2_caps() {
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.MethodDescriptor;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.MethodOrderer.Alphanumeric;
-import org.junit.jupiter.api.MethodOrderer.DisplayNameAnnotation;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.MethodOrderer.Random;
 import org.junit.jupiter.api.MethodOrdererContext;
@@ -101,9 +100,9 @@ class OrderedMethodTests {
 		tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
 
 		assertThat(callSequence)//
-			.containsExactly("$", "AAA", "No_display_name_attribute_1_caps()", "No_display_name_attribute_2_caps()",
-				"ZZ_Top", "___", "a1", "a2", "b()", "no_display_name_attribute_1()",
-				"no_display_name_attribute_2()", "repetition 1 of 1");
+				.containsExactly("$", "AAA", "No_display_name_attribute_1_caps()", "No_display_name_attribute_2_caps()",
+					"ZZ_Top", "___", "a1", "a2", "b()", "no_display_name_attribute_1()",
+					"no_display_name_attribute_2()", "repetition 1 of 1", "⑦ϼ\uD83D\uDC69\u200D⚕\uD83E\uDDD8\u200D♂");
 		assertThat(threadNames).hasSize(1);
 	}
 
@@ -370,7 +369,7 @@ class OrderedMethodTests {
 		}
 	}
 
-	@TestMethodOrder(DisplayNameAnnotation.class)
+	@TestMethodOrder(MethodOrderer.DisplayName.class)
 	static class DisplayNameTestCase {
 
 		@BeforeEach
@@ -418,6 +417,11 @@ class OrderedMethodTests {
 		@DisplayName("zzz")
 		@RepeatedTest(1)
 		void zzz() {
+		}
+
+		@Test
+		@DisplayName("⑦ϼ\uD83D\uDC69\u200D⚕\uD83E\uDDD8\u200D♂")
+		void special_characters() {
 		}
 
 		@Test


### PR DESCRIPTION
## Overview

Added new implementation of MethodOrderer named DisplayName, allowing you to control test execution order based on the test display name that is generated for a test method.

<!-- Please describe your changes here and list any open questions you might have. -->

Added implementation, tests, user docs and release notes.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
