### PR TITLE
Upgrade ArchUnit to 0.13.1

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,7 +13,7 @@ object Versions {
     val univocity = "2.8.4"
 
     // Test Dependencies
-    val archunit = "0.12.0"
+    val archunit = "0.13.1"
     val assertJ = "3.14.0"
     val bartholdy = "0.2.3"
     val classgraph = "4.8.65"

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
@@ -12,8 +12,12 @@ package platform.tooling.support.tests;
 
 import static com.tngtech.archunit.base.DescribedPredicate.describe;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANONYMOUS_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.TOP_LEVEL_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
+import static com.tngtech.archunit.core.domain.JavaModifier.PUBLIC;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
@@ -26,9 +30,7 @@ import static platform.tooling.support.Helper.loadJarFiles;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -43,9 +45,10 @@ class ArchUnitTests {
 
 	@ArchTest
 	private final ArchRule allPublicTopLevelTypesHaveApiAnnotations = classes() //
-			.that(have(modifier(JavaModifier.PUBLIC))) //
-			.and(describe("are top-level", javaClass -> !javaClass.getEnclosingClass().isPresent())) //
-			.and(not(describe("are anonymous", JavaClass::isAnonymousClass))) //
+			.that(have(modifier(PUBLIC))) //
+			.and(TOP_LEVEL_CLASSES) //
+			.and(not(ANONYMOUS_CLASSES)) //
+			.and(not(describe("are Kotlin SAM type implementations", simpleName("")))) //
 			.and(not(describe("are shadowed", resideInAnyPackage("..shadow..")))) //
 			.should().beAnnotatedWith(API.class);
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
@@ -45,7 +45,7 @@ class ArchUnitTests {
 	private final ArchRule allPublicTopLevelTypesHaveApiAnnotations = classes() //
 			.that(have(modifier(JavaModifier.PUBLIC))) //
 			.and(describe("are top-level", javaClass -> !javaClass.getEnclosingClass().isPresent())) //
-			.and(not(describe("are anonymous", JavaClass::isAnonymous))) //
+			.and(not(describe("are anonymous", JavaClass::isAnonymousClass))) //
 			.and(not(describe("are shadowed", resideInAnyPackage("..shadow..")))) //
 			.should().beAnnotatedWith(API.class);
 


### PR DESCRIPTION
See #2226 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
