### PR TITLE
Introduce getJavaClass() and getJavaMethod() in MethodSource

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -40,7 +40,8 @@ on GitHub.
 * Support `FilePosition` in `FileSelector` and `ClasspathResourceSelector`.
 * Custom `PostDiscoveryFilter` implementations can now be registered via Java’s
   `ServiceLoader` mechanism.
-* New `getJavaClass` and `getJavaMethod` methods in class `MethodSource`
+* New `getJavaClass()` and `getJavaMethod()` methods in
+   `org.junit.platform.engine.support.descriptor.MethodSource`.
 
 [[release-notes-5.7.0-M2-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -40,6 +40,7 @@ on GitHub.
 * Support `FilePosition` in `FileSelector` and `ClasspathResourceSelector`.
 * Custom `PostDiscoveryFilter` implementations can now be registered via Java’s
   `ServiceLoader` mechanism.
+* New `getJavaClass` and `getJavaMethod` methods in class `MethodSource`
 
 [[release-notes-5.7.0-M2-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
@@ -181,10 +181,10 @@ public class MethodSource implements TestSource {
 	 * attempts to lazily load the {@link Class} based on its name and throws a
 	 * {@link PreconditionViolationException} if the class cannot be loaded.
 	 *
-	 * @since 5.7
+	 * @since 1.7
 	 * @see #getClassName()
 	 */
-	@API(status = STABLE, since = "5.7")
+	@API(status = STABLE, since = "1.7")
 	public final Class<?> getJavaClass() {
 		if (this.javaClass == null) {
 			this.javaClass = ReflectionUtils.tryToLoadClass(this.className).getOrThrow(
@@ -201,10 +201,10 @@ public class MethodSource implements TestSource {
 	 * attempts to lazily load the {@code Method} based on its name and throws a
 	 * {@link PreconditionViolationException} if the method cannot be loaded.
 	 *
-	 * @since 5.7
+	 * @since 1.7
 	 * @see #getMethodName()
 	 */
-	@API(status = STABLE, since = "5.7")
+	@API(status = STABLE, since = "1.7")
 	public Method getJavaMethod() {
 		if (this.javaMethod == null) {
 			if (StringUtils.isNotBlank(this.methodParameterTypes)) {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
@@ -222,14 +222,6 @@ class MethodSourceTests extends AbstractTestSourceTests {
 	}
 
 	@Test
-	void getJavaMethodFromString() throws Exception {
-		Method testMethod = getMethod("method1");
-		MethodSource source = MethodSource.from(testMethod);
-
-		assertThat(source.getJavaMethod()).isEqualTo(testMethod);
-	}
-
-	@Test
 	void getJavaMethodShouldReturnGivenMethodIfOverloadExists() throws Exception {
 		Method testMethod = getMethod("method3");
 		MethodSource source = MethodSource.from(testMethod);
@@ -238,15 +230,39 @@ class MethodSourceTests extends AbstractTestSourceTests {
 	}
 
 	@Test
-	void getJavaMethodShouldThrowExceptionIfMultipleMethodsExist() {
+	void getJavaMethodFromStringShouldFindVoidMethod() throws Exception {
+		Method testMethod = getClass().getDeclaredMethod("methodVoid");
+		MethodSource source = MethodSource.from(getClass().getName(), testMethod.getName());
+
+		assertThat(source.getJavaMethod()).isEqualTo(testMethod);
+	}
+
+	@Test
+	void getJavaMethodFromStringShouldFindMethodWithParameter() throws Exception {
+		Method testMethod = getClass().getDeclaredMethod("method3", Integer.TYPE);
+		MethodSource source = MethodSource.from(getClass().getName(), testMethod.getName(),
+			testMethod.getParameterTypes());
+
+		assertThat(source.getJavaMethod()).isEqualTo(testMethod);
+	}
+
+	@Test
+	void getJavaMethodFromStringShouldThrowExceptionParameterTypesNotGiven() {
 		MethodSource source = MethodSource.from(getClass().getName(), "method3");
 
 		assertThrows(PreconditionViolationException.class, source::getJavaMethod);
 	}
 
 	@Test
-	void getJavaMethodShouldThrowExceptionMethodDoesNotExist() {
-		MethodSource source = MethodSource.from(getClass().getName(), "method4");
+	void getJavaMethodFromStringShouldThrowExceptionIfParameterTypesDoNotMatch() {
+		MethodSource source = MethodSource.from(getClass().getName(), "method3", Double.TYPE);
+
+		assertThrows(PreconditionViolationException.class, source::getJavaMethod);
+	}
+
+	@Test
+	void getJavaMethodFromStringShouldThrowExceptionIfMethodDoesNotExist() {
+		MethodSource source = MethodSource.from(getClass().getName(), "methodX");
 
 		assertThrows(PreconditionViolationException.class, source::getJavaMethod);
 	}
@@ -269,6 +285,10 @@ class MethodSourceTests extends AbstractTestSourceTests {
 
 	@SuppressWarnings("unused")
 	void method3(int number) {
+	}
+
+	@SuppressWarnings("unused")
+	void methodVoid() {
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
@@ -45,6 +45,8 @@ class MethodSourceTests extends AbstractTestSourceTests {
 		assertThat(source.getClassName()).isEqualTo(getClass().getName());
 		assertThat(source.getMethodName()).isEqualTo(testMethod.getName());
 		assertThat(source.getMethodParameterTypes()).isEqualTo(String.class.getName());
+		assertThat(source.getJavaClass()).isEqualTo(getClass());
+		assertThat(source.getJavaMethod()).isEqualTo(testMethod);
 	}
 
 	@Test
@@ -205,6 +207,50 @@ class MethodSourceTests extends AbstractTestSourceTests {
 		assertNotEquals(MethodSource.from(m1).hashCode(), MethodSource.from(m2).hashCode());
 	}
 
+	@Test
+	void getJavaClassFromString() {
+		MethodSource source = MethodSource.from(getClass().getName(), "method1");
+
+		assertThat(source.getJavaClass()).isEqualTo(getClass());
+	}
+
+	@Test
+	void getJavaClassShouldThrowExceptionIfClassNotFound() {
+		MethodSource source = MethodSource.from(getClass().getName() + "X", "method1");
+
+		assertThrows(PreconditionViolationException.class, source::getJavaClass);
+	}
+
+	@Test
+	void getJavaMethodFromString() throws Exception {
+		Method testMethod = getMethod("method1");
+		MethodSource source = MethodSource.from(testMethod);
+
+		assertThat(source.getJavaMethod()).isEqualTo(testMethod);
+	}
+
+	@Test
+	void getJavaMethodShouldReturnGivenMethodIfOverloadExists() throws Exception {
+		Method testMethod = getMethod("method3");
+		MethodSource source = MethodSource.from(testMethod);
+
+		assertThat(source.getJavaMethod()).isEqualTo(testMethod);
+	}
+
+	@Test
+	void getJavaMethodShouldThrowExceptionIfMultipleMethodsExist() {
+		MethodSource source = MethodSource.from(getClass().getName(), "method3");
+
+		assertThrows(PreconditionViolationException.class, source::getJavaMethod);
+	}
+
+	@Test
+	void getJavaMethodShouldThrowExceptionMethodDoesNotExist() {
+		MethodSource source = MethodSource.from(getClass().getName(), "method4");
+
+		assertThrows(PreconditionViolationException.class, source::getJavaMethod);
+	}
+
 	private Method getMethod(String name) throws Exception {
 		return getClass().getDeclaredMethod(name, String.class);
 	}
@@ -215,6 +261,14 @@ class MethodSourceTests extends AbstractTestSourceTests {
 
 	@SuppressWarnings("unused")
 	void method2(String text) {
+	}
+
+	@SuppressWarnings("unused")
+	void method3(String text) {
+	}
+
+	@SuppressWarnings("unused")
+	void method3(int number) {
 	}
 
 }


### PR DESCRIPTION
Issue: #2294

## Overview

I saw there was some discussion about the issue reporter's working on a PR, but it had been almost a month so I hope I'm not stepping on any toes!

I added a getJavaMethods() method as well, because I was unsure what to do about overloaded methods. I see there is a methodParameterTypes field, which I imagine I could use to find the exact specified method. But I'm unsure about the format of the field and how consistent that format would be. Also does a null methodParameterTypes field mean there are no arguments, or just that no arguments were specified?

Also I made getJavaMethod() throw exceptions if there are 0 or >1 methods with the given name. Unsure if this is the desired behavior.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/master/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
