### PR TITLE
Replace illegal chars with their char reference

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -15,7 +15,8 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Characters in exception messages and other user-supplied values that are not allowed in
+  XML are now replaced with their character reference (e.g. `\0` becomes `&#0;`).
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -112,19 +112,19 @@ class XmlReportWriter {
 	private void writeSuiteAttributes(TestIdentifier testIdentifier, List<TestIdentifier> tests,
 			NumberFormat numberFormat, XMLStreamWriter writer) throws XMLStreamException {
 
-		writer.writeAttribute("name", testIdentifier.getDisplayName());
+		writeAttributeSafely(writer, "name", testIdentifier.getDisplayName());
 		writeTestCounts(tests, writer);
-		writer.writeAttribute("time", getTime(testIdentifier, numberFormat));
-		writer.writeAttribute("hostname", getHostname().orElse("<unknown host>"));
-		writer.writeAttribute("timestamp", ISO_LOCAL_DATE_TIME.format(getCurrentDateTime()));
+		writeAttributeSafely(writer, "time", getTime(testIdentifier, numberFormat));
+		writeAttributeSafely(writer, "hostname", getHostname().orElse("<unknown host>"));
+		writeAttributeSafely(writer, "timestamp", ISO_LOCAL_DATE_TIME.format(getCurrentDateTime()));
 	}
 
 	private void writeTestCounts(List<TestIdentifier> tests, XMLStreamWriter writer) throws XMLStreamException {
 		TestCounts testCounts = TestCounts.from(this.reportData, tests);
-		writer.writeAttribute("tests", String.valueOf(testCounts.getTotal()));
-		writer.writeAttribute("skipped", String.valueOf(testCounts.getSkipped()));
-		writer.writeAttribute("failures", String.valueOf(testCounts.getFailures()));
-		writer.writeAttribute("errors", String.valueOf(testCounts.getErrors()));
+		writeAttributeSafely(writer, "tests", String.valueOf(testCounts.getTotal()));
+		writeAttributeSafely(writer, "skipped", String.valueOf(testCounts.getSkipped()));
+		writeAttributeSafely(writer, "failures", String.valueOf(testCounts.getFailures()));
+		writeAttributeSafely(writer, "errors", String.valueOf(testCounts.getErrors()));
 	}
 
 	private void writeSystemProperties(XMLStreamWriter writer) throws XMLStreamException {
@@ -133,8 +133,8 @@ class XmlReportWriter {
 		Properties systemProperties = System.getProperties();
 		for (String propertyName : new TreeSet<>(systemProperties.stringPropertyNames())) {
 			writer.writeEmptyElement("property");
-			writer.writeAttribute("name", propertyName);
-			writer.writeAttribute("value", escapeIllegalChars(systemProperties.getProperty(propertyName)));
+			writeAttributeSafely(writer, "name", propertyName);
+			writeAttributeSafely(writer, "value", systemProperties.getProperty(propertyName));
 			newLine(writer);
 		}
 		writer.writeEndElement();
@@ -146,9 +146,9 @@ class XmlReportWriter {
 
 		writer.writeStartElement("testcase");
 
-		writer.writeAttribute("name", getName(testIdentifier));
-		writer.writeAttribute("classname", getClassName(testIdentifier));
-		writer.writeAttribute("time", getTime(testIdentifier, numberFormat));
+		writeAttributeSafely(writer, "name", getName(testIdentifier));
+		writeAttributeSafely(writer, "classname", getClassName(testIdentifier));
+		writeAttributeSafely(writer, "time", getTime(testIdentifier, numberFormat));
 		newLine(writer);
 
 		writeSkippedOrErrorOrFailureElement(testIdentifier, writer);
@@ -217,9 +217,9 @@ class XmlReportWriter {
 			throws XMLStreamException {
 
 		if (throwable.getMessage() != null) {
-			writer.writeAttribute("message", escapeIllegalChars(throwable.getMessage()));
+			writeAttributeSafely(writer, "message", throwable.getMessage());
 		}
-		writer.writeAttribute("type", throwable.getClass().getName());
+		writeAttributeSafely(writer, "type", throwable.getClass().getName());
 		writeCDataSafely(writer, readStackTrace(throwable));
 	}
 
@@ -295,6 +295,10 @@ class XmlReportWriter {
 		writeCDataSafely(writer, "\n" + content + "\n");
 		writer.writeEndElement();
 		newLine(writer);
+	}
+
+	private void writeAttributeSafely(XMLStreamWriter writer, String name, String value) throws XMLStreamException {
+		writer.writeAttribute(name, escapeIllegalChars(value));
 	}
 
 	private void writeCDataSafely(XMLStreamWriter writer, String data) throws XMLStreamException {


### PR DESCRIPTION
Prior to this commit, characters not allowed according to the XML 1.0
spec where written to the XML reports if present in exception messages
etc. Now, we detect them and replace them with their character
reference.

Fixes #2269.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
