### PR TITLE
Make ForkJoinPoolHierarchicalTestExecutorService easier to use

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -57,7 +57,8 @@ on GitHub.
   events.
 * `ExecutionRecorder` in junit-platform-testkit is now public for fine-grained testing of
   classes that use `EngineExecutionListener`.
-* `ForkJoinPoolHierarchicalTestExecutorService` can now be constructed using `ParallelExecutionConfiguration`
+* `ForkJoinPoolHierarchicalTestExecutorService` can now be constructed by supplying a
+  `ParallelExecutionConfiguration`.
 
 [[release-notes-5.7.0-M2-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -57,6 +57,7 @@ on GitHub.
   events.
 * `ExecutionRecorder` in junit-platform-testkit is now public for fine-grained testing of
   classes that use `EngineExecutionListener`.
+* `ForkJoinPoolHierarchicalTestExecutorService` can now be constructed using `ParallelExecutionConfiguration`
 
 [[release-notes-5.7.0-M2-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -66,6 +66,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 	 *
 	 * @since 1.7
 	 */
+	@API(status = EXPERIMENTAL, since = "1.7")
 	public ForkJoinPoolHierarchicalTestExecutorService(ParallelExecutionConfiguration configuration) {
 		forkJoinPool = createForkJoinPool(configuration);
 		parallelism = forkJoinPool.getParallelism();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -57,15 +57,28 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 	 * @see DefaultParallelExecutionConfigurationStrategy
 	 */
 	public ForkJoinPoolHierarchicalTestExecutorService(ConfigurationParameters configurationParameters) {
-		forkJoinPool = createForkJoinPool(configurationParameters);
+		this(createConfiguration(configurationParameters));
+	}
+
+	/**
+	 * Create a new {@code ForkJoinPoolHierarchicalTestExecutorService} based on
+	 * the supplied {@link ParallelExecutionConfiguration}.
+	 *
+	 * @since 1.7
+	 */
+	public ForkJoinPoolHierarchicalTestExecutorService(ParallelExecutionConfiguration configuration) {
+		forkJoinPool = createForkJoinPool(configuration);
 		parallelism = forkJoinPool.getParallelism();
 		LoggerFactory.getLogger(getClass()).config(() -> "Using ForkJoinPool with parallelism of " + parallelism);
 	}
 
-	private ForkJoinPool createForkJoinPool(ConfigurationParameters configurationParameters) {
+	private static ParallelExecutionConfiguration createConfiguration(ConfigurationParameters configurationParameters) {
 		ParallelExecutionConfigurationStrategy strategy = DefaultParallelExecutionConfigurationStrategy.getStrategy(
 			configurationParameters);
-		ParallelExecutionConfiguration configuration = strategy.createConfiguration(configurationParameters);
+		return strategy.createConfiguration(configurationParameters);
+	}
+
+	private ForkJoinPool createForkJoinPool(ParallelExecutionConfiguration configuration) {
 		ForkJoinWorkerThreadFactory threadFactory = new WorkerThreadFactory();
 		return Try.call(() -> {
 			// Try to use constructor available in Java >= 9


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

This change adds a new constructor `ForkJoinPoolHierarchicalTestExecutorService(ParallelExecutionConfiguration configuration)` so that engines can pass in an instance of `ParallelExecutionConfiguration` directly, instead of having to map it to `ConfigurationParameters` first.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
