### PR TITLE
Allow using DynamicTestExecutor with custom listener

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -29,6 +29,11 @@ on GitHub.
   one to specify a comma-separated list of patterns for deactivating
   `TestExecutionListener` implementations registered via the `ServiceLoader` mechanism.
 * The `@Testable` annotation may now be applied _directly_ to fields.
+* Add `Node.DynamicTestExecutor#execute(TestDescriptor, EngineExecutionListener)` for
+  engines that wish to pass a custom `EngineExecutionListener` and cancel or wait for the
+  execution of a submitted test via the returned `Future`.
+* Add `EngineExecutionListener.NOOP` and change all declared methods to have empty default
+  implementations.
 
 
 [[release-notes-5.7.0-M1-junit-jupiter]]

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineExecutionListener.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineExecutionListener.java
@@ -32,6 +32,12 @@ import org.junit.platform.engine.reporting.ReportEntry;
 public interface EngineExecutionListener {
 
 	/**
+	 * No-op implementation of {@code EngineExecutionListener}
+	 */
+	EngineExecutionListener NOOP = new EngineExecutionListener() {
+	};
+
+	/**
 	 * Must be called when a new, dynamic {@link TestDescriptor} has been
 	 * registered.
 	 *
@@ -41,7 +47,8 @@ public interface EngineExecutionListener {
 	 * @param testDescriptor the descriptor of the newly registered test
 	 * or container
 	 */
-	void dynamicTestRegistered(TestDescriptor testDescriptor);
+	default void dynamicTestRegistered(TestDescriptor testDescriptor) {
+	}
 
 	/**
 	 * Must be called when the execution of a leaf or subtree of the test tree
@@ -59,7 +66,8 @@ public interface EngineExecutionListener {
 	 * @param reason a human-readable message describing why the execution
 	 * has been skipped
 	 */
-	void executionSkipped(TestDescriptor testDescriptor, String reason);
+	default void executionSkipped(TestDescriptor testDescriptor, String reason) {
+	}
 
 	/**
 	 * Must be called when the execution of a leaf or subtree of the test tree
@@ -78,7 +86,8 @@ public interface EngineExecutionListener {
 	 *
 	 * @param testDescriptor the descriptor of the started test or container
 	 */
-	void executionStarted(TestDescriptor testDescriptor);
+	default void executionStarted(TestDescriptor testDescriptor) {
+	}
 
 	/**
 	 * Must be called when the execution of a leaf or subtree of the test tree
@@ -106,7 +115,8 @@ public interface EngineExecutionListener {
 	 *
 	 * @see TestExecutionResult
 	 */
-	void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult);
+	default void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
+	}
 
 	/**
 	 * Can be called for any {@link TestDescriptor} in order to publish additional
@@ -124,6 +134,7 @@ public interface EngineExecutionListener {
 	 * the reporting entry belongs
 	 * @param entry a {@code ReportEntry} instance to be published
 	 */
