### PR TITLE
Support custom reason in @Disabled* / @Enabled* variants

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -39,7 +39,9 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* All `@EnabledIf*`/`@DisabledIf*` annotations now have an optional `disabledReason`
+  field that can be used to provide additional explanation as to why a test or container
+  might be disabled.
 
 
 [[release-notes-5.7.0-M2-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -39,9 +39,9 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* All `@EnabledIf*`/`@DisabledIf*` annotations now have an optional `disabledReason`
-  field that can be used to provide additional explanation as to why a test or container
-  might be disabled.
+* All `@Enabled*`/`@Disabled*` annotations now have an optional `disabledReason`
+  attribute that can be used to provide additional explanation as to why a test or
+  container might be disabled.
 
 
 [[release-notes-5.7.0-M2-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -343,8 +343,8 @@ several other annotation-based conditions in the `org.junit.jupiter.api.conditio
 package that allow developers to enable or disable containers and tests _declaratively_.
 When multiple `ExecutionCondition` extensions are registered, a container or test is
 disabled as soon as one of the conditions returns _disabled_. If you wish to provide
-details about why they might be disabled, every annotation associated to these built-in
-conditions have a `disabledReason` attribute available for that purpose.
+details about why they might be disabled, every annotation associated with these built-in
+conditions has a `disabledReason` attribute available for that purpose.
 
 See <<extensions-conditions, `ExecutionCondition`>> and the following sections for
 details.

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -342,7 +342,9 @@ conditions _programmatically_. The simplest example of such a condition is the b
 several other annotation-based conditions in the `org.junit.jupiter.api.condition`
 package that allow developers to enable or disable containers and tests _declaratively_.
 When multiple `ExecutionCondition` extensions are registered, a container or test is
-disabled as soon as one of the conditions returns _disabled_.
+disabled as soon as one of the conditions returns _disabled_. If you wish to provide
+details about why they might be disabled, every annotation associated to these built-in
+conditions have a `disabledReason` attribute available for that purpose.
 
 See <<extensions-conditions, `ExecutionCondition`>> and the following sections for
 details.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public abstract class BooleanExecutionCondition<A extends Annotation> implements ExecutionCondition {
+
+	private final Class<A> annotationType;
+
+	protected BooleanExecutionCondition(Class<A> annotationType) {
+		this.annotationType = annotationType;
+	}
+
+	abstract ConditionEvaluationResult defaultResult();
+
+	abstract String disabledReason(A annotation);
+
+	abstract String enabledReason(A annotation);
+
+	abstract boolean isEnabled(A annotation);
+
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		Optional<A> optional = findAnnotation(context.getElement(), annotationType);
+		if (optional.isPresent()) {
+			A annotation = optional.get();
+			return isEnabled(annotation) ? enabled(enabledReason(annotation)) : disabled(disabledReason(annotation));
+		}
+		return defaultResult();
+	}
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public abstract class BooleanExecutionCondition<A extends Annotation> implements ExecutionCondition {
+abstract class BooleanExecutionCondition<A extends Annotation> implements ExecutionCondition {
 
 	private final Class<A> annotationType;
 	private final String enabledReason;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
@@ -45,17 +45,10 @@ public abstract class BooleanExecutionCondition<A extends Annotation> implements
 		Optional<A> optional = findAnnotation(context.getElement(), annotationType);
 		if (optional.isPresent()) {
 			A annotation = optional.get();
-			return isEnabled(annotation) ? enabled(enabledReason) : disabled(disabledReason(annotation));
+			String customReason = customDisabledReason.apply(annotation);
+			return isEnabled(annotation) ? enabled(enabledReason) : disabled(disabledReason, customReason);
 		}
 		return enabledByDefault();
-	}
-
-	private String disabledReason(A annotation) {
-		String customReason = customDisabledReason.apply(annotation);
-		if (customReason.isEmpty()) {
-			return disabledReason;
-		}
-		return String.format("%s ==> %s", disabledReason, customReason);
 	}
 
 	private ConditionEvaluationResult enabledByDefault() {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public abstract class BooleanExecutionCondition<A extends Annotation> implements ExecutionCondition {
 
 	private final Class<A> annotationType;
-
 	private final String enabledReason;
 	private final String disabledReason;
 	private final Function<A, String> customDisabledReason;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.lang.annotation.Annotation;
-import java.util.Optional;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
@@ -41,13 +40,10 @@ abstract class BooleanExecutionCondition<A extends Annotation> implements Execut
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<A> optional = findAnnotation(context.getElement(), annotationType);
-		if (optional.isPresent()) {
-			A annotation = optional.get();
-			String customReason = customDisabledReason.apply(annotation);
-			return isEnabled(annotation) ? enabled(enabledReason) : disabled(disabledReason, customReason);
-		}
-		return enabledByDefault();
+		return findAnnotation(context.getElement(), annotationType) //
+				.map(annotation -> isEnabled(annotation) ? enabled(enabledReason)
+						: disabled(disabledReason, customDisabledReason.apply(annotation))) //
+				.orElseGet(this::enabledByDefault);
 	}
 
 	private ConditionEvaluationResult enabledByDefault() {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
@@ -95,4 +95,9 @@ public @interface DisabledForJreRange {
 	 */
 	JRE max() default JRE.OTHER;
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRangeCondition.java
@@ -12,12 +12,8 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.condition.EnabledOnJreCondition.DISABLED_ON_CURRENT_JRE;
 import static org.junit.jupiter.api.condition.EnabledOnJreCondition.ENABLED_ON_CURRENT_JRE;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -26,23 +22,24 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.6
  * @see DisabledForJreRange
  */
-class DisabledForJreRangeCondition implements ExecutionCondition {
+class DisabledForJreRangeCondition extends BooleanExecutionCondition<DisabledForJreRange> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@DisabledForJreRange is not present");
+	DisabledForJreRangeCondition() {
+		super(DisabledForJreRange.class, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE,
+			DisabledForJreRange::disabledReason);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		return findAnnotation(context.getElement(), DisabledForJreRange.class) //
-				.map(disabledForJreRange -> {
-					JRE min = disabledForJreRange.min();
-					JRE max = disabledForJreRange.max();
-					Preconditions.condition((min != JRE.JAVA_8 || max != JRE.OTHER),
-						"You must declare a non-default value for min or max in @DisabledForJreRange");
-					Preconditions.condition(max.compareTo(min) >= 0,
-						"@DisabledForJreRange.min must be less than or equal to @DisabledForJreRange.max");
+	boolean isEnabled(DisabledForJreRange annotation) {
+		JRE min = annotation.min();
+		JRE max = annotation.max();
 
-					return JRE.isCurrentVersionWithinRange(min, max) ? DISABLED_ON_CURRENT_JRE : ENABLED_ON_CURRENT_JRE;
-				}).orElse(ENABLED_BY_DEFAULT);
+		Preconditions.condition((min != JRE.JAVA_8 || max != JRE.OTHER),
+			"You must declare a non-default value for min or max in @DisabledForJreRange");
+		Preconditions.condition(max.compareTo(min) >= 0,
+			"@DisabledForJreRange.min must be less than or equal to @DisabledForJreRange.max");
+
+		return !JRE.isCurrentVersionWithinRange(min, max);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
@@ -83,4 +83,9 @@ public @interface DisabledIf {
 	 */
 	String value();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfCondition.java
@@ -46,8 +46,16 @@ class DisabledIfCondition extends MethodBasedCondition {
 	}
 
 	@Override
-	ConditionEvaluationResult getResultBasedOnBoolean(boolean result) {
-		return result ? DISABLED : ENABLED;
+	ConditionEvaluationResult getResultBasedOnBoolean(boolean methodResult, ExtensionContext context) {
+		if (!methodResult) {
+			return ENABLED;
+		}
+		String customReason = findAnnotation(context.getElement(), DisabledIf.class) //
+				.map(DisabledIf::disabledReason).get();
+		if (customReason.isEmpty()) {
+			return DISABLED;
+		}
+		return disabled(customReason);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfCondition.java
@@ -10,15 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
-
-import java.util.Optional;
-
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * {@link ExecutionCondition} for {@link DisabledIf @DisabledIf}.
@@ -26,36 +18,14 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * @since 5.7
  * @see DisabledIf
  */
-class DisabledIfCondition extends MethodBasedCondition {
+class DisabledIfCondition extends MethodBasedCondition<DisabledIf> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@DisabledIf is not present");
-	private static final ConditionEvaluationResult ENABLED = enabled(
-		"Condition provided in @DisabledIf evaluates to false");
-	private static final ConditionEvaluationResult DISABLED = disabled(
-		"Condition provided in @DisabledIf evaluates to true");
-
-	@Override
-	Optional<String> getMethodName(ExtensionContext context) {
-		return findAnnotation(context.getElement(), DisabledIf.class) //
-				.map(DisabledIf::value);
+	DisabledIfCondition() {
+		super(DisabledIf.class, DisabledIf::value, DisabledIf::disabledReason);
 	}
 
 	@Override
-	ConditionEvaluationResult getDefaultResult() {
-		return ENABLED_BY_DEFAULT;
+	protected boolean isEnabled(boolean methodResult) {
+		return !methodResult;
 	}
-
-	@Override
-	ConditionEvaluationResult getResultBasedOnBoolean(boolean methodResult, ExtensionContext context) {
-		if (!methodResult) {
-			return ENABLED;
-		}
-		String customReason = findAnnotation(context.getElement(), DisabledIf.class) //
-				.map(DisabledIf::disabledReason).get();
-		if (customReason.isEmpty()) {
-			return DISABLED;
-		}
-		return disabled(customReason);
-	}
-
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
@@ -91,4 +91,9 @@ public @interface DisabledIfEnvironmentVariable {
 	 */
 	String matches();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableCondition.java
@@ -54,7 +54,7 @@ class DisabledIfEnvironmentVariableCondition
 
 		if (actual.matches(regex)) {
 			return disabled(format("Environment variable [%s] with value [%s] matches regular expression [%s]", name,
-				actual, regex));
+				actual, regex), annotation.disabledReason());
 		}
 		// else
 		return enabled(format("Environment variable [%s] with value [%s] does not match regular expression [%s]", name,

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
@@ -91,4 +91,9 @@ public @interface DisabledIfSystemProperty {
 	 */
 	String matches();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyCondition.java
@@ -53,7 +53,8 @@ class DisabledIfSystemPropertyCondition extends AbstractRepeatableAnnotationCond
 
 		if (actual.matches(regex)) {
 			return disabled(
-				format("System property [%s] with value [%s] matches regular expression [%s]", name, actual, regex));
+				format("System property [%s] with value [%s] matches regular expression [%s]", name, actual, regex),
+				annotation.disabledReason());
 		}
 		// else
 		return enabled(

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
@@ -79,4 +79,9 @@ public @interface DisabledOnJre {
 	 */
 	JRE[] value();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJreCondition.java
@@ -12,15 +12,10 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.condition.EnabledOnJreCondition.DISABLED_ON_CURRENT_JRE;
 import static org.junit.jupiter.api.condition.EnabledOnJreCondition.ENABLED_ON_CURRENT_JRE;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.util.Arrays;
-import java.util.Optional;
 
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -29,20 +24,17 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see DisabledOnJre
  */
-class DisabledOnJreCondition implements ExecutionCondition {
+class DisabledOnJreCondition extends BooleanExecutionCondition<DisabledOnJre> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@DisabledOnJre is not present");
+	DisabledOnJreCondition() {
+		super(DisabledOnJre.class, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE, DisabledOnJre::disabledReason);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<DisabledOnJre> optional = findAnnotation(context.getElement(), DisabledOnJre.class);
-		if (optional.isPresent()) {
-			JRE[] versions = optional.get().value();
-			Preconditions.condition(versions.length > 0, "You must declare at least one JRE in @DisabledOnJre");
-			return (Arrays.stream(versions).anyMatch(JRE::isCurrentVersion)) ? DISABLED_ON_CURRENT_JRE
-					: ENABLED_ON_CURRENT_JRE;
-		}
-		return ENABLED_BY_DEFAULT;
+	boolean isEnabled(DisabledOnJre annotation) {
+		JRE[] versions = annotation.value();
+		Preconditions.condition(versions.length > 0, "You must declare at least one JRE in @DisabledOnJre");
+		return Arrays.stream(versions).noneMatch(JRE::isCurrentVersion);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOs.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOs.java
@@ -79,4 +79,9 @@ public @interface DisabledOnOs {
 	 */
 	OS[] value();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
@@ -21,8 +21,8 @@ import org.junit.platform.commons.util.Preconditions;
 /**
  * {@link ExecutionCondition} for {@link DisabledOnOs @DisabledOnOs}.
  *
- * @see DisabledOnOs
  * @since 5.1
+ * @see DisabledOnOs
  */
 class DisabledOnOsCondition extends BooleanExecutionCondition<DisabledOnOs> {
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.condition.EnabledOnOsCondition.DISABLED_ON_CURRENT_OS;
 import static org.junit.jupiter.api.condition.EnabledOnOsCondition.ENABLED_ON_CURRENT_OS;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
@@ -37,10 +38,13 @@ class DisabledOnOsCondition implements ExecutionCondition {
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
 		Optional<DisabledOnOs> optional = findAnnotation(context.getElement(), DisabledOnOs.class);
 		if (optional.isPresent()) {
-			OS[] operatingSystems = optional.get().value();
+			DisabledOnOs annotation = optional.get();
+			OS[] operatingSystems = annotation.value();
 			Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @DisabledOnOs");
-			return (Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs)) ? DISABLED_ON_CURRENT_OS
-					: ENABLED_ON_CURRENT_OS;
+
+			return Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs)
+					? disabled(DISABLED_ON_CURRENT_OS, annotation.disabledReason())
+					: enabled(ENABLED_ON_CURRENT_OS);
 		}
 		return ENABLED_BY_DEFAULT;
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
@@ -12,41 +12,51 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.condition.EnabledOnOsCondition.DISABLED_ON_CURRENT_OS;
 import static org.junit.jupiter.api.condition.EnabledOnOsCondition.ENABLED_ON_CURRENT_OS;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
  * {@link ExecutionCondition} for {@link DisabledOnOs @DisabledOnOs}.
  *
- * @since 5.1
  * @see DisabledOnOs
+ * @since 5.1
  */
-class DisabledOnOsCondition implements ExecutionCondition {
+class DisabledOnOsCondition extends BooleanExecutionCondition<DisabledOnOs> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@DisabledOnOs is not present");
+	DisabledOnOsCondition() {
+		super(DisabledOnOs.class);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<DisabledOnOs> optional = findAnnotation(context.getElement(), DisabledOnOs.class);
-		if (optional.isPresent()) {
-			DisabledOnOs annotation = optional.get();
-			OS[] operatingSystems = annotation.value();
-			Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @DisabledOnOs");
+	ConditionEvaluationResult defaultResult() {
+		return enabled("@DisabledOnOs is not present");
+	}
 
-			return Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs)
-					? disabled(DISABLED_ON_CURRENT_OS, annotation.disabledReason())
-					: enabled(ENABLED_ON_CURRENT_OS);
+	@Override
+	String disabledReason(DisabledOnOs annotation) {
+		String customReason = annotation.disabledReason();
+		if (customReason.isEmpty()) {
+			return DISABLED_ON_CURRENT_OS;
 		}
-		return ENABLED_BY_DEFAULT;
+		return String.format("%s ==> %s", DISABLED_ON_CURRENT_OS, customReason);
+
+	}
+
+	@Override
+	String enabledReason(DisabledOnOs annotation) {
+		return ENABLED_ON_CURRENT_OS;
+	}
+
+	@Override
+	boolean isEnabled(DisabledOnOs annotation) {
+		OS[] operatingSystems = annotation.value();
+		Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @DisabledOnOs");
+		return Arrays.stream(operatingSystems).noneMatch(OS::isCurrentOs);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
@@ -12,11 +12,9 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.condition.EnabledOnOsCondition.DISABLED_ON_CURRENT_OS;
 import static org.junit.jupiter.api.condition.EnabledOnOsCondition.ENABLED_ON_CURRENT_OS;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 
 import java.util.Arrays;
 
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.platform.commons.util.Preconditions;
 
@@ -29,27 +27,7 @@ import org.junit.platform.commons.util.Preconditions;
 class DisabledOnOsCondition extends BooleanExecutionCondition<DisabledOnOs> {
 
 	DisabledOnOsCondition() {
-		super(DisabledOnOs.class);
-	}
-
-	@Override
-	ConditionEvaluationResult defaultResult() {
-		return enabled("@DisabledOnOs is not present");
-	}
-
-	@Override
-	String disabledReason(DisabledOnOs annotation) {
-		String customReason = annotation.disabledReason();
-		if (customReason.isEmpty()) {
-			return DISABLED_ON_CURRENT_OS;
-		}
-		return String.format("%s ==> %s", DISABLED_ON_CURRENT_OS, customReason);
-
-	}
-
-	@Override
-	String enabledReason(DisabledOnOs annotation) {
-		return ENABLED_ON_CURRENT_OS;
+		super(DisabledOnOs.class, ENABLED_ON_CURRENT_OS, DISABLED_ON_CURRENT_OS, DisabledOnOs::disabledReason);
 	}
 
 	@Override

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
@@ -95,4 +95,9 @@ public @interface EnabledForJreRange {
 	 */
 	JRE max() default JRE.OTHER;
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRangeCondition.java
@@ -12,12 +12,8 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.condition.EnabledOnJreCondition.DISABLED_ON_CURRENT_JRE;
 import static org.junit.jupiter.api.condition.EnabledOnJreCondition.ENABLED_ON_CURRENT_JRE;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -26,23 +22,24 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.6
  * @see EnabledForJreRange
  */
-class EnabledForJreRangeCondition implements ExecutionCondition {
+class EnabledForJreRangeCondition extends BooleanExecutionCondition<EnabledForJreRange> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@EnabledForJreRange is not present");
+	EnabledForJreRangeCondition() {
+		super(EnabledForJreRange.class, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE,
+			EnabledForJreRange::disabledReason);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		return findAnnotation(context.getElement(), EnabledForJreRange.class) //
-				.map(enabledForJreRange -> {
-					JRE min = enabledForJreRange.min();
-					JRE max = enabledForJreRange.max();
-					Preconditions.condition((min != JRE.JAVA_8 || max != JRE.OTHER),
-						"You must declare a non-default value for min or max in @EnabledForJreRange");
-					Preconditions.condition(max.compareTo(min) >= 0,
-						"@EnabledForJreRange.min must be less than or equal to @EnabledForJreRange.max");
+	boolean isEnabled(EnabledForJreRange annotation) {
+		JRE min = annotation.min();
+		JRE max = annotation.max();
 
-					return JRE.isCurrentVersionWithinRange(min, max) ? ENABLED_ON_CURRENT_JRE : DISABLED_ON_CURRENT_JRE;
-				}).orElse(ENABLED_BY_DEFAULT);
+		Preconditions.condition((min != JRE.JAVA_8 || max != JRE.OTHER),
+			"You must declare a non-default value for min or max in @EnabledForJreRange");
+		Preconditions.condition(max.compareTo(min) >= 0,
+			"@EnabledForJreRange.min must be less than or equal to @EnabledForJreRange.max");
+
+		return JRE.isCurrentVersionWithinRange(min, max);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
@@ -83,4 +83,9 @@ public @interface EnabledIf {
 	 */
 	String value();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfCondition.java
@@ -46,8 +46,16 @@ class EnabledIfCondition extends MethodBasedCondition {
 	}
 
 	@Override
-	ConditionEvaluationResult getResultBasedOnBoolean(boolean result) {
-		return result ? ENABLED : DISABLED;
+	ConditionEvaluationResult getResultBasedOnBoolean(boolean methodResult, ExtensionContext context) {
+		if (methodResult) {
+			return ENABLED;
+		}
+		String customReason = findAnnotation(context.getElement(), EnabledIf.class) //
+				.map(EnabledIf::disabledReason).get();
+		if (customReason.isEmpty()) {
+			return DISABLED;
+		}
+		return disabled(customReason);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfCondition.java
@@ -10,15 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
-
-import java.util.Optional;
-
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * {@link ExecutionCondition} for {@link EnabledIf @EnabledIf}.
@@ -26,36 +18,15 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * @since 5.7
  * @see EnabledIf
  */
-class EnabledIfCondition extends MethodBasedCondition {
+class EnabledIfCondition extends MethodBasedCondition<EnabledIf> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@EnabledIf is not present");
-	private static final ConditionEvaluationResult ENABLED = enabled(
-		"Condition provided in @EnabledIf evaluates to true");
-	private static final ConditionEvaluationResult DISABLED = disabled(
-		"Condition provided in @EnabledIf evaluates to false");
-
-	@Override
-	Optional<String> getMethodName(ExtensionContext context) {
-		return findAnnotation(context.getElement(), EnabledIf.class) //
-				.map(EnabledIf::value);
+	EnabledIfCondition() {
+		super(EnabledIf.class, EnabledIf::value, EnabledIf::disabledReason);
 	}
 
 	@Override
-	ConditionEvaluationResult getDefaultResult() {
-		return ENABLED_BY_DEFAULT;
-	}
-
-	@Override
-	ConditionEvaluationResult getResultBasedOnBoolean(boolean methodResult, ExtensionContext context) {
-		if (methodResult) {
-			return ENABLED;
-		}
-		String customReason = findAnnotation(context.getElement(), EnabledIf.class) //
-				.map(EnabledIf::disabledReason).get();
-		if (customReason.isEmpty()) {
-			return DISABLED;
-		}
-		return disabled(customReason);
+	protected boolean isEnabled(boolean methodResult) {
+		return methodResult;
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
@@ -90,4 +90,9 @@ public @interface EnabledIfEnvironmentVariable {
 	 */
 	String matches();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableCondition.java
@@ -50,14 +50,14 @@ class EnabledIfEnvironmentVariableCondition
 
 		// Nothing to match against?
 		if (actual == null) {
-			return disabled(format("Environment variable [%s] does not exist", name));
+			return disabled(format("Environment variable [%s] does not exist", name), annotation.disabledReason());
 		}
 		if (actual.matches(regex)) {
 			return enabled(format("Environment variable [%s] with value [%s] matches regular expression [%s]", name,
 				actual, regex));
 		}
 		return disabled(format("Environment variable [%s] with value [%s] does not match regular expression [%s]", name,
-			actual, regex));
+			actual, regex), annotation.disabledReason());
 	}
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
@@ -90,4 +90,9 @@ public @interface EnabledIfSystemProperty {
 	 */
 	String matches();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyCondition.java
@@ -49,14 +49,15 @@ class EnabledIfSystemPropertyCondition extends AbstractRepeatableAnnotationCondi
 
 		// Nothing to match against?
 		if (actual == null) {
-			return disabled(format("System property [%s] does not exist", name));
+			return disabled(format("System property [%s] does not exist", name), annotation.disabledReason());
 		}
 		if (actual.matches(regex)) {
 			return enabled(
 				format("System property [%s] with value [%s] matches regular expression [%s]", name, actual, regex));
 		}
 		return disabled(
-			format("System property [%s] with value [%s] does not match regular expression [%s]", name, actual, regex));
+			format("System property [%s] with value [%s] does not match regular expression [%s]", name, actual, regex),
+			annotation.disabledReason());
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * this annotation may be used in conjunction with other {@code @Enabled*} or
  * {@code @Disabled*} annotations in this package.
  *
- * @since 5.1
  * @see JRE
  * @see org.junit.jupiter.api.condition.DisabledOnJre
  * @see org.junit.jupiter.api.condition.EnabledForJreRange
@@ -63,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @since 5.1
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
@@ -79,4 +79,8 @@ public @interface EnabledOnJre {
 	 */
 	JRE[] value();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * this annotation may be used in conjunction with other {@code @Enabled*} or
  * {@code @Disabled*} annotations in this package.
  *
+ * @since 5.1
  * @see JRE
  * @see org.junit.jupiter.api.condition.DisabledOnJre
  * @see org.junit.jupiter.api.condition.EnabledForJreRange
@@ -62,7 +63,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
- * @since 5.1
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJreCondition.java
@@ -10,16 +10,9 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
-
 import java.util.Arrays;
-import java.util.Optional;
 
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -28,26 +21,23 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see EnabledOnJre
  */
-class EnabledOnJreCondition implements ExecutionCondition {
+class EnabledOnJreCondition extends BooleanExecutionCondition<EnabledOnJre> {
 
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@EnabledOnJre is not present");
+	static final String ENABLED_ON_CURRENT_JRE = //
+		"Enabled on JRE version: " + System.getProperty("java.version");
 
-	static final ConditionEvaluationResult ENABLED_ON_CURRENT_JRE = //
-		enabled("Enabled on JRE version: " + System.getProperty("java.version"));
+	static final String DISABLED_ON_CURRENT_JRE = //
+		"Disabled on JRE version: " + System.getProperty("java.version");
 
-	static final ConditionEvaluationResult DISABLED_ON_CURRENT_JRE = //
-		disabled("Disabled on JRE version: " + System.getProperty("java.version"));
+	EnabledOnJreCondition() {
+		super(EnabledOnJre.class, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE, EnabledOnJre::disabledReason);
+	}
 
 	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<EnabledOnJre> optional = findAnnotation(context.getElement(), EnabledOnJre.class);
-		if (optional.isPresent()) {
-			JRE[] versions = optional.get().value();
-			Preconditions.condition(versions.length > 0, "You must declare at least one JRE in @EnabledOnJre");
-			return (Arrays.stream(versions).anyMatch(JRE::isCurrentVersion)) ? ENABLED_ON_CURRENT_JRE
-					: DISABLED_ON_CURRENT_JRE;
-		}
-		return ENABLED_BY_DEFAULT;
+	boolean isEnabled(EnabledOnJre annotation) {
+		JRE[] versions = annotation.value();
+		Preconditions.condition(versions.length > 0, "You must declare at least one JRE in @EnabledOnJre");
+		return Arrays.stream(versions).anyMatch(JRE::isCurrentVersion);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOs.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOs.java
@@ -79,4 +79,9 @@ public @interface EnabledOnOs {
 	 */
 	OS[] value();
 
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOsCondition.java
@@ -10,16 +10,12 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -28,26 +24,40 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see EnabledOnOs
  */
-class EnabledOnOsCondition implements ExecutionCondition {
-
-	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@EnabledOnOs is not present");
+class EnabledOnOsCondition extends BooleanExecutionCondition<EnabledOnOs> {
 
 	static final String ENABLED_ON_CURRENT_OS = "Enabled on operating system: " + System.getProperty("os.name");
 
 	static final String DISABLED_ON_CURRENT_OS = "Disabled on operating system: " + System.getProperty("os.name");
 
-	@Override
-	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<EnabledOnOs> optional = findAnnotation(context.getElement(), EnabledOnOs.class);
-		if (optional.isPresent()) {
-			EnabledOnOs annotation = optional.get();
-			OS[] operatingSystems = annotation.value();
-			Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @EnabledOnOs");
+	EnabledOnOsCondition() {
+		super(EnabledOnOs.class);
+	}
 
-			return Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs) ? enabled(ENABLED_ON_CURRENT_OS)
-					: disabled(DISABLED_ON_CURRENT_OS, annotation.disabledReason());
+	@Override
+	ConditionEvaluationResult defaultResult() {
+		return enabled("@EnabledOnOs is not present");
+	}
+
+	@Override
+	String disabledReason(EnabledOnOs annotation) {
+		String customReason = annotation.disabledReason();
+		if (customReason.isEmpty()) {
+			return DISABLED_ON_CURRENT_OS;
 		}
-		return ENABLED_BY_DEFAULT;
+		return String.format("%s ==> %s", DISABLED_ON_CURRENT_OS, customReason);
+	}
+
+	@Override
+	String enabledReason(EnabledOnOs annotation) {
+		return ENABLED_ON_CURRENT_OS;
+	}
+
+	@Override
+	boolean isEnabled(EnabledOnOs annotation) {
+		OS[] operatingSystems = annotation.value();
+		Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @EnabledOnOs");
+		return Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOsCondition.java
@@ -10,11 +10,8 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
-
 import java.util.Arrays;
 
-import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.platform.commons.util.Preconditions;
 
@@ -31,26 +28,7 @@ class EnabledOnOsCondition extends BooleanExecutionCondition<EnabledOnOs> {
 	static final String DISABLED_ON_CURRENT_OS = "Disabled on operating system: " + System.getProperty("os.name");
 
 	EnabledOnOsCondition() {
-		super(EnabledOnOs.class);
-	}
-
-	@Override
-	ConditionEvaluationResult defaultResult() {
-		return enabled("@EnabledOnOs is not present");
-	}
-
-	@Override
-	String disabledReason(EnabledOnOs annotation) {
-		String customReason = annotation.disabledReason();
-		if (customReason.isEmpty()) {
-			return DISABLED_ON_CURRENT_OS;
-		}
-		return String.format("%s ==> %s", DISABLED_ON_CURRENT_OS, customReason);
-	}
-
-	@Override
-	String enabledReason(EnabledOnOs annotation) {
-		return ENABLED_ON_CURRENT_OS;
+		super(EnabledOnOs.class, ENABLED_ON_CURRENT_OS, DISABLED_ON_CURRENT_OS, EnabledOnOs::disabledReason);
 	}
 
 	@Override

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOsCondition.java
@@ -32,20 +32,20 @@ class EnabledOnOsCondition implements ExecutionCondition {
 
 	private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = enabled("@EnabledOnOs is not present");
 
-	static final ConditionEvaluationResult ENABLED_ON_CURRENT_OS = //
-		enabled("Enabled on operating system: " + System.getProperty("os.name"));
+	static final String ENABLED_ON_CURRENT_OS = "Enabled on operating system: " + System.getProperty("os.name");
 
-	static final ConditionEvaluationResult DISABLED_ON_CURRENT_OS = //
-		disabled("Disabled on operating system: " + System.getProperty("os.name"));
+	static final String DISABLED_ON_CURRENT_OS = "Disabled on operating system: " + System.getProperty("os.name");
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
 		Optional<EnabledOnOs> optional = findAnnotation(context.getElement(), EnabledOnOs.class);
 		if (optional.isPresent()) {
-			OS[] operatingSystems = optional.get().value();
+			EnabledOnOs annotation = optional.get();
+			OS[] operatingSystems = annotation.value();
 			Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @EnabledOnOs");
-			return (Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs)) ? ENABLED_ON_CURRENT_OS
-					: DISABLED_ON_CURRENT_OS;
+
+			return Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs) ? enabled(ENABLED_ON_CURRENT_OS)
+					: disabled(DISABLED_ON_CURRENT_OS, annotation.disabledReason());
 		}
 		return ENABLED_BY_DEFAULT;
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
@@ -28,14 +28,14 @@ abstract class MethodBasedCondition implements ExecutionCondition {
 
 	abstract ConditionEvaluationResult getDefaultResult();
 
-	abstract ConditionEvaluationResult getResultBasedOnBoolean(boolean result);
+	abstract ConditionEvaluationResult getResultBasedOnBoolean(boolean methodResult, ExtensionContext context);
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
 		return getMethodName(context) //
 				.map(methodName -> getConditionMethod(methodName, context)) //
 				.map(method -> (boolean) evaluateCondition(method, context)) //
-				.map(this::getResultBasedOnBoolean) //
+				.map(result -> getResultBasedOnBoolean(result, context)) //
 				.orElse(getDefaultResult());
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
@@ -11,9 +11,14 @@
 package org.junit.jupiter.api.condition;
 
 import static java.lang.String.format;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
@@ -22,37 +27,42 @@ import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 
-abstract class MethodBasedCondition implements ExecutionCondition {
+abstract class MethodBasedCondition<A extends Annotation> implements ExecutionCondition {
 
-	abstract Optional<String> getMethodName(ExtensionContext context);
+	private final Class<A> annotationType;
+	private final Function<A, String> methodName;
+	private final Function<A, String> customDisabledReason;
 
-	abstract ConditionEvaluationResult getDefaultResult();
+	MethodBasedCondition(Class<A> annotationType, Function<A, String> methodName,
+			Function<A, String> customDisabledReason) {
+		this.annotationType = annotationType;
+		this.methodName = methodName;
+		this.customDisabledReason = customDisabledReason;
+	}
 
-	abstract ConditionEvaluationResult getResultBasedOnBoolean(boolean methodResult, ExtensionContext context);
+	protected abstract boolean isEnabled(boolean methodResult);
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		return getMethodName(context) //
+		Optional<A> annotation = findAnnotation(context.getElement(), annotationType);
+		return annotation //
+				.map(methodName) //
 				.map(methodName -> getConditionMethod(methodName, context)) //
-				.map(method -> (boolean) evaluateCondition(method, context)) //
-				.map(result -> getResultBasedOnBoolean(result, context)) //
-				.orElse(getDefaultResult());
+				.map(method -> (boolean) invokeMethod(method, context)) //
+				.map(methodResult -> buildConditionEvaluationResult(methodResult, annotation.get())) //
+				.orElse(enabledByDefault());
 	}
 
 	private Method getConditionMethod(String methodName, ExtensionContext context) {
-		if (methodName.contains("#")) {
-			return findMethodByFullyQualifiedName(methodName);
+		if (!methodName.contains("#")) {
+			return findMethod(context.getRequiredTestClass(), methodName);
 		}
-		return findMethod(context.getRequiredTestClass(), methodName);
-	}
-
-	private Method findMethodByFullyQualifiedName(String fullyQualifiedMethodName) {
-		String[] methodParts = ReflectionUtils.parseFullyQualifiedMethodName(fullyQualifiedMethodName);
+		String[] methodParts = ReflectionUtils.parseFullyQualifiedMethodName(methodName);
 		String className = methodParts[0];
-		String methodName = methodParts[1];
+		String methodName1 = methodParts[1];
 		Class<?> clazz = ReflectionUtils.tryToLoadClass(className).getOrThrow(
 			cause -> new JUnitException(format("Could not load class [%s]", className), cause));
-		return findMethod(clazz, methodName);
+		return findMethod(clazz, methodName1);
 	}
 
 	private Method findMethod(Class<?> clazz, String methodName) {
@@ -60,7 +70,7 @@ abstract class MethodBasedCondition implements ExecutionCondition {
 				.orElseGet(() -> ReflectionUtils.getRequiredMethod(clazz, methodName, ExtensionContext.class));
 	}
 
-	private Object evaluateCondition(Method method, ExtensionContext context) {
+	private Object invokeMethod(Method method, ExtensionContext context) {
 		Preconditions.condition(method.getReturnType() == boolean.class,
 			() -> format("method [%s] should return a boolean", method.getName()));
 		Preconditions.condition(areParametersSupported(method),
@@ -82,6 +92,24 @@ abstract class MethodBasedCondition implements ExecutionCondition {
 			default:
 				return false;
 		}
+	}
+
+	private ConditionEvaluationResult buildConditionEvaluationResult(boolean methodResult, A annotation) {
+		String defaultReason = format("Condition provided in @%s evaluates to %s", annotationType.getSimpleName(),
+			methodResult);
+		if (isEnabled(methodResult)) {
+			return enabled(defaultReason);
+		}
+		String customReason = customDisabledReason.apply(annotation);
+		if (customReason.isEmpty()) {
+			return disabled(defaultReason);
+		}
+		return disabled(customReason);
+	}
+
+	private ConditionEvaluationResult enabledByDefault() {
+		String reason = String.format("@%s is not present", annotationType.getSimpleName());
+		return enabled(reason);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -29,7 +29,6 @@ public class ConditionEvaluationResult {
 	 * Factory for creating <em>enabled</em> results.
 	 *
 	 * @param reason the reason why the container or test should be enabled
-	 *
 	 * @return an enabled {@code ConditionEvaluationResult} with the given reason
 	 */
 	public static ConditionEvaluationResult enabled(String reason) {
@@ -40,7 +39,6 @@ public class ConditionEvaluationResult {
 	 * Factory for creating <em>disabled</em> results.
 	 *
 	 * @param reason the reason why the container or test should be disabled
-	 *
 	 * @return a disabled {@code ConditionEvaluationResult} with the given reason
 	 */
 	public static ConditionEvaluationResult disabled(String reason) {
@@ -53,7 +51,6 @@ public class ConditionEvaluationResult {
 	 *
 	 * @param reason the default reason why the container or test should be disabled
 	 * @param customReason the custom reason why the container or test should be disabled
-	 *
 	 * @return a disabled {@code ConditionEvaluationResult} with the given reasons
 	 */
 	public static ConditionEvaluationResult disabled(String reason, String customReason) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -15,6 +15,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
@@ -54,7 +55,7 @@ public class ConditionEvaluationResult {
 	 * @return a disabled {@code ConditionEvaluationResult} with the given reasons
 	 */
 	public static ConditionEvaluationResult disabled(String reason, String customReason) {
-		if (customReason.isEmpty()) {
+		if (StringUtils.isBlank(customReason)) {
 			return disabled(reason);
 		}
 		return disabled(String.format("%s ==> %s", reason, customReason));

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -47,14 +47,6 @@ public class ConditionEvaluationResult {
 		return new ConditionEvaluationResult(false, reason);
 	}
 
-	public static ConditionEvaluationResult disabled(String defaultReason, String customReason) {
-		if (customReason.isEmpty()) {
-			return new ConditionEvaluationResult(false, defaultReason);
-		}
-		String reason = String.format("%s ==> %s", defaultReason, customReason);
-		return new ConditionEvaluationResult(false, reason);
-	}
-
 	private final boolean enabled;
 
 	private final Optional<String> reason;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -47,6 +47,22 @@ public class ConditionEvaluationResult {
 		return new ConditionEvaluationResult(false, reason);
 	}
 
+	/**
+	 * Factory for creating <em>disabled</em> results with custom reasons
+	 * added by the user.
+	 *
+	 * @param reason the default reason why the container or test should be disabled
+	 * @param customReason the custom reason why the container or test should be disabled
+	 *
+	 * @return a disabled {@code ConditionEvaluationResult} with the given reasons
+	 */
+	public static ConditionEvaluationResult disabled(String reason, String customReason) {
+		if (customReason.isEmpty()) {
+			return disabled(reason);
+		}
+		return disabled(String.format("%s ==> %s", reason, customReason));
+	}
+
 	private final boolean enabled;
 
 	private final Optional<String> reason;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -29,6 +29,7 @@ public class ConditionEvaluationResult {
 	 * Factory for creating <em>enabled</em> results.
 	 *
 	 * @param reason the reason why the container or test should be enabled
+	 *
 	 * @return an enabled {@code ConditionEvaluationResult} with the given reason
 	 */
 	public static ConditionEvaluationResult enabled(String reason) {
@@ -39,9 +40,18 @@ public class ConditionEvaluationResult {
 	 * Factory for creating <em>disabled</em> results.
 	 *
 	 * @param reason the reason why the container or test should be disabled
+	 *
 	 * @return a disabled {@code ConditionEvaluationResult} with the given reason
 	 */
 	public static ConditionEvaluationResult disabled(String reason) {
+		return new ConditionEvaluationResult(false, reason);
+	}
+
+	public static ConditionEvaluationResult disabled(String defaultReason, String customReason) {
+		if (customReason.isEmpty()) {
+			return new ConditionEvaluationResult(false, defaultReason);
+		}
+		String reason = String.format("%s ==> %s", defaultReason, customReason);
 		return new ConditionEvaluationResult(false, reason);
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/AbstractExecutionConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/AbstractExecutionConditionTests.java
@@ -89,6 +89,13 @@ abstract class AbstractExecutionConditionTests {
 		assertThat(this.result.getReason()).hasValueSatisfying(reason -> assertThat(reason).contains(text));
 	}
 
+	protected void assertCustomDisabledReasonIs(String text) {
+		if (this.result.isDisabled()) {
+			assertThat(this.result.getReason()).hasValueSatisfying(
+				reason -> assertThat(reason).contains(" ==> " + text));
+		}
+	}
+
 	private Optional<AnnotatedElement> method(TestInfo testInfo) {
 		return method(getTestClass(), testInfo.getTestMethod().get().getName());
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeConditionTests.java
@@ -80,6 +80,7 @@ class DisabledForJreRangeConditionTests extends AbstractExecutionConditionTests 
 	void java8to11() {
 		evaluateCondition();
 		assertDisabledOnCurrentJreIf(onJava8() || onJava9() || onJava10() || onJava11());
+		assertCustomDisabledReasonIs("Disabled on some JRE");
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
@@ -56,7 +56,7 @@ class DisabledForJreRangeIntegrationTests {
 	}
 
 	@Test
-	@DisabledForJreRange(min = JAVA_8, max = JAVA_11)
+	@DisabledForJreRange(min = JAVA_8, max = JAVA_11, disabledReason = "Disabled on some JRE")
 	void java8to11() {
 		assertFalse(onJava8() || onJava9() || onJava10() || onJava11());
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfConditionTests.java
@@ -51,7 +51,7 @@ public class DisabledIfConditionTests extends AbstractExecutionConditionTests {
 	void disabledBecauseStaticConditionMethodReturnsTrue() {
 		evaluateCondition();
 		assertDisabled();
-		assertReasonContains("Condition provided in @DisabledIf evaluates to true");
+		assertReasonContains("Disabled for some reason");
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableConditionTests.java
@@ -88,6 +88,7 @@ class DisabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondi
 		evaluateCondition();
 		assertDisabled();
 		assertReasonContains("matches regular expression");
+		assertCustomDisabledReasonIs("That's an enigma");
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableIntegrationTests.java
@@ -54,7 +54,7 @@ class DisabledIfEnvironmentVariableIntegrationTests {
 	}
 
 	@Test
-	@DisabledIfEnvironmentVariable(named = KEY1, matches = ENIGMA)
+	@DisabledIfEnvironmentVariable(named = KEY1, matches = ENIGMA, disabledReason = "That's an enigma")
 	void disabledBecauseEnvironmentVariableMatchesExactly() {
 		fail("should be disabled");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfIntegrationTests.java
@@ -29,7 +29,7 @@ public class DisabledIfIntegrationTests {
 	}
 
 	@Test
-	@DisabledIf("staticMethodThatReturnsTrue")
+	@DisabledIf(value = "staticMethodThatReturnsTrue", disabledReason = "Disabled for some reason")
 	void disabledBecauseStaticConditionMethodReturnsTrue() {
 		fail("Should be disabled");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyConditionTests.java
@@ -85,6 +85,7 @@ class DisabledIfSystemPropertyConditionTests extends AbstractExecutionConditionT
 		evaluateCondition();
 		assertDisabled();
 		assertReasonContains("matches regular expression");
+		assertCustomDisabledReasonIs("That's an enigma");
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyIntegrationTests.java
@@ -68,7 +68,7 @@ class DisabledIfSystemPropertyIntegrationTests {
 	}
 
 	@Test
-	@DisabledIfSystemProperty(named = KEY1, matches = ENIGMA)
+	@DisabledIfSystemProperty(named = KEY1, matches = ENIGMA, disabledReason = "That's an enigma")
 	void disabledBecauseSystemPropertyMatchesExactly() {
 		fail("should be disabled");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnJreConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnJreConditionTests.java
@@ -71,6 +71,7 @@ class DisabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	void disabledOnAllJavaVersions() {
 		evaluateCondition();
 		assertDisabledOnCurrentJreIf(true);
+		assertCustomDisabledReasonIs("Disabled on every JRE");
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java
@@ -53,7 +53,8 @@ class DisabledOnJreIntegrationTests {
 	}
 
 	@Test
-	@DisabledOnJre({ JAVA_8, JAVA_9, JAVA_10, JAVA_11, JAVA_12, JAVA_13, JAVA_14, JAVA_15, OTHER })
+	@DisabledOnJre(value = { JAVA_8, JAVA_9, JAVA_10, JAVA_11, JAVA_12, JAVA_13, JAVA_14, JAVA_15,
+			OTHER }, disabledReason = "Disabled on every JRE")
 	void disabledOnAllJavaVersions() {
 		fail("should be disabled");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
@@ -31,6 +31,8 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 
+	private static final String OS_NAME = System.getProperty("os.name");
+
 	@Override
 	protected ExecutionCondition getExecutionCondition() {
 		return new DisabledOnOsCondition();
@@ -66,7 +68,8 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void disabledOnEveryOs() {
 		evaluateCondition();
-		assertDisabledOnCurrentOsIf(true);
+		assertDisabled();
+		assertReasonContains("Disabled on operating system: " + OS_NAME + " ==> Disabled on every OS");
 	}
 
 	/**
@@ -126,11 +129,11 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	private void assertDisabledOnCurrentOsIf(boolean condition) {
 		if (condition) {
 			assertDisabled();
-			assertReasonContains("Disabled on operating system: " + System.getProperty("os.name"));
+			assertReasonContains("Disabled on operating system: " + OS_NAME);
 		}
 		else {
 			assertEnabled();
-			assertReasonContains("Enabled on operating system: " + System.getProperty("os.name"));
+			assertReasonContains("Enabled on operating system: " + OS_NAME);
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsIntegrationTests.java
@@ -50,7 +50,7 @@ class DisabledOnOsIntegrationTests {
 	}
 
 	@Test
-	@DisabledOnOs({ LINUX, MAC, WINDOWS, SOLARIS, OTHER })
+	@DisabledOnOs(value = { LINUX, MAC, WINDOWS, SOLARIS, OTHER }, disabledReason = "Disabled on every OS")
 	void disabledOnEveryOs() {
 		fail("should be disabled");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
@@ -80,6 +80,7 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	void java8to11() {
 		evaluateCondition();
 		assertEnabledOnCurrentJreIf(onJava8() || onJava9() || onJava10() || onJava11());
+		assertCustomDisabledReasonIs("Disabled on some JRE");
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
@@ -57,7 +57,7 @@ class EnabledForJreRangeIntegrationTests {
 	}
 
 	@Test
-	@EnabledForJreRange(min = JAVA_8, max = JAVA_11)
+	@EnabledForJreRange(min = JAVA_8, max = JAVA_11, disabledReason = "Disabled on some JRE")
 	void java8to11() {
 		assertTrue(onJava8() || onJava9() || onJava10() || onJava11());
 		assertFalse(onJava12());

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfConditionTests.java
@@ -61,7 +61,7 @@ public class EnabledIfConditionTests extends AbstractExecutionConditionTests {
 	void disabledBecauseStaticConditionMethodReturnsFalse() {
 		evaluateCondition();
 		assertDisabled();
-		assertReasonContains("Condition provided in @EnabledIf evaluates to false");
+		assertReasonContains("Disabled for some reason");
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableConditionTests.java
@@ -130,6 +130,7 @@ class EnabledIfEnvironmentVariableConditionTests extends AbstractExecutionCondit
 		evaluateCondition();
 		assertDisabled();
 		assertReasonContains("does not match regular expression");
+		assertCustomDisabledReasonIs("Not bogus");
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableIntegrationTests.java
@@ -74,7 +74,7 @@ class EnabledIfEnvironmentVariableIntegrationTests {
 	}
 
 	@Test
-	@EnabledIfEnvironmentVariable(named = KEY1, matches = BOGUS)
+	@EnabledIfEnvironmentVariable(named = KEY1, matches = BOGUS, disabledReason = "Not bogus")
 	void disabledBecauseEnvironmentVariableDoesNotMatch() {
 		fail("should be disabled");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfIntegrationTests.java
@@ -34,7 +34,7 @@ public class EnabledIfIntegrationTests {
 	}
 
 	@Test
-	@EnabledIf("staticMethodThatReturnsFalse")
+	@EnabledIf(value = "staticMethodThatReturnsFalse", disabledReason = "Disabled for some reason")
 	void disabledBecauseStaticConditionMethodReturnsFalse() {
 		fail("Should be disabled");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyConditionTests.java
@@ -115,6 +115,7 @@ class EnabledIfSystemPropertyConditionTests extends AbstractExecutionConditionTe
 		evaluateCondition();
 		assertDisabled();
 		assertReasonContains("does not match regular expression");
+		assertCustomDisabledReasonIs("Not bogus");
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyIntegrationTests.java
@@ -86,7 +86,7 @@ class EnabledIfSystemPropertyIntegrationTests {
 	}
 
 	@Test
-	@EnabledIfSystemProperty(named = KEY1, matches = BOGUS)
+	@EnabledIfSystemProperty(named = KEY1, matches = BOGUS, disabledReason = "Not bogus")
 	void disabledBecauseSystemPropertyDoesNotMatch() {
 		fail("should be disabled");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnJreConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnJreConditionTests.java
@@ -153,6 +153,7 @@ class EnabledOnJreConditionTests extends AbstractExecutionConditionTests {
 		evaluateCondition();
 		assertEnabledOnCurrentJreIf(!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13()
 				|| onJava14() || onJava15()));
+		assertCustomDisabledReasonIs("Disabled on almost every JRE");
 	}
 
 	private void assertEnabledOnCurrentJreIf(boolean condition) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java
@@ -99,7 +99,7 @@ class EnabledOnJreIntegrationTests {
 	}
 
 	@Test
-	@EnabledOnJre(OTHER)
+	@EnabledOnJre(value = OTHER, disabledReason = "Disabled on almost every JRE")
 	void other() {
 		assertFalse(
 			onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15());

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
@@ -31,6 +31,8 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 
+	private static final String OS_NAME = System.getProperty("os.name");
+
 	@Override
 	protected ExecutionCondition getExecutionCondition() {
 		return new EnabledOnOsCondition();
@@ -120,17 +122,23 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertEnabledOnCurrentOsIf(!(onLinux() || onMac() || onSolaris() || onWindows()));
+		assertEnabledOnCurrentOsIf(!(onLinux() || onMac() || onSolaris() || onWindows()),
+			"Disabled on almost every OS");
 	}
 
 	private void assertEnabledOnCurrentOsIf(boolean condition) {
+		assertEnabledOnCurrentOsIf(condition, null);
+	}
+
+	private void assertEnabledOnCurrentOsIf(boolean condition, String customDisabledReason) {
 		if (condition) {
 			assertEnabled();
-			assertReasonContains("Enabled on operating system: " + System.getProperty("os.name"));
+			assertReasonContains("Enabled on operating system: " + OS_NAME);
 		}
 		else {
 			assertDisabled();
-			assertReasonContains("Disabled on operating system: " + System.getProperty("os.name"));
+			assertReasonContains("Disabled on operating system: " + OS_NAME //
+					+ (customDisabledReason == null ? "" : " ==> " + customDisabledReason));
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
@@ -122,23 +122,18 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertEnabledOnCurrentOsIf(!(onLinux() || onMac() || onSolaris() || onWindows()),
-			"Disabled on almost every OS");
+		assertEnabledOnCurrentOsIf(!(onLinux() || onMac() || onSolaris() || onWindows()));
+		assertCustomDisabledReasonIs("Disabled on almost every OS");
 	}
 
 	private void assertEnabledOnCurrentOsIf(boolean condition) {
-		assertEnabledOnCurrentOsIf(condition, null);
-	}
-
-	private void assertEnabledOnCurrentOsIf(boolean condition, String customDisabledReason) {
 		if (condition) {
 			assertEnabled();
 			assertReasonContains("Enabled on operating system: " + OS_NAME);
 		}
 		else {
 			assertDisabled();
-			assertReasonContains("Disabled on operating system: " + OS_NAME //
-					+ (customDisabledReason == null ? "" : " ==> " + customDisabledReason));
+			assertReasonContains("Disabled on operating system: " + OS_NAME);
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
@@ -83,7 +83,7 @@ class EnabledOnOsIntegrationTests {
 	}
 
 	@Test
-	@EnabledOnOs(OTHER)
+	@EnabledOnOs(value = OTHER, disabledReason = "Disabled on almost every OS")
 	void other() {
 		assertFalse(onLinux() || onMac() || onSolaris() || onWindows());
 	}


### PR DESCRIPTION
## Overview

Add the possibility to give a custom reason in case a test/container is disabled with one of the `@Enabled*`/`@Disabled*` annotations. This reason will be printed in addition to the current default reason.

Resolves #1787.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
