### PR TITLE
Always call pre-destroy callbacks if instance was created

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -46,7 +46,9 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Registered `TestInstancePreDestroyCallback` extensions are now always called if an
+  instance of a test class was created, regardless whether any registered
+  `TestInstancePostProcessor` extension threw an exception.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -180,8 +180,11 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 			// Eagerly load test instance for BeforeAllCallbacks, if necessary,
 			// and store the instance in the ExtensionContext.
 			ClassExtensionContext extensionContext = (ClassExtensionContext) context.getExtensionContext();
-			throwableCollector.execute(() -> extensionContext.setTestInstances(
-				context.getTestInstancesProvider().getTestInstances(context.getExtensionRegistry())));
+			throwableCollector.execute(() -> {
+				TestInstances testInstances = context.getTestInstancesProvider().getTestInstances(
+					context.getExtensionRegistry(), throwableCollector);
+				extensionContext.setTestInstances(testInstances);
+			});
 		}
 
 		if (throwableCollector.isEmpty()) {
@@ -213,7 +216,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 			invokeAfterAllCallbacks(context);
 		}
 
-		if (isPerClassLifecycle(context)) {
+		if (isPerClassLifecycle(context) && context.getExtensionContext().getTestInstance().isPresent()) {
 			invokeTestInstancePreDestroyCallbacks(context);
 		}
 
@@ -252,24 +255,30 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 	private TestInstancesProvider testInstancesProvider(JupiterEngineExecutionContext parentExecutionContext,
 			ClassExtensionContext extensionContext) {
 
-		return (registry, registrar) -> extensionContext.getTestInstances().orElseGet(
-			() -> instantiateAndPostProcessTestInstance(parentExecutionContext, extensionContext, registry, registrar));
+		return (registry, registrar, throwableCollector) -> extensionContext.getTestInstances().orElseGet(
+			() -> instantiateAndPostProcessTestInstance(parentExecutionContext, extensionContext, registry, registrar,
+				throwableCollector));
 	}
 
 	private TestInstances instantiateAndPostProcessTestInstance(JupiterEngineExecutionContext parentExecutionContext,
-			ExtensionContext extensionContext, ExtensionRegistry registry, ExtensionRegistrar registrar) {
+			ExtensionContext extensionContext, ExtensionRegistry registry, ExtensionRegistrar registrar,
+			ThrowableCollector throwableCollector) {
 
-		TestInstances instances = instantiateTestClass(parentExecutionContext, registry, registrar, extensionContext);
-		invokeTestInstancePostProcessors(instances.getInnermostInstance(), registry, extensionContext);
-		// In addition, we register extensions from instance fields here since the
-		// best time to do that is immediately following test class instantiation
-		// and post processing.
-		registerExtensionsFromFields(registrar, this.testClass, instances.getInnermostInstance());
+		TestInstances instances = instantiateTestClass(parentExecutionContext, registry, registrar, extensionContext,
+			throwableCollector);
+		throwableCollector.execute(() -> {
+			invokeTestInstancePostProcessors(instances.getInnermostInstance(), registry, extensionContext);
+			// In addition, we register extensions from instance fields here since the
+			// best time to do that is immediately following test class instantiation
+			// and post processing.
+			registerExtensionsFromFields(registrar, this.testClass, instances.getInnermostInstance());
+		});
 		return instances;
 	}
 
 	protected abstract TestInstances instantiateTestClass(JupiterEngineExecutionContext parentExecutionContext,
-			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext);
+			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext,
+			ThrowableCollector throwableCollector);
 
 	protected TestInstances instantiateTestClass(Optional<TestInstances> outerInstances, ExtensionRegistry registry,
 			ExtensionContext extensionContext) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * {@link TestDescriptor} for tests based on Java classes.
