### PR TITLE
Report disabled TestTemplate methods to TestWatchers

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -56,6 +56,8 @@ on GitHub.
 * Registered `TestInstancePreDestroyCallback` extensions are now always called if an
   instance of a test class was created, regardless whether any registered
   `TestInstancePostProcessor` extension threw an exception.
+* Disabled `@TestTemplate` methods (e.g. `@ParameterizedTest` and `@RepeatedTest` methods)
+  are now reported to registered `TestWatcher` extensions.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -15,9 +15,6 @@ import static org.junit.jupiter.engine.descriptor.ExtensionUtils.populateNewExte
 import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.createThrowableCollector;
 
 import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -41,9 +38,6 @@ import org.junit.jupiter.engine.execution.ExecutableInvoker.ReflectiveIntercepto
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
@@ -73,7 +67,6 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 
 	public static final String SEGMENT_TYPE = "method";
 	private static final ExecutableInvoker executableInvoker = new ExecutableInvoker();
-	private static final Logger logger = LoggerFactory.getLogger(TestMethodTestDescriptor.class);
 	private static final ReflectiveInterceptorCall<Method, Void> defaultInterceptorCall = ReflectiveInterceptorCall.ofVoidMethod(
 		InvocationInterceptor::interceptTestMethod);
 
@@ -278,20 +271,6 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 	}
 
 	/**
-	 * Invoke {@link TestWatcher#testDisabled(ExtensionContext, Optional)} on each
-	 * registered {@link TestWatcher}, in registration order.
-	 *
-	 * @since 5.4
-	 */
-	@Override
-	public void nodeSkipped(JupiterEngineExecutionContext context, TestDescriptor descriptor, SkipResult result) {
-		if (context != null) {
-			invokeTestWatchers(context, false,
-				watcher -> watcher.testDisabled(context.getExtensionContext(), result.getReason()));
-		}
-	}
-
-	/**
 	 * Invoke {@link TestWatcher#testSuccessful testSuccessful()},
 	 * {@link TestWatcher#testAborted testAborted()}, or
 	 * {@link TestWatcher#testFailed testFailed()} on each
@@ -322,35 +301,6 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 				}
 			});
 		}
-	}
-
-	/**
-	 * @since 5.4
-	 */
-	private void invokeTestWatchers(JupiterEngineExecutionContext context, boolean reverseOrder,
-			Consumer<TestWatcher> callback) {
-
-		ExtensionRegistry registry = context.getExtensionRegistry();
-
-		List<TestWatcher> watchers = reverseOrder //
-				? registry.getReversedExtensions(TestWatcher.class)
-				: registry.getExtensions(TestWatcher.class);
-
-		watchers.forEach(watcher -> {
-			try {
-				callback.accept(watcher);
-			}
-			catch (Throwable throwable) {
-				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
-				ExtensionContext extensionContext = context.getExtensionContext();
-				logger.warn(throwable,
-					() -> String.format("Failed to invoke TestWatcher [%s] for method [%s] with display name [%s]",
-						watcher.getClass().getName(),
-						ReflectionUtils.getFullyQualifiedMethodName(extensionContext.getRequiredTestClass(),
-							extensionContext.getRequiredTestMethod()),
-						getDisplayName()));
-			}
-		});
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
-import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
@@ -82,10 +82,10 @@ class TestWatcherTests extends AbstractJupiterTestEngineTests {
 
 		ArrayList<String> expectedMethods = new ArrayList<>(testWatcherMethodNames);
 		// Since the @RepeatedTest container is disabled, the individual invocations never occur.
-		expectedMethods.remove("testDisabled");
 		assertThat(TrackingTestWatcher.results.keySet()).containsAll(expectedMethods);
 		// 2 => number of iterations declared in @RepeatedTest(2).
-		TrackingTestWatcher.results.values().forEach(uidList -> assertEquals(2, uidList.size()));
+		TrackingTestWatcher.results.forEach(
+			(methodName, uidList) -> assertEquals("testDisabled".endsWith(methodName) ? 1 : 2, uidList.size()));
 	}
 
 	@Test
@@ -107,7 +107,7 @@ class TestWatcherTests extends AbstractJupiterTestEngineTests {
 		assertCommonStatistics(executeTestsForClass(ExceptionThrowingTestWatcherTestCase.class));
 
 		// @formatter:off
-		long exceptionCount = logRecordListener.stream(TestMethodTestDescriptor.class, Level.WARNING)
+		long exceptionCount = logRecordListener.stream(MethodBasedTestDescriptor.class, Level.WARNING)
 				.map(LogRecord::getThrown)
 				.filter(throwable -> throwable instanceof JUnitException)
 				.filter(throwable -> testWatcherMethodNames.contains(throwable.getStackTrace()[0].getMethodName()))


### PR DESCRIPTION
Fixes #2355.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
