### PR TITLE
Fix selecting Spock methods via MethodSelector

### DIFF
--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -32,5 +32,6 @@ dependencies {
 		api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions["kotlinx-coroutines-core"]}")
 		api("org.mockito:mockito-junit-jupiter:${versions["mockito"]}")
 		api("biz.aQute.bnd:biz.aQute.bndlib:${versions["bnd"]}")
+		api("org.spockframework:spock-core:${versions["spock"]}")
 	}
 }

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -43,7 +43,8 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* The Jupiter engine now ignores `MethodSelectors` for methods in non-Jupiter test
+  classes instead of failing for missing methods in such cases.
 
 ==== Deprecations and Breaking Changes
 

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -77,7 +77,9 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* The Vintage engine no longer fails when resolving a `MethodSelector` for methods of test
+  classes that cannot be found via reflection. This allows selecting Spock feature methods
+  by their source code name even though they have a generated method name in the bytecode.
 
 ==== Deprecations and Breaking Changes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,6 +39,7 @@ groovy.version=3.0.2
 log4j.version=2.13.1
 mockito.version=3.3.3
 slf4j.version=1.7.30
+spock.version=1.3-groovy-2.5
 
 # Tools
 checkstyle.version=8.31

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -109,6 +109,15 @@ class DiscoverySelectorResolverTests {
 	}
 
 	@Test
