### PR TITLE
Give PDF user guide a better name

### DIFF
--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -52,6 +52,7 @@ val releaseBranch = if (snapshot) "master" else "r${rootProject.version}"
 val docsDir = file("$buildDir/ghpages-docs")
 val replaceCurrentDocs = project.hasProperty("replaceCurrentDocs")
 val uploadPdfs = !snapshot
+val userGuidePdfFileName = "junit-user-guide-${rootProject.version}.pdf"
 val ota4jDocVersion = if (versions.opentest4j.contains("SNAPSHOT")) "snapshot" else versions.opentest4j
 val apiGuardianDocVersion = if (versions.apiguardian.contains("SNAPSHOT")) "snapshot" else versions.apiguardian
 
@@ -136,10 +137,6 @@ tasks {
 		dependsOn(generateConsoleLauncherOptions, generateExperimentalApisTable, generateDeprecatedApisTable)
 		inputs.files(consoleLauncherOptionsFile, experimentalApisTableFile, deprecatedApisTableFile)
 
-		sources {
-			include("**/index.adoc")
-		}
-
 		resources {
 			from(sourceDir) {
 				include("**/images/**/*.png")
@@ -148,7 +145,6 @@ tasks {
 		}
 
 		attributes(mapOf(
-				"linkToPdf" to uploadPdfs,
 				"jupiter-version" to version,
 				"platform-version" to project.property("platformVersion"),
 				"vintage-version" to project.property("vintageVersion"),
@@ -188,15 +184,27 @@ tasks {
 	}
 
 	asciidoctor {
+		sources {
+			include("**/index.adoc")
+		}
 		resources {
 			from(sourceDir) {
 				include("tocbot-*/**")
 			}
 		}
+		attributes(mapOf(
+				"linkToPdf" to uploadPdfs,
+				"userGuidePdfFileName" to userGuidePdfFileName,
+				"releaseNotesUrl" to "../release-notes/index.html#release-notes"
+		))
 	}
 
 	asciidoctorPdf {
+		sources {
+			include("user-guide/index.adoc")
+		}
 		copyAllResources()
+		attributes(mapOf("releaseNotesUrl" to "https://junit.org/junit5/docs/$docsVersion/release-notes/"))
 	}
 
 	val downloadJavadocElementLists by registering {
@@ -326,6 +334,7 @@ tasks {
 		if (uploadPdfs) {
 			from(asciidoctorPdf.map { it.outputDir }) {
 				include("**/*.pdf")
+				rename { userGuidePdfFileName }
 			}
 		}
 		from(fixJavadoc.map { it.destinationDir }) {

--- a/documentation/src/docs/asciidoc/user-guide/index.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/index.adoc
@@ -37,6 +37,6 @@ include::{basedir}/contributors.adoc[]
 [[release-notes]]
 == Release Notes
 
-The release notes are available <<../release-notes/index.adoc#release-notes,here>>.
+The release notes are available link:{releaseNotesUrl}[here].
 
 include::{basedir}/appendix.adoc[]

--- a/documentation/src/docs/asciidoc/user-guide/overview.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/overview.adoc
@@ -5,11 +5,11 @@ The goal of this document is to provide comprehensive reference documentation fo
 programmers writing tests, extension authors, and engine authors as well as build tool
 and IDE vendors.
 
-ifdef::linkToPdf[]
 ifdef::backend-html5[]
-This document is also available as a link:index.pdf[PDF download].
-endif::backend-html5[]
+ifdef::linkToPdf[]
+This document is also available as a link:{userGuidePdfFileName}[PDF download].
 endif::linkToPdf[]
+endif::backend-html5[]
 
 [[overview-what-is-junit-5]]
 === What is JUnit 5?


### PR DESCRIPTION
- No longer build release notes PDF
- Link from PDF user guide to HTML release notes

Issue: #770