### PR TITLE
Publish to standalone file repo instead of mavenLocal()

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,9 @@ val license by extra(License(
 		headerFile = file("src/spotless/eclipse-public-license-2.0.java")
 ))
 
+val tempRepoName by extra("temp")
+val tempRepoDir by extra(file("$buildDir/repo"))
+
 val enableJaCoCo = project.hasProperty("enableJaCoCo")
 val jacocoTestProjects = listOf(
 		project(":junit-jupiter-engine"),
@@ -144,6 +147,19 @@ subprojects {
 					onlyIf { jarTask.enabled }
 				}
 				jarTask.finalizedBy(extractJar)
+			}
+		}
+	}
+
+	pluginManager.withPlugin("maven-publish") {
+		configure<PublishingExtension> {
+			repositories {
+				repositories {
+					maven {
+						name = tempRepoName
+						url = uri(tempRepoDir)
+					}
+				}
 			}
 		}
 	}

--- a/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-conventions.gradle.kts
@@ -11,9 +11,12 @@ val isContinuousIntegrationEnvironment = System.getenv("CI")?.toBoolean() ?: fal
 val isJitPackEnvironment = System.getenv("JITPACK")?.toBoolean() ?: false
 
 // ensure project is built successfully before publishing it
-val build = tasks[LifecycleBasePlugin.BUILD_TASK_NAME]
-tasks[PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME].dependsOn(build)
-tasks[MavenPublishPlugin.PUBLISH_LOCAL_LIFECYCLE_TASK_NAME].dependsOn(build)
+tasks.withType<PublishToMavenRepository>().configureEach {
+	dependsOn(tasks.build)
+}
+tasks.withType<PublishToMavenLocal>().configureEach {
+	dependsOn(tasks.build)
+}
 
 signing {
 	sign(publishing.publications)

--- a/platform-tooling-support-tests/projects/gradle-kotlin-extensions/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/gradle-kotlin-extensions/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 repositories {
-	mavenLocal()
+	maven { url = uri(file(System.getProperty("maven.repo"))) }
 	mavenCentral()
 	maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
 }

--- a/platform-tooling-support-tests/projects/gradle-missing-engine/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/gradle-missing-engine/build.gradle.kts
@@ -26,7 +26,7 @@ platformVersion=$platformVersion
 """)
 
 repositories {
-	mavenLocal()
+	maven { url = uri(file(System.getProperty("maven.repo"))) }
 	mavenCentral()
 	maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
 }

--- a/platform-tooling-support-tests/projects/gradle-starter/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/gradle-starter/build.gradle.kts
@@ -19,7 +19,7 @@ platformVersion=$platformVersion
 """)
 
 repositories {
-	mavenLocal()
+	maven { url = uri(file(System.getProperty("maven.repo"))) }
 	mavenCentral()
 	maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
 }

--- a/platform-tooling-support-tests/projects/java-versions/pom.xml
+++ b/platform-tooling-support-tests/projects/java-versions/pom.xml
@@ -49,6 +49,16 @@
 
     <repositories>
         <repository>
+            <id>local-temp</id>
+            <url>file://${maven.repo}</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
             <id>sonatype-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <snapshots>

--- a/platform-tooling-support-tests/projects/maven-starter/pom.xml
+++ b/platform-tooling-support-tests/projects/maven-starter/pom.xml
@@ -56,6 +56,16 @@
 
     <repositories>
         <repository>
+            <id>local-temp</id>
+            <url>file://${maven.repo}</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
             <id>sonatype-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <snapshots>

--- a/platform-tooling-support-tests/projects/multi-release-jar/default/pom.xml
+++ b/platform-tooling-support-tests/projects/multi-release-jar/default/pom.xml
@@ -56,6 +56,16 @@
 
     <repositories>
         <repository>
+            <id>local-temp</id>
+            <url>file://${maven.repo}</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
             <id>sonatype-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <snapshots>

--- a/platform-tooling-support-tests/projects/vintage/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/vintage/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 repositories {
-	mavenLocal()
+	maven { url = uri(file(System.getProperty("maven.repo"))) }
 	mavenCentral()
 	maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleKotlinExtensionsTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleKotlinExtensionsTests.java
@@ -35,6 +35,7 @@ class GradleKotlinExtensionsTests {
 		var result = Request.builder() //
 				.setTool(new GradleWrapper(Paths.get(".."))) //
 				.setProject("gradle-kotlin-extensions") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
 				.addArguments("build", "--no-daemon", "--debug", "--stacktrace") //
 				.setTimeout(Duration.ofMinutes(2)) //
 				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleMissingEngineTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleMissingEngineTests.java
@@ -42,6 +42,7 @@ class GradleMissingEngineTests {
 				.setProject(project) //
 				.setWorkspace(project + '-' + version) //
 				.setTool(gradle) //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
 				.addArguments("build", "--no-daemon", "--debug", "--stacktrace") //
 				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.build() //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleStarterTests.java
@@ -36,6 +36,7 @@ class GradleStarterTests {
 		var result = Request.builder() //
 				.setTool(new GradleWrapper(Paths.get(".."))) //
 				.setProject("gradle-starter") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
 				.addArguments("build", "--no-daemon", "--debug", "--stacktrace") //
 				.setTimeout(Duration.ofMinutes(2)) //
 				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
@@ -52,6 +52,7 @@ class JavaVersionsTests {
 				.setTool(Request.maven()) //
 				.setProject("java-versions") //
 				.setWorkspace("java-versions-" + version) //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
 				.addArguments("--debug", "verify") //
 				.setTimeout(Duration.ofMinutes(2)) //
 				.setJavaHome(javaHome) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
@@ -33,6 +33,7 @@ class MavenStarterTests {
 		var result = Request.builder() //
 				.setTool(Request.maven()) //
 				.setProject("maven-starter") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
 				.addArguments("--debug", "verify") //
 				.setTimeout(Duration.ofMinutes(2)) //
 				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
@@ -81,6 +81,7 @@ class MultiReleaseJarTests {
 		var result = Request.builder() //
 				.setTool(Request.maven()) //
 				.setProject("multi-release-jar") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
 				.addArguments("--show-version", "--errors", "--file", variant, "test") //
 				.setTimeout(Duration.ofMinutes(2)) //
 				.build() //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageGradleIntegrationTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageGradleIntegrationTests.java
@@ -61,6 +61,7 @@ class VintageGradleIntegrationTests {
 				.setProject("vintage") //
 				.setWorkspace("vintage-gradle-" + version) //
 				.addArguments("clean", "test", "--stacktrace") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
 				.addArguments("-Djunit4Version=" + version) //
 				.setTimeout(Duration.ofMinutes(2)) //
 				.build() //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageMavenIntegrationTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageMavenIntegrationTests.java
@@ -61,6 +61,7 @@ class VintageMavenIntegrationTests {
 				.setProject("vintage") //
 				.setWorkspace("vintage-maven-" + version) //
 				.addArguments("clean", "test", "--debug") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
 				.addArguments("-Djunit4Version=" + version) //
 				.setTimeout(Duration.ofMinutes(2)) //
 				.build() //


### PR DESCRIPTION
Instead of polluting the local Maven repository and being potentially
influenced by its other contents, we now publish to a standalone file
repo in build/repo and use it in our Maven/Gradle integration tests.