### PR TITLE
Move versions to gradle.properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ allprojects {
 	if (enableJaCoCo) {
 		apply(plugin = "jacoco")
 		configure<JacocoPluginExtension> {
-			toolVersion = versions.jacoco
+			toolVersion = versions["jacoco"]
 		}
 	}
 
@@ -149,7 +149,7 @@ subprojects {
 			}
 
 			kotlin {
-				ktlint(versions.ktlint)
+				ktlint(versions["ktlint"])
 				licenseHeaderFile(headerFile)
 				trimTrailingWhitespace()
 				endWithNewline()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,6 @@ buildScan {
 	}
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
 val buildTimeAndDate by extra {
 
 	// SOURCE_DATE_EPOCH is a UNIX timestamp for pinning build metadata against
@@ -100,7 +98,7 @@ allprojects {
 	if (enableJaCoCo) {
 		apply(plugin = "jacoco")
 		configure<JacocoPluginExtension> {
-			toolVersion = "jacoco".version
+			toolVersion = versions.jacoco
 		}
 	}
 
@@ -151,7 +149,7 @@ subprojects {
 			}
 
 			kotlin {
-				ktlint("ktlint".version)
+				ktlint(versions.ktlint)
 				licenseHeaderFile(headerFile)
 				trimTrailingWhitespace()
 				endWithNewline()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,8 @@ buildScan {
 	}
 }
 
+val String.v: String get() = rootProject.extra["$this.version"] as String
+
 val buildTimeAndDate by extra {
 
 	// SOURCE_DATE_EPOCH is a UNIX timestamp for pinning build metadata against
@@ -98,7 +100,7 @@ allprojects {
 	if (enableJaCoCo) {
 		apply(plugin = "jacoco")
 		configure<JacocoPluginExtension> {
-			toolVersion = Versions.jacoco
+			toolVersion = "jacoco".v
 		}
 	}
 
@@ -149,7 +151,7 @@ subprojects {
 			}
 
 			kotlin {
-				ktlint(Versions.ktlint)
+				ktlint("ktlint".v)
 				licenseHeaderFile(headerFile)
 				trimTrailingWhitespace()
 				endWithNewline()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ buildScan {
 	}
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 val buildTimeAndDate by extra {
 
@@ -100,7 +100,7 @@ allprojects {
 	if (enableJaCoCo) {
 		apply(plugin = "jacoco")
 		configure<JacocoPluginExtension> {
-			toolVersion = "jacoco".v
+			toolVersion = "jacoco".version
 		}
 	}
 
@@ -151,7 +151,7 @@ subprojects {
 			}
 
 			kotlin {
-				ktlint("ktlint".v)
+				ktlint("ktlint".version)
 				licenseHeaderFile(headerFile)
 				trimTrailingWhitespace()
 				endWithNewline()

--- a/buildSrc/src/main/kotlin/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/ProjectExtensions.kt
@@ -8,8 +8,5 @@ val Project.javaModuleName: String
 val Project.versions: Versions
     get() {
         var versions: Versions? by rootProject.extra
-        if (versions == null) {
-            versions = Versions(rootProject)
-        }
-        return versions!!
+        return versions ?: Versions(rootProject).also { versions = it }
     }

--- a/buildSrc/src/main/kotlin/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/ProjectExtensions.kt
@@ -7,7 +7,7 @@ val Project.javaModuleName: String
 
 val Project.versions: Versions
     get() {
-        val versions: Versions by rootProject.extra {
+        val versions by rootProject.extra {
             Versions(rootProject)
         }
         return versions

--- a/buildSrc/src/main/kotlin/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/ProjectExtensions.kt
@@ -1,4 +1,14 @@
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.extra
 
 val Project.javaModuleName: String
     get() = "org." + this.name.replace('-', '.')
+
+val Project.versions: Versions
+    get() {
+        val extra = rootProject.extra
+        if (!extra.has("versions")) {
+            extra.set("versions", Versions(rootProject))
+        }
+        return extra.get("versions") as Versions
+    }

--- a/buildSrc/src/main/kotlin/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/ProjectExtensions.kt
@@ -1,14 +1,15 @@
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.extra
-import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.provideDelegate
 
 val Project.javaModuleName: String
     get() = "org." + this.name.replace('-', '.')
 
 val Project.versions: Versions
     get() {
-        val versions by rootProject.extra {
-            Versions(rootProject)
+        var versions: Versions? by rootProject.extra
+        if (versions == null) {
+            versions = Versions(rootProject)
         }
-        return versions
+        return versions!!
     }

--- a/buildSrc/src/main/kotlin/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/ProjectExtensions.kt
@@ -1,14 +1,14 @@
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.extra
+import org.gradle.kotlin.dsl.invoke
 
 val Project.javaModuleName: String
     get() = "org." + this.name.replace('-', '.')
 
 val Project.versions: Versions
     get() {
-        val extra = rootProject.extra
-        if (!extra.has("versions")) {
-            extra.set("versions", Versions(rootProject))
+        val versions: Versions by rootProject.extra {
+            Versions(rootProject)
         }
-        return extra.get("versions") as Versions
+        return versions
     }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,39 +3,13 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.extra
 import kotlin.reflect.KProperty
 
-class Versions(project: Project) {
+class Versions(private val project: Project) {
 
     companion object {
         val jvmTarget = JavaVersion.VERSION_1_8
     }
 
-    private val properties = object {
-        operator fun getValue(receiver: Any?, property: KProperty<*>): String =
-                project.extra.get(property.name + ".version") as String
-    }
+    operator fun get(name: String): String =
+            project.extra.get("$name.version") as String
 
-    val `apiguardian-api` by properties
-    val junit4 by properties
-    val junit4Min by properties
-    val opentest4j by properties
-    val picocli by properties
-    val `univocity-parsers` by properties
-
-    val archunit by properties
-    val assertj by properties
-    val bartholdy by properties
-    val classgraph by properties
-    val `commons-io` by properties
-    val `kotlinx-coroutines-core` by properties
-    val groovy by properties
-    val log4j by properties
-    val mockito by properties
-    val slf4j by properties
-
-    val checkstyle by properties
-    val jacoco by properties
-    val jmh by properties
-    val ktlint by properties
-    val surefire by properties
-    val bnd by properties
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,39 @@
 import org.gradle.api.JavaVersion
+import org.gradle.api.Project
 
-object Versions {
+class Versions(project: Project) {
 
-    val jvmTarget = JavaVersion.VERSION_1_8
+    companion object {
+        val jvmTarget = JavaVersion.VERSION_1_8
+    }
 
+    private val properties = project.rootProject.properties
+            .filterKeys { it.endsWith(".version") }
+            .mapKeys { it.key.substringBeforeLast(".version") }
+            .mapValues { it.value.toString() }
+
+    val `apiguardian-api` by properties
+    val junit4 by properties
+    val junit4Min by properties
+    val opentest4j by properties
+    val picocli by properties
+    val `univocity-parsers` by properties
+
+    val archunit by properties
+    val assertj by properties
+    val bartholdy by properties
+    val classgraph by properties
+    val `commons-io` by properties
+    val `kotlinx-coroutines-core` by properties
+    val groovy by properties
+    val log4j by properties
+    val mockito by properties
+    val slf4j by properties
+
+    val checkstyle by properties
+    val jacoco by properties
+    val jmh by properties
+    val ktlint by properties
+    val surefire by properties
+    val bnd by properties
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -9,7 +9,15 @@ class Versions(private val project: Project) {
         val jvmTarget = JavaVersion.VERSION_1_8
     }
 
-    operator fun get(name: String): String =
-            project.extra.get("$name.version") as String
+    private val properties = object {
+        operator fun getValue(receiver: Any?, property: KProperty<*>) = get(property.name)
+    }
+
+    val junit4 by properties
+    val junit4Min by properties
+    val opentest4j by properties
+    val apiguardian by properties
+
+    operator fun get(name: String) = project.extra.get("$name.version") as String
 
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,7 @@
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.extra
+import kotlin.reflect.KProperty
 
 class Versions(project: Project) {
 
@@ -7,10 +9,10 @@ class Versions(project: Project) {
         val jvmTarget = JavaVersion.VERSION_1_8
     }
 
-    private val properties = project.rootProject.properties
-            .filterKeys { it.endsWith(".version") }
-            .mapKeys { it.key.substringBeforeLast(".version") }
-            .mapValues { it.value.toString() }
+    private val properties = object {
+        operator fun getValue(receiver: Any?, property: KProperty<*>): String =
+                project.extra.get(property.name + ".version") as String
+    }
 
     val `apiguardian-api` by properties
     val junit4 by properties

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,32 +4,4 @@ object Versions {
 
     val jvmTarget = JavaVersion.VERSION_1_8
 
-    // Dependencies
-    val apiGuardian = "1.1.0"
-    val junit4 = "4.13"
-    val junit4Min = "4.12"
-    val ota4j = "1.2.0"
-    val picocli = "4.2.0"
-    val univocity = "2.8.4"
-
-    // Test Dependencies
-    val archunit = "0.13.1"
-    val assertJ = "3.14.0"
-    val bartholdy = "0.2.3"
-    val classgraph = "4.8.65"
-    val commonsIo = "2.6"
-    val coroutines = "1.3.3"
-    val groovy = "3.0.2"
-    val log4j = "2.13.1"
-    val mockito = "3.3.3"
-    val slf4j = "1.7.30"
-
-    // Tools
-    val checkstyle = "8.25"
-    val jacoco = "0.8.5"
-    val jmh = "1.23"
-    val ktlint = "0.35.0"
-    val surefire = "2.22.2"
-    var bnd = "5.0.0"
-
 }

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -274,7 +274,7 @@ afterEvaluate {
 }
 
 checkstyle {
-	toolVersion = versions.checkstyle
+	toolVersion = versions["checkstyle"]
 	configDirectory.set(rootProject.file("src/checkstyle"))
 }
 

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 	id("custom-java-home")
 }
 
+val String.v: String get() = rootProject.extra["$this.version"] as String
+
 val mavenizedProjects: List<Project> by rootProject.extra
 val modularProjects: List<Project> by rootProject.extra
 val buildDate: String by rootProject.extra
@@ -274,7 +276,7 @@ afterEvaluate {
 }
 
 checkstyle {
-	toolVersion = Versions.checkstyle
+	toolVersion = "checkstyle".v
 	configDirectory.set(rootProject.file("src/checkstyle"))
 }
 

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -6,8 +6,6 @@ plugins {
 	id("custom-java-home")
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
 val mavenizedProjects: List<Project> by rootProject.extra
 val modularProjects: List<Project> by rootProject.extra
 val buildDate: String by rootProject.extra
@@ -276,7 +274,7 @@ afterEvaluate {
 }
 
 checkstyle {
-	toolVersion = "checkstyle".version
+	toolVersion = versions.checkstyle
 	configDirectory.set(rootProject.file("src/checkstyle"))
 }
 

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 	id("custom-java-home")
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 val mavenizedProjects: List<Project> by rootProject.extra
 val modularProjects: List<Project> by rootProject.extra
@@ -276,7 +276,7 @@ afterEvaluate {
 }
 
 checkstyle {
-	toolVersion = "checkstyle".v
+	toolVersion = "checkstyle".version
 	configDirectory.set(rootProject.file("src/checkstyle"))
 }
 

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -2,49 +2,35 @@ plugins {
 	`java-platform`
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
-fun DependencyConstraintHandlerScope.apiv(
-		notation: String,
-		versionProp: String = notation.substringAfterLast(':')
-) =
-		"api"(notation + ":" + versionProp.version)
-
-fun DependencyConstraintHandlerScope.runtimev(
-		notation: String,
-		versionProp: String = notation.substringAfterLast(':')
-) =
-		"runtime"(notation + ":" + versionProp.version)
-
 dependencies {
 	constraints {
 		// api means "the dependency is for both compilation and runtime"
 		// runtime means "the dependency is only for runtime, not for compilation"
 		// In other words, marking dependency as "runtime" would avoid accidental
 		// dependency on it during compilation
-		apiv("org.apiguardian:apiguardian-api")
-		apiv("org.opentest4j:opentest4j")
-		runtimev("org.apache.logging.log4j:log4j-core", "log4j")
-		runtimev("org.apache.logging.log4j:log4j-jul", "log4j")
-		apiv("io.github.classgraph:classgraph")
-		apiv("org.codehaus.groovy:groovy-all", "groovy")
-		api("junit:junit:[${"junit4Min".version},)") {
+		api("org.apiguardian:apiguardian-api:${versions.`apiguardian-api`}")
+		api("org.opentest4j:opentest4j:${versions.opentest4j}")
+		runtime("org.apache.logging.log4j:log4j-core:${versions.log4j}")
+		runtime("org.apache.logging.log4j:log4j-jul:${versions.log4j}")
+		api("io.github.classgraph:classgraph:${versions.classgraph}")
+		api("org.codehaus.groovy:groovy-all:${versions.groovy}")
+		api("junit:junit:[${versions.junit4Min},)") {
 			version {
-				prefer("junit4".version)
+				prefer(versions.junit4)
 			}
 		}
-		apiv("com.univocity:univocity-parsers")
-		apiv("info.picocli:picocli")
-		apiv("org.assertj:assertj-core", "assertj")
-		apiv("org.openjdk.jmh:jmh-core", "jmh")
-		apiv("org.openjdk.jmh:jmh-generator-annprocess", "jmh")
-		apiv("de.sormuras:bartholdy")
-		apiv("commons-io:commons-io")
-		apiv("com.tngtech.archunit:archunit-junit5-api", "archunit")
-		apiv("com.tngtech.archunit:archunit-junit5-engine", "archunit")
-		apiv("org.slf4j:slf4j-jdk14", "slf4j")
-		apiv("org.jetbrains.kotlinx:kotlinx-coroutines-core")
-		apiv("org.mockito:mockito-junit-jupiter", "mockito")
-		apiv("biz.aQute.bnd:biz.aQute.bndlib", "bnd")
+		api("com.univocity:univocity-parsers:${versions.`univocity-parsers`}")
+		api("info.picocli:picocli:${versions.picocli}")
+		api("org.assertj:assertj-core:${versions.assertj}")
+		api("org.openjdk.jmh:jmh-core:${versions.jmh}")
+		api("org.openjdk.jmh:jmh-generator-annprocess:${versions.jmh}")
+		api("de.sormuras:bartholdy:${versions.bartholdy}")
+		api("commons-io:commons-io:${versions.`commons-io`}")
+		api("com.tngtech.archunit:archunit-junit5-api:${versions.archunit}")
+		api("com.tngtech.archunit:archunit-junit5-engine:${versions.archunit}")
+		api("org.slf4j:slf4j-jdk14:${versions.slf4j}")
+		api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.`kotlinx-coroutines-core`}")
+		api("org.mockito:mockito-junit-jupiter:${versions.mockito}")
+		api("biz.aQute.bnd:biz.aQute.bndlib:${versions.bnd}")
 	}
 }

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -2,19 +2,19 @@ plugins {
 	`java-platform`
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 fun DependencyConstraintHandlerScope.apiv(
 		notation: String,
 		versionProp: String = notation.substringAfterLast(':')
 ) =
-		"api"(notation + ":" + versionProp.v)
+		"api"(notation + ":" + versionProp.version)
 
 fun DependencyConstraintHandlerScope.runtimev(
 		notation: String,
 		versionProp: String = notation.substringAfterLast(':')
 ) =
-		"runtime"(notation + ":" + versionProp.v)
+		"runtime"(notation + ":" + versionProp.version)
 
 dependencies {
 	constraints {
@@ -28,9 +28,9 @@ dependencies {
 		runtimev("org.apache.logging.log4j:log4j-jul", "log4j")
 		apiv("io.github.classgraph:classgraph")
 		apiv("org.codehaus.groovy:groovy-all", "groovy")
-		api("junit:junit:[${"junit4Min".v},)") {
+		api("junit:junit:[${"junit4Min".version},)") {
 			version {
-				prefer("junit4".v)
+				prefer("junit4".version)
 			}
 		}
 		apiv("com.univocity:univocity-parsers")

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -2,29 +2,49 @@ plugins {
 	`java-platform`
 }
 
+val String.v: String get() = rootProject.extra["$this.version"] as String
+
+fun DependencyConstraintHandlerScope.apiv(
+		notation: String,
+		versionProp: String = notation.substringAfterLast(':')
+) =
+		"api"(notation + ":" + versionProp.v)
+
+fun DependencyConstraintHandlerScope.runtimev(
+		notation: String,
+		versionProp: String = notation.substringAfterLast(':')
+) =
+		"runtime"(notation + ":" + versionProp.v)
+
 dependencies {
 	constraints {
-		api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
-		api("org.opentest4j:opentest4j:${Versions.ota4j}")
-		api("org.apache.logging.log4j:log4j-core:${Versions.log4j}")
-		api("org.apache.logging.log4j:log4j-jul:${Versions.log4j}")
-		api("io.github.classgraph:classgraph:${Versions.classgraph}")
-		api("org.codehaus.groovy:groovy-all:${Versions.groovy}")
-		api("junit:junit:[${Versions.junit4Min},)") {
+		// api means "the dependency is for both compilation and runtime"
+		// runtime means "the dependency is only for runtime, not for compilation"
+		// In other words, marking dependency as "runtime" would avoid accidental
+		// dependency on it during compilation
+		apiv("org.apiguardian:apiguardian-api")
+		apiv("org.opentest4j:opentest4j")
+		runtimev("org.apache.logging.log4j:log4j-core", "log4j")
+		runtimev("org.apache.logging.log4j:log4j-jul", "log4j")
+		apiv("io.github.classgraph:classgraph")
+		apiv("org.codehaus.groovy:groovy-all", "groovy")
+		api("junit:junit:[${"junit4Min".v},)") {
 			version {
-				prefer(Versions.junit4)
+				prefer("junit4".v)
 			}
 		}
-		api("com.univocity:univocity-parsers:${Versions.univocity}")
-		api("info.picocli:picocli:${Versions.picocli}")
-		api("org.assertj:assertj-core:${Versions.assertJ}")
-		api("org.openjdk.jmh:jmh-core:${Versions.jmh}")
-		api("org.openjdk.jmh:jmh-generator-annprocess:${Versions.jmh}")
-		api("de.sormuras:bartholdy:${Versions.bartholdy}")
-		api("commons-io:commons-io:${Versions.commonsIo}")
-		api("com.tngtech.archunit:archunit-junit5-api:${Versions.archunit}")
-		api("com.tngtech.archunit:archunit-junit5-engine:${Versions.archunit}")
-		api("org.slf4j:slf4j-jdk14:${Versions.slf4j}")
-		api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}")
+		apiv("com.univocity:univocity-parsers")
+		apiv("info.picocli:picocli")
+		apiv("org.assertj:assertj-core", "assertj")
+		apiv("org.openjdk.jmh:jmh-core", "jmh")
+		apiv("org.openjdk.jmh:jmh-generator-annprocess", "jmh")
+		apiv("de.sormuras:bartholdy")
+		apiv("commons-io:commons-io")
+		apiv("com.tngtech.archunit:archunit-junit5-api", "archunit")
+		apiv("com.tngtech.archunit:archunit-junit5-engine", "archunit")
+		apiv("org.slf4j:slf4j-jdk14", "slf4j")
+		apiv("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+		apiv("org.mockito:mockito-junit-jupiter", "mockito")
+		apiv("biz.aQute.bnd:biz.aQute.bndlib", "bnd")
 	}
 }

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -8,15 +8,15 @@ dependencies {
 		// runtime means "the dependency is only for runtime, not for compilation"
 		// In other words, marking dependency as "runtime" would avoid accidental
 		// dependency on it during compilation
-		api("org.apiguardian:apiguardian-api:${versions["apiguardian-api"]}")
-		api("org.opentest4j:opentest4j:${versions["opentest4j"]}")
+		api("org.apiguardian:apiguardian-api:${versions.apiguardian}")
+		api("org.opentest4j:opentest4j:${versions.opentest4j}")
 		runtime("org.apache.logging.log4j:log4j-core:${versions["log4j"]}")
 		runtime("org.apache.logging.log4j:log4j-jul:${versions["log4j"]}")
 		api("io.github.classgraph:classgraph:${versions["classgraph"]}")
 		api("org.codehaus.groovy:groovy-all:${versions["groovy"]}")
-		api("junit:junit:[${versions["junit4Min"]},)") {
+		api("junit:junit:[${versions.junit4Min},)") {
 			version {
-				prefer(versions["junit4"])
+				prefer(versions.junit4)
 			}
 		}
 		api("com.univocity:univocity-parsers:${versions["univocity-parsers"]}")

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -8,29 +8,29 @@ dependencies {
 		// runtime means "the dependency is only for runtime, not for compilation"
 		// In other words, marking dependency as "runtime" would avoid accidental
 		// dependency on it during compilation
-		api("org.apiguardian:apiguardian-api:${versions.`apiguardian-api`}")
-		api("org.opentest4j:opentest4j:${versions.opentest4j}")
-		runtime("org.apache.logging.log4j:log4j-core:${versions.log4j}")
-		runtime("org.apache.logging.log4j:log4j-jul:${versions.log4j}")
-		api("io.github.classgraph:classgraph:${versions.classgraph}")
-		api("org.codehaus.groovy:groovy-all:${versions.groovy}")
-		api("junit:junit:[${versions.junit4Min},)") {
+		api("org.apiguardian:apiguardian-api:${versions["apiguardian-api"]}")
+		api("org.opentest4j:opentest4j:${versions["opentest4j"]}")
+		runtime("org.apache.logging.log4j:log4j-core:${versions["log4j"]}")
+		runtime("org.apache.logging.log4j:log4j-jul:${versions["log4j"]}")
+		api("io.github.classgraph:classgraph:${versions["classgraph"]}")
+		api("org.codehaus.groovy:groovy-all:${versions["groovy"]}")
+		api("junit:junit:[${versions["junit4Min"]},)") {
 			version {
-				prefer(versions.junit4)
+				prefer(versions["junit4"])
 			}
 		}
-		api("com.univocity:univocity-parsers:${versions.`univocity-parsers`}")
-		api("info.picocli:picocli:${versions.picocli}")
-		api("org.assertj:assertj-core:${versions.assertj}")
-		api("org.openjdk.jmh:jmh-core:${versions.jmh}")
-		api("org.openjdk.jmh:jmh-generator-annprocess:${versions.jmh}")
-		api("de.sormuras:bartholdy:${versions.bartholdy}")
-		api("commons-io:commons-io:${versions.`commons-io`}")
-		api("com.tngtech.archunit:archunit-junit5-api:${versions.archunit}")
-		api("com.tngtech.archunit:archunit-junit5-engine:${versions.archunit}")
-		api("org.slf4j:slf4j-jdk14:${versions.slf4j}")
-		api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.`kotlinx-coroutines-core`}")
-		api("org.mockito:mockito-junit-jupiter:${versions.mockito}")
-		api("biz.aQute.bnd:biz.aQute.bndlib:${versions.bnd}")
+		api("com.univocity:univocity-parsers:${versions["univocity-parsers"]}")
+		api("info.picocli:picocli:${versions["picocli"]}")
+		api("org.assertj:assertj-core:${versions["assertj"]}")
+		api("org.openjdk.jmh:jmh-core:${versions["jmh"]}")
+		api("org.openjdk.jmh:jmh-generator-annprocess:${versions["jmh"]}")
+		api("de.sormuras:bartholdy:${versions["bartholdy"]}")
+		api("commons-io:commons-io:${versions["commons-io"]}")
+		api("com.tngtech.archunit:archunit-junit5-api:${versions["archunit"]}")
+		api("com.tngtech.archunit:archunit-junit5-engine:${versions["archunit"]}")
+		api("org.slf4j:slf4j-jdk14:${versions["slf4j"]}")
+		api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions["kotlinx-coroutines-core"]}")
+		api("org.mockito:mockito-junit-jupiter:${versions["mockito"]}")
+		api("biz.aQute.bnd:biz.aQute.bndlib:${versions["bnd"]}")
 	}
 }

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -52,8 +52,8 @@ val docsVersion = if (snapshot) "snapshot" else rootProject.version
 val docsDir = file("$buildDir/ghpages-docs")
 val replaceCurrentDocs = project.hasProperty("replaceCurrentDocs")
 val uploadPdfs = !snapshot
-val ota4jDocVersion = if (versions["opentest4j"].contains("SNAPSHOT")) "snapshot" else versions["opentest4j"]
-val apiGuardianDocVersion = if (versions["apiguardian-api"].contains("SNAPSHOT")) "snapshot" else versions["apiguardian-api"]
+val ota4jDocVersion = if (versions.opentest4j.contains("SNAPSHOT")) "snapshot" else versions.opentest4j
+val apiGuardianDocVersion = if (versions.apiguardian.contains("SNAPSHOT")) "snapshot" else versions.apiguardian
 
 gitPublish {
 	repoUri.set("https://github.com/junit-team/junit5.git")
@@ -152,9 +152,9 @@ tasks {
 				"platform-version" to project.properties["platformVersion"],
 				"vintage-version" to project.properties["vintageVersion"],
 				"bom-version" to version,
-				"junit4-version" to versions["junit4"],
-				"apiguardian-version" to versions["apiguardian-api"],
-				"ota4j-version" to versions["opentest4j"],
+				"junit4-version" to versions.junit4,
+				"apiguardian-version" to versions.apiguardian,
+				"ota4j-version" to versions.opentest4j,
 				"surefire-version" to versions["surefire"],
 				"release-branch" to project.properties["releaseBranch"],
 				"docs-version" to project.properties["docsVersion"],
@@ -246,7 +246,7 @@ tasks {
 				jFlags("-Xmx1g")
 
 				links("https://docs.oracle.com/en/java/javase/11/docs/api/")
-				links("https://junit.org/junit4/javadoc/${versions["junit4"]}/")
+				links("https://junit.org/junit4/javadoc/${versions.junit4}/")
 				externalModulesWithoutModularJavadoc.forEach { (moduleName, coordinates) ->
 					linksOffline(coordinates.baseUrl, "$elementListsDir/$moduleName")
 				}

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -47,15 +47,13 @@ asciidoctorj {
 	}
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
 val snapshot = rootProject.version.toString().contains("SNAPSHOT")
 val docsVersion = if (snapshot) "snapshot" else rootProject.version
 val docsDir = file("$buildDir/ghpages-docs")
 val replaceCurrentDocs = project.hasProperty("replaceCurrentDocs")
 val uploadPdfs = !snapshot
-val ota4jDocVersion = if ("opentest4j".version.contains("SNAPSHOT")) "snapshot" else "opentest4j".version
-val apiGuardianDocVersion = if ("apiguardian-api".version.contains("SNAPSHOT")) "snapshot" else "apiguardian-api".version
+val ota4jDocVersion = if (versions.opentest4j.contains("SNAPSHOT")) "snapshot" else versions.opentest4j
+val apiGuardianDocVersion = if (versions.`apiguardian-api`.contains("SNAPSHOT")) "snapshot" else versions.`apiguardian-api`
 
 gitPublish {
 	repoUri.set("https://github.com/junit-team/junit5.git")
@@ -154,10 +152,10 @@ tasks {
 				"platform-version" to project.properties["platformVersion"],
 				"vintage-version" to project.properties["vintageVersion"],
 				"bom-version" to version,
-				"junit4-version" to "junit4".version,
-				"apiguardian-version" to "apiguardian-api".version,
-				"ota4j-version" to "opentest4j".version,
-				"surefire-version" to "surefire".version,
+				"junit4-version" to versions.junit4,
+				"apiguardian-version" to versions.`apiguardian-api`,
+				"ota4j-version" to versions.opentest4j,
+				"surefire-version" to versions.surefire,
 				"release-branch" to project.properties["releaseBranch"],
 				"docs-version" to project.properties["docsVersion"],
 				"revnumber" to version,
@@ -248,7 +246,7 @@ tasks {
 				jFlags("-Xmx1g")
 
 				links("https://docs.oracle.com/en/java/javase/11/docs/api/")
-				links("https://junit.org/junit4/javadoc/${"junit4".version}/")
+				links("https://junit.org/junit4/javadoc/${versions.junit4}/")
 				externalModulesWithoutModularJavadoc.forEach { (moduleName, coordinates) ->
 					linksOffline(coordinates.baseUrl, "$elementListsDir/$moduleName")
 				}

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -87,8 +87,6 @@ val externalModulesWithoutModularJavadoc = mapOf(
 enum class JavadocListType { ELEMENT_LIST, PACKAGE_LIST }
 data class JavadocCoordinates(val baseUrl: String, val listType: JavadocListType) : java.io.Serializable
 
-tasks["test"].enabled = false
-
 tasks {
 
 	val consoleLauncherTest by registering(JavaExec::class) {

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -47,13 +47,15 @@ asciidoctorj {
 	}
 }
 
+val String.v: String get() = rootProject.extra["$this.version"] as String
+
 val snapshot = rootProject.version.toString().contains("SNAPSHOT")
 val docsVersion = if (snapshot) "snapshot" else rootProject.version
 val docsDir = file("$buildDir/ghpages-docs")
 val replaceCurrentDocs = project.hasProperty("replaceCurrentDocs")
 val uploadPdfs = !snapshot
-val ota4jDocVersion = if (Versions.ota4j.contains("SNAPSHOT")) "snapshot" else Versions.ota4j
-val apiGuardianDocVersion = if (Versions.apiGuardian.contains("SNAPSHOT")) "snapshot" else Versions.apiGuardian
+val ota4jDocVersion = if ("opentest4j".v.contains("SNAPSHOT")) "snapshot" else "opentest4j".v
+val apiGuardianDocVersion = if ("apiguardian-api".v.contains("SNAPSHOT")) "snapshot" else "apiguardian-api".v
 
 gitPublish {
 	repoUri.set("https://github.com/junit-team/junit5.git")
@@ -152,10 +154,10 @@ tasks {
 				"platform-version" to project.properties["platformVersion"],
 				"vintage-version" to project.properties["vintageVersion"],
 				"bom-version" to version,
-				"junit4-version" to Versions.junit4,
-				"apiguardian-version" to Versions.apiGuardian,
-				"ota4j-version" to Versions.ota4j,
-				"surefire-version" to Versions.surefire,
+				"junit4-version" to "junit4".v,
+				"apiguardian-version" to "apiguardian-api".v,
+				"ota4j-version" to "opentest4j".v,
+				"surefire-version" to "surefire".v,
 				"release-branch" to project.properties["releaseBranch"],
 				"docs-version" to project.properties["docsVersion"],
 				"revnumber" to version,
@@ -246,7 +248,7 @@ tasks {
 				jFlags("-Xmx1g")
 
 				links("https://docs.oracle.com/en/java/javase/11/docs/api/")
-				links("https://junit.org/junit4/javadoc/${Versions.junit4}/")
+				links("https://junit.org/junit4/javadoc/${"junit4".v}/")
 				externalModulesWithoutModularJavadoc.forEach { (moduleName, coordinates) ->
 					linksOffline(coordinates.baseUrl, "$elementListsDir/$moduleName")
 				}

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -47,15 +47,15 @@ asciidoctorj {
 	}
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 val snapshot = rootProject.version.toString().contains("SNAPSHOT")
 val docsVersion = if (snapshot) "snapshot" else rootProject.version
 val docsDir = file("$buildDir/ghpages-docs")
 val replaceCurrentDocs = project.hasProperty("replaceCurrentDocs")
 val uploadPdfs = !snapshot
-val ota4jDocVersion = if ("opentest4j".v.contains("SNAPSHOT")) "snapshot" else "opentest4j".v
-val apiGuardianDocVersion = if ("apiguardian-api".v.contains("SNAPSHOT")) "snapshot" else "apiguardian-api".v
+val ota4jDocVersion = if ("opentest4j".version.contains("SNAPSHOT")) "snapshot" else "opentest4j".version
+val apiGuardianDocVersion = if ("apiguardian-api".version.contains("SNAPSHOT")) "snapshot" else "apiguardian-api".version
 
 gitPublish {
 	repoUri.set("https://github.com/junit-team/junit5.git")
@@ -154,10 +154,10 @@ tasks {
 				"platform-version" to project.properties["platformVersion"],
 				"vintage-version" to project.properties["vintageVersion"],
 				"bom-version" to version,
-				"junit4-version" to "junit4".v,
-				"apiguardian-version" to "apiguardian-api".v,
-				"ota4j-version" to "opentest4j".v,
-				"surefire-version" to "surefire".v,
+				"junit4-version" to "junit4".version,
+				"apiguardian-version" to "apiguardian-api".version,
+				"ota4j-version" to "opentest4j".version,
+				"surefire-version" to "surefire".version,
 				"release-branch" to project.properties["releaseBranch"],
 				"docs-version" to project.properties["docsVersion"],
 				"revnumber" to version,
@@ -248,7 +248,7 @@ tasks {
 				jFlags("-Xmx1g")
 
 				links("https://docs.oracle.com/en/java/javase/11/docs/api/")
-				links("https://junit.org/junit4/javadoc/${"junit4".v}/")
+				links("https://junit.org/junit4/javadoc/${"junit4".version}/")
 				externalModulesWithoutModularJavadoc.forEach { (moduleName, coordinates) ->
 					linksOffline(coordinates.baseUrl, "$elementListsDir/$moduleName")
 				}

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -52,8 +52,8 @@ val docsVersion = if (snapshot) "snapshot" else rootProject.version
 val docsDir = file("$buildDir/ghpages-docs")
 val replaceCurrentDocs = project.hasProperty("replaceCurrentDocs")
 val uploadPdfs = !snapshot
-val ota4jDocVersion = if (versions.opentest4j.contains("SNAPSHOT")) "snapshot" else versions.opentest4j
-val apiGuardianDocVersion = if (versions.`apiguardian-api`.contains("SNAPSHOT")) "snapshot" else versions.`apiguardian-api`
+val ota4jDocVersion = if (versions["opentest4j"].contains("SNAPSHOT")) "snapshot" else versions["opentest4j"]
+val apiGuardianDocVersion = if (versions["apiguardian-api"].contains("SNAPSHOT")) "snapshot" else versions["apiguardian-api"]
 
 gitPublish {
 	repoUri.set("https://github.com/junit-team/junit5.git")
@@ -86,6 +86,8 @@ val externalModulesWithoutModularJavadoc = mapOf(
 )
 enum class JavadocListType { ELEMENT_LIST, PACKAGE_LIST }
 data class JavadocCoordinates(val baseUrl: String, val listType: JavadocListType) : java.io.Serializable
+
+tasks["test"].enabled = false
 
 tasks {
 
@@ -152,10 +154,10 @@ tasks {
 				"platform-version" to project.properties["platformVersion"],
 				"vintage-version" to project.properties["vintageVersion"],
 				"bom-version" to version,
-				"junit4-version" to versions.junit4,
-				"apiguardian-version" to versions.`apiguardian-api`,
-				"ota4j-version" to versions.opentest4j,
-				"surefire-version" to versions.surefire,
+				"junit4-version" to versions["junit4"],
+				"apiguardian-version" to versions["apiguardian-api"],
+				"ota4j-version" to versions["opentest4j"],
+				"surefire-version" to versions["surefire"],
 				"release-branch" to project.properties["releaseBranch"],
 				"docs-version" to project.properties["docsVersion"],
 				"revnumber" to version,
@@ -246,7 +248,7 @@ tasks {
 				jFlags("-Xmx1g")
 
 				links("https://docs.oracle.com/en/java/javase/11/docs/api/")
-				links("https://junit.org/junit4/javadoc/${versions.junit4}/")
+				links("https://junit.org/junit4/javadoc/${versions["junit4"]}/")
 				externalModulesWithoutModularJavadoc.forEach { (moduleName, coordinates) ->
 					linksOffline(coordinates.baseUrl, "$elementListsDir/$moduleName")
 				}

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,31 @@ org.gradle.parallel=true
 # Workaround for https://issues.sonatype.org/browse/NEXUS-21802
 # See https://github.com/gradle/gradle/issues/11308 for additional context.
 systemProp.org.gradle.internal.publish.checksums.insecure=true
+
+# Dependencies
+apiguardian-api.version=1.1.0
+junit4.version=4.13
+junit4Min.version=4.12
+opentest4j.version=1.2.0
+picocli.version=4.2.0
+univocity-parsers.version=2.8.4
+
+# Test Dependencies
+archunit.version=0.13.1
+assertj.version=3.14.0
+bartholdy.version=0.2.3
+classgraph.version=4.8.65
+commons-io.version=2.6
+kotlinx-coroutines-core.version=1.3.3
+groovy.version=3.0.2
+log4j.version=2.13.1
+mockito.version=3.3.3
+slf4j.version=1.7.30
+
+# Tools
+checkstyle.version=8.25
+jacoco.version=0.8.5
+jmh.version=1.23
+ktlint.version=0.35.0
+surefire.version=2.22.2
+bnd.version=5.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.parallel=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 # Dependencies
-apiguardian-api.version=1.1.0
+apiguardian.version=1.1.0
 junit4.version=4.13
 junit4Min.version=4.12
 opentest4j.version=1.2.0

--- a/gradle/testing.gradle.kts
+++ b/gradle/testing.gradle.kts
@@ -16,8 +16,8 @@ tasks.withType<Test>().configureEach {
 }
 
 dependencies {
-	"testImplementation"("org.assertj:assertj-core:${Versions.assertJ}")
-	"testImplementation"("org.mockito:mockito-junit-jupiter:${Versions.mockito}") {
+	"testImplementation"("org.assertj:assertj-core")
+	"testImplementation"("org.mockito:mockito-junit-jupiter") {
 		exclude(module = "junit-jupiter-engine")
 	}
 
@@ -31,6 +31,6 @@ dependencies {
 
 	"testRuntimeOnly"(project(":junit-platform-launcher"))
 
-	"testRuntimeOnly"("org.apache.logging.log4j:log4j-core:${Versions.log4j}")
-	"testRuntimeOnly"("org.apache.logging.log4j:log4j-jul:${Versions.log4j}")
+	"testRuntimeOnly"("org.apache.logging.log4j:log4j-core")
+	"testRuntimeOnly"("org.apache.logging.log4j:log4j-jul")
 }

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -23,15 +23,17 @@ dependencies {
 	testImplementation(project(":junit-platform-testkit"))
 }
 
+val String.v: String get() = rootProject.extra["$this.version"] as String
+
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
 		bnd("""
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				org.junit;version="[${Versions.junit4Min},5)",\
+				org.junit;version="[${"junit4Min".v},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.rules;version="[${Versions.junit4Min},5)",\
+				org.junit.rules;version="[${"junit4Min".v},5)",\
 				*
 		""")
 	}

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -29,9 +29,9 @@ tasks.jar {
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				org.junit;version="[${versions["junit4Min"]},5)",\
+				org.junit;version="[${versions.junit4Min},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.rules;version="[${versions["junit4Min"]},5)",\
+				org.junit.rules;version="[${versions.junit4Min},5)",\
 				*
 		""")
 	}

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -29,9 +29,9 @@ tasks.jar {
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				org.junit;version="[${versions.junit4Min},5)",\
+				org.junit;version="[${versions["junit4Min"]},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.rules;version="[${versions.junit4Min},5)",\
+				org.junit.rules;version="[${versions["junit4Min"]},5)",\
 				*
 		""")
 	}

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -23,18 +23,15 @@ dependencies {
 	testImplementation(project(":junit-platform-testkit"))
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
-		val junit4Min = "junit4Min".version
 		bnd("""
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				org.junit;version="[$junit4Min,5)",\
+				org.junit;version="[${versions.junit4Min},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.rules;version="[$junit4Min,5)",\
+				org.junit.rules;version="[${versions.junit4Min},5)",\
 				*
 		""")
 	}

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -27,13 +27,14 @@ val String.version: String get() = rootProject.extra["$this.version"] as String
 
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
+		val junit4Min = "junit4Min".version
 		bnd("""
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				org.junit;version="[${"junit4Min".version},5)",\
+				org.junit;version="[$junit4Min,5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.rules;version="[${"junit4Min".version},5)",\
+				org.junit.rules;version="[$junit4Min,5)",\
 				*
 		""")
 	}

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 	testImplementation(project(":junit-platform-testkit"))
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
@@ -31,9 +31,9 @@ tasks.jar {
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				org.junit;version="[${"junit4Min".v},5)",\
+				org.junit;version="[${"junit4Min".version},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.rules;version="[${"junit4Min".v},5)",\
+				org.junit.rules;version="[${"junit4Min".version},5)",\
 				*
 		""")
 	}

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -27,7 +27,7 @@ tasks.jar {
 			Import-Package: \
 				!org.apiguardian.api,\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${versions["junit4Min"]},5)",\
+				org.junit.runner.*;version="[${versions.junit4Min},5)",\
 				*
 		""")
 	}

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
 	testImplementation(testFixtures(project(":junit-platform-launcher")))
 }
 
+val String.v: String get() = rootProject.extra["$this.version"] as String
+
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
 		bnd("""
@@ -27,7 +29,7 @@ tasks.jar {
 			Import-Package: \
 				!org.apiguardian.api,\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${Versions.junit4Min},5)",\
+				org.junit.runner.*;version="[${"junit4Min".v},5)",\
 				*
 		""")
 	}

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -20,8 +20,6 @@ dependencies {
 	testImplementation(testFixtures(project(":junit-platform-launcher")))
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
 		bnd("""
@@ -29,7 +27,7 @@ tasks.jar {
 			Import-Package: \
 				!org.apiguardian.api,\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${"junit4Min".version},5)",\
+				org.junit.runner.*;version="[${versions.junit4Min},5)",\
 				*
 		""")
 	}

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -27,7 +27,7 @@ tasks.jar {
 			Import-Package: \
 				!org.apiguardian.api,\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${versions.junit4Min},5)",\
+				org.junit.runner.*;version="[${versions["junit4Min"]},5)",\
 				*
 		""")
 	}

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 	testImplementation(testFixtures(project(":junit-platform-launcher")))
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
@@ -29,7 +29,7 @@ tasks.jar {
 			Import-Package: \
 				!org.apiguardian.api,\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${"junit4Min".v},5)",\
+				org.junit.runner.*;version="[${"junit4Min".version},5)",\
 				*
 		""")
 	}

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 	internal(platform(project(":dependencies")))
 
 	api(platform(project(":junit-bom")))
-	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
+	api("org.apiguardian:apiguardian-api")
 
 	osgiVerification(project(":junit-platform-commons"))
 }

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -28,13 +28,13 @@ tasks.jar {
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				junit.runner;version="[${versions["junit4Min"]},5)",\
-				org.junit;version="[${versions["junit4Min"]},5)",\
-				org.junit.experimental.categories;version="[${versions["junit4Min"]},5)",\
-				org.junit.internal.builders;version="[${versions["junit4Min"]},5)",\
+				junit.runner;version="[${versions.junit4Min},5)",\
+				org.junit;version="[${versions.junit4Min},5)",\
+				org.junit.experimental.categories;version="[${versions.junit4Min},5)",\
+				org.junit.internal.builders;version="[${versions.junit4Min},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${versions["junit4Min"]},5)",\
-				org.junit.runners.model;version="[${versions["junit4Min"]},5)",\
+				org.junit.runner.*;version="[${versions.junit4Min},5)",\
+				org.junit.runners.model;version="[${versions.junit4Min},5)",\
 				*
 		""")
 	}

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -28,13 +28,13 @@ tasks.jar {
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				junit.runner;version="[${versions.junit4Min},5)",\
-				org.junit;version="[${versions.junit4Min},5)",\
-				org.junit.experimental.categories;version="[${versions.junit4Min},5)",\
-				org.junit.internal.builders;version="[${versions.junit4Min},5)",\
+				junit.runner;version="[${versions["junit4Min"]},5)",\
+				org.junit;version="[${versions["junit4Min"]},5)",\
+				org.junit.experimental.categories;version="[${versions["junit4Min"]},5)",\
+				org.junit.internal.builders;version="[${versions["junit4Min"]},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${versions.junit4Min},5)",\
-				org.junit.runners.model;version="[${versions.junit4Min},5)",\
+				org.junit.runner.*;version="[${versions["junit4Min"]},5)",\
+				org.junit.runners.model;version="[${versions["junit4Min"]},5)",\
 				*
 		""")
 	}

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -22,22 +22,19 @@ dependencies {
 	testImplementation(project(":junit-platform-testkit"))
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
-		val junit4Min = "junit4Min".version
 		bnd("""
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				junit.runner;version="[$junit4Min,5)",\
-				org.junit;version="[$junit4Min,5)",\
-				org.junit.experimental.categories;version="[$junit4Min,5)",\
-				org.junit.internal.builders;version="[$junit4Min,5)",\
+				junit.runner;version="[${versions.junit4Min},5)",\
+				org.junit;version="[${versions.junit4Min},5)",\
+				org.junit.experimental.categories;version="[${versions.junit4Min},5)",\
+				org.junit.internal.builders;version="[${versions.junit4Min},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[$junit4Min,5)",\
-				org.junit.runners.model;version="[$junit4Min,5)",\
+				org.junit.runner.*;version="[${versions.junit4Min},5)",\
+				org.junit.runners.model;version="[${versions.junit4Min},5)",\
 				*
 		""")
 	}

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -22,19 +22,21 @@ dependencies {
 	testImplementation(project(":junit-platform-testkit"))
 }
 
+val String.v: String get() = rootProject.extra["$this.version"] as String
+
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
 		bnd("""
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				junit.runner;version="[${Versions.junit4Min},5)",\
-				org.junit;version="[${Versions.junit4Min},5)",\
-				org.junit.experimental.categories;version="[${Versions.junit4Min},5)",\
-				org.junit.internal.builders;version="[${Versions.junit4Min},5)",\
+				junit.runner;version="[${"junit4Min".v},5)",\
+				org.junit;version="[${"junit4Min".v},5)",\
+				org.junit.experimental.categories;version="[${"junit4Min".v},5)",\
+				org.junit.internal.builders;version="[${"junit4Min".v},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${Versions.junit4Min},5)",\
-				org.junit.runners.model;version="[${Versions.junit4Min},5)",\
+				org.junit.runner.*;version="[${"junit4Min".v},5)",\
+				org.junit.runners.model;version="[${"junit4Min".v},5)",\
 				*
 		""")
 	}

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 	testImplementation(project(":junit-platform-testkit"))
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
@@ -30,13 +30,13 @@ tasks.jar {
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				junit.runner;version="[${"junit4Min".v},5)",\
-				org.junit;version="[${"junit4Min".v},5)",\
-				org.junit.experimental.categories;version="[${"junit4Min".v},5)",\
-				org.junit.internal.builders;version="[${"junit4Min".v},5)",\
+				junit.runner;version="[${"junit4Min".version},5)",\
+				org.junit;version="[${"junit4Min".version},5)",\
+				org.junit.experimental.categories;version="[${"junit4Min".version},5)",\
+				org.junit.internal.builders;version="[${"junit4Min".version},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${"junit4Min".v},5)",\
-				org.junit.runners.model;version="[${"junit4Min".v},5)",\
+				org.junit.runner.*;version="[${"junit4Min".version},5)",\
+				org.junit.runners.model;version="[${"junit4Min".version},5)",\
 				*
 		""")
 	}

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -26,17 +26,18 @@ val String.version: String get() = rootProject.extra["$this.version"] as String
 
 tasks.jar {
 	withConvention(BundleTaskConvention::class) {
+		val junit4Min = "junit4Min".version
 		bnd("""
 			# Import JUnit4 packages with a version
 			Import-Package: \
 				!org.apiguardian.api,\
-				junit.runner;version="[${"junit4Min".version},5)",\
-				org.junit;version="[${"junit4Min".version},5)",\
-				org.junit.experimental.categories;version="[${"junit4Min".version},5)",\
-				org.junit.internal.builders;version="[${"junit4Min".version},5)",\
+				junit.runner;version="[$junit4Min,5)",\
+				org.junit;version="[$junit4Min,5)",\
+				org.junit.experimental.categories;version="[$junit4Min,5)",\
+				org.junit.internal.builders;version="[$junit4Min,5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
-				org.junit.runner.*;version="[${"junit4Min".version},5)",\
-				org.junit.runners.model;version="[${"junit4Min".version},5)",\
+				org.junit.runner.*;version="[$junit4Min,5)",\
+				org.junit.runners.model;version="[$junit4Min,5)",\
 				*
 		""")
 	}

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -40,10 +40,8 @@ dependencies {
 	jmh("junit:junit")
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
 jmh {
-	jmhVersion = "jmh".version
+	jmhVersion = versions.jmh
 
 	duplicateClassesStrategy = DuplicatesStrategy.WARN
 	fork = 0 // Too long command line on Windows...

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 }
 
 jmh {
-	jmhVersion = versions.jmh
+	jmhVersion = versions["jmh"]
 
 	duplicateClassesStrategy = DuplicatesStrategy.WARN
 	fork = 0 // Too long command line on Windows...

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -40,10 +40,10 @@ dependencies {
 	jmh("junit:junit")
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 jmh {
-	jmhVersion = "jmh".v
+	jmhVersion = "jmh".version
 
 	duplicateClassesStrategy = DuplicatesStrategy.WARN
 	fork = 0 // Too long command line on Windows...

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -40,8 +40,10 @@ dependencies {
 	jmh("junit:junit")
 }
 
+val String.v: String get() = rootProject.extra["$this.version"] as String
+
 jmh {
-	jmhVersion = Versions.jmh
+	jmhVersion = "jmh".v
 
 	duplicateClassesStrategy = DuplicatesStrategy.WARN
 	fork = 0 // Too long command line on Windows...

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 		because("it provides convenience methods to handle process output")
 		exclude(group = "org.junit.platform", module = "junit-platform-launcher")
 	}
-	testImplementation("biz.aQute.bnd:biz.aQute.bndlib:${Versions.bnd}") {
+	testImplementation("biz.aQute.bnd:biz.aQute.bndlib") {
 		because("parsing OSGi metadata")
 	}
 	testRuntimeOnly("com.tngtech.archunit:archunit-junit5-engine") {
@@ -38,6 +38,8 @@ dependencies {
 		because("provide appropriate SLF4J binding")
 	}
 }
+
+val String.v: String get() = rootProject.extra["$this.version"] as String
 
 tasks.test {
 	inputs.dir("projects")
@@ -69,10 +71,10 @@ tasks.test {
 		// systemProperty("junit.jupiter.execution.parallel.enabled", "true")
 
 		// Pass version constants (declared in Versions.kt) to tests as system properties
-		systemProperty("Versions.apiGuardian", Versions.apiGuardian)
-		systemProperty("Versions.assertJ", Versions.assertJ)
-		systemProperty("Versions.junit4", Versions.junit4)
-		systemProperty("Versions.ota4j", Versions.ota4j)
+		systemProperty("Versions.apiGuardian", "apiguardian-api".v)
+		systemProperty("Versions.assertJ", "assertj".v)
+		systemProperty("Versions.junit4", "junit4".v)
+		systemProperty("Versions.ota4j", "opentest4j".v)
 		jvmArgumentProviders += MavenRepo(tempRepoDir)
 	}
 

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 	}
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
+val String.version: String get() = rootProject.extra["$this.version"] as String
 
 tasks.test {
 	inputs.dir("projects")
@@ -71,10 +71,10 @@ tasks.test {
 		// systemProperty("junit.jupiter.execution.parallel.enabled", "true")
 
 		// Pass version constants (declared in Versions.kt) to tests as system properties
-		systemProperty("Versions.apiGuardian", "apiguardian-api".v)
-		systemProperty("Versions.assertJ", "assertj".v)
-		systemProperty("Versions.junit4", "junit4".v)
-		systemProperty("Versions.ota4j", "opentest4j".v)
+		systemProperty("Versions.apiGuardian", "apiguardian-api".version)
+		systemProperty("Versions.assertJ", "assertj".version)
+		systemProperty("Versions.junit4", "junit4".version)
+		systemProperty("Versions.ota4j", "opentest4j".version)
 		jvmArgumentProviders += MavenRepo(tempRepoDir)
 	}
 

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -39,8 +39,6 @@ dependencies {
 	}
 }
 
-val String.version: String get() = rootProject.extra["$this.version"] as String
-
 tasks.test {
 	inputs.dir("projects")
 
@@ -71,10 +69,10 @@ tasks.test {
 		// systemProperty("junit.jupiter.execution.parallel.enabled", "true")
 
 		// Pass version constants (declared in Versions.kt) to tests as system properties
-		systemProperty("Versions.apiGuardian", "apiguardian-api".version)
-		systemProperty("Versions.assertJ", "assertj".version)
-		systemProperty("Versions.junit4", "junit4".version)
-		systemProperty("Versions.ota4j", "opentest4j".version)
+		systemProperty("Versions.apiGuardian", versions.`apiguardian-api`)
+		systemProperty("Versions.assertJ", versions.assertj)
+		systemProperty("Versions.junit4", versions.junit4)
+		systemProperty("Versions.ota4j", versions.opentest4j)
 		jvmArgumentProviders += MavenRepo(tempRepoDir)
 	}
 

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -69,10 +69,10 @@ tasks.test {
 		// systemProperty("junit.jupiter.execution.parallel.enabled", "true")
 
 		// Pass version constants (declared in Versions.kt) to tests as system properties
-		systemProperty("Versions.apiGuardian", versions.`apiguardian-api`)
-		systemProperty("Versions.assertJ", versions.assertj)
-		systemProperty("Versions.junit4", versions.junit4)
-		systemProperty("Versions.ota4j", versions.opentest4j)
+		systemProperty("Versions.apiGuardian", versions["apiguardian-api"])
+		systemProperty("Versions.assertJ", versions["assertj"])
+		systemProperty("Versions.junit4", versions["junit4"])
+		systemProperty("Versions.ota4j", versions["opentest4j"])
 		jvmArgumentProviders += MavenRepo(tempRepoDir)
 	}
 

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -69,10 +69,10 @@ tasks.test {
 		// systemProperty("junit.jupiter.execution.parallel.enabled", "true")
 
 		// Pass version constants (declared in Versions.kt) to tests as system properties
-		systemProperty("Versions.apiGuardian", versions["apiguardian-api"])
+		systemProperty("Versions.apiGuardian", versions.apiguardian)
 		systemProperty("Versions.assertJ", versions["assertj"])
-		systemProperty("Versions.junit4", versions["junit4"])
-		systemProperty("Versions.ota4j", versions["opentest4j"])
+		systemProperty("Versions.junit4", versions.junit4)
+		systemProperty("Versions.ota4j", versions.opentest4j)
 		jvmArgumentProviders += MavenRepo(tempRepoDir)
 	}
 


### PR DESCRIPTION
This reduces Gradle script recompilation, and it enables to specify
dependency versions from the command line.

fixes #2234

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
