### PR TITLE
Replace "blacklisted" with "unrecoverable" exceptions

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertAll.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertAll.java
@@ -18,8 +18,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.function.Executable;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.opentest4j.MultipleFailuresError;
 
 /**
@@ -69,7 +69,7 @@ class AssertAll {
 						return null;
 					}
 					catch (Throwable t) {
-						BlacklistedExceptions.rethrowIfBlacklisted(t);
+						UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 						return t;
 					}
 				}) //

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
@@ -17,8 +17,8 @@ import java.util.function.Supplier;
 
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingSupplier;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -50,7 +50,7 @@ class AssertDoesNotThrow {
 			executable.execute();
 		}
 		catch (Throwable t) {
-			BlacklistedExceptions.rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			throw createAssertionFailedError(messageOrSupplier, t);
 		}
 	}
@@ -72,7 +72,7 @@ class AssertDoesNotThrow {
 			return supplier.get();
 		}
 		catch (Throwable t) {
-			BlacklistedExceptions.rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			throw createAssertionFailedError(messageOrSupplier, t);
 		}
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.function.Executable;
-import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -59,7 +59,7 @@ class AssertThrows {
 				return (T) actualException;
 			}
 			else {
-				BlacklistedExceptions.rethrowIfBlacklisted(actualException);
+				UnrecoverableExceptions.rethrowIfUnrecoverable(actualException);
 				String message = buildPrefix(nullSafeGet(messageOrSupplier))
 						+ format(expectedType, actualException.getClass(), "Unexpected exception type thrown");
 				throw new AssertionFailedError(message, actualException);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -15,8 +15,8 @@ import static java.util.stream.Collectors.joining;
 import java.util.Deque;
 import java.util.function.Supplier;
 
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -103,7 +103,7 @@ class AssertionUtils {
 			return (canonicalName != null ? canonicalName : clazz.getName());
 		}
 		catch (Throwable t) {
-			BlacklistedExceptions.rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			return clazz.getName();
 		}
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -2971,9 +2971,9 @@ public class Assertions {
 	 * and all exceptions will be aggregated and reported in a {@link MultipleFailuresError}.
 	 * In addition, all aggregated exceptions will be added as {@linkplain
 	 * Throwable#addSuppressed(Throwable) suppressed exceptions} to the
-	 * {@code MultipleFailuresError}. However, if an {@code executable} throws a
-	 * <em>blacklisted</em> exception &mdash; for example, an {@link OutOfMemoryError}
-	 * &mdash; execution will halt immediately, and the blacklisted exception will be
+	 * {@code MultipleFailuresError}. However, if an {@code executable} throws an
+	 * <em>unrecoverable</em> exception &mdash; for example, an {@link OutOfMemoryError}
+	 * &mdash; execution will halt immediately, and the unrecoverable exception will be
 	 * rethrown <em>as is</em> but <em>masked</em> as an unchecked exception.
 	 *
 	 * <p>The supplied {@code heading} will be included in the message string for the

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -59,10 +59,10 @@ import org.junit.jupiter.engine.extension.ExtensionRegistrar;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
 import org.junit.platform.commons.JUnitException;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
@@ -290,7 +290,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 				new DefaultTestInstanceFactoryContext(this.testClass, outerInstance), extensionContext);
 		}
 		catch (Throwable throwable) {
-			BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 
 			if (throwable instanceof TestInstantiationException) {
 				throw (TestInstantiationException) throwable;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -40,8 +40,8 @@ import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
@@ -123,7 +123,7 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 			handlerInvoker.invoke(exceptionHandlers.remove(0), throwable);
 		}
 		catch (Throwable handledThrowable) {
-			BlacklistedExceptions.rethrowIfBlacklisted(handledThrowable);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(handledThrowable);
 			invokeExecutionExceptionHandlers(exceptionHandlers, handledThrowable, handlerInvoker);
 		}
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -43,8 +43,8 @@ import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
@@ -213,7 +213,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 					interceptorCall);
 			}
 			catch (Throwable throwable) {
-				BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 				invokeTestExecutionExceptionHandlers(context.getExtensionRegistry(), extensionContext, throwable);
 			}
 		});
@@ -336,7 +336,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 				callback.accept(watcher);
 			}
 			catch (Throwable throwable) {
-				BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 				ExtensionContext extensionContext = context.getExtensionContext();
 				logger.warn(throwable,
 					() -> String.format("Failed to invoke TestWatcher [%s] for method [%s] with display name [%s]",

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.engine.descriptor.JupiterTestDescriptor;
 import org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestDescriptor;
 
 /**
@@ -52,7 +52,7 @@ class MethodOrderingVisitor implements TestDescriptor.Visitor {
 				orderContainedMethods(classBasedTestDescriptor, classBasedTestDescriptor.getTestClass());
 			}
 			catch (Throwable t) {
-				BlacklistedExceptions.rethrowIfBlacklisted(t);
+				UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 				logger.error(t, () -> "Failed to order methods for " + classBasedTestDescriptor.getTestClass());
 			}
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExecutableInvoker.java
@@ -33,9 +33,9 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 
 /**
  * {@code ExecutableInvoker} encapsulates the invocation of a
@@ -227,7 +227,7 @@ public class ExecutableInvoker {
 			throw ex;
 		}
 		catch (Throwable throwable) {
-			BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 
 			String message = String.format("Failed to resolve parameter [%s] in %s [%s]",
 				parameterContext.getParameter(), asLabel(executable), executable.toGenericString());

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocation.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
-import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 
 /**
  * @since 5.5
@@ -46,7 +46,7 @@ class TimeoutInvocation<T> implements Invocation<T> {
 			result = delegate.proceed();
 		}
 		catch (Throwable t) {
-			BlacklistedExceptions.rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			failure = t;
 		}
 		finally {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/OpenTest4JAndJUnit4AwareThrowableCollector.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/OpenTest4JAndJUnit4AwareThrowableCollector.java
@@ -15,8 +15,8 @@ import java.util.function.Supplier;
 
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 import org.opentest4j.TestAbortedException;
 
@@ -55,7 +55,7 @@ class OpenTest4JAndJUnit4AwareThrowableCollector extends ThrowableCollector {
 			}
 		}
 		catch (Throwable throwable) {
-			BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 			Supplier<String> messageSupplier = (throwable instanceof NoClassDefFoundError)
 					? () -> COMMON_FAILURE_MESSAGE + " Note that " + ASSUMPTION_VIOLATED_EXCEPTION
 							+ " requires that Hamcrest is on the classpath."

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertAllAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertAllAssertionsTests.java
@@ -175,7 +175,7 @@ class AssertAllAssertionsTests {
 	}
 
 	@Test
-	void assertAllWithExecutableThatThrowsBlacklistedException() {
+	void assertAllWithExecutableThatThrowsUnrecoverableException() {
 		OutOfMemoryError outOfMemoryError = assertThrows(OutOfMemoryError.class,
 			() -> assertAll(AssertionTestUtils::runOutOfMemory));
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/LifecycleMethodExecutionExceptionHandlerTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/LifecycleMethodExecutionExceptionHandlerTests.java
@@ -81,10 +81,10 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 		ConvertExceptionHandler.afterEachCalls = 0;
 		ConvertExceptionHandler.afterAllCalls = 0;
 
-		BlacklistedExceptionHandler.beforeAllCalls = 0;
-		BlacklistedExceptionHandler.beforeEachCalls = 0;
-		BlacklistedExceptionHandler.afterEachCalls = 0;
-		BlacklistedExceptionHandler.afterAllCalls = 0;
+		UnrecoverableExceptionHandler.beforeAllCalls = 0;
+		UnrecoverableExceptionHandler.beforeEachCalls = 0;
+		UnrecoverableExceptionHandler.afterEachCalls = 0;
+		UnrecoverableExceptionHandler.afterAllCalls = 0;
 
 		ShouldNotBeCalledHandler.beforeAllCalls = 0;
 		ShouldNotBeCalledHandler.beforeEachCalls = 0;
@@ -229,59 +229,60 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 	}
 
 	@Test
-	void blacklistedExceptionsAreNotPropagatedInBeforeAll() {
+	void unrecoverableExceptionsAreNotPropagatedInBeforeAll() {
 		throwExceptionBeforeAll = true;
 		throwExceptionBeforeEach = false;
 		throwExceptionAfterEach = false;
 		throwExceptionAfterAll = false;
 
-		boolean blackListedExceptionThrown = executeThrowingOutOfMemoryException();
-		assertTrue(blackListedExceptionThrown, "Blacklisted Exception should be thrown");
-		assertEquals(1, BlacklistedExceptionHandler.beforeAllCalls, "Exception should be handled in @BeforeAll");
+		boolean unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
+		assertTrue(unrecoverableExceptionThrown, "Unrecoverable Exception should be thrown");
+		assertEquals(1, UnrecoverableExceptionHandler.beforeAllCalls, "Exception should be handled in @BeforeAll");
 		assertEquals(0, ShouldNotBeCalledHandler.beforeAllCalls, "Exception should not propagate in @BeforeAll");
 	}
 
 	@Test
-	void blacklistedExceptionsAreNotPropagatedInBeforeEach() {
+	void unrecoverableExceptionsAreNotPropagatedInBeforeEach() {
 		throwExceptionBeforeAll = false;
 		throwExceptionBeforeEach = true;
 		throwExceptionAfterEach = false;
 		throwExceptionAfterAll = false;
 
-		boolean blackListedExceptionThrown = executeThrowingOutOfMemoryException();
-		assertTrue(blackListedExceptionThrown, "Blacklisted Exception should be thrown");
-		assertEquals(1, BlacklistedExceptionHandler.beforeEachCalls, "Exception should be handled in @BeforeEach");
+		boolean unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
+		assertTrue(unrecoverableExceptionThrown, "Unrecoverable Exception should be thrown");
+		assertEquals(1, UnrecoverableExceptionHandler.beforeEachCalls, "Exception should be handled in @BeforeEach");
 		assertEquals(0, ShouldNotBeCalledHandler.beforeEachCalls, "Exception should not propagate in @BeforeEach");
 	}
 
 	@Test
-	void blacklistedExceptionsAreNotPropagatedInAfterEach() {
+	void unrecoverableExceptionsAreNotPropagatedInAfterEach() {
 		throwExceptionBeforeAll = false;
 		throwExceptionBeforeEach = false;
 		throwExceptionAfterEach = true;
 		throwExceptionAfterAll = false;
 
-		boolean blackListedExceptionThrown = executeThrowingOutOfMemoryException();
-		assertTrue(blackListedExceptionThrown, "Blacklisted Exception should be thrown");
-		assertEquals(1, BlacklistedExceptionHandler.afterEachCalls, "Exception should be handled in @AfterEach");
+		boolean unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
+		assertTrue(unrecoverableExceptionThrown, "Unrecoverable Exception should be thrown");
+		assertEquals(1, UnrecoverableExceptionHandler.afterEachCalls, "Exception should be handled in @AfterEach");
 		assertEquals(0, ShouldNotBeCalledHandler.afterEachCalls, "Exception should not propagate in @AfterEach");
 	}
 
 	@Test
-	void blacklistedExceptionsAreNotPropagatedInAfterAll() {
+	void unrecoverableExceptionsAreNotPropagatedInAfterAll() {
 		throwExceptionBeforeAll = false;
 		throwExceptionBeforeEach = false;
 		throwExceptionAfterEach = false;
 		throwExceptionAfterAll = true;
 
-		boolean blackListedExceptionThrown = executeThrowingOutOfMemoryException();
-		assertTrue(blackListedExceptionThrown, "Blacklisted Exception should be thrown");
-		assertEquals(1, BlacklistedExceptionHandler.afterAllCalls, "Exception should be handled in @AfterAll");
+		boolean unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
+		assertTrue(unrecoverableExceptionThrown, "Unrecoverable Exception should be thrown");
+		assertEquals(1, UnrecoverableExceptionHandler.afterAllCalls, "Exception should be handled in @AfterAll");
 		assertEquals(0, ShouldNotBeCalledHandler.afterAllCalls, "Exception should not propagate in @AfterAll");
 	}
 
 	private boolean executeThrowingOutOfMemoryException() {
-		LauncherDiscoveryRequest request = request().selectors(selectClass(BlacklistedExceptionTestCase.class)).build();
+		LauncherDiscoveryRequest request = request().selectors(
+			selectClass(UnrecoverableExceptionTestCase.class)).build();
 		try {
 			executeTests(request);
 		}
@@ -340,8 +341,8 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 	}
 
 	@ExtendWith(ShouldNotBeCalledHandler.class)
-	@ExtendWith(BlacklistedExceptionHandler.class)
-	static class BlacklistedExceptionTestCase extends BaseTestCase {
+	@ExtendWith(UnrecoverableExceptionHandler.class)
+	static class UnrecoverableExceptionTestCase extends BaseTestCase {
 	}
 
 	@ExtendWith(ShouldNotBeCalledHandler.class)
@@ -493,7 +494,7 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 		}
 	}
 
-	static class BlacklistedExceptionHandler implements LifecycleMethodExecutionExceptionHandler {
+	static class UnrecoverableExceptionHandler implements LifecycleMethodExecutionExceptionHandler {
 		static int beforeAllCalls = 0;
 		static int beforeEachCalls = 0;
 		static int afterEachCalls = 0;
@@ -502,28 +503,28 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 		@Override
 		public void handleBeforeAllMethodExecutionException(ExtensionContext context, Throwable throwable) {
 			beforeAllCalls++;
-			handlerCalls.add("BlacklistedExceptionBeforeAll");
+			handlerCalls.add("UnrecoverableExceptionBeforeAll");
 			throw new OutOfMemoryError();
 		}
 
 		@Override
 		public void handleBeforeEachMethodExecutionException(ExtensionContext context, Throwable throwable) {
 			beforeEachCalls++;
-			handlerCalls.add("BlacklistedExceptionBeforeEach");
+			handlerCalls.add("UnrecoverableExceptionBeforeEach");
 			throw new OutOfMemoryError();
 		}
 
 		@Override
 		public void handleAfterEachMethodExecutionException(ExtensionContext context, Throwable throwable) {
 			afterEachCalls++;
-			handlerCalls.add("BlacklistedExceptionAfterEach");
+			handlerCalls.add("UnrecoverableExceptionAfterEach");
 			throw new OutOfMemoryError();
 		}
 
 		@Override
 		public void handleAfterAllMethodExecutionException(ExtensionContext context, Throwable throwable) {
 			afterAllCalls++;
-			handlerCalls.add("BlacklistedExceptionAfterAll");
+			handlerCalls.add("UnrecoverableExceptionAfterAll");
 			throw new OutOfMemoryError();
 		}
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
@@ -286,9 +286,9 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
-	@DisplayName("does not swallow blacklisted exceptions")
-	void doesNotSwallowBlacklistedExceptions() {
-		assertThrows(OutOfMemoryError.class, () -> executeTestsForClass(BlacklistedExceptionTestCase.class));
+	@DisplayName("does not swallow unrecoverable exceptions")
+	void doesNotSwallowUnrecoverableExceptions() {
+		assertThrows(OutOfMemoryError.class, () -> executeTestsForClass(UnrecoverableExceptionTestCase.class));
 	}
 
 	@Test
@@ -474,7 +474,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 		}
 	}
 
-	static class BlacklistedExceptionTestCase {
+	static class UnrecoverableExceptionTestCase {
 		@Test
 		@Timeout(value = 1, unit = NANOSECONDS)
 		void test() {

--- a/junit-jupiter-migrationsupport/src/test/java/org/junit/jupiter/migrationsupport/rules/FailAfterAllHelper.java
+++ b/junit-jupiter-migrationsupport/src/test/java/org/junit/jupiter/migrationsupport/rules/FailAfterAllHelper.java
@@ -16,7 +16,7 @@ package org.junit.jupiter.migrationsupport.rules;
 class FailAfterAllHelper {
 
 	static void fail() {
-		// hack: use this blacklisted exception to fail the build, since all others would be swallowed...
+		// hack: use this unrecoverable exception to fail the build, since all others would be swallowed...
 		throw new OutOfMemoryError("a postcondition was violated");
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -24,8 +24,8 @@ import com.univocity.parsers.csv.CsvParser;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 import org.junit.platform.commons.PreconditionViolationException;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 
 /**
  * @since 5.0
@@ -75,7 +75,7 @@ class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvS
 	}
 
 	static void handleCsvException(Throwable throwable, Annotation annotation) {
-		BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+		UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 		if (throwable instanceof PreconditionViolationException) {
 			throw (PreconditionViolationException) throwable;
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/BlacklistedExceptions.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/BlacklistedExceptions.java
@@ -32,7 +32,9 @@ import org.apiguardian.api.API;
  * Use at your own risk!
  *
  * @since 1.0
+ * @deprecated Use {@link UnrecoverableExceptions} instead.
  */
