### PR TITLE
Update Asciidoctor instructions

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -15,7 +15,7 @@ This subproject contains the AsciiDoc sources for the JUnit 5 User Guide.
 ### Generate AsciiDoc
 
 This following Gradle command generates the HTML version of the User Guide as
-`build/asciidoc/index.html`.
+`build/docs/asciidoc/user-guide/index.html`.
 
 ```
 gradlew asciidoctor
@@ -23,3 +23,12 @@ gradlew asciidoctor
 
 On Linux operating systems, the `graphviz` package providing `/usr/bin/dot` must be
 installed in order to generate the User Guide.
+
+### Generate AsciiDocPdf
+
+This following Gradle command generates the PDF version of the User Guide to 
+`build/docs/asciidocPdf/user-guide/index.pdf`
+
+```
+gradlew asciidoctorPdf
+```

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -26,7 +26,7 @@ installed in order to generate the User Guide.
 
 ### Generate AsciiDocPdf
 
-This following Gradle command generates the PDF version of the User Guide to 
+This following Gradle command generates the PDF version of the User Guide to
 `build/docs/asciidocPdf/user-guide/index.pdf`.
 
 ```

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -27,7 +27,7 @@ installed in order to generate the User Guide.
 ### Generate AsciiDocPdf
 
 This following Gradle command generates the PDF version of the User Guide to 
-`build/docs/asciidocPdf/user-guide/index.pdf`
+`build/docs/asciidocPdf/user-guide/index.pdf`.
 
 ```
 gradlew asciidoctorPdf


### PR DESCRIPTION
…f the user guide

## Overview

Hello! I was taking a look at this issue: https://github.com/junit-team/junit5/issues/2315 and I was trying to generate the pdf 
version of the user guide. I had to look around a bit and noticed that the readme was missing information on generating the pdf 
report.
I am actually tacking the issue #2315 now but thought that it would be good to update the readme. Also some outdated stuff
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
