### PR TITLE
Execute explicitly selected classes regardless of class name filters

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -23,7 +23,9 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* When using `ConsoleLauncher`, explicitly selected classes from `--select-class`
+  and `--select-method` are now always executed regardless of class name patterns
+  provided with `--include-classname`.
 
 
 [[release-notes-5.7.0-M2-junit-jupiter]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -25,7 +25,7 @@ on GitHub.
 
 * When using `ConsoleLauncher`, explicitly selected classes from `--select-class`
   and `--select-method` are now always executed regardless of class name patterns
-  provided with `--include-classname`.
+  provided with `--include-classname` or the default class name pattern.
 
 
 [[release-notes-5.7.0-M2-junit-jupiter]]

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
@@ -134,7 +134,7 @@ class DiscoveryRequestCreator {
 		classNamePatterns.addAll(patterns.getIncludedClassNamePatterns());
 		classNamePatterns.addAll(patterns.getSelectedClasses());
 		classNamePatterns.addAll(patterns.getSelectedMethods().stream() //
-				.map(fullyQualifiedName -> fullyQualifiedName.split("#")[0]) //
+				.map(name -> ReflectionUtils.parseFullyQualifiedMethodName(name)[0]) //
 				.collect(Collectors.toList()));
 		return includeClassNamePatterns(classNamePatterns.toArray(new String[0]));
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
@@ -27,12 +27,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.platform.commons.util.ModuleUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.console.options.CommandLineOptions;
 import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.ClasspathRootSelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -95,7 +97,7 @@ class DiscoveryRequestCreator {
 	}
 
 	private void addFilters(LauncherDiscoveryRequestBuilder requestBuilder, CommandLineOptions options) {
-		requestBuilder.filters(includeClassNamePatterns(options.getIncludedClassNamePatterns().toArray(new String[0])));
+		requestBuilder.filters(includedClassNamePatterns(options));
 
 		if (!options.getExcludedClassNamePatterns().isEmpty()) {
 			requestBuilder.filters(
@@ -125,6 +127,16 @@ class DiscoveryRequestCreator {
 		if (!options.getExcludedEngines().isEmpty()) {
 			requestBuilder.filters(excludeEngines(options.getExcludedEngines()));
 		}
+	}
+
+	private ClassNameFilter includedClassNamePatterns(CommandLineOptions patterns) {
+		List<String> classNamePatterns = new ArrayList<>();
+		classNamePatterns.addAll(patterns.getIncludedClassNamePatterns());
+		classNamePatterns.addAll(patterns.getSelectedClasses());
+		classNamePatterns.addAll(patterns.getSelectedMethods().stream() //
+				.map(fullyQualifiedName -> fullyQualifiedName.split("#")[0]) //
+				.collect(Collectors.toList()));
+		return includeClassNamePatterns(classNamePatterns.toArray(new String[0]));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
@@ -112,7 +112,7 @@ class DiscoveryRequestCreatorTests {
 
 		List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 		assertThat(filters).hasSize(1);
-		assertFilters(filters.get(0), STANDARD_INCLUDE_PATTERN);
+		assertExcludes(filters.get(0), STANDARD_INCLUDE_PATTERN);
 	}
 
 	@Test
@@ -124,8 +124,8 @@ class DiscoveryRequestCreatorTests {
 
 		List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 		assertThat(filters).hasSize(1);
-		assertFilters(filters.get(0), "Foo.*Bar");
-		assertFilters(filters.get(0), "Bar.*Foo");
+		assertIncludes(filters.get(0), "Foo.*Bar");
+		assertIncludes(filters.get(0), "Bar.*Foo");
 	}
 
 	@Test
@@ -138,9 +138,9 @@ class DiscoveryRequestCreatorTests {
 
 		List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 		assertThat(filters).hasSize(1);
-		assertFilters(filters.get(0), "SomeTest");
-		assertFilters(filters.get(0), "com.acme.Foo");
-		assertFilters(filters.get(0), "Foo.*Bar");
+		assertIncludes(filters.get(0), "SomeTest");
+		assertIncludes(filters.get(0), "com.acme.Foo");
+		assertIncludes(filters.get(0), "Foo.*Bar");
 	}
 
 	@Test
@@ -152,8 +152,8 @@ class DiscoveryRequestCreatorTests {
 
 		List<ClassNameFilter> filters = request.getFiltersByType(ClassNameFilter.class);
 		assertThat(filters).hasSize(2);
-		assertFilters(filters.get(1), "Foo.*Bar");
-		assertFilters(filters.get(1), "Bar.*Foo");
+		assertExcludes(filters.get(1), "Foo.*Bar");
+		assertExcludes(filters.get(1), "Bar.*Foo");
 	}
 
 	@Test
@@ -166,10 +166,10 @@ class DiscoveryRequestCreatorTests {
 		List<PackageNameFilter> packageNameFilters = request.getFiltersByType(PackageNameFilter.class);
 
 		assertThat(packageNameFilters).hasSize(2);
-		assertFilters(packageNameFilters.get(0), "org.junit.included1");
-		assertFilters(packageNameFilters.get(0), "org.junit.included2");
-		assertFilters(packageNameFilters.get(0), "org.junit.included3");
-		assertFilters(packageNameFilters.get(1), "org.junit.excluded1");
+		assertIncludes(packageNameFilters.get(0), "org.junit.included1");
+		assertIncludes(packageNameFilters.get(0), "org.junit.included2");
+		assertIncludes(packageNameFilters.get(0), "org.junit.included3");
+		assertExcludes(packageNameFilters.get(1), "org.junit.excluded1");
 	}
 
 	@Test
@@ -182,8 +182,8 @@ class DiscoveryRequestCreatorTests {
 		List<PostDiscoveryFilter> postDiscoveryFilters = request.getPostDiscoveryFilters();
 
 		assertThat(postDiscoveryFilters).hasSize(2);
-		assertFilters(postDiscoveryFilters.get(0), "TagFilter");
-		assertFilters(postDiscoveryFilters.get(1), "TagFilter");
+		assertThat(postDiscoveryFilters.get(0).toString()).contains("TagFilter");
+		assertThat(postDiscoveryFilters.get(1).toString()).contains("TagFilter");
 	}
 
 	@Test
@@ -298,8 +298,12 @@ class DiscoveryRequestCreatorTests {
 		return creator.toDiscoveryRequest(options);
 	}
 
-	private void assertFilters(Filter<?> filter, String filteredElement) {
-		assertThat(filter.toString()).contains(filteredElement);
+	private void assertIncludes(Filter<String> filter, String included) {
+		assertThat(filter.apply(included).included()).isTrue();
+	}
+
+	private void assertExcludes(Filter<String> filter, String excluded) {
+		assertThat(filter.apply(excluded).excluded()).isTrue();
 	}
 
 	@SafeVarargs

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
@@ -277,6 +277,21 @@ class DiscoveryRequestCreatorTests {
 		assertThat(configurationParameters.getBoolean("baz")).contains(true);
 	}
 
+	@Test
+	void includeSelectedClassesAndMethodsRegardlessOfClassNamePatterns() {
+		options.setSelectedClasses(singletonList("SomeTest"));
+		options.setSelectedMethods(asList("com.acme.Foo#m()"));
+		options.setIncludedClassNamePatterns(asList("Foo.*Bar"));
+
+		LauncherDiscoveryRequest request = convert();
+
+		List<ClassNameFilter> filter = request.getFiltersByType(ClassNameFilter.class);
+		assertThat(filter).hasSize(1);
+		assertThat(filter.get(0).toString()).contains("SomeTest");
+		assertThat(filter.get(0).toString()).contains("com.acme.Foo");
+		assertThat(filter.get(0).toString()).contains("Foo.*Bar");
+	}
+
 	private LauncherDiscoveryRequest convert() {
 		DiscoveryRequestCreator creator = new DiscoveryRequestCreator();
 		return creator.toDiscoveryRequest(options);


### PR DESCRIPTION
## Overview

Add explicitly selected classes from `--select-class` and `--select-method` to the include patterns passed when constructing the `ClassNameFilter` so that these are always executed regardless of the implicit or explicit class name filter.

Resolves #2259.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
