### PR TITLE
Introduce Stream<String> variants of assertLinesMatch methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -52,8 +52,8 @@ on GitHub.
 * All `@Enabled*`/`@Disabled*` annotations now have an optional `disabledReason`
   attribute that can be used to provide additional explanation as to why a test or
   container might be disabled.
-* New `assertLinesMatch` method overloads added to class `Assertions` that take in
-  two `Stream<String>` instances for comparision.
+* New `assertLinesMatch` method overloads added to class `Assertions` that accept
+  two `Stream<String>` instances for comparison.
 
 [[release-notes-5.7.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -52,7 +52,8 @@ on GitHub.
 * All `@Enabled*`/`@Disabled*` annotations now have an optional `disabledReason`
   attribute that can be used to provide additional explanation as to why a test or
   container might be disabled.
-
+* New `assertLinesMatch` method overloads added to class `Assertions` that take in
+  two `Stream<String>` instances for comparision.
 
 [[release-notes-5.7.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * {@code AssertLinesMatch} is a collection of utility methods that support asserting
@@ -45,6 +47,28 @@ class AssertLinesMatch {
 
 	static void assertLinesMatch(List<String> expectedLines, List<String> actualLines, String message) {
 		assertLinesMatch(expectedLines, actualLines, (Object) message);
+	}
+
+	static void assertLinesMatch(Stream<String> expectedLines, Stream<String> actualLines) {
+		assertLinesMatch(expectedLines, actualLines, (Object) null);
+	}
+
+	static void assertLinesMatch(Stream<String> expectedLines, Stream<String> actualLines, String message) {
+		assertLinesMatch(expectedLines, actualLines, (Object) message);
+	}
+
+	static void assertLinesMatch(Stream<String> expectedLines, Stream<String> actualLines, Object messageOrSupplier) {
+		notNull(expectedLines, "expectedLines must not be null");
+		notNull(actualLines, "actualLines must not be null");
+
+		// trivial case: same stream instance
+		if (expectedLines == actualLines) {
+			return;
+		}
+
+		List<String> expectedListOfStrings = expectedLines.collect(Collectors.toList());
+		List<String> actualListOfStrings = actualLines.collect(Collectors.toList());
+		assertLinesMatch(expectedListOfStrings, actualListOfStrings, messageOrSupplier);
 	}
 
 	static void assertLinesMatch(List<String> expectedLines, List<String> actualLines, Object messageOrSupplier) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -1613,6 +1613,61 @@ public class Assertions {
 		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines, messageSupplier);
 	}
 
+	/**
+	 * <em>Assert</em> that {@code expected} stream of {@linkplain String}s matches {@code actual}
+	 * stream.
+	 *
+	 * <p>Find a detailed description of the matching algorithm in {@link #assertLinesMatch(List, List)}.
+	 *
+	 * <p>Note: An implementation of this method may consume all lines of both streams eagerly and
+	 * delegate the evaluation to {@link #assertLinesMatch(List, List)}.
+	 *
+	 * @since 5.7
+	 * @see #assertLinesMatch(List, List)
+	 */
+	public static void assertLinesMatch(Stream<String> expectedLines, Stream<String> actualLines) {
+		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines);
+	}
+
+	/**
+	 * <em>Assert</em> that {@code expected} stream of {@linkplain String}s matches {@code actual}
+	 * stream.
+	 *
+	 * <p>Find a detailed description of the matching algorithm in {@link #assertLinesMatch(List, List)}.
+	 *
+	 * <p>Fails with the supplied failure {@code message} and the generated message.
+	 *
+	 * <p>Note: An implementation of this method may consume all lines of both streams eagerly and
+	 * delegate the evaluation to {@link #assertLinesMatch(List, List)}.
+	 *
+	 * @since 5.7
+	 * @see #assertLinesMatch(List, List)
+	 */
+	public static void assertLinesMatch(Stream<String> expectedLines, Stream<String> actualLines, String message) {
+		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines, message);
+	}
+
+	/**
+	 * <em>Assert</em> that {@code expected} stream of {@linkplain String}s matches {@code actual}
+	 * stream.
+	 *
+	 * <p>Find a detailed description of the matching algorithm in {@link #assertLinesMatch(List, List)}.
+	 *
+	 * <p>If necessary, a custom failure message will be retrieved lazily from the supplied
+	 * {@code messageSupplier}. Fails with the custom failure message prepended to
+	 * a generated failure message describing the difference.
+	 *
+	 * <p>Note: An implementation of this method may consume all lines of both streams eagerly and
+	 * delegate the evaluation to {@link #assertLinesMatch(List, List)}.
+	 *
+	 * @since 5.7
+	 * @see #assertLinesMatch(List, List)
+	 */
+	public static void assertLinesMatch(Stream<String> expectedLines, Stream<String> actualLines,
+			Supplier<String> messageSupplier) {
+		AssertLinesMatch.assertLinesMatch(expectedLines, actualLines, messageSupplier);
+	}
+
 	// --- assertNotEquals -----------------------------------------------------
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
@@ -29,6 +29,7 @@ import java.util.Random;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.junit.platform.commons.PreconditionViolationException;
 import org.opentest4j.AssertionFailedError;
@@ -94,8 +95,9 @@ class AssertLinesMatchAssertionsTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	void assertLinesMatchWithNullFails() {
-		assertThrows(PreconditionViolationException.class, () -> assertLinesMatch(null, null));
+		assertThrows(PreconditionViolationException.class, () -> assertLinesMatch((List) null, (List) null));
 		assertThrows(PreconditionViolationException.class, () -> assertLinesMatch(null, Collections.emptyList()));
 		assertThrows(PreconditionViolationException.class, () -> assertLinesMatch(Collections.emptyList(), null));
 	}
@@ -342,6 +344,34 @@ class AssertLinesMatchAssertionsTests {
 				"c", //
 				">");
 			assertLinesMatch(expectedErrorMessageLines, Arrays.asList(error.getMessage().split("\\R")));
+		}
+	}
+
+	@Nested
+	class WithStreamsOfStrings {
+		@Test
+		void assertLinesMatchEmptyStreams() {
+			assertLinesMatch(Stream.empty(), Stream.empty());
+		}
+
+		@Test
+		void assertLinesMatchSameListInstance() {
+			Stream<String> stream = Stream.of("first line", "second line", "third line", "last line");
+			assertLinesMatch(stream, stream);
+		}
+
+		@Test
+		void assertLinesMatchPlainEqualLists() {
+			List<String> expected = Arrays.asList("first line", "second line", "third line", "last line");
+			List<String> actual = Arrays.asList("first line", "second line", "third line", "last line");
+			assertLinesMatch(expected, actual);
+		}
+
+		@Test
+		void assertLinesMatchUsingRegexPatterns() {
+			List<String> expected = Arrays.asList("^first.+line", "second\\s*line", "th.rd l.ne", "last line$");
+			List<String> actual = Arrays.asList("first line", "second line", "third line", "last line");
+			assertLinesMatch(expected, actual);
 		}
 	}
 }


### PR DESCRIPTION
## Overview

Closes #2290

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
