### PR TITLE
Delete files in read-only dirs by making them writable

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M1.adoc
@@ -43,6 +43,7 @@ on GitHub.
 
 ==== Bug Fixes
 
+* `@TempDir` is now able to clean up files in read-only directories.
 * The Jupiter engine now ignores `MethodSelectors` for methods in non-Jupiter test
   classes instead of failing for missing methods in such cases.
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -219,18 +219,25 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 				private void makeWritableAndTryToDeleteAgain(Path path, IOException exception) {
 					try {
-						Path relativePath = dir.relativize(path);
-						Path parent = dir;
-						for (int i = 0; i < relativePath.getNameCount(); i++) {
-							makeWritable(parent);
-							parent = parent.resolve(relativePath.getName(i));
-						}
+						tryToMakeParentDirsWritable(path);
 						makeWritable(path);
 						Files.delete(path);
 					}
 					catch (Exception suppressed) {
 						exception.addSuppressed(suppressed);
 						failures.put(path, exception);
+					}
+				}
+
+				private void tryToMakeParentDirsWritable(Path path) {
+					Path relativePath = dir.relativize(path);
+					Path parent = dir;
+					for (int i = 0; i < relativePath.getNameCount(); i++) {
+						boolean writable = parent.toFile().setWritable(true);
+						if (!writable) {
+							break;
+						}
+						parent = parent.resolve(relativePath.getName(i));
 					}
 				}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -219,6 +219,12 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 				private void makeWritableAndTryToDeleteAgain(Path path, IOException exception) {
 					try {
+						Path relativePath = dir.relativize(path);
+						Path parent = dir;
+						for (int i = 0; i < relativePath.getNameCount(); i++) {
+							makeWritable(parent);
+							parent = parent.resolve(relativePath.getName(i));
+						}
 						makeWritable(path);
 						Files.delete(path);
 					}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.io.TempDir;
@@ -90,6 +92,7 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	@DisabledOnOs(OS.WINDOWS)
 	@DisplayName("is capable of removal of a read-only file in a read-only dir")
 	void readOnlyFileInReadOnlyDirDoesNotCauseFailure() {
 		executeTestsForClass(ReadOnlyFileInReadOnlyDirDoesNotCauseFailureTestCase.class).testEvents()//
@@ -97,6 +100,7 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	@DisabledOnOs(OS.WINDOWS)
 	@DisplayName("is capable of removal of a read-only file in a dir in a read-only dir")
 	void readOnlyFileInNestedReadOnlyDirDoesNotCauseFailure() {
 		executeTestsForClass(ReadOnlyFileInDirInReadOnlyDirDoesNotCauseFailureTestCase.class).testEvents()//

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -84,8 +84,22 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	@DisplayName("is capable of removal of a read-only file")
-	void nonWritableFileDoesNotCauseFailureTestCase() {
+	void nonWritableFileDoesNotCauseFailure() {
 		executeTestsForClass(NonWritableFileDoesNotCauseFailureTestCase.class).testEvents()//
+				.assertStatistics(stats -> stats.started(1).succeeded(1));
+	}
+
+	@Test
+	@DisplayName("is capable of removal of a read-only file in a read-only dir")
+	void readOnlyFileInReadOnlyDirDoesNotCauseFailure() {
+		executeTestsForClass(ReadOnlyFileInReadOnlyDirDoesNotCauseFailureTestCase.class).testEvents()//
+				.assertStatistics(stats -> stats.started(1).succeeded(1));
+	}
+
+	@Test
+	@DisplayName("is capable of removal of a read-only file in a dir in a read-only dir")
+	void readOnlyFileInNestedReadOnlyDirDoesNotCauseFailure() {
+		executeTestsForClass(ReadOnlyFileInDirInReadOnlyDirDoesNotCauseFailureTestCase.class).testEvents()//
 				.assertStatistics(stats -> stats.started(1).succeeded(1));
 	}
 
@@ -776,6 +790,34 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 			var path = Files.write(tempDir.resolve("test.txt"), new byte[0]);
 			assumeTrue(path.toFile().setWritable(false),
 				() -> "Unable to set file " + path + " readonly via .toFile().setWritable(false)");
+		}
+
+	}
+
+	// https://github.com/junit-team/junit5/issues/2171
+	static class ReadOnlyFileInReadOnlyDirDoesNotCauseFailureTestCase {
+
+		@Test
+		void createReadOnlyFileInReadOnlyDir(@TempDir File tempDir) throws IOException {
+			File file = tempDir.toPath().resolve("file").toFile();
+			assumeTrue(file.createNewFile());
+			assumeTrue(tempDir.setReadOnly());
+			assumeTrue(file.setReadOnly());
+		}
+
+	}
+
+	// https://github.com/junit-team/junit5/issues/2171
+	static class ReadOnlyFileInDirInReadOnlyDirDoesNotCauseFailureTestCase {
+
+		@Test
+		void createReadOnlyFileInReadOnlyDir(@TempDir File tempDir) throws IOException {
+			File file = tempDir.toPath().resolve("dir").resolve("file").toFile();
+			assumeTrue(file.getParentFile().mkdirs());
+			assumeTrue(file.createNewFile());
+			assumeTrue(tempDir.setReadOnly());
+			assumeTrue(file.getParentFile().setReadOnly());
+			assumeTrue(file.setReadOnly());
 		}
 
 	}


### PR DESCRIPTION
Fixes #2171.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
