### PR TITLE
Respect `--disable-ansi-colors` option when showing usage help

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -67,7 +67,7 @@ public class ConsoleLauncher {
 				displayBanner(out);
 			}
 			if (options.isDisplayHelp()) {
-				commandLineOptionsParser.printHelp(out);
+				commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
 				return ConsoleLauncherExecutionResult.success();
 			}
 			return executeTests(options, out);
@@ -75,7 +75,7 @@ public class ConsoleLauncher {
 		catch (JUnitException ex) {
 			err.println(ex.getMessage());
 			err.println();
-			commandLineOptionsParser.printHelp(err);
+			commandLineOptionsParser.printHelp(err, false);
 			return ConsoleLauncherExecutionResult.failed();
 		}
 		finally {
@@ -98,7 +98,7 @@ public class ConsoleLauncher {
 		catch (Exception exception) {
 			exception.printStackTrace(err);
 			err.println();
-			commandLineOptionsParser.printHelp(out);
+			commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
 		}
 		return ConsoleLauncherExecutionResult.failed();
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptionsParser.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptionsParser.java
@@ -24,6 +24,6 @@ public interface CommandLineOptionsParser {
 
 	CommandLineOptions parse(String... arguments);
 
-	void printHelp(Writer writer);
+	void printHelp(Writer writer, boolean disableColor);
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/PicocliCommandLineOptionsParser.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/PicocliCommandLineOptionsParser.java
@@ -41,9 +41,16 @@ public class PicocliCommandLineOptionsParser implements CommandLineOptionsParser
 	}
 
 	@Override
-	public void printHelp(Writer writer) {
+	public void printHelp(Writer writer, boolean disableColor) {
 		try {
-			writer.write(getAvailableOptions().getParser().getUsageMessage());
+			if (disableColor) {
+				CommandLine parser = getAvailableOptions().getParser();
+				parser.setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.OFF));
+				writer.append(parser.getUsageMessage());
+			}
+			else {
+				writer.write(getAvailableOptions().getParser().getUsageMessage());
+			}
 		}
 		catch (IOException e) {
 			throw new JUnitException("Error printing help", e);

--- a/platform-tests/src/test/java/org/junit/platform/console/options/PicocliCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/PicocliCommandLineOptionsParserTests.java
@@ -539,7 +539,7 @@ class PicocliCommandLineOptionsParserTests {
 	void printHelpOutputsHelpOption() {
 		StringWriter writer = new StringWriter();
 
-		createParser().printHelp(writer);
+		createParser().printHelp(writer, true);
 
 		assertThat(writer.toString()).contains("--help");
 	}
@@ -563,7 +563,7 @@ class PicocliCommandLineOptionsParserTests {
 		};
 
 		CommandLineOptionsParser parser = createParser();
-		RuntimeException exception = assertThrows(RuntimeException.class, () -> parser.printHelp(writer));
+		RuntimeException exception = assertThrows(RuntimeException.class, () -> parser.printHelp(writer, true));
 
 		assertThat(exception).hasCauseInstanceOf(IOException.class);
 		assertThat(exception.getCause()).hasMessage("Something went wrong");


### PR DESCRIPTION
## Overview

I have updated the command line parser so that the `ConsoleLauncher` disables colors when printing help (see #1537).

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