-	void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry);
+	default void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
+	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -284,7 +284,8 @@ public interface Node<C extends EngineExecutionContext> {
 		/**
 		 * Submit a dynamic test descriptor for immediate execution.
 		 *
-		 * @param testDescriptor the test descriptor to be executed
+		 * @param testDescriptor the test descriptor to be executed; never
+		 * {@code null}
 		 */
 		void execute(TestDescriptor testDescriptor);
 
@@ -292,8 +293,10 @@ public interface Node<C extends EngineExecutionContext> {
 		 * Submit a dynamic test descriptor for immediate execution with a
 		 * custom, potentially no-op, execution listener.
 		 *
-		 * @param testDescriptor the test descriptor to be executed
-		 * @param executionListener the executionListener to be notified
+		 * @param testDescriptor the test descriptor to be executed; never
+		 * {@code null}
+		 * @param executionListener the executionListener to be notified; never
+		 * {@code null}
 		 * @return a future to cancel or wait for the execution
 		 * @see EngineExecutionListener#NOOP
 		 * @since 5.7

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -16,9 +16,11 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Future;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.ToStringBuilder;
+import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 
@@ -285,6 +287,19 @@ public interface Node<C extends EngineExecutionContext> {
 		 * @param testDescriptor the test descriptor to be executed
 		 */
 		void execute(TestDescriptor testDescriptor);
+
+		/**
+		 * Submit a dynamic test descriptor for immediate execution with a
+		 * custom, potentially no-op, execution listener.
+		 *
+		 * @param testDescriptor the test descriptor to be executed
+		 * @param executionListener the executionListener to be notified
+		 * @return a future to cancel or wait for the execution
+		 * @see EngineExecutionListener#NOOP
+		 * @since 5.7
+		 */
+		@API(status = EXPERIMENTAL, since = "5.7")
+		Future<?> execute(TestDescriptor testDescriptor, EngineExecutionListener executionListener);
 
 		/**
 		 * Block until all dynamic test descriptors submitted to this executor

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTaskContext.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTaskContext.java
@@ -30,6 +30,13 @@ class NodeTestTaskContext {
 		this.executionAdvisor = executionAdvisor;
 	}
 
+	NodeTestTaskContext withListener(EngineExecutionListener listener) {
+		if (this.listener == listener) {
+			return this;
+		}
+		return new NodeTestTaskContext(listener, executorService, throwableCollectorFactory, executionAdvisor);
+	}
+
 	EngineExecutionListener getListener() {
 		return listener;
 	}

--- a/junit-platform-launcher/src/testFixtures/java/org/junit/platform/launcher/core/ConfigurationParametersFactoryForTests.java
+++ b/junit-platform-launcher/src/testFixtures/java/org/junit/platform/launcher/core/ConfigurationParametersFactoryForTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import java.util.Map;
+
+import org.junit.platform.engine.ConfigurationParameters;
+
+public class ConfigurationParametersFactoryForTests {
+
+	private ConfigurationParametersFactoryForTests() {
+	}
+
+	public static ConfigurationParameters create(Map<String, String> configParams) {
+		return new LauncherConfigurationParameters(configParams, "/dev/null");
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -590,7 +590,7 @@ class HierarchicalTestExecutorTests {
 		}
 
 		verify(listener).executionFinished(child, successful());
-		assertTrue(interrupted.get(), "child was interrupted");
+		assertTrue(interrupted.get(), "dynamic node was interrupted");
 	}
 
 	private Answer<Object> execute(TestDescriptor dynamicChild) {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -14,21 +14,31 @@ import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
 import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
 import static org.junit.platform.engine.TestExecutionResult.Status.SUCCESSFUL;
+import static org.junit.platform.engine.TestExecutionResult.successful;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
@@ -37,6 +47,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode;
 import org.junit.platform.engine.support.hierarchical.Node.DynamicTestExecutor;
+import org.junit.platform.launcher.core.ConfigurationParametersFactoryForTests;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -64,8 +75,14 @@ class HierarchicalTestExecutorTests {
 
 	@BeforeEach
 	void init() {
+		executor = createExecutor(new SameThreadHierarchicalTestExecutorService());
+	}
+
+	private HierarchicalTestExecutor<MyEngineExecutionContext> createExecutor(
+			HierarchicalTestExecutorService executorService) {
 		ExecutionRequest request = new ExecutionRequest(root, listener, null);
-		executor = new MyExecutor(request, rootContext);
+		return new HierarchicalTestExecutor<>(request, rootContext, executorService,
+			OpenTest4JAwareThrowableCollector::new);
 	}
 
 	@Test
@@ -437,11 +454,7 @@ class HierarchicalTestExecutorTests {
 		MyLeaf child = spy(new MyLeaf(leafUniqueId));
 		MyLeaf dynamicTestDescriptor = spy(new MyLeaf(leafUniqueId.append("dynamic", "child")));
 
-		when(child.execute(any(), any())).thenAnswer(invocation -> {
-			DynamicTestExecutor dynamicTestExecutor = invocation.getArgument(1);
-			dynamicTestExecutor.execute(dynamicTestDescriptor);
-			return invocation.getArgument(0);
-		});
+		when(child.execute(any(), any())).thenAnswer(execute(dynamicTestDescriptor));
 		root.addChild(child);
 
 		InOrder inOrder = inOrder(listener, root, child, dynamicTestDescriptor);
@@ -477,8 +490,8 @@ class HierarchicalTestExecutorTests {
 		MyLeaf dynamicLeaf = spy(new MyLeaf(dynamicContainerAndTest.getUniqueId().append("test", "dynamicLeaf")));
 
 		root.addChild(child);
-		when(child.execute(any(), any())).thenAnswer(registerAndExecute(dynamicContainerAndTest));
-		when(dynamicContainerAndTest.execute(any(), any())).thenAnswer(registerAndExecute(dynamicLeaf));
+		when(child.execute(any(), any())).thenAnswer(execute(dynamicContainerAndTest));
+		when(dynamicContainerAndTest.execute(any(), any())).thenAnswer(execute(dynamicLeaf));
 		when(dynamicLeaf.execute(any(), any())).thenAnswer(invocation -> {
 			throw new AssertionError("test fails");
 		});
@@ -516,10 +529,77 @@ class HierarchicalTestExecutorTests {
 			FAILED, SUCCESSFUL, SUCCESSFUL);
 	}
 
-	private Answer<Object> registerAndExecute(TestDescriptor dynamicChild) {
+	@Test
+	void executesDynamicTestDescriptorsWithCustomListener() {
+
+		UniqueId leafUniqueId = UniqueId.root("leaf", "child leaf");
+		MyLeaf child = spy(new MyLeaf(leafUniqueId));
+		MyLeaf dynamicTestDescriptor = spy(new MyLeaf(leafUniqueId.append("dynamic", "child")));
+		root.addChild(child);
+
+		EngineExecutionListener anotherListener = mock(EngineExecutionListener.class);
+		when(child.execute(any(), any())).thenAnswer(
+			useDynamicTestExecutor(executor -> executor.execute(dynamicTestDescriptor, anotherListener)));
+
+		executor.execute();
+
+		InOrder inOrder = inOrder(listener, anotherListener, root, child, dynamicTestDescriptor);
+		inOrder.verify(anotherListener).dynamicTestRegistered(dynamicTestDescriptor);
+		inOrder.verify(anotherListener).executionStarted(dynamicTestDescriptor);
+		inOrder.verify(dynamicTestDescriptor).execute(eq(rootContext), any());
+		inOrder.verify(dynamicTestDescriptor).nodeFinished(rootContext, dynamicTestDescriptor, successful());
+		inOrder.verify(anotherListener).executionFinished(dynamicTestDescriptor, successful());
+	}
+
+	@Test
+	void canAbortExecutionOfDynamicChild() throws Exception {
+
+		UniqueId leafUniqueId = UniqueId.root("leaf", "child leaf");
+		MyLeaf child = spy(new MyLeaf(leafUniqueId));
+		MyLeaf dynamicTestDescriptor = spy(new MyLeaf(leafUniqueId.append("dynamic", "child")));
+		root.addChild(child);
+
+		CountDownLatch startedLatch = new CountDownLatch(1);
+		AtomicBoolean interrupted = new AtomicBoolean();
+
+		when(child.execute(any(), any())).thenAnswer(useDynamicTestExecutor(executor -> {
+			Future<?> future = executor.execute(dynamicTestDescriptor, EngineExecutionListener.NOOP);
+			startedLatch.await();
+			future.cancel(true);
+			executor.awaitFinished();
+		}));
+		when(dynamicTestDescriptor.execute(any(), any())).thenAnswer(invocation -> {
+			startedLatch.countDown();
+			try {
+				new CountDownLatch(1).await(); // block until interrupted
+				return null;
+			}
+			catch (InterruptedException e) {
+				interrupted.set(true);
+				throw e;
+			}
+		});
+
+		ConfigurationParameters parameters = ConfigurationParametersFactoryForTests.create(Map.of(//
+			DefaultParallelExecutionConfigurationStrategy.CONFIG_STRATEGY_PROPERTY_NAME, "fixed", //
+			DefaultParallelExecutionConfigurationStrategy.CONFIG_FIXED_PARALLELISM_PROPERTY_NAME, "2"));
+
+		try (var executorService = new ForkJoinPoolHierarchicalTestExecutorService(parameters)) {
+			createExecutor(executorService).execute().get();
+		}
+
+		verify(listener).executionFinished(child, successful());
+		assertTrue(interrupted.get(), "child was interrupted");
+	}
+
+	private Answer<Object> execute(TestDescriptor dynamicChild) {
+		return useDynamicTestExecutor(executor -> executor.execute(dynamicChild));
+	}
+
+	private Answer<Object> useDynamicTestExecutor(ThrowingConsumer<DynamicTestExecutor> action) {
 		return invocation -> {
 			DynamicTestExecutor dynamicTestExecutor = invocation.getArgument(1);
-			dynamicTestExecutor.execute(dynamicChild);
+			action.accept(dynamicTestExecutor);
 			return invocation.getArgument(0);
 		};
 	}
@@ -585,11 +665,7 @@ class HierarchicalTestExecutorTests {
 		when(dynamicTestDescriptor.getExclusiveResources()).thenReturn(
 			singleton(new ExclusiveResource("foo", LockMode.READ)));
 
-		when(child.execute(any(), any())).thenAnswer(invocation -> {
-			DynamicTestExecutor dynamicTestExecutor = invocation.getArgument(1);
-			dynamicTestExecutor.execute(dynamicTestDescriptor);
-			return invocation.getArgument(0);
-		});
+		when(child.execute(any(), any())).thenAnswer(execute(dynamicTestDescriptor));
 		root.addChild(child);
 
 		executor.execute();
@@ -674,14 +750,6 @@ class HierarchicalTestExecutorTests {
 		@Override
 		public Type getType() {
 			return Type.CONTAINER_AND_TEST;
-		}
-	}
-
-	private static class MyExecutor extends HierarchicalTestExecutor<MyEngineExecutionContext> {
-
-		MyExecutor(ExecutionRequest request, MyEngineExecutionContext rootContext) {
-			super(request, rootContext, new SameThreadHierarchicalTestExecutorService(),
-				OpenTest4JAwareThrowableCollector::new);
 		}
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -30,9 +30,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -559,8 +559,8 @@ class HierarchicalTestExecutorTests {
 		MyLeaf dynamicTestDescriptor = spy(new MyLeaf(leafUniqueId.append("dynamic", "child")));
 		root.addChild(child);
 
-		CountDownLatch startedLatch = new CountDownLatch(1);
-		AtomicBoolean interrupted = new AtomicBoolean();
+		var startedLatch = new CountDownLatch(1);
+		var interrupted = new CompletableFuture<Boolean>();
 
 		when(child.execute(any(), any())).thenAnswer(useDynamicTestExecutor(executor -> {
 			Future<?> future = executor.execute(dynamicTestDescriptor, EngineExecutionListener.NOOP);
@@ -572,10 +572,11 @@ class HierarchicalTestExecutorTests {
 			startedLatch.countDown();
 			try {
 				new CountDownLatch(1).await(); // block until interrupted
+				interrupted.complete(false);
 				return null;
 			}
 			catch (InterruptedException e) {
-				interrupted.set(true);
+				interrupted.complete(true);
 				throw e;
 			}
 		});


### PR DESCRIPTION
- Add `Node.DynamicTestExecutor#execute(TestDescriptor,
  EngineExecutionListener)` for engines that wish to pass a custom
  `EngineExecutionListener` and cancel or wait for the execution of a
  submitted test via the returned `Future`.
- Add `EngineExecutionListener.NOOP` and change all declared methods to
  have empty default implementations.

Resolves #2188.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