@@ -73,7 +74,8 @@ public class ClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	@Override
 	protected TestInstances instantiateTestClass(JupiterEngineExecutionContext parentExecutionContext,
-			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext) {
+			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext,
+			ThrowableCollector throwableCollector) {
 		return instantiateTestClass(Optional.empty(), registry, extensionContext);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * {@link TestDescriptor} for tests based on nested (but not static) Java classes.
@@ -76,12 +77,13 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	@Override
 	protected TestInstances instantiateTestClass(JupiterEngineExecutionContext parentExecutionContext,
-			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext) {
+			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext,
+			ThrowableCollector throwableCollector) {
 
 		// Extensions registered for nested classes and below are not to be used for instantiating and initializing outer classes
 		ExtensionRegistry extensionRegistryForOuterInstanceCreation = parentExecutionContext.getExtensionRegistry();
 		TestInstances outerInstances = parentExecutionContext.getTestInstancesProvider().getTestInstances(
-			extensionRegistryForOuterInstanceCreation, registrar);
+			extensionRegistryForOuterInstanceCreation, registrar, throwableCollector);
 		return instantiateTestClass(Optional.of(outerInstances), registry, extensionContext);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/TestInstancesProvider.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/TestInstancesProvider.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.extension.ExtensionRegistrar;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
+import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * @since 5.0
@@ -25,10 +26,12 @@ import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
 @API(status = INTERNAL, since = "5.0")
 public interface TestInstancesProvider {
 
-	default TestInstances getTestInstances(MutableExtensionRegistry extensionRegistry) {
-		return getTestInstances(extensionRegistry, extensionRegistry);
+	default TestInstances getTestInstances(MutableExtensionRegistry extensionRegistry,
+			ThrowableCollector throwableCollector) {
+		return getTestInstances(extensionRegistry, extensionRegistry, throwableCollector);
 	}
 
-	TestInstances getTestInstances(ExtensionRegistry extensionRegistry, ExtensionRegistrar extensionRegistrar);
+	TestInstances getTestInstances(ExtensionRegistry extensionRegistry, ExtensionRegistrar extensionRegistrar,
+			ThrowableCollector throwableCollector);
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestInstancePostProcessorAndPreDestroyCallbackTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestInstancePostProcessorAndPreDestroyCallbackTests.java
@@ -92,11 +92,14 @@ class TestInstancePostProcessorAndPreDestroyCallbackTests extends AbstractJupite
 
 	@Test
 	void postProcessTestInstanceMethodThrowsAnException() {
-		// @formatter:off
 		assertPostProcessorAndPreDestroyCallbacks(ExceptionInTestInstancePostProcessorTestCase.class, 0,
-			"exceptionThrowingTestInstancePostProcessor"
-		);
-		// @formatter:on
+			"exceptionThrowingTestInstancePostProcessor", "exceptionPreDestroyTestInstance");
+	}
+
+	@Test
+	void testClassConstructorThrowsAnException() {
+		assertPostProcessorAndPreDestroyCallbacks(ExceptionInTestClassConstructorTestCase.class, 0,
+			"exceptionThrowingConstructor");
 	}
 
 	private void assertPostProcessorAndPreDestroyCallbacks(Class<?> testClass, String... expectedCalls) {
@@ -149,6 +152,7 @@ class TestInstancePostProcessorAndPreDestroyCallbackTests extends AbstractJupite
 
 	@ExtendWith(ExceptionThrowingTestInstancePreDestroyCallback.class)
 	static class ExceptionInTestInstancePreDestroyCallbackTestCase {
+
 		@Test
 		void test() {
 			callSequence.add("test");
@@ -157,6 +161,21 @@ class TestInstancePostProcessorAndPreDestroyCallbackTests extends AbstractJupite
 
 	@ExtendWith(ExceptionThrowingTestInstancePostProcessor.class)
 	static class ExceptionInTestInstancePostProcessorTestCase {
+
+		@Test
+		void test() {
+			callSequence.add("test");
+		}
+	}
+
+	@ExtendWith(FooTestInstanceCallbacks.class)
+	static class ExceptionInTestClassConstructorTestCase {
+
+		ExceptionInTestClassConstructorTestCase() {
+			callSequence.add("exceptionThrowingConstructor");
+			throw new RuntimeException("in constructor");
+		}
+
 		@Test
 		void test() {
 			callSequence.add("test");


### PR DESCRIPTION
Prior to this commit, pre-destroy callbacks were not called when an
instance was created but post-processing it failed. Now, they are always
called if the instance was created, regardless if any subsequent step
failed.

We previously had a test that asserted the old behavior. However, IMHO
the new behavior is more consistent and changing it is ok since
`TestInstancePreDestroyCallback` is still experimental.

Resolves #2312.