### PR TITLE
Switch to Rouge as Asciidoctor syntax highlighter

### DIFF
--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -164,7 +164,7 @@ tasks {
 				"experimentalApisTableFile" to experimentalApisTableFile,
 				"deprecatedApisTableFile" to deprecatedApisTableFile,
 				"outdir" to outputDir.absolutePath,
-				"source-highlighter" to "coderay@", // TODO switch to "rouge" once supported by the html5 backend and on MS Windows
+				"source-highlighter" to "rouge",
 				"tabsize" to "4",
 				"toc" to "left",
 				"icons" to "font",


### PR DESCRIPTION
Now that https://github.com/asciidoctor/asciidoctorj/issues/429 is resolved, we can switch to Rouge, assuming it works on Windows.

@sormuras Could you please run `./gradlew asciidoctor asciidoctorPdf` to check the result on Windows?

Resolves #777.