+	void doesNotAttemptToResolveMethodsForNonTestClasses() {
+		var methodSelector = selectMethod(NonTestClass.class, "doesNotExist");
+		resolve(request().selectors(methodSelector));
+
+		assertTrue(engineDescriptor.getDescendants().isEmpty());
+		assertUnresolved(methodSelector);
+	}
+
+	@Test
 	void abstractClassResolution() {
 		resolve(request().selectors(selectClass(AbstractTestClass.class)));
 

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -3,6 +3,8 @@ import aQute.bnd.gradle.BundleTaskConvention;
 plugins {
 	`java-library-conventions`
 	`junit4-compatibility`
+	`java-test-fixtures`
+	groovy
 }
 
 apply(from = "$rootDir/gradle/testing.gradle.kts")
@@ -17,9 +19,20 @@ dependencies {
 	api(project(":junit-platform-engine"))
 	api("junit:junit")
 
+	testFixturesApi("org.spockframework:spock-core")
+
 	testImplementation(project(":junit-platform-launcher"))
 	testImplementation(project(":junit-platform-runner"))
 	testImplementation(project(":junit-platform-testkit"))
+}
+
+configurations.all {
+	resolutionStrategy.eachDependency {
+		if (requested.group == "org.codehaus.groovy") {
+			useVersion("2.5.11")
+			because("Spock is not yet compatible with Groovy 3.x")
+		}
+	}
 }
 
 tasks {

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
@@ -15,7 +15,6 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqu
 import static org.junit.platform.engine.support.discovery.SelectorResolver.Resolution.unresolved;
 import static org.junit.vintage.engine.descriptor.VintageTestDescriptor.SEGMENT_TYPE_RUNNER;
 
-import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -74,8 +73,8 @@ class MethodSelectorResolver implements SelectorResolver {
 
 	private Filter toMethodFilter(MethodSelector methodSelector) {
 		Class<?> testClass = methodSelector.getJavaClass();
-		Method testMethod = methodSelector.getJavaMethod();
-		return matchMethodDescription(Description.createTestDescription(testClass, testMethod.getName()));
+		String methodName = methodSelector.getMethodName();
+		return matchMethodDescription(Description.createTestDescription(testClass, methodName));
 	}
 
 	private Filter toUniqueIdFilter(RunnerTestDescriptor runnerTestDescriptor, UniqueId uniqueId) {

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
@@ -12,6 +12,7 @@ package org.junit.vintage.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.testkit.engine.EventConditions.abortedWithReason;
 import static org.junit.platform.testkit.engine.EventConditions.container;
@@ -84,6 +85,7 @@ import org.junit.vintage.engine.samples.junit4.PlainJUnit4TestCaseWithLifecycleM
 import org.junit.vintage.engine.samples.junit4.PlainJUnit4TestCaseWithSingleTestWhichFails;
 import org.junit.vintage.engine.samples.junit4.PlainJUnit4TestCaseWithSingleTestWhichIsIgnored;
 import org.junit.vintage.engine.samples.junit4.PlainJUnit4TestCaseWithTwoTestMethods;
+import org.junit.vintage.engine.samples.spock.SpockTestCaseWithUnrolledAndRegularFeatureMethods;
 import org.opentest4j.MultipleFailuresError;
 
 /**
@@ -745,6 +747,37 @@ class VintageTestEngineExecutionTests {
 			event(test("1"), started()), //
 			event(test("1"), finishedSuccessfully()), //
 			event(container("2nd"), finishedSuccessfully()), //
+			event(container(testClass), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void executesUnrolledSpockFeatureMethod() {
+		Class<?> testClass = SpockTestCaseWithUnrolledAndRegularFeatureMethods.class;
+		var request = LauncherDiscoveryRequestBuilder.request().selectors(
+			selectMethod(testClass, "unrolled feature for #input")).build();
+		execute(request).allEvents().assertEventsMatchExactly( //
+			event(engine(), started()), //
+			event(uniqueIdSubstring(testClass.getName()), started()), //
+			event(dynamicTestRegistered("unrolled feature for 23")), //
+			event(test("unrolled feature for 23"), started()), //
+			event(test("unrolled feature for 23"), finishedWithFailure()), //
+			event(dynamicTestRegistered("unrolled feature for 42")), //
+			event(test("unrolled feature for 42"), started()), //
+			event(test("unrolled feature for 42"), finishedSuccessfully()), //
+			event(uniqueIdSubstring(testClass.getName()), finishedSuccessfully()), //
+			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void executesRegularSpockFeatureMethod() {
+		Class<?> testClass = SpockTestCaseWithUnrolledAndRegularFeatureMethods.class;
+		var request = LauncherDiscoveryRequestBuilder.request().selectors(selectMethod(testClass, "regular")).build();
+		execute(request).allEvents().assertEventsMatchExactly( //
+			event(engine(), started()), //
+			event(container(testClass), started()), //
+			event(test("regular"), started()), //
+			event(test("regular"), finishedSuccessfully()), //
 			event(container(testClass), finishedSuccessfully()), //
 			event(engine(), finishedSuccessfully()));
 	}

--- a/junit-vintage-engine/src/testFixtures/groovy/org/junit/vintage/engine/samples/spock/SpockTestCaseWithUnrolledAndRegularFeatureMethods.groovy
+++ b/junit-vintage-engine/src/testFixtures/groovy/org/junit/vintage/engine/samples/spock/SpockTestCaseWithUnrolledAndRegularFeatureMethods.groovy
@@ -1,0 +1,20 @@
+package org.junit.vintage.engine.samples.spock
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SpockTestCaseWithUnrolledAndRegularFeatureMethods extends Specification {
+
+    @Unroll
+    def "unrolled feature for #input"() {
+        expect:
+        input == 42
+        where:
+        input << [23, 42]
+    }
+
+    def "regular"() {
+        expect:
+        true
+    }
+}


### PR DESCRIPTION
## Overview

Spock uses a Groovy AST transform to generate methods during compilation. Thus, `MethodSelector.getJavaMethod()` always threw an exception when selecting a test method by its name in the source code. Thus, the Vintage engine now uses `MethodSelector.getMethodName()` instead of `MethodSelector.getJavaMethod().getName()` which is then correctly used by Spock's Runner for filtering as demonstrated by the added integration test. Moreover, when both Vintage and Jupiter are present, such a `MethodSelector` caused the Jupiter engine to fail during discovery because it could not resolve `MethodSelector.getJavaMethod()` either. Its `MethodSelectorResolver` now checks if a test class is a Jupiter test class before making that call.

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
