### PR TITLE
Truncate arguments in display name if they exceed max length

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -109,7 +109,7 @@ on GitHub.
   reducing boilerplate type checks compared to implementing `ArgumentConverter` directly.
 * Added `ExtensionContext.getConfigurationParameter(String, Function<String, T>)`
   convenience method for reading transformed configuration parameters from extensions.
-* Arguments of in display names of parameterized test invocations are now truncated if
+* Arguments in display names of parameterized test invocations are now truncated if
   they exceed a configurable maximum length (defaults to 512 characters).
 
 [[release-notes-5.7.0-M2-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -109,6 +109,8 @@ on GitHub.
   reducing boilerplate type checks compared to implementing `ArgumentConverter` directly.
 * Added `ExtensionContext.getConfigurationParameter(String, Function<String, T>)`
   convenience method for reading transformed configuration parameters from extensions.
+* Arguments of in display names of parameterized test invocations are now truncated if
+  they exceed a configurable maximum length (defaults to 512 characters).
 
 [[release-notes-5.7.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -107,6 +107,8 @@ on GitHub.
   thread in the cause of the `AssertionFailedError`.
 * New `TypedArgumentConverter` for converting one specific type to another, therefore
   reducing boilerplate type checks compared to implementing `ArgumentConverter` directly.
+* Added `ExtensionContext.getConfigurationParameter(String, Function<String, T>)`
+  convenience method for reading transformed configuration parameters from extensions.
 
 [[release-notes-5.7.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1563,8 +1563,8 @@ The following placeholders are supported within custom display names.
 | `{0}`, `{1}`, ...        | an individual argument
 |===
 
-NOTE: When including arguments in display names, their string representation is truncated
-if it exceeds the configured maximum length. The limit is configurable via the
+NOTE: When including arguments in display names, their string representations are truncated
+if they exceed the configured maximum length. The limit is configurable via the
 `junit.jupiter.params.displayname.argument.maxlength` configuration parameter and defaults
 to 512 characters.
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1563,6 +1563,11 @@ The following placeholders are supported within custom display names.
 | `{0}`, `{1}`, ...        | an individual argument
 |===
 
+NOTE: When including arguments in display names, their string representation is truncated
+if it exceeds the configured maximum length. The limit is configurable via the
+`junit.jupiter.params.displayname.argument.maxlength` configuration parameter and defaults
+to 512 characters.
+
 
 [[writing-tests-parameterized-tests-lifecycle-interop]]
 ==== Lifecycle and Interoperability

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.AnnotatedElement;
@@ -290,6 +291,31 @@ public interface ExtensionContext {
 	 */
 	@API(status = STABLE, since = "5.1")
 	Optional<String> getConfigurationParameter(String key);
+
+	/**
+	 * Get and transform the configuration parameter stored under the specified
+	 * {@code key} using the specified {@code transformer}.
+	 *
+	 * <p>If no such key is present in the {@code ConfigurationParameters} for
+	 * the JUnit Platform, an attempt will be made to look up the value as a
+	 * JVM system property. If no such system property exists, an attempt will
+	 * be made to look up the value in the JUnit Platform properties file.
+	 *
+	 * <p>In case the transformer throws an exception, it will be wrapped in a
+	 * {@link org.junit.platform.commons.JUnitException} with a helpful message.
+	 *
+	 * @param key the key to look up; never {@code null} or blank
+	 * @param transformer the transformer to apply in case a value is found;
+	 * never {@code null}
+	 * @return an {@code Optional} containing the value; never {@code null}
+	 * but potentially empty
+	 *
+	 * @see System#getProperty(String)
+	 * @see org.junit.platform.engine.ConfigurationParameters
+	 * @since 5.7
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	<T> Optional<T> getConfigurationParameter(String key, Function<String, T> transformer);
 
 	/**
 	 * Publish a map of key-value pairs to be consumed by an

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
@@ -41,6 +42,11 @@ public class CachingJupiterConfiguration implements JupiterConfiguration {
 	@Override
 	public Optional<String> getRawConfigurationParameter(String key) {
 		return delegate.getRawConfigurationParameter(key);
+	}
+
+	@Override
+	public <T> Optional<T> getRawConfigurationParameter(String key, Function<String, T> transformer) {
+		return delegate.getRawConfigurationParameter(key, transformer);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.config;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
@@ -55,6 +56,11 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 	@Override
 	public Optional<String> getRawConfigurationParameter(String key) {
 		return configurationParameters.get(key);
+	}
+
+	@Override
+	public <T> Optional<T> getRawConfigurationParameter(String key, Function<String, T> transformer) {
+		return configurationParameters.get(key, transformer);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.config;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
@@ -52,6 +53,8 @@ public interface JupiterConfiguration {
 	String TIMEOUT_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.mode";
 
 	Optional<String> getRawConfigurationParameter(String key);
+
+	<T> Optional<T> getRawConfigurationParameter(String key, Function<String, T> transformer);
 
 	boolean isParallelExecutionEnabled();
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
@@ -122,4 +123,8 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 		return this.configuration.getRawConfigurationParameter(key);
 	}
 
+	@Override
+	public <V> Optional<V> getConfigurationParameter(String key, Function<String, V> transformer) {
+		return this.configuration.getRawConfigurationParameter(key, transformer);
+	}
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -32,11 +32,14 @@ class ParameterizedTestNameFormatter {
 	private final String pattern;
 	private final String displayName;
 	private final ParameterizedTestMethodContext methodContext;
+	private final int argumentMaxLength;
 
-	ParameterizedTestNameFormatter(String pattern, String displayName, ParameterizedTestMethodContext methodContext) {
+	ParameterizedTestNameFormatter(String pattern, String displayName, ParameterizedTestMethodContext methodContext,
+			int argumentMaxLength) {
 		this.pattern = pattern;
 		this.displayName = displayName;
 		this.methodContext = methodContext;
+		this.argumentMaxLength = argumentMaxLength;
 	}
 
 	String format(int invocationIndex, Object... arguments) {
@@ -91,10 +94,17 @@ class ParameterizedTestNameFormatter {
 		Object[] result = Arrays.copyOf(arguments, Math.min(arguments.length, formats.length), Object[].class);
 		for (int i = 0; i < result.length; i++) {
 			if (formats[i] == null) {
-				result[i] = StringUtils.nullSafeToString(arguments[i]);
+				result[i] = truncateIfExceedsMaxLength(StringUtils.nullSafeToString(arguments[i]));
 			}
 		}
 		return result;
+	}
+
+	private String truncateIfExceedsMaxLength(String argument) {
+		if (argument.length() > argumentMaxLength) {
+			return argument.substring(0, argumentMaxLength - 1) + "\u2026";
+		}
+		return argument;
 	}
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -29,6 +29,8 @@ import org.junit.platform.commons.util.StringUtils;
  */
 class ParameterizedTestNameFormatter {
 
+	private static final char ELLIPSIS = '\u2026';
+
 	private final String pattern;
 	private final String displayName;
 	private final ParameterizedTestMethodContext methodContext;
@@ -102,7 +104,7 @@ class ParameterizedTestNameFormatter {
 
 	private String truncateIfExceedsMaxLength(String argument) {
 		if (argument.length() > argumentMaxLength) {
-			return argument.substring(0, argumentMaxLength - 1) + "\u2026";
+			return argument.substring(0, argumentMaxLength - 1) + ELLIPSIS;
 		}
 		return argument;
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -221,6 +222,11 @@ class ParameterizedTestExtensionTests {
 
 			@Override
 			public Optional<String> getConfigurationParameter(String key) {
+				return Optional.empty();
+			}
+
+			@Override
+			public <T> Optional<T> getConfigurationParameter(String key, Function<String, T> transformer) {
 				return Optional.empty();
 			}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -21,6 +21,7 @@ import static org.junit.platform.testkit.engine.EventConditions.container;
 import static org.junit.platform.testkit.engine.EventConditions.displayName;
 import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.started;
 import static org.junit.platform.testkit.engine.EventConditions.test;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
@@ -217,6 +218,17 @@ class ParameterizedTestIntegrationTests {
 					"afterEach:[2] argument=bar",
 			"afterAll:ParameterizedTestIntegrationTests$LifecycleTestCase");
 		// @formatter:on
+	}
+
+	@Test
+	void truncatesArgumentsThatExceedMaxLength() {
+		var results = EngineTestKit.engine(new JupiterTestEngine()) //
+				.configurationParameter(ParameterizedTestExtension.ARGUMENT_MAX_LENGTH_KEY, "2") //
+				.selectors(selectMethod(TestCase.class, "testWithCsvSource", String.class.getName())) //
+				.execute();
+		results.testEvents().assertThatEvents() //
+				.haveExactly(1, event(displayName("[1] argument=f…"), started())) //
+				.haveExactly(1, event(displayName("[2] argument=b…"), started()));
 	}
 
 	private EngineExecutionResults execute(DiscoverySelector... selectors) {

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -213,12 +213,28 @@ class ParameterizedTestNameFormatterTests {
 		assertThat(formattedName).isEqualTo("foo, baz");
 	}
 
+	@Test
+	void truncatesArgumentsThatExceedMaxLength() {
+		ParameterizedTestNameFormatter formatter = formatter("{arguments}", 3);
+
+		String formattedName = formatter.format(1, "fo", "foo", "fooo");
+
+		assertThat(formattedName).isEqualTo("fo, foo, fo…");
+	}
+
 	private static ParameterizedTestNameFormatter formatter(String pattern, String displayName) {
-		return new ParameterizedTestNameFormatter(pattern, displayName, mock(ParameterizedTestMethodContext.class));
+		return new ParameterizedTestNameFormatter(pattern, displayName, mock(ParameterizedTestMethodContext.class),
+			512);
+	}
+
+	private static ParameterizedTestNameFormatter formatter(String pattern, int argumentMaxLength) {
+		return new ParameterizedTestNameFormatter(pattern, "display name", mock(ParameterizedTestMethodContext.class),
+			argumentMaxLength);
 	}
 
 	private static ParameterizedTestNameFormatter formatter(String pattern, String displayName, Method method) {
-		return new ParameterizedTestNameFormatter(pattern, displayName, new ParameterizedTestMethodContext(method));
+		return new ParameterizedTestNameFormatter(pattern, displayName, new ParameterizedTestMethodContext(method),
+			512);
 	}
 
 	// -------------------------------------------------------------------


### PR DESCRIPTION
Resolves #2358.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
