### PR TITLE
Add potentially failing use-case of #2171

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.io.TempDir;
@@ -86,6 +88,14 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 	@DisplayName("is capable of removal of a read-only file")
 	void nonWritableFileDoesNotCauseFailureTestCase() {
 		executeTestsForClass(NonWritableFileDoesNotCauseFailureTestCase.class).testEvents()//
+				.assertStatistics(stats -> stats.started(1).succeeded(1));
+	}
+
+	@Test
+	@DisplayName("is capable of removal of a read-only directory")
+	@DisabledOnOs(OS.WINDOWS)
+	void nonWritableDirectoryDoesNotCauseFailureTestCase() {
+		executeTestsForClass(NonWritableDirectoryDoesNotCauseFailureTestCase.class).testEvents()//
 				.assertStatistics(stats -> stats.started(1).succeeded(1));
 	}
 
@@ -776,6 +786,18 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 			var path = Files.write(tempDir.resolve("test.txt"), new byte[0]);
 			assumeTrue(path.toFile().setWritable(false),
 				() -> "Unable to set file " + path + " readonly via .toFile().setWritable(false)");
+		}
+
+	}
+
+	// https://github.com/junit-team/junit5/issues/2171
+	static class NonWritableDirectoryDoesNotCauseFailureTestCase {
+
+		@Test
+		void createReadonlyDirectory(@TempDir Path tempDir) throws IOException {
+			var dir = Files.createDirectories(tempDir.resolve("dir"));
+			assumeTrue(dir.toFile().setWritable(false),
+				() -> "Unable to set directory " + dir + " readonly via .toFile().setWritable(false)");
 		}
 
 	}


### PR DESCRIPTION
## Overview

> "[...] any read-only directory in the tree causes cleanup to fail."

Issue #2171

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