+@Deprecated
 @API(status = DEPRECATED, since = "1.7")
 public final class BlacklistedExceptions {
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassLoaderUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassLoaderUtils.java
@@ -44,7 +44,7 @@ public final class ClassLoaderUtils {
 			}
 		}
 		catch (Throwable t) {
-			BlacklistedExceptions.rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			/* otherwise ignore */
 		}
 		return ClassLoader.getSystemClassLoader();
@@ -75,7 +75,7 @@ public final class ClassLoaderUtils {
 				return Optional.ofNullable(loader.getResource(name));
 			}
 			catch (Throwable t) {
-				BlacklistedExceptions.rethrowIfBlacklisted(t);
+				UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 				/* otherwise ignore */
 			}
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScanner.java
@@ -14,7 +14,6 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static org.junit.platform.commons.util.BlacklistedExceptions.rethrowIfBlacklisted;
 import static org.junit.platform.commons.util.ClassFileVisitor.CLASS_FILE_SUFFIX;
 
 import java.io.IOException;
@@ -186,7 +185,7 @@ class ClasspathScanner {
 	}
 
 	private void handleThrowable(Path classFile, Throwable throwable) {
-		rethrowIfBlacklisted(throwable);
+		UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 		logGenericFileProcessingException(classFile, throwable);
 	}
 
