### PR TITLE
Introduce `TypedArgumentConverter` as a more specific `ArgumentConverter`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -105,6 +105,8 @@ on GitHub.
   same functionality but a more descriptive name.
 * `assertTimeoutPreemptively` in `Assertions` now reports the stacktrace of the timed out
   thread in the cause of the `AssertionFailedError`.
+* New `TypedArgumentConverter` that always convert one specific type to another, therefore
+  reducing boilerplate type checks compared to `ArgumentConverter`.
 
 [[release-notes-5.7.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -105,8 +105,8 @@ on GitHub.
   same functionality but a more descriptive name.
 * `assertTimeoutPreemptively` in `Assertions` now reports the stacktrace of the timed out
   thread in the cause of the `AssertionFailedError`.
-* New `TypedArgumentConverter` that always convert one specific type to another, therefore
-  reducing boilerplate type checks compared to `ArgumentConverter`.
+* New `TypedArgumentConverter` for converting one specific type to another, therefore
+  reducing boilerplate type checks compared to implementing `ArgumentConverter` directly.
 
 [[release-notes-5.7.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1442,6 +1442,14 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=explicit_conversion_e
 include::{testDir}/example/ParameterizedTestDemo.java[tags=explicit_conversion_example_ToStringArgumentConverter]
 ----
 
+If the converter is only meant to convert one type to another, you can extend
+`TypedArgumentConverter` that reduce boilerplate type checks.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=explicit_conversion_example_TypedArgumentConverter]
+----
+
 Explicit argument converters are meant to be implemented by test and extension authors.
 Thus, `junit-jupiter-params` only provides a single explicit argument converter that may
 also serve as a reference implementation: `JavaTimeArgumentConverter`. It is used via the

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1443,7 +1443,7 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=explicit_conversion_e
 ----
 
 If the converter is only meant to convert one type to another, you can extend
-`TypedArgumentConverter` that reduce boilerplate type checks.
+`TypedArgumentConverter` to avoid boilerplate type checks.
 
 [source,java,indent=0]
 ----

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAggregator;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.converter.JavaTimeConversionPattern;
 import org.junit.jupiter.params.converter.SimpleArgumentConverter;
+import org.junit.jupiter.params.converter.TypedArgumentConverter;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -332,6 +333,22 @@ class ParameterizedTestDemo {
 		}
 	}
 	// end::explicit_conversion_example_ToStringArgumentConverter[]
+
+	static
+	// tag::explicit_conversion_example_TypedArgumentConverter[]
+	public class ToLengthArgumentConverter extends TypedArgumentConverter<String, Integer> {
+
+		protected ToLengthArgumentConverter() {
+			super(String.class, Integer.class);
+		}
+
+		@Override
+		protected Integer convert(String source) {
+			return source.length();
+		}
+
+	}
+	// end::explicit_conversion_example_TypedArgumentConverter[]
 
 	// tag::explicit_java_time_converter[]
 	@ParameterizedTest

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/SimpleArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/SimpleArgumentConverter.java
@@ -31,7 +31,7 @@ public abstract class SimpleArgumentConverter implements ArgumentConverter {
 	}
 
 	/**
-	 * Convert the supplied {@code source} object into to the supplied
+	 * Convert the supplied {@code source} object into the supplied
 	 * {@code targetType}.
 	 *
 	 * @param source the source object to convert; may be {@code null}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/TypedArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/TypedArgumentConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.converter;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+/**
+ * {@code TypedArgumentConverter} is an {@code ArgumentConverter} that
+ * always converts a given type to another.
+ *
+ * @param <S> the type of the argument to convert
+ * @param <T> the type of the target
+ * @since 5.7
+ * @see ArgumentConverter
+ */
+@API(status = EXPERIMENTAL, since = "5.7")
+public abstract class TypedArgumentConverter<S, T> implements ArgumentConverter {
+
+	private final Class<S> sourceType;
+	private final Class<T> targetType;
+
+	protected TypedArgumentConverter(Class<S> sourceType, Class<T> targetType) {
+		this.sourceType = sourceType;
+		this.targetType = targetType;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public final Object convert(Object source, ParameterContext context) throws ArgumentConversionException {
+		if (!sourceType.isAssignableFrom(source.getClass())) {
+			throw new ArgumentConversionException("Can only convert objects of type " + sourceType);
+		}
+		if (!targetType.isAssignableFrom(context.getParameter().getType())) {
+			throw new ArgumentConversionException("Can only convert to type " + targetType);
+		}
+		return convert((S) source);
+	}
+
+	/**
+	 * Convert the supplied {@code source} object of type S into an object
+	 * of type T.
+	 *
+	 * @param source the source object to convert; may be {@code null}
+	 * @return the converted object
+	 * @throws ArgumentConversionException in case an error occurs during the
+	 * conversion
+	 */
+	protected abstract T convert(S source) throws ArgumentConversionException;
+
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/TypedArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/TypedArgumentConverter.java
@@ -36,7 +36,6 @@ public abstract class TypedArgumentConverter<S, T> implements ArgumentConverter 
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public final Object convert(Object source, ParameterContext context) throws ArgumentConversionException {
 		if (!sourceType.isAssignableFrom(source.getClass())) {
 			throw new ArgumentConversionException("Can only convert objects of type " + sourceType);
@@ -44,7 +43,7 @@ public abstract class TypedArgumentConverter<S, T> implements ArgumentConverter 
 		if (!targetType.isAssignableFrom(context.getParameter().getType())) {
 			throw new ArgumentConversionException("Can only convert to type " + targetType);
 		}
-		return convert((S) source);
+		return convert(sourceType.cast(source));
 	}
 
 	/**

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/TypedArgumentConverterTest.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/TypedArgumentConverterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TypedArgumentConverter}.
+ *
+ * @since 5.7
+ */
+public class TypedArgumentConverterTest {
+
+	@Test
+	void convertsSourceToTarget() {
+		assertConverts("abcd", 4);
+		assertConverts("", 0);
+	}
+
+	private void assertConverts(String input, Integer expectedOutput) {
+		Integer result = new StringLengthArgumentConverter().convert(input);
+		assertThat(result).isEqualTo(expectedOutput);
+	}
+
+	private static class StringLengthArgumentConverter extends TypedArgumentConverter<String, Integer> {
+
+		protected StringLengthArgumentConverter() {
+			super(String.class, Integer.class);
+		}
+
+		@Override
+		protected Integer convert(String source) throws ArgumentConversionException {
+			return source.length();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Resolves #2284.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
