### PR TITLE
WIP: Class-based platform-suites from experiments/platform-suites based on 5.6.0

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -38,7 +38,7 @@ public class UniqueId implements Cloneable, Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private static final String ENGINE_SEGMENT_TYPE = "engine";
+	public static final String ENGINE_SEGMENT_TYPE = "engine";
 
 	/**
 	 * Parse a {@code UniqueId} from the supplied string representation using the

--- a/junit-platform-launcher/junit-platform-launcher.gradle.kts
+++ b/junit-platform-launcher/junit-platform-launcher.gradle.kts
@@ -11,4 +11,6 @@ dependencies {
 	api("org.apiguardian:apiguardian-api:${Versions.apiGuardian}")
 
 	api(project(":junit-platform-engine"))
+
+	implementation(project(":junit-platform-suite-api"))
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
@@ -10,10 +10,12 @@
 
 package org.junit.platform.launcher.core;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.logging.Logger;
@@ -29,22 +31,23 @@ class InternalTestPlan extends TestPlan {
 	private static final Logger logger = LoggerFactory.getLogger(InternalTestPlan.class);
 
 	private final AtomicBoolean warningEmitted = new AtomicBoolean(false);
-	private final Root root;
+	private final List<Root> roots;
 	private final TestPlan delegate;
 
-	static InternalTestPlan from(Root root) {
-		TestPlan delegate = TestPlan.from(root.getEngineDescriptors());
-		return new InternalTestPlan(root, delegate);
+	static InternalTestPlan from(List<Root> roots) {
+		TestPlan delegate = TestPlan.from(roots.parallelStream().flatMap(
+				root -> root.getEngineDescriptors().stream()).collect(Collectors.toList()));
+		return new InternalTestPlan(roots, delegate);
 	}
 
-	private InternalTestPlan(Root root, TestPlan delegate) {
+	private InternalTestPlan(List<Root> roots, TestPlan delegate) {
 		super(delegate.containsTests());
-		this.root = root;
+		this.roots = roots;
 		this.delegate = delegate;
 	}
 
-	Root getRoot() {
-		return root;
+	List<Root> getInternalRoots() {
+		return roots;
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -46,6 +46,10 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 		this.configParamsFromFile = fromClasspathResource(configFileName.trim());
 	}
 
+	Map<String, String> getExplicitConfigParams() {
+		return explicitConfigParams;
+	}
+
 	private static Properties fromClasspathResource(String configFileName) {
 		Properties props = new Properties();
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SuiteDescriptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SuiteDescriptor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+class SuiteDescriptor extends AbstractTestDescriptor {
+
+	SuiteDescriptor(Class<?> suiteClass) {
+		super(UniqueId.root("suite", suiteClass.getName()), determineDisplayName(suiteClass),
+			ClassSource.from(suiteClass));
+	}
+
+	private static String determineDisplayName(Class<?> suiteClass) {
+		return AnnotationSupport.findAnnotation(suiteClass, SuiteDisplayName.class).map(SuiteDisplayName::value).orElse(
+			suiteClass.getName());
+	}
+
+	@Override
+	public Type getType() {
+		return Type.CONTAINER;
+	}
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SuiteDiscoverer.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/SuiteDiscoverer.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
+import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInClasspathRoot;
+import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInModule;
+import static org.junit.platform.commons.util.ReflectionUtils.findAllClassesInPackage;
+import static org.junit.platform.commons.util.ReflectionUtils.isAbstract;
+import static org.junit.platform.commons.util.ReflectionUtils.isInnerClass;
+import static org.junit.platform.commons.util.ReflectionUtils.isPrivate;
+import static org.junit.platform.engine.Filter.composeFilters;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.util.ClassFilter;
+import org.junit.platform.engine.DiscoveryFilter;
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.discovery.ClassNameFilter;
+import org.junit.platform.engine.discovery.ClassSelector;
+import org.junit.platform.engine.discovery.ClasspathRootSelector;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.engine.discovery.ModuleSelector;
+import org.junit.platform.engine.discovery.PackageNameFilter;
+import org.junit.platform.engine.discovery.PackageSelector;
+import org.junit.platform.launcher.EngineFilter;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TagFilter;
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.ExcludeEngines;
+import org.junit.platform.suite.api.ExcludePackages;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludePackages;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+
+class SuiteDiscoverer {
+
+	public List<Root> resolve(LauncherDiscoveryRequest request) {
+		SuiteClassResolver classResolver = new SuiteClassResolver(request);
+		ClassFilter classFilter = buildClassFilter(request, SuiteDiscoverer::isSuiteClass);
+		request.getSelectorsByType(ClasspathRootSelector.class).forEach(selector -> {
+			findAllClassesInClasspathRoot(selector.getClasspathRoot(), classFilter).forEach(
+				classResolver::resolveClass);
+		});
+		request.getSelectorsByType(ModuleSelector.class).forEach(selector -> {
+			findAllClassesInModule(selector.getModuleName(), classFilter).forEach(classResolver::resolveClass);
+		});
+		request.getSelectorsByType(PackageSelector.class).forEach(selector -> {
+			findAllClassesInPackage(selector.getPackageName(), classFilter).forEach(classResolver::resolveClass);
+		});
+		request.getSelectorsByType(ClassSelector.class).forEach(selector -> {
+			classResolver.resolveClass(selector.getJavaClass());
+		});
+		return classResolver.requests;
+	}
+
+	// start TODO
+	// use org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver instead of
+	// copied (deprecated) utility methods from org.junit.platform.engine.support.filter.ClasspathScanningSupport
+
+	/**
+	 * Build a {@link Predicate} for fully qualified class names to be used for
+	 * classpath scanning from an {@link EngineDiscoveryRequest}.
+	 *
+	 * @param request the request to build a predicate from
+	 */
+	public static Predicate<String> buildClassNamePredicate(EngineDiscoveryRequest request) {
+		List<DiscoveryFilter<String>> filters = new ArrayList<>();
+		filters.addAll(request.getFiltersByType(ClassNameFilter.class));
+		filters.addAll(request.getFiltersByType(PackageNameFilter.class));
+		return composeFilters(filters).toPredicate();
+	}
+
+	/**
+	 * Build a {@link ClassFilter} by combining the name predicate built by
+	 * {@link #buildClassNamePredicate(EngineDiscoveryRequest)} and the passed-in
+	 * class predicate.
+	 *
+	 * @param request the request to build a name predicate from
+	 * @param classPredicate the class predicate
+	 */
+	public static ClassFilter buildClassFilter(EngineDiscoveryRequest request, Predicate<Class<?>> classPredicate) {
+		return ClassFilter.of(buildClassNamePredicate(request), classPredicate);
+	}
+
+	// end TODO
+
+	private static boolean isSuiteClass(Class<?> candidate) {
+		// Please do not collapse the following into a single statement.
+		// TODO duplication with IsPotentialTestContainer
+		if (isPrivate(candidate)) {
+			return false;
+		}
+		if (isAbstract(candidate)) {
+			return false;
+		}
+		if (candidate.isLocalClass()) {
+			return false;
+		}
+		if (candidate.isAnonymousClass()) {
+			return false;
+		}
+		if (isInnerClass(candidate)) {
+			return false;
+		}
+		return AnnotationSupport.isAnnotated(candidate, Suite.class);
+	}
+
+	static class SuiteClassResolver {
+		private final List<Root> requests = new ArrayList<>();
+		private final LauncherDiscoveryRequest originalRequest;
+
+		SuiteClassResolver(LauncherDiscoveryRequest originalRequest) {
+			this.originalRequest = originalRequest;
+		}
+
+		void resolveClass(Class<?> javaClass) {
+			if (isSuiteClass(javaClass)) {
+				requests.add(new Root(toRequest(javaClass), new SuiteDescriptor(javaClass)));
+			}
+		}
+
+		private LauncherDiscoveryRequest toRequest(Class<?> javaClass) {
+			LauncherDiscoveryRequestBuilder request = LauncherDiscoveryRequestBuilder.request();
+			// TODO Decide which parameters to copy from original request
+			LauncherConfigurationParameters originalConfigurationParameters = (LauncherConfigurationParameters) originalRequest.getConfigurationParameters();
+			request.configurationParameters(originalConfigurationParameters.getExplicitConfigParams());
+			// @formatter:off
+            findAnnotation(javaClass, SelectClasses.class).map(SelectClasses::value)
+                    .ifPresent(classes -> request.selectors(selectClasses(classes)));
+            findAnnotation(javaClass, SelectPackages.class).map(SelectPackages::value)
+                    .ifPresent(packages -> request.selectors(selectPackages(packages)));
+            findAnnotation(javaClass, ExcludeClassNamePatterns.class).map(ExcludeClassNamePatterns::value)
+                    .ifPresent(patterns -> request.filters(ClassNameFilter.excludeClassNamePatterns(patterns)));
+            findAnnotation(javaClass, IncludeClassNamePatterns.class).map(IncludeClassNamePatterns::value)
+                    .ifPresent(patterns -> request.filters(ClassNameFilter.includeClassNamePatterns(patterns)));
+            findAnnotation(javaClass, ExcludeEngines.class).map(ExcludeEngines::value)
+                    .ifPresent(engineIds -> request.filters(EngineFilter.excludeEngines(engineIds)));
+            findAnnotation(javaClass, IncludeEngines.class).map(IncludeEngines::value)
+                    .ifPresent(engineIds -> request.filters(EngineFilter.includeEngines(engineIds)));
+            findAnnotation(javaClass, ExcludePackages.class).map(ExcludePackages::value)
+                    .ifPresent(packageNames -> request.filters(PackageNameFilter.excludePackageNames(packageNames)));
+            findAnnotation(javaClass, IncludePackages.class).map(IncludePackages::value)
+                    .ifPresent(packageNames -> request.filters(PackageNameFilter.includePackageNames(packageNames)));
+            findAnnotation(javaClass, ExcludeTags.class).map(ExcludeTags::value)
+                    .ifPresent(tagExpressions -> request.filters(TagFilter.excludeTags(tagExpressions)));
+            findAnnotation(javaClass, IncludeTags.class).map(IncludeTags::value)
+                    .ifPresent(tagExpressions -> request.filters(TagFilter.includeTags(tagExpressions)));
+            // @formatter:on
+            return request.build();
+		}
+
+		private List<ClassSelector> selectClasses(Class<?>[] classes) {
+			return Arrays.stream(classes).map(DiscoverySelectors::selectClass).collect(toList());
+		}
+
+		private List<PackageSelector> selectPackages(String[] packages) {
+			return Arrays.stream(packages).map(DiscoverySelectors::selectPackage).collect(toList());
+		}
+	}
+
+}

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/Suite.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/Suite.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.api;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code @Suite} marks a class as a test suite for the JUnit Platform.
+ *
+ * @since 1.7
+ * @see SelectPackages
+ * @see SelectClasses
+ * @see IncludeClassNamePatterns
+ * @see ExcludeClassNamePatterns
+ * @see IncludePackages
+ * @see ExcludePackages
+ * @see IncludeTags
+ * @see ExcludeTags
+ * @see IncludeEngines
+ * @see ExcludeEngines
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@Documented
+@API(status = EXPERIMENTAL, since = "1.7")
+public @interface Suite {
+}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.TestExecutionResult.successful;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.EngineFilter.excludeEngines;
@@ -40,6 +41,7 @@ import java.util.logging.LogRecord;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.fixtures.TrackLogRecords;
+import org.junit.jupiter.engine.JupiterTestEngine;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.JUnitException;
@@ -69,7 +71,11 @@ import org.junit.platform.launcher.PostDiscoveryFilterStub;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.listeners.LoggingListener;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -765,5 +771,31 @@ class DefaultLauncherTests {
 			"Third-party TestEngine '%s' is forbidden to use the reserved '%s' TestEngine ID.",
 			impostor.getClass().getName(), id);
 	}
