### PR TITLE
Cache Gradle wrapper and dependencies on CI builds

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -23,6 +23,22 @@ jobs:
     container: "junitteam/build:${{ matrix.jdk }}"
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Gradle wrapper and dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            /root/.gradle/caches/
+            /root/.gradle/wrapper/dists
+          key: test-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
+          restore-keys: |
+            test-${{ runner.os }}-gradle-
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: /root/.m2/repository
+          key: test-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            test-${{ runner.os }}-maven-
       - name: Prepare Gradle Enterprise credentials
         run: |
           mkdir -p /root/.gradle/enterprise/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,22 @@ jobs:
     container: junitteam/build:latest
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Gradle wrapper and dependencies
+      uses: actions/cache@v2
+      with:
+        path: | 
+          /root/.gradle/caches/
+          /root/.gradle/wrapper/dists
+        key: test-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
+        restore-keys: |
+          test-${{ runner.os }}-gradle-
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: /root/.m2/repository
+        key: test-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          test-${{ runner.os }}-maven-
     - name: Prepare Gradle Enterprise credentials
       run: |
         mkdir -p /root/.gradle/enterprise/
@@ -34,6 +50,22 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Gradle wrapper and dependencies
+      uses: actions/cache@v2
+      with:
+        path: | 
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/dists
+        key: test-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
+        restore-keys: |
+          test-${{ runner.os }}-gradle-
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: test-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          test-${{ runner.os }}-maven-
     - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
@@ -48,12 +80,28 @@ jobs:
       run: |
         ./gradlew --version
         ./gradlew --scan --no-parallel --warning-mode=all -Dplatform.tooling.support.tests.enabled=true build
-
+        ./gradlew --stop
   mac:
     name: 'Mac OS'
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Gradle wrapper and dependencies
+      uses: actions/cache@v2
+      with:
+        path: | 
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/dists
+        key: test-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
+        restore-keys: |
+          test-${{ runner.os }}-gradle-
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: test-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          test-${{ runner.os }}-maven-
     - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
@@ -74,6 +122,22 @@ jobs:
     container: junitteam/build:latest
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Gradle wrapper and dependencies
+      uses: actions/cache@v2
+      with:
+        path: | 
+          /root/.gradle/caches/
+          /root/.gradle/wrapper/dists
+        key: coverage-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
+        restore-keys: |
+          coverage-${{ runner.os }}-gradle-
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: /root/.m2/repository
+        key: coverage-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          coverage-${{ runner.os }}-maven-
     - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
@@ -101,6 +165,15 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'junit-team/junit5' && (startsWith(github.ref, 'refs/heads/releases/') || github.ref == 'refs/heads/main')
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Gradle wrapper and dependencies
+      uses: actions/cache@v2
+      with:
+        path: | 
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/dists
+        key: assemble-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
+        restore-keys: |
+          assemble-${{ runner.os }}-gradle-
     - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:
@@ -119,6 +192,15 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'junit-team/junit5' && github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Gradle wrapper and dependencies
+      uses: actions/cache@v2
+      with:
+        path: | 
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/dists
+        key: assemble-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
+        restore-keys: |
+          assemble-${{ runner.os }}-gradle-
     - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -15,6 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Gradle wrapper and dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/dists
+        key: assemble-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
+        restore-keys: |
+          assemble-${{ runner.os }}-gradle-
     - name: 'Set up JDK 11'
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
## Overview

This should speed up CI builds as Gradle distributions and external dependencies no longer have to be downloaded each time. Since there are also some Maven integration tests, the local Maven repository is also cached.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
