### PR TITLE
Use specific name prefix in preemptive timeout threads

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -105,6 +105,8 @@ on GitHub.
   same functionality but a more descriptive name.
 * `assertTimeoutPreemptively` in `Assertions` now reports the stacktrace of the timed out
   thread in the cause of the `AssertionFailedError`.
+* `assertTimeoutPreemptively` now uses threads with a specific name, conveying their use
+  by the framework, to facilitate debugging and stack trace analysis.
 * New `TypedArgumentConverter` for converting one specific type to another, therefore
   reducing boilerplate type checks compared to implementing `ArgumentConverter` directly.
 * Added `ExtensionContext.getConfigurationParameter(String, Function<String, T>)`

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -193,12 +193,7 @@ class AssertTimeout {
 		private static final AtomicInteger threadNumber = new AtomicInteger(1);
 
 		public Thread newThread(Runnable r) {
-			Thread t = new Thread(null, r, "junit-timeout-thread-" + threadNumber.getAndIncrement(), 0);
-			if (t.isDaemon())
-				t.setDaemon(false);
-			if (t.getPriority() != Thread.NORM_PRIORITY)
-				t.setPriority(Thread.NORM_PRIORITY);
-			return t;
+			return new Thread(null, r, "junit-timeout-thread-" + threadNumber.getAndIncrement(), 0);
 		}
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -19,8 +19,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -127,7 +129,7 @@ class AssertTimeout {
 			Object messageOrSupplier) {
 
 		AtomicReference<Thread> threadReference = new AtomicReference<>();
-		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		ExecutorService executorService = Executors.newSingleThreadExecutor(new TimeoutThreadFactory());
 
 		try {
 			Future<T> future = executorService.submit(() -> {
@@ -177,6 +179,32 @@ class AssertTimeout {
 
 		ExecutionTimeoutException(String message) {
 			super(message);
+		}
+	}
+
+	/**
+	 * The thread factory used for preemptive timeout.
+	 *
+	 * This factory is the same with {@link Executors#defaultThreadFactory()} but provides more meaningful thread names,
+	 * helpful for debugging purposes.
+	 *
+	 */
+	private static class TimeoutThreadFactory implements ThreadFactory {
+		private static final AtomicInteger threadNumber = new AtomicInteger(1);
+		private final ThreadGroup group;
+
+		TimeoutThreadFactory() {
+			SecurityManager s = System.getSecurityManager();
+			group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+		}
+
+		public Thread newThread(Runnable r) {
+			Thread t = new Thread(group, r, "junit-timeout-thread-" + threadNumber.getAndIncrement(), 0);
+			if (t.isDaemon())
+				t.setDaemon(false);
+			if (t.getPriority() != Thread.NORM_PRIORITY)
+				t.setPriority(Thread.NORM_PRIORITY);
+			return t;
 		}
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -191,15 +191,9 @@ class AssertTimeout {
 	 */
 	private static class TimeoutThreadFactory implements ThreadFactory {
 		private static final AtomicInteger threadNumber = new AtomicInteger(1);
-		private final ThreadGroup group;
-
-		TimeoutThreadFactory() {
-			SecurityManager s = System.getSecurityManager();
-			group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
-		}
 
 		public Thread newThread(Runnable r) {
-			Thread t = new Thread(group, r, "junit-timeout-thread-" + threadNumber.getAndIncrement(), 0);
+			Thread t = new Thread(null, r, "junit-timeout-thread-" + threadNumber.getAndIncrement(), 0);
 			if (t.isDaemon())
 				t.setDaemon(false);
 			if (t.getPriority() != Thread.NORM_PRIORITY)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -190,9 +190,9 @@ class AssertTimeout {
 	private static class TimeoutThreadFactory implements ThreadFactory {
 		private static final AtomicInteger threadNumber = new AtomicInteger(1);
 
-    public Thread newThread(Runnable r) {
-      return new Thread(r, "junit-timeout-thread-" + threadNumber.getAndIncrement());
-    }
+		public Thread newThread(Runnable r) {
+			return new Thread(r, "junit-timeout-thread-" + threadNumber.getAndIncrement());
+		}
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -190,9 +190,9 @@ class AssertTimeout {
 	private static class TimeoutThreadFactory implements ThreadFactory {
 		private static final AtomicInteger threadNumber = new AtomicInteger(1);
 
-		public Thread newThread(Runnable r) {
-			return new Thread(null, r, "junit-timeout-thread-" + threadNumber.getAndIncrement(), 0);
-		}
+    public Thread newThread(Runnable r) {
+      return new Thread(r, "junit-timeout-thread-" + threadNumber.getAndIncrement());
+    }
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -185,9 +185,7 @@ class AssertTimeout {
 	/**
 	 * The thread factory used for preemptive timeout.
 	 *
-	 * This factory is the same with {@link Executors#defaultThreadFactory()} but provides more meaningful thread names,
-	 * helpful for debugging purposes.
-	 *
+	 * The factory creates threads with meaningful names, helpful for debugging purposes.
 	 */
 	private static class TimeoutThreadFactory implements ThreadFactory {
 		private static final AtomicInteger threadNumber = new AtomicInteger(1);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -297,7 +297,7 @@ class AssertTimeoutAssertionsTests {
 	@Test
 	void assertTimeoutPreemptivelyUsesThreadsWithSpecificNamePrefix() {
 		AtomicReference<String> threadName = new AtomicReference<>("");
-		assertTimeoutPreemptively(ofMillis(10), () -> threadName.set(Thread.currentThread().getName()));
+		assertTimeoutPreemptively(ofMillis(1000), () -> threadName.set(Thread.currentThread().getName()));
 		assertTrue(threadName.get().startsWith("junit-timeout-thread-"),
 			"Thread name does not match the expected prefix");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.function.Executable;
 import org.junit.platform.commons.util.ExceptionUtils;
@@ -291,6 +292,14 @@ class AssertTimeoutAssertionsTests {
 		assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms");
 		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
 		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyUsesThreadsWithSpecificNamePrefix() {
+		AtomicReference<String> threadName = new AtomicReference<>("");
+		assertTimeoutPreemptively(ofMillis(10), () -> threadName.set(Thread.currentThread().getName()));
+		assertTrue(threadName.get().startsWith("junit-timeout-thread-"),
+			"Thread name does not match the expected prefix");
 	}
 
 	/**


### PR DESCRIPTION
## Overview

Having a specific name prefix is useful when debugging stack traces to
quickly identify which threads are created by the junit framework and
from where exactly.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
