### PR TITLE
Describe deprecation in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,3 +126,20 @@ In multi-line bullet point entries, subsequent lines should be indented.
   - _config_ (JUL: `CONFIG`, Log4J: `CONFIG`): information related to configuration of the system (Example: `ServiceLoaderTestEngineRegistry` logs IDs of discovered engines)
   - _debug_ (JUL: `FINE`, Log4J: `DEBUG`)
   - _trace_ (JUL: `FINER`, Log4J: `TRACE`)
+
+### Deprecation
+
+Publicly available interfaces, classes and methods have a defined lifecycle
+which is described in detail in [User Guide - API
+Evolution](https://junit.org/junit5/docs/current/user-guide/#api-evolution).
+This process is using the `@API` annotation from API Guardian. It also describes
+the deprecation process followed for API items.
+
+To deprecate items,
+- Update the `@API.status` to reflect the new status. eg `DEPRECATED`,
+  `MAINTAINED`, etc.
+- Update `@API.since`. Please note `since` describes the version when the
+  status was changed and not the introduction of the element.
+- Add the java `@Deprecated` annotation and `@deprecated` javadoc tag to
+  describe the deprecation. If the element is used in existing code add
+  `@SuppressWarnings("deprecation")` to make the build pass.


### PR DESCRIPTION
## Overview

While working for #2336 we have found that it could be useful to document the deprecation procedure in more detail in the CONTRIBUTING.md.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