@@ -196,7 +195,7 @@ class ClasspathScanner {
 				classFile.toAbsolutePath(), fullyQualifiedClassName));
 		}
 		catch (Throwable t) {
-			rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			ex.addSuppressed(t);
 			logGenericFileProcessingException(classFile, ex);
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
@@ -193,7 +193,7 @@ public final class StringUtils {
 			return obj.toString();
 		}
 		catch (Throwable throwable) {
-			BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 
 			return defaultToString(obj);
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/UnrecoverableExceptions.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/UnrecoverableExceptions.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.commons.util;
 
-import static org.apiguardian.api.API.Status.DEPRECATED;
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 
@@ -31,12 +31,12 @@ import org.apiguardian.api.API;
  * itself. <strong>Any usage by external parties is not supported.</strong>
  * Use at your own risk!
  *
- * @since 1.0
+ * @since 1.7
  */
-@API(status = DEPRECATED, since = "1.7")
-public final class BlacklistedExceptions {
+@API(status = INTERNAL, since = "1.7")
+public final class UnrecoverableExceptions {
 
-	private BlacklistedExceptions() {
+	private UnrecoverableExceptions() {
 		/* no-op */
 	}
 
@@ -46,13 +46,11 @@ public final class BlacklistedExceptions {
 	 *
 	 * <p>If the supplied {@code exception} is not <em>unrecoverable</em>, this
 	 * method does nothing.
-	 *
-	 * @deprecated Use {@link UnrecoverableExceptions#rethrowIfUnrecoverable}
-	 * instead.
 	 */
-	@Deprecated
-	public static void rethrowIfBlacklisted(Throwable exception) {
-		UnrecoverableExceptions.rethrowIfUnrecoverable(exception);
+	public static void rethrowIfUnrecoverable(Throwable exception) {
+		if (exception instanceof OutOfMemoryError) {
+			ExceptionUtils.throwAsUncheckedException(exception);
+		}
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolution.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolution.java
@@ -11,7 +11,6 @@
 package org.junit.platform.engine.support.discovery;
 
 import static java.util.stream.Collectors.joining;
-import static org.junit.platform.commons.util.BlacklistedExceptions.rethrowIfBlacklisted;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.SelectorResolutionResult.failed;
 import static org.junit.platform.engine.SelectorResolutionResult.resolved;
@@ -30,6 +29,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryListener;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -98,7 +98,7 @@ class EngineDiscoveryRequestResolution {
 			}
 		}
 		catch (Throwable t) {
-			rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			discoveryListener.selectorProcessed(engineId, selector, failed(t));
 		}
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -24,9 +24,9 @@ import java.util.concurrent.Future;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService.TestTask;
@@ -161,7 +161,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 				node.nodeSkipped(context, testDescriptor, skipResult);
 			}
 			catch (Throwable throwable) {
-				BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 				logger.debug(throwable,
 					() -> String.format("Failed to invoke nodeSkipped() on Node %s", testDescriptor.getUniqueId()));
 			}
@@ -176,7 +176,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 			node.nodeFinished(context, testDescriptor, throwableCollector.toTestExecutionResult());
 		}
 		catch (Throwable throwable) {
-			BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 			logger.debug(throwable,
 				() -> String.format("Failed to invoke nodeFinished() on Node %s", testDescriptor.getUniqueId()));
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleTestExecutor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleTestExecutor.java
@@ -11,12 +11,12 @@
 package org.junit.platform.engine.support.hierarchical;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.junit.platform.commons.util.BlacklistedExceptions.rethrowIfBlacklisted;
 import static org.junit.platform.engine.TestExecutionResult.aborted;
 import static org.junit.platform.engine.TestExecutionResult.failed;
 import static org.junit.platform.engine.TestExecutionResult.successful;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestExecutionResult;
 import org.opentest4j.TestAbortedException;
 
@@ -54,7 +54,7 @@ public class SingleTestExecutor {
 	 * Execute the supplied {@link Executable} and return a
 	 * {@link TestExecutionResult} based on the outcome.
 	 *
-	 * <p>If the {@code Executable} throws a <em>blacklisted</em> exception
+	 * <p>If the {@code Executable} throws an <em>unrecoverable</em> exception
 	 * &mdash; for example, an {@link OutOfMemoryError} &mdash; this method will
 	 * rethrow it.
 	 *
@@ -74,7 +74,7 @@ public class SingleTestExecutor {
 			return aborted(e);
 		}
 		catch (Throwable t) {
-			rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			return failed(t);
 		}
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ThrowableCollector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ThrowableCollector.java
@@ -11,7 +11,6 @@
 package org.junit.platform.engine.support.hierarchical;
 
 import static org.apiguardian.api.API.Status.MAINTAINED;
-import static org.junit.platform.commons.util.BlacklistedExceptions.rethrowIfBlacklisted;
 import static org.junit.platform.engine.TestExecutionResult.aborted;
 import static org.junit.platform.engine.TestExecutionResult.failed;
 import static org.junit.platform.engine.TestExecutionResult.successful;
@@ -21,6 +20,7 @@ import java.util.function.Predicate;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestExecutionResult;
 
 /**
@@ -61,7 +61,7 @@ public class ThrowableCollector {
 	 * Execute the supplied {@link Executable} and collect any {@link Throwable}
 	 * thrown during the execution.
 	 *
-	 * <p>If the {@code Executable} throws a <em>blacklisted</em> exception
+	 * <p>If the {@code Executable} throws an <em>unrecoverable</em> exception
 	 * &mdash; for example, an {@link OutOfMemoryError} &mdash; this method will
 	 * rethrow it.
 	 *
@@ -73,7 +73,7 @@ public class ThrowableCollector {
 			executable.execute();
 		}
 		catch (Throwable t) {
-			rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			add(t);
 		}
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -25,7 +25,7 @@ import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
@@ -106,7 +106,7 @@ public class EngineDiscoveryOrchestrator {
 			return engineRoot;
 		}
 		catch (Throwable throwable) {
-			BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 			String message = String.format("TestEngine with ID '%s' failed to discover tests", testEngine.getId());
 			JUnitException cause = new JUnitException(message, throwable);
 			discoveryListener.engineDiscoveryFinished(uniqueEngineId, EngineDiscoveryResult.failed(cause));

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
-import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
@@ -108,7 +108,7 @@ public class EngineExecutionOrchestrator {
 			delayingListener.reportEngineOutcome();
 		}
 		catch (Throwable throwable) {
-			BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 			delayingListener.reportEngineFailure(new JUnitException(
 				String.format("TestEngine with ID '%s' failed to execute tests", testEngine.getId()), throwable));
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestExecutionListenerRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestExecutionListenerRegistry.java
@@ -19,7 +19,7 @@ import java.util.function.Supplier;
 
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -67,7 +67,7 @@ class TestExecutionListenerRegistry {
 				consumer.accept(listener);
 			}
 			catch (Throwable throwable) {
-				BlacklistedExceptions.rethrowIfBlacklisted(throwable);
+				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 				logger.warn(throwable, () -> String.format("TestExecutionListener [%s] threw exception for method: %s",
 					listener.getClass().getName(), description.get()));
 			}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LauncherDiscoveryListeners.java
@@ -53,7 +53,7 @@ public class LauncherDiscoveryListeners {
 	 *         {@link UniqueIdSelector} that starts with the engine's unique ID.
 	 *     </li>
 	 *     <li>
-	 *         any non-blacklisted {@link Throwable} thrown by
+	 *         any recoverable {@link Throwable} thrown by
 	 *         {@link TestEngine#discover}.
 	 *     </li>
 	 * </ul>

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Assertions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Assertions.java
@@ -15,9 +15,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.platform.commons.util.BlacklistedExceptions;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.MultipleFailuresError;
 
@@ -45,7 +45,7 @@ class Assertions {
 						return null;
 					}
 					catch (Throwable t) {
-						BlacklistedExceptions.rethrowIfBlacklisted(t);
+						UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 						return t;
 					}
 				}) //

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/JUnit4VersionCheck.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/JUnit4VersionCheck.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 import junit.runner.Version;
 
 import org.junit.platform.commons.JUnitException;
-import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 
 /**
  * @since 5.4
@@ -69,7 +69,7 @@ class JUnit4VersionCheck {
 			return versionSupplier.get();
 		}
 		catch (Throwable t) {
-			BlacklistedExceptions.rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			throw new JUnitException("Failed to read version of junit:junit", t);
 		}
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunnerExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunnerExecutor.java
@@ -14,7 +14,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.engine.TestExecutionResult.failed;
 
 import org.apiguardian.api.API;
-import org.junit.platform.commons.util.BlacklistedExceptions;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.runner.JUnitCore;
@@ -43,7 +43,7 @@ public class RunnerExecutor {
 			core.run(runnerTestDescriptor.toRequest());
 		}
 		catch (Throwable t) {
-			BlacklistedExceptions.rethrowIfBlacklisted(t);
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			reportUnexpectedFailure(testRun, runnerTestDescriptor, failed(t));
 		}
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestExecutorTests.java
@@ -606,7 +606,7 @@ class HierarchicalTestExecutorTests {
 	}
 
 	/**
-	 * Verifies support for blacklisted exceptions.
+	 * Verifies support for unrecoverable exceptions.
 	 */
 	@Test
 	void outOfMemoryErrorInShouldBeSkipped() throws Exception {
@@ -620,7 +620,7 @@ class HierarchicalTestExecutorTests {
 	}
 
 	/**
-	 * Verifies support for blacklisted exceptions.
+	 * Verifies support for unrecoverable exceptions.
 	 */
 	@Test
 	void outOfMemoryErrorInLeafExecution() {


### PR DESCRIPTION
This commit replaces the oppressive term "blacklist" [1] with a more
descriptive, domain-specific one. Exceptions that are rethrown by the
new `UnrecoverableExceptions.rethrowIfUnrecoverable` method, are
_unrecoverable_, i.e. they should always terminate test plan execution
immediately instead of being caught and potentially wrapped in another
exception.

To support running newer engines on an older Platform, the existing
class is deprecated instead of deleted for now.

[1] https://tools.ietf.org/id/draft-knodel-terminology-00.html#rfc.section.1.2