### PR TITLE
Report stacktrace of the stuck thread in `assertTimeoutPreemptively`

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.api;
 
 import static java.time.Duration.ofMillis;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -189,6 +190,8 @@ class AssertTimeoutAssertionsTests {
 		AssertionFailedError error = assertThrows(AssertionFailedError.class,
 			() -> assertTimeoutPreemptively(ofMillis(10), this::waitForInterrupt));
 		assertMessageEquals(error, "execution timed out after 10 ms");
+		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
 	}
 
 	@Test
@@ -196,6 +199,8 @@ class AssertTimeoutAssertionsTests {
 		AssertionFailedError error = assertThrows(AssertionFailedError.class,
 			() -> assertTimeoutPreemptively(ofMillis(10), this::waitForInterrupt, "Tempus Fugit"));
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
+		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
 	}
 
 	@Test
@@ -203,6 +208,8 @@ class AssertTimeoutAssertionsTests {
 		AssertionFailedError error = assertThrows(AssertionFailedError.class,
 			() -> assertTimeoutPreemptively(ofMillis(10), this::waitForInterrupt, () -> "Tempus" + " " + "Fugit"));
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
+		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
 	}
 
 	@Test
@@ -256,6 +263,8 @@ class AssertTimeoutAssertionsTests {
 			});
 		});
 		assertMessageEquals(error, "execution timed out after 10 ms");
+		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertStackTraceContains(error.getCause().getStackTrace(), "AssertTimeoutAssertionsTests", "nap");
 	}
 
 	@Test
@@ -267,6 +276,8 @@ class AssertTimeoutAssertionsTests {
 			}, "Tempus Fugit");
 		});
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
+		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertStackTraceContains(error.getCause().getStackTrace(), "AssertTimeoutAssertionsTests", "nap");
 	}
 
 	@Test
@@ -278,6 +289,8 @@ class AssertTimeoutAssertionsTests {
 			}, () -> "Tempus" + " " + "Fugit");
 		});
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
+		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertStackTraceContains(error.getCause().getStackTrace(), "AssertTimeoutAssertionsTests", "nap");
 	}
 
 	/**
@@ -298,6 +311,16 @@ class AssertTimeoutAssertionsTests {
 		catch (InterruptedException ignore) {
 			// ignore
 		}
+	}
+
+	/**
+	 * Assert the given stack trace elements contain an element with the given class name and method name.
+	 */
+	private static void assertStackTraceContains(StackTraceElement[] stackTrace, String className, String methodName) {
+		assertThat(stackTrace).anySatisfy(element -> {
+			assertThat(element.getClassName()).endsWith(className);
+			assertThat(element.getMethodName()).isEqualTo(methodName);
+		});
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -190,7 +190,7 @@ class AssertTimeoutAssertionsTests {
 		AssertionFailedError error = assertThrows(AssertionFailedError.class,
 			() -> assertTimeoutPreemptively(ofMillis(10), this::waitForInterrupt));
 		assertMessageEquals(error, "execution timed out after 10 ms");
-		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
 		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
 	}
 
@@ -199,7 +199,7 @@ class AssertTimeoutAssertionsTests {
 		AssertionFailedError error = assertThrows(AssertionFailedError.class,
 			() -> assertTimeoutPreemptively(ofMillis(10), this::waitForInterrupt, "Tempus Fugit"));
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
-		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
 		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
 	}
 
@@ -208,7 +208,7 @@ class AssertTimeoutAssertionsTests {
 		AssertionFailedError error = assertThrows(AssertionFailedError.class,
 			() -> assertTimeoutPreemptively(ofMillis(10), this::waitForInterrupt, () -> "Tempus" + " " + "Fugit"));
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
-		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
 		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
 	}
 
@@ -263,7 +263,7 @@ class AssertTimeoutAssertionsTests {
 			});
 		});
 		assertMessageEquals(error, "execution timed out after 10 ms");
-		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
 		assertStackTraceContains(error.getCause().getStackTrace(), "AssertTimeoutAssertionsTests", "nap");
 	}
 
@@ -276,7 +276,7 @@ class AssertTimeoutAssertionsTests {
 			}, "Tempus Fugit");
 		});
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
-		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
 		assertStackTraceContains(error.getCause().getStackTrace(), "AssertTimeoutAssertionsTests", "nap");
 	}
 
@@ -289,7 +289,7 @@ class AssertTimeoutAssertionsTests {
 			}, () -> "Tempus" + " " + "Fugit");
 		});
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
-		assertMessageEquals(error.getCause(), "Execution timed out");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
 		assertStackTraceContains(error.getCause().getStackTrace(), "AssertTimeoutAssertionsTests", "nap");
 	}
 


### PR DESCRIPTION
## Overview

Fixes https://github.com/junit-team/junit5/issues/2239.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
