### PR TITLE
Prevent multiple executions of a TestPlan

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -32,6 +32,8 @@ on GitHub.
 
 * Characters in exception messages and other user-supplied values that are not allowed in
   XML are now replaced with their character reference – for example, `\0` becomes `&#0;`.
+* The `Launcher` now throws an exception when a previously executed `TestPlan` is
+  attempted to be executed again.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/Launcher.java
@@ -66,7 +66,8 @@ public interface Launcher {
 	 *
 	 * @apiNote This method may be called to generate a preview of the test
 	 * tree. The resulting {@link TestPlan} is unmodifiable and may be passed to
-	 * {@link #execute(TestPlan, TestExecutionListener...)} for execution.
+	 * {@link #execute(TestPlan, TestExecutionListener...)} for execution at
+	 * most once.
 	 *
 	 * @param launcherDiscoveryRequest the launcher discovery request; never
 	 * {@code null}
@@ -106,6 +107,9 @@ public interface Launcher {
 	 * <p>Supplied test execution listeners are registered in addition to
 	 * already registered listeners but only for the execution of the supplied
 	 * test plan.
+	 *
+	 * @apiNote The supplied {@link TestPlan} must not have been executed
+	 * previously.
 	 *
 	 * @param testPlan the test plan to execute; never {@code null}
 	 * @param listeners additional test execution listeners; never {@code null}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -45,6 +45,7 @@ public class EngineExecutionOrchestrator {
 	}
 
 	void execute(InternalTestPlan internalTestPlan, TestExecutionListener... listeners) {
+		internalTestPlan.markStarted();
 		LauncherDiscoveryResult discoveryResult = internalTestPlan.getDiscoveryResult();
 		ConfigurationParameters configurationParameters = discoveryResult.getConfigurationParameters();
 		TestExecutionListenerRegistry listenerRegistry = buildListenerRegistryForExecution(listeners);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
@@ -28,6 +28,7 @@ class InternalTestPlan extends TestPlan {
 
 	private static final Logger logger = LoggerFactory.getLogger(InternalTestPlan.class);
 
+	private final AtomicBoolean executionStarted = new AtomicBoolean(false);
 	private final AtomicBoolean warningEmitted = new AtomicBoolean(false);
 	private final LauncherDiscoveryResult discoveryResult;
 	private final TestPlan delegate;
@@ -41,6 +42,12 @@ class InternalTestPlan extends TestPlan {
 		super(delegate.containsTests());
 		this.discoveryResult = discoveryResult;
 		this.delegate = delegate;
+	}
+
+	void markStarted() {
+		if (!executionStarted.compareAndSet(false, true)) {
+			throw new PreconditionViolationException("TestPlan must only be executed once");
+		}
 	}
 
 	LauncherDiscoveryResult getDiscoveryResult() {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -698,7 +698,7 @@ class DefaultLauncherTests {
 	}
 
 	@Test
-	void launcherCanExecuteTestPlan() {
+	void launcherCanExecuteTestPlanExactlyOnce() {
 		TestEngine engine = mock(TestEngine.class);
 		when(engine.getId()).thenReturn("some-engine");
 		when(engine.discover(any(), any())).thenAnswer(invocation -> {
@@ -712,6 +712,9 @@ class DefaultLauncherTests {
 
 		launcher.execute(testPlan);
 		verify(engine, times(1)).execute(any());
+
+		var e = assertThrows(PreconditionViolationException.class, () -> launcher.execute(testPlan));
+		assertEquals(e.getMessage(), "TestPlan must only be executed once");
 	}
 
 	@Test


### PR DESCRIPTION
The `Launcher` now fails with a descriptive error message when a
previously executed `TestPlan` is attempted to be executed again. The
Javadoc of `Launcher` now clearly states that a TestPlan must not be
executed more than once.

Resolves #2379.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