+
+	@Test
+	void executesSuite() {
+		SummaryGeneratingListener listener = new SummaryGeneratingListener();
+
+		Launcher launcher = createLauncher(new JupiterTestEngine());
+		launcher.execute(request().selectors(selectClass(MyFirstSuite.class)).build(), listener,
+			LoggingListener.forBiConsumer((t, s) -> System.out.println(s.get())));
+
+		assertThat(listener.getSummary()).isNotNull();
+		assertThat(listener.getSummary().getContainersFoundCount()).isEqualTo(4);
+		assertThat(listener.getSummary().getTestsFoundCount()).isEqualTo(1);
+	}
+
+	@Suite
+	@SuiteDisplayName("My 1st JUnit Platform Suite 😎")
+	@SelectClasses(TestCase.class)
+	static class MyFirstSuite {
+	}
+
+	static class TestCase {
+		@Test
+		void test() {
+		}
+	}
+
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/ExecutionListenerAdapterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/ExecutionListenerAdapterTests.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.ReflectionUtils;
@@ -38,7 +39,7 @@ class ExecutionListenerAdapterTests {
 		//cannot mock final classes with mockito
 		Root root = new Root(null);
 		root.add(mock(TestEngine.class), testDescriptor);
-		InternalTestPlan testPlan = InternalTestPlan.from(root);
+		InternalTestPlan testPlan = InternalTestPlan.from(Collections.singletonList(root));
 		TestIdentifier testIdentifier = testPlan.getTestIdentifier(testDescriptor.getUniqueId().toString());
 
 		//not yet spyable with mockito? -> https://github.com/mockito/mockito/issues/146


### PR DESCRIPTION
## Overview

As I would have use of platform-level suites, especially to hold engine-specific configuration, I grabbed the code from experiments/platform-suites and ported it onto platform 1.6.0, adding recursive suite discovery and arbitrary engine configuration.

This is by no means a finished work, nor an original work, but it fulfils my immediate needs, and seems to be in line with some interests for 5.7 (see issue #744).

As this is my first attempt to contribute to this project, I am fully open to any guidance to improve this proposal to hopefully get it integrated.

I did some copy-paste of deprecated method I did not know how to replace, I did not check to coding conventions, nor did I update any documentation: this is a work in progress.

This Works for Me with cucumber-junit-platform-engine, pitest-junit5-plugin, serenity-cucumber5, from maven and eclipse, without visible problems.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
