### PR TITLE
Ignore implicit config params in EngineTestKit by default

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -27,7 +27,10 @@ on GitHub.
 
 ==== Deprecations and Breaking Changes
 
-* ❓
+* `EngineTestKit` no longer takes into account implicit configuration parameters (i.e.
+  system properties and the `junit-platform.properties` classpath resource) by default.
+  This change makes tests executed via `EngineTestKit` independent of the environment they
+  are executed in.
 
 ==== New Features and Improvements
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ToStringBuilder.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ToStringBuilder.java
@@ -33,16 +33,20 @@ import org.apiguardian.api.API;
 @API(status = INTERNAL, since = "1.0")
 public class ToStringBuilder {
 
-	private final Class<?> type;
+	private final String typeName;
 
 	private final List<String> values = new ArrayList<>();
 
 	public ToStringBuilder(Object obj) {
-		this.type = Preconditions.notNull(obj, "Object must not be null").getClass();
+		this(Preconditions.notNull(obj, "Object must not be null").getClass().getSimpleName());
 	}
 
 	public ToStringBuilder(Class<?> type) {
-		this.type = Preconditions.notNull(type, "Class must not be null");
+		this(Preconditions.notNull(type, "Class must not be null").getSimpleName());
+	}
+
+	public ToStringBuilder(String typeName) {
+		this.typeName = Preconditions.notNull(typeName, "Type name must not be null");
 	}
 
 	public ToStringBuilder append(String name, Object value) {
@@ -57,7 +61,7 @@ public class ToStringBuilder {
 
 	@Override
 	public String toString() {
-		return this.type.getSimpleName() + " [" + join(", ", this.values) + "]";
+		return this.typeName + " [" + join(", ", this.values) + "]";
 	}
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ToStringBuilder.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ToStringBuilder.java
@@ -45,6 +45,7 @@ public class ToStringBuilder {
 		this(Preconditions.notNull(type, "Class must not be null").getSimpleName());
 	}
 
+	@API(status = INTERNAL, since = "1.7")
 	public ToStringBuilder(String typeName) {
 		this.typeName = Preconditions.notNull(typeName, "Type name must not be null");
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -10,14 +10,16 @@
 
 package org.junit.platform.launcher.core;
 
-import static java.util.Collections.emptyMap;
-
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -36,25 +38,157 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 
 	private static final Logger logger = LoggerFactory.getLogger(LauncherConfigurationParameters.class);
 
-	private final Map<String, String> explicitConfigParams;
-	private final Properties configParamsFromFile;
-
-	LauncherConfigurationParameters() {
-		this(emptyMap(), ConfigurationParameters.CONFIG_FILE_NAME);
+	static Builder builder() {
+		return new Builder();
 	}
 
-	LauncherConfigurationParameters(Map<String, String> configParams) {
-		this(configParams, ConfigurationParameters.CONFIG_FILE_NAME);
+	private final List<Lookup> lookups;
+
+	private LauncherConfigurationParameters(List<Lookup> lookups) {
+		this.lookups = lookups;
 	}
 
-	LauncherConfigurationParameters(Map<String, String> configParams, String configFileName) {
-		Preconditions.notNull(configParams, "configuration parameters must not be null");
-		Preconditions.notBlank(configFileName, "configFileName must not be null or blank");
-		this.explicitConfigParams = configParams;
-		this.configParamsFromFile = fromClasspathResource(configFileName.trim());
+	@Override
+	public Optional<String> get(String key) {
+		return Optional.ofNullable(getProperty(key));
 	}
 
-	private static Properties fromClasspathResource(String configFileName) {
+	@Override
+	public Optional<Boolean> getBoolean(String key) {
+		return get(key).map(Boolean::parseBoolean);
+	}
+
+	@Override
+	public int size() {
+		return lookups.stream() //
+				.mapToInt(Lookup::size) //
+				.sum();
+	}
+
+	private String getProperty(String key) {
+		Preconditions.notBlank(key, "key must not be null or blank");
+		return lookups.stream() //
+				.map(lookup -> lookup.getValue(key)) //
+				.filter(Objects::nonNull) //
+				.findFirst() //
+				.orElse(null);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this) //
+				.append("lookups", lookups) //
+				.toString();
+	}
+
+	static final class Builder {
+
+		private final Map<String, String> explicitParameters = new HashMap<>();
+		private boolean useImplicitLookups = true;
+		private String configFileName = ConfigurationParameters.CONFIG_FILE_NAME;
+
+		private Builder() {
+		}
+
+		Builder withExplicitParameters(Map<String, String> parameters) {
+			Preconditions.notNull(parameters, "configuration parameters must not be null");
+			explicitParameters.putAll(parameters);
+			return this;
+		}
+
+		Builder withImplicitLookups(boolean useImplicitLookups) {
+			this.useImplicitLookups = useImplicitLookups;
+			return this;
+		}
+
+		Builder withConfigFileName(String configFileName) {
+			Preconditions.notBlank(configFileName, "configFileName must not be null or blank");
+			this.configFileName = configFileName;
+			return this;
+		}
+
+		LauncherConfigurationParameters build() {
+			List<Lookup> lookups = new ArrayList<>();
+			if (!explicitParameters.isEmpty()) {
+				lookups.add(Lookup.explicit(explicitParameters));
+			}
+			if (useImplicitLookups) {
+				lookups.add(Lookup.systemProperties());
+				lookups.add(Lookup.propertiesFile(configFileName));
+			}
+			return new LauncherConfigurationParameters(lookups);
+		}
+	}
+
+	private interface Lookup {
+
+		String getValue(String key);
+
+		default int size() {
+			return 0;
+		}
+
+		static Lookup explicit(Map<String, String> configParams) {
+			return new Lookup() {
+				@Override
+				public String getValue(String key) {
+					return configParams.get(key);
+				}
+
+				@Override
+				public int size() {
+					return configParams.size();
+				}
+
+				@Override
+				public String toString() {
+					ToStringBuilder builder = new ToStringBuilder("explicit");
+					configParams.forEach(builder::append);
+					return builder.toString();
+				}
+			};
+		}
+
+		static Lookup systemProperties() {
+			return new Lookup() {
+				@Override
+				public String getValue(String key) {
+					try {
+						return System.getProperty(key);
+					}
+					catch (Exception ignore) {
+						return null;
+					}
+				}
+
+				@Override
+				public String toString() {
+					return "systemProperties [...]";
+				}
+			};
+		}
+
+		static Lookup propertiesFile(String configFileName) {
+			Preconditions.notBlank(configFileName, "configFileName must not be null or blank");
+			Properties properties = loadClasspathResource(configFileName.trim());
+			return new Lookup() {
+				@Override
+				public String getValue(String key) {
+					return properties.getProperty(key);
+				}
+
+				@Override
+				public String toString() {
+					ToStringBuilder builder = new ToStringBuilder("propertiesFile");
+					properties.stringPropertyNames().forEach(key -> builder.append(key, getValue(key)));
+					return builder.toString();
+				}
+			};
+		}
+
+	}
+
+	private static Properties loadClasspathResource(String configFileName) {
 		Properties props = new Properties();
 
 		try {
@@ -86,64 +220,6 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 		}
 
 		return props;
-	}
-
-	@Override
-	public Optional<String> get(String key) {
-		return Optional.ofNullable(getProperty(key));
-	}
-
-	@Override
-	public Optional<Boolean> getBoolean(String key) {
-		String property = getProperty(key);
-		if (property != null) {
-			return Optional.of(Boolean.parseBoolean(property));
-		}
-		return Optional.empty();
-	}
-
-	@Override
-	public int size() {
-		return this.explicitConfigParams.size();
-	}
-
-	private String getProperty(String key) {
-		Preconditions.notBlank(key, "key must not be null or blank");
-
-		// 1) Check explicit config param.
-		String value = this.explicitConfigParams.get(key);
-
-		// 2) Check system property.
-		if (value == null) {
-			try {
-				value = System.getProperty(key);
-			}
-			catch (Exception ex) {
-				/* ignore */
-			}
-
-			// 3) Check config file.
-			if (value == null) {
-				value = this.configParamsFromFile.getProperty(key);
-			}
-		}
-
-		return value;
-	}
-
-	@Override
-	public String toString() {
-		ToStringBuilder builder = new ToStringBuilder(this);
-
-		this.explicitConfigParams.forEach(builder::append);
-
-		// @formatter:off
-		this.configParamsFromFile.stringPropertyNames().stream()
-				.filter(key -> !this.explicitConfigParams.containsKey(key))
-				.forEach(key -> builder.append(key, this.configParamsFromFile.getProperty(key)));
-		// @formatter:on
-
-		return builder.toString();
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -93,12 +93,13 @@ public final class LauncherDiscoveryRequestBuilder {
 	 */
 	public static final String DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME = "junit.platform.discovery.listener.default";
 
-	private List<DiscoverySelector> selectors = new ArrayList<>();
-	private List<EngineFilter> engineFilters = new ArrayList<>();
-	private List<DiscoveryFilter<?>> discoveryFilters = new ArrayList<>();
-	private List<PostDiscoveryFilter> postDiscoveryFilters = new ArrayList<>();
-	private Map<String, String> configurationParameters = new HashMap<>();
-	private List<LauncherDiscoveryListener> discoveryListeners = new ArrayList<>();
+	private final List<DiscoverySelector> selectors = new ArrayList<>();
+	private final List<EngineFilter> engineFilters = new ArrayList<>();
+	private final List<DiscoveryFilter<?>> discoveryFilters = new ArrayList<>();
+	private final List<PostDiscoveryFilter> postDiscoveryFilters = new ArrayList<>();
+	private final Map<String, String> configurationParameters = new HashMap<>();
+	private final List<LauncherDiscoveryListener> discoveryListeners = new ArrayList<>();
+	private boolean useImplicitConfigurationParameters = true;
 
 	/**
 	 * Create a new {@code LauncherDiscoveryRequestBuilder}.
@@ -225,16 +226,29 @@ public final class LauncherDiscoveryRequestBuilder {
 		}
 	}
 
+	@API(status = API.Status.EXPERIMENTAL, since = "1.7")
+	public LauncherDiscoveryRequestBuilder withImplicitConfigurationParameters(
+			boolean useImplicitConfigurationParameters) {
+		this.useImplicitConfigurationParameters = useImplicitConfigurationParameters;
+		return this;
+	}
+
 	/**
 	 * Build the {@link LauncherDiscoveryRequest} that has been configured via
 	 * this builder.
 	 */
 	public LauncherDiscoveryRequest build() {
-		LauncherConfigurationParameters launcherConfigurationParameters = new LauncherConfigurationParameters(
-			this.configurationParameters);
+		LauncherConfigurationParameters launcherConfigurationParameters = buildLauncherConfigurationParameters();
 		LauncherDiscoveryListener discoveryListener = getLauncherDiscoveryListener(launcherConfigurationParameters);
 		return new DefaultDiscoveryRequest(this.selectors, this.engineFilters, this.discoveryFilters,
 			this.postDiscoveryFilters, launcherConfigurationParameters, discoveryListener);
+	}
+
+	private LauncherConfigurationParameters buildLauncherConfigurationParameters() {
+		return LauncherConfigurationParameters.builder() //
+				.withExplicitParameters(this.configurationParameters) //
+				.withImplicitLookups(this.useImplicitConfigurationParameters) //
+				.build();
 	}
 
 	private LauncherDiscoveryListener getLauncherDiscoveryListener(ConfigurationParameters configurationParameters) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -99,7 +99,7 @@ public final class LauncherDiscoveryRequestBuilder {
 	private final List<PostDiscoveryFilter> postDiscoveryFilters = new ArrayList<>();
 	private final Map<String, String> configurationParameters = new HashMap<>();
 	private final List<LauncherDiscoveryListener> discoveryListeners = new ArrayList<>();
-	private boolean useImplicitConfigurationParameters = true;
+	private boolean implicitConfigurationParametersEnabled = true;
 
 	/**
 	 * Create a new {@code LauncherDiscoveryRequestBuilder}.
@@ -227,9 +227,8 @@ public final class LauncherDiscoveryRequestBuilder {
 	}
 
 	@API(status = API.Status.EXPERIMENTAL, since = "1.7")
-	public LauncherDiscoveryRequestBuilder withImplicitConfigurationParameters(
-			boolean useImplicitConfigurationParameters) {
-		this.useImplicitConfigurationParameters = useImplicitConfigurationParameters;
+	public LauncherDiscoveryRequestBuilder enableImplicitConfigurationParameters(boolean enabled) {
+		this.implicitConfigurationParametersEnabled = enabled;
 		return this;
 	}
 
@@ -246,8 +245,8 @@ public final class LauncherDiscoveryRequestBuilder {
 
 	private LauncherConfigurationParameters buildLauncherConfigurationParameters() {
 		return LauncherConfigurationParameters.builder() //
-				.withExplicitParameters(this.configurationParameters) //
-				.withImplicitLookups(this.useImplicitConfigurationParameters) //
+				.explicitParameters(this.configurationParameters) //
+				.enableImplicitProviders(this.implicitConfigurationParametersEnabled) //
 				.build();
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -209,6 +209,24 @@ public final class LauncherDiscoveryRequestBuilder {
 		return this;
 	}
 
+	/**
+	 * Configure whether implicit configuration parameters should be considered.
+	 *
+	 * <p>By default, in addition to those parameters that are passed explicitly
+	 * to this builder, configuration parameters are read from system properties
+	 * and from the {@code junit-platform.properties} classpath resource.
+	 * Passing {@code false} to this method, disables the latter two sources so
+	 * that only explicit configuration parameters are taken into account.
+	 *
+	 * @see #configurationParameter(String, String)
+	 * @see #configurationParameters(Map)
+	 */
+	@API(status = API.Status.EXPERIMENTAL, since = "1.7")
+	public LauncherDiscoveryRequestBuilder enableImplicitConfigurationParameters(boolean enabled) {
+		this.implicitConfigurationParametersEnabled = enabled;
+		return this;
+	}
+
 	private void storeFilter(Filter<?> filter) {
 		if (filter instanceof EngineFilter) {
 			this.engineFilters.add((EngineFilter) filter);
@@ -224,12 +242,6 @@ public final class LauncherDiscoveryRequestBuilder {
 				String.format("Filter [%s] must implement %s, %s, or %s.", filter, EngineFilter.class.getSimpleName(),
 					PostDiscoveryFilter.class.getSimpleName(), DiscoveryFilter.class.getSimpleName()));
 		}
-	}
-
-	@API(status = API.Status.EXPERIMENTAL, since = "1.7")
-	public LauncherDiscoveryRequestBuilder enableImplicitConfigurationParameters(boolean enabled) {
-		this.implicitConfigurationParametersEnabled = enabled;
-		return this;
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
@@ -105,7 +105,7 @@ public class LauncherFactory {
 
 	private static Stream<TestExecutionListener> loadAndFilterTestExecutionListeners() {
 		Iterable<TestExecutionListener> listeners = new ServiceLoaderTestExecutionListenerRegistry().loadListeners();
-		ConfigurationParameters configurationParameters = new LauncherConfigurationParameters();
+		ConfigurationParameters configurationParameters = LauncherConfigurationParameters.builder().build();
 		String deactivatedListenersPattern = configurationParameters.get(
 			DEACTIVATE_LISTENERS_PATTERN_PROPERTY_NAME).orElse(null);
 		// @formatter:off

--- a/junit-platform-launcher/src/testFixtures/java/org/junit/platform/launcher/core/ConfigurationParametersFactoryForTests.java
+++ b/junit-platform-launcher/src/testFixtures/java/org/junit/platform/launcher/core/ConfigurationParametersFactoryForTests.java
@@ -20,6 +20,9 @@ public class ConfigurationParametersFactoryForTests {
 	}
 
 	public static ConfigurationParameters create(Map<String, String> configParams) {
-		return new LauncherConfigurationParameters(configParams, "/dev/null");
+		return LauncherConfigurationParameters.builder() //
+				.withExplicitParameters(configParams) //
+				.withImplicitLookups(false) //
+				.build();
 	}
 }

--- a/junit-platform-launcher/src/testFixtures/java/org/junit/platform/launcher/core/ConfigurationParametersFactoryForTests.java
+++ b/junit-platform-launcher/src/testFixtures/java/org/junit/platform/launcher/core/ConfigurationParametersFactoryForTests.java
@@ -21,8 +21,8 @@ public class ConfigurationParametersFactoryForTests {
 
 	public static ConfigurationParameters create(Map<String, String> configParams) {
 		return LauncherConfigurationParameters.builder() //
-				.withExplicitParameters(configParams) //
-				.withImplicitLookups(false) //
+				.explicitParameters(configParams) //
+				.enableImplicitProviders(false) //
 				.build();
 	}
 }

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -330,7 +330,8 @@ public final class EngineTestKit {
 	 */
 	public static final class Builder {
 
-		private final LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request();
+		private final LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request() //
+				.withImplicitConfigurationParameters(false);
 		private final TestEngine testEngine;
 
 		private Builder(TestEngine testEngine) {
@@ -438,6 +439,12 @@ public final class EngineTestKit {
 			return this;
 		}
 
+		@API(status = API.Status.EXPERIMENTAL, since = "1.7")
+		public Builder withImplicitConfigurationParameters(boolean useImplicitConfigurationParameters) {
+			this.requestBuilder.withImplicitConfigurationParameters(useImplicitConfigurationParameters);
+			return this;
+		}
+
 		/**
 		 * Execute tests for the configured {@link TestEngine},
 		 * {@linkplain DiscoverySelector discovery selectors},
@@ -451,9 +458,9 @@ public final class EngineTestKit {
 		 * @see #configurationParameters(Map)
 		 */
 		public EngineExecutionResults execute() {
+			LauncherDiscoveryRequest request = this.requestBuilder.build();
 			ExecutionRecorder executionRecorder = new ExecutionRecorder();
-			EngineTestKit.executeUsingLauncherOrchestration(this.testEngine, this.requestBuilder.build(),
-				executionRecorder);
+			EngineTestKit.executeUsingLauncherOrchestration(this.testEngine, request, executionRecorder);
 			return executionRecorder.getExecutionResults();
 		}
 

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -439,6 +439,20 @@ public final class EngineTestKit {
 			return this;
 		}
 
+		/**
+		 * Configure whether implicit configuration parameters should be
+		 * considered.
+		 *
+		 * <p>By default, only configuration parameters that are passed
+		 * explicitly to this builder are taken into account. Passing
+		 * {@code true} to this method, enables additionally reading
+		 * configuration parameters from implicit sources, i.e. system
+		 * properties and the {@code junit-platform.properties} classpath
+		 * resource.
+		 *
+		 * @see #configurationParameter(String, String)
+		 * @see #configurationParameters(Map)
+		 */
 		@API(status = API.Status.EXPERIMENTAL, since = "1.7")
 		public Builder enableImplicitConfigurationParameters(boolean enabled) {
 			this.requestBuilder.enableImplicitConfigurationParameters(enabled);

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -331,7 +331,7 @@ public final class EngineTestKit {
 	public static final class Builder {
 
 		private final LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request() //
-				.withImplicitConfigurationParameters(false);
+				.enableImplicitConfigurationParameters(false);
 		private final TestEngine testEngine;
 
 		private Builder(TestEngine testEngine) {
@@ -440,8 +440,8 @@ public final class EngineTestKit {
 		}
 
 		@API(status = API.Status.EXPERIMENTAL, since = "1.7")
-		public Builder withImplicitConfigurationParameters(boolean useImplicitConfigurationParameters) {
-			this.requestBuilder.withImplicitConfigurationParameters(useImplicitConfigurationParameters);
+		public Builder enableImplicitConfigurationParameters(boolean enabled) {
+			this.requestBuilder.enableImplicitConfigurationParameters(enabled);
 			return this;
 		}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
@@ -149,19 +149,19 @@ class LauncherConfigurationParametersTests {
 	void ignoresSystemPropertyAndConfigFileWhenImplicitLookupsAreDisabled() {
 		System.setProperty(KEY, SYSTEM_PROPERTY);
 		ConfigurationParameters configParams = LauncherConfigurationParameters.builder() //
-				.withImplicitLookups(false) //
+				.enableImplicitProviders(false) //
 				.build();
 		assertThat(configParams.get(KEY)).isEmpty();
 	}
 
 	private static LauncherConfigurationParameters fromMap(Map<String, String> map) {
-		return LauncherConfigurationParameters.builder().withExplicitParameters(map).build();
+		return LauncherConfigurationParameters.builder().explicitParameters(map).build();
 	}
 
 	private static LauncherConfigurationParameters fromMapAndFile(Map<String, String> map, String configFileName) {
 		return LauncherConfigurationParameters.builder() //
-				.withExplicitParameters(map) //
-				.withConfigFileName(configFileName) //
+				.explicitParameters(map) //
+				.configFileName(configFileName) //
 				.build();
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherConfigurationParametersTests.java
@@ -53,9 +53,9 @@ class LauncherConfigurationParametersTests {
 	@Test
 	void constructorPreconditions() {
 		assertThrows(PreconditionViolationException.class, () -> fromMap(null));
-		assertThrows(PreconditionViolationException.class, () -> fromMap(emptyMap(), null));
-		assertThrows(PreconditionViolationException.class, () -> fromMap(emptyMap(), ""));
-		assertThrows(PreconditionViolationException.class, () -> fromMap(emptyMap(), "  "));
+		assertThrows(PreconditionViolationException.class, () -> fromMapAndFile(emptyMap(), null));
+		assertThrows(PreconditionViolationException.class, () -> fromMapAndFile(emptyMap(), ""));
+		assertThrows(PreconditionViolationException.class, () -> fromMapAndFile(emptyMap(), "  "));
 	}
 
 	@Test
@@ -91,7 +91,7 @@ class LauncherConfigurationParametersTests {
 
 	@Test
 	void configFile() {
-		ConfigurationParameters configParams = fromMap(emptyMap(), CONFIG_FILE_NAME);
+		ConfigurationParameters configParams = fromMapAndFile(emptyMap(), CONFIG_FILE_NAME);
 		assertThat(configParams.get(KEY)).contains(CONFIG_FILE);
 		assertThat(configParams.toString()).contains(CONFIG_FILE);
 	}
@@ -106,16 +106,15 @@ class LauncherConfigurationParametersTests {
 
 	@Test
 	void explicitConfigParamOverridesConfigFile() {
-		ConfigurationParameters configParams = fromMap(singletonMap(KEY, CONFIG_PARAM), CONFIG_FILE_NAME);
+		ConfigurationParameters configParams = fromMapAndFile(singletonMap(KEY, CONFIG_PARAM), CONFIG_FILE_NAME);
 		assertThat(configParams.get(KEY)).contains(CONFIG_PARAM);
 		assertThat(configParams.toString()).contains(CONFIG_PARAM);
-		assertThat(configParams.toString()).doesNotContain(CONFIG_FILE);
 	}
 
 	@Test
 	void systemPropertyOverridesConfigFile() {
 		System.setProperty(KEY, SYSTEM_PROPERTY);
-		ConfigurationParameters configParams = fromMap(emptyMap(), CONFIG_FILE_NAME);
+		ConfigurationParameters configParams = fromMapAndFile(emptyMap(), CONFIG_FILE_NAME);
 		assertThat(configParams.get(KEY)).contains(SYSTEM_PROPERTY);
 		assertThat(configParams.toString()).contains(CONFIG_FILE);
 	}
@@ -146,12 +145,24 @@ class LauncherConfigurationParametersTests {
 			"Failed to transform configuration parameter with key '" + KEY + "' and initial value '42'");
 	}
 
-	private static LauncherConfigurationParameters fromMap(Map<String, String> map) {
-		return new LauncherConfigurationParameters(map);
+	@Test
+	void ignoresSystemPropertyAndConfigFileWhenImplicitLookupsAreDisabled() {
+		System.setProperty(KEY, SYSTEM_PROPERTY);
+		ConfigurationParameters configParams = LauncherConfigurationParameters.builder() //
+				.withImplicitLookups(false) //
+				.build();
+		assertThat(configParams.get(KEY)).isEmpty();
 	}
 
-	private static LauncherConfigurationParameters fromMap(Map<String, String> map, String configFileName) {
-		return new LauncherConfigurationParameters(map, configFileName);
+	private static LauncherConfigurationParameters fromMap(Map<String, String> map) {
+		return LauncherConfigurationParameters.builder().withExplicitParameters(map).build();
+	}
+
+	private static LauncherConfigurationParameters fromMapAndFile(Map<String, String> map, String configFileName) {
+		return LauncherConfigurationParameters.builder() //
+				.withExplicitParameters(map) //
+				.withConfigFileName(configFileName) //
+				.build();
 	}
 
 	private static class Mutator implements TestInstancePostProcessor {

--- a/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.testkit.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.platform.engine.reporting.ReportEntry;
+
+public class EngineTestKitTests {
+
+	private static final String KEY = EngineTestKitTests.class.getName();
+
+	@BeforeEach
+	void setSystemProperty() {
+		System.setProperty(KEY, "from system property");
+	}
+
+	@AfterEach
+	void resetSystemProperty() {
+		System.clearProperty(KEY);
+	}
+
+	@Test
+	void ignoresImplicitConfigurationParametersByDefault() {
+		var value = executeExampleTestCaseAndCollectValue(builder -> builder);
+
+		assertThat(value).isEmpty();
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "true, from system property", "false," })
+	void usesImplicitConfigurationParametersWhenEnabled(boolean enabled, String expectedValue) {
+		var value = executeExampleTestCaseAndCollectValue(
+			builder -> builder.withImplicitConfigurationParameters(enabled));
+
+		assertThat(value).isEqualTo(Optional.ofNullable(expectedValue));
+	}
+
+	private Optional<String> executeExampleTestCaseAndCollectValue(UnaryOperator<EngineTestKit.Builder> configuration) {
+		return configuration.apply(EngineTestKit.engine("junit-jupiter")) //
+				.selectors(selectClass(ExampleTestCase.class)) //
+				.execute() //
+				.allEvents() //
+				.reportingEntryPublished() //
+				.map(event -> event.getPayload(ReportEntry.class).orElseThrow()) //
+				.map(ReportEntry::getKeyValuePairs) //
+				.map(entries -> entries.get(KEY)) //
+				.findFirst();
+	}
+
+	static class ExampleTestCase {
+
+		@RegisterExtension
+		BeforeEachCallback callback = context -> context.getConfigurationParameter(KEY) //
+				.ifPresent(value -> context.publishReportEntry(KEY, value));
+
+		@Test
+		void test() {
+		}
+
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
@@ -50,7 +50,7 @@ public class EngineTestKitTests {
 	@CsvSource({ "true, from system property", "false," })
 	void usesImplicitConfigurationParametersWhenEnabled(boolean enabled, String expectedValue) {
 		var value = executeExampleTestCaseAndCollectValue(
-			builder -> builder.withImplicitConfigurationParameters(enabled));
+			builder -> builder.enableImplicitConfigurationParameters(enabled));
 
 		assertThat(value).isEqualTo(Optional.ofNullable(expectedValue));
 	}


### PR DESCRIPTION
Resolves #2285.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
