### PR TITLE
Avoid inner class cycle detection for non-matching predicate

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestClassWithTestsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestClassWithTestsTests.java
@@ -84,6 +84,15 @@ class IsTestClassWithTestsTests {
 		assertFalse(isTestClassWithTests.test(PrivateStaticTestCase.class));
 	}
 
+	/**
+	 * @see https://github.com/junit-team/junit5/issues/2249
+	 */
+	@Test
+	void recursiveHierarchies() {
+		assertTrue(isTestClassWithTests.test(OuterClass.class));
+		assertFalse(isTestClassWithTests.test(OuterClass.RecursiveInnerClass.class));
+	}
+
 	// -------------------------------------------------------------------------
 
 	private class PrivateClassWithTestMethod {
@@ -140,6 +149,22 @@ class IsTestClassWithTestsTests {
 
 		@Test
 		void test() {
+		}
+	}
+
+	static class OuterClass {
+
+		@Nested
+		class InnerClass {
+
+			@Test
+			void test() {
+			}
+		}
+
+		// Intentionally commented out so that RecursiveInnerClass is NOT a candidate test class
+		// @Nested
+		class RecursiveInnerClass extends OuterClass {
 		}
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -690,6 +690,14 @@ class ReflectionUtilsTests {
 		assertThat(findNestedClasses(AbstractOuterClass.class))//
 				.containsExactly(AbstractOuterClass.InnerClass.class);
 
+		// OuterClass contains recursive hierarchies, but the non-matching
+		// predicate should prevent cycle detection.
+		// See https://github.com/junit-team/junit5/issues/2249
+		assertThat(ReflectionUtils.findNestedClasses(OuterClass.class, clazz -> false)).isEmpty();
+		// RecursiveInnerInnerClass is part of a recursive hierarchy, but the non-matching
+		// predicate should prevent cycle detection.
+		assertThat(ReflectionUtils.findNestedClasses(RecursiveInnerInnerClass.class, clazz -> false)).isEmpty();
+
 		// Sibling types don't actually result in cycles.
 		assertThat(findNestedClasses(StaticNestedSiblingClass.class))//
 				.containsExactly(AbstractOuterClass.InnerClass.class);


### PR DESCRIPTION
This PR is incomplete with regard to documentation in the release notes, but it is ready for peer review.

Fixes #2249 

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
