### PR TITLE
Add examples to Javadoc section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,15 +95,15 @@ In multi-line bullet point entries, subsequent lines should be indented.
 - Insert a blank line before at-clauses/tags.
 - Favor `{@code foo}` over `<code>foo</code>`.
 - Favor literals (e.g., `{@literal @}`) over HTML entities.
-- New classes and methods should have `@since ...` annotation  
+- New classes and methods should have `@since ...` annotation.
 - Use `@since 5.0` instead of `@since 5.0.0`.
-- Do not use `@author` tags. Instead, contributors are listed on [GitHub](https://github.com/junit-team/junit5/graphs/contributors). 
+- Do not use `@author` tags. Instead, contributors are listed on [GitHub](https://github.com/junit-team/junit5/graphs/contributors).
 - Do not use verbs in third person form (e.g. use "Discover tests..." instead of "Discover tests...")
   in the first sentence describing a method.
 
 #### Examples
 
-See [`ExtensionContext`](junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java) and 
+See [`ExtensionContext`](junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java) and
 [`ParameterContext`](junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java) for example Javadoc.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,56 +95,16 @@ In multi-line bullet point entries, subsequent lines should be indented.
 - Insert a blank line before at-clauses/tags.
 - Favor `{@code foo}` over `<code>foo</code>`.
 - Favor literals (e.g., `{@literal @}`) over HTML entities.
-- New classes should have the JavaDoc that describes the class
-- New classes should have `@since ...` annotation  
+- New classes and methods should have `@since ...` annotation  
 - Use `@since 5.0` instead of `@since 5.0.0`.
 - Do not use `@author` tags. Instead, contributors are listed on [GitHub](https://github.com/junit-team/junit5/graphs/contributors). 
-- Do not use verbs in third person form (use "Get" instead of "Gets" for example). 
+- Do not use verbs in third person form (e.g. use "Discover tests..." instead of "Discover tests..." 
+  in the first sentence describing a method). 
 
 #### JavaDoc Examples
 
-Below is an example of a standard Java-Doc for method `Optional<AnnotatedElement> getElement()`: 
-
-```
-/**
- * Get the {@link AnnotatedElement} corresponding to the current extension
- * context, if available.
- *
- * <p>For example, if the current extension context encapsulates a test
- * class, test method, test factory method, or test template method, the
- * annotated element will be the corresponding {@link Class} or {@link Method}
- * reference.
- *
- * <p>Favor this method over more specific methods whenever the
- * {@code AnnotatedElement} API suits the task at hand &mdash; for example,
- * when looking up annotations regardless of concrete element type.
- *
- * @return an {@code Optional} containing the {@code AnnotatedElement};
- * never {@code null} but potentially empty
- * @see #getTestClass()
- * @see #getTestMethod()
- */
-``` 
-
-Another example that shows the JavaDoc for ParameterContext interface: 
-
-```
-/**
- * {@code ParameterContext} encapsulates the <em>context</em> in which an
- * {@link #getDeclaringExecutable Executable} will be invoked for a given
- * {@link #getParameter Parameter}.
- *
- * <p>A {@code ParameterContext} is used to support parameter resolution via
- * a {@link ParameterResolver}.
- *
- * @since 5.0
- * @see ParameterResolver
- * @see java.lang.reflect.Parameter
- * @see java.lang.reflect.Executable
- * @see java.lang.reflect.Method
- * @see java.lang.reflect.Constructor
- */
-```
+See [here](java\org\junit\jupiter\api\extension\ExtensionContext.java) and 
+[here](java\org\junit\jupiter\api\extension\ParameterContext.java) for example javadoc
 
 
 ### Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,56 @@ In multi-line bullet point entries, subsequent lines should be indented.
 - Insert a blank line before at-clauses/tags.
 - Favor `{@code foo}` over `<code>foo</code>`.
 - Favor literals (e.g., `{@literal @}`) over HTML entities.
+- New classes should have the JavaDoc that describes the class
+- New classes should have `@since ...` annotation  
 - Use `@since 5.0` instead of `@since 5.0.0`.
-- Do not use `@author` tags. Instead, contributors are listed on [GitHub](https://github.com/junit-team/junit5/graphs/contributors).
+- Do not use `@author` tags. Instead, contributors are listed on [GitHub](https://github.com/junit-team/junit5/graphs/contributors). 
+
+#### JavaDoc Examples
+
+Below is an example of a standard Java-Doc for method `Optional<AnnotatedElement> getElement()`: 
+
+```
+/**
+ * Get the {@link AnnotatedElement} corresponding to the current extension
+ * context, if available.
+ *
+ * <p>For example, if the current extension context encapsulates a test
+ * class, test method, test factory method, or test template method, the
+ * annotated element will be the corresponding {@link Class} or {@link Method}
+ * reference.
+ *
+ * <p>Favor this method over more specific methods whenever the
+ * {@code AnnotatedElement} API suits the task at hand &mdash; for example,
+ * when looking up annotations regardless of concrete element type.
+ *
+ * @return an {@code Optional} containing the {@code AnnotatedElement};
+ * never {@code null} but potentially empty
+ * @see #getTestClass()
+ * @see #getTestMethod()
+ */
+``` 
+
+Another example that shows the JavaDoc for ParameterContext interface: 
+
+```
+/**
+ * {@code ParameterContext} encapsulates the <em>context</em> in which an
+ * {@link #getDeclaringExecutable Executable} will be invoked for a given
+ * {@link #getParameter Parameter}.
+ *
+ * <p>A {@code ParameterContext} is used to support parameter resolution via
+ * a {@link ParameterResolver}.
+ *
+ * @since 5.0
+ * @see ParameterResolver
+ * @see java.lang.reflect.Parameter
+ * @see java.lang.reflect.Executable
+ * @see java.lang.reflect.Method
+ * @see java.lang.reflect.Constructor
+ */
+```
+
 
 ### Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ In multi-line bullet point entries, subsequent lines should be indented.
 - New classes should have `@since ...` annotation  
 - Use `@since 5.0` instead of `@since 5.0.0`.
 - Do not use `@author` tags. Instead, contributors are listed on [GitHub](https://github.com/junit-team/junit5/graphs/contributors). 
+- Do not use verbs in third person form (use "Get" instead of "Gets" for example). 
 
 #### JavaDoc Examples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,8 @@ In multi-line bullet point entries, subsequent lines should be indented.
 
 #### JavaDoc Examples
 
-See [here](java\org\junit\jupiter\api\extension\ExtensionContext.java) and 
-[here](java\org\junit\jupiter\api\extension\ParameterContext.java) for example javadoc
+See [here](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java) and 
+[here](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java) for example javadoc
 
 
 ### Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,13 +98,13 @@ In multi-line bullet point entries, subsequent lines should be indented.
 - New classes and methods should have `@since ...` annotation  
 - Use `@since 5.0` instead of `@since 5.0.0`.
 - Do not use `@author` tags. Instead, contributors are listed on [GitHub](https://github.com/junit-team/junit5/graphs/contributors). 
-- Do not use verbs in third person form (e.g. use "Discover tests..." instead of "Discover tests..." 
-  in the first sentence describing a method). 
+- Do not use verbs in third person form (e.g. use "Discover tests..." instead of "Discover tests...")
+  in the first sentence describing a method.
 
-#### JavaDoc Examples
+#### Examples
 
-See [here](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java) and 
-[here](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java) for example javadoc
+See [`ExtensionContext`](junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java) and 
+[`ParameterContext`](junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java) for example Javadoc.
 
 
 ### Tests


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
Hello! I want to contribute and found the simplest issue I could: #1007

It is unclear to me whether it was resolved or not since there is a javadoc section under contribute.md. 

I tried to read the linked issue but it seems like the latest versions have their own standards. 

So I added an example section for the javadoc section. If this is good for you I can continue updating the document. 

If the issue is no longer valid then you can discard this merge request. 

Resolves #1007

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
