### PR TITLE
Introduce global default lock to facilitate isolated test execution

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -73,6 +73,7 @@ endif::[]
 :TestTemplate:                               {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/TestTemplate.html[@TestTemplate]
 // Jupiter Parallel API
 :Execution:                                  {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/Execution.html[@Execution]
+:Isolated:                                   {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/Isolated.html[@Isolated]
 :ResourceLock:                               {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/ResourceLock.html[@ResourceLock]
 :Resources:                                  {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/Resources.html[Resources]
 // Jupiter Extension APIs

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0-M2.adoc
@@ -59,6 +59,7 @@ on GitHub.
   classes that use `EngineExecutionListener`.
 * `ForkJoinPoolHierarchicalTestExecutorService` can now be constructed by supplying a
   `ParallelExecutionConfiguration`.
+* `HierarchicalTestEngine` now supports a global resource lock.
 
 
 [[release-notes-5.7.0-M2-junit-jupiter]]
@@ -119,6 +120,8 @@ on GitHub.
   reducing boilerplate type checks compared to implementing `ArgumentConverter` directly.
 * New `ExtensionContext.getConfigurationParameter(String, Function<String, T>)`
   convenience method for reading transformed configuration parameters from extensions.
+* New `@Isolated` annotation allows to run test classes in isolation of other test classes
+  when using parallel test execution.
 
 
 [[release-notes-5.7.0-M2-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2023,9 +2023,18 @@ If the tests in the following example were run in parallel _without_ the use of
 would fail due to the inherent race condition of writing and then reading the same JVM
 System Property.
 
-When access to shared resources is declared using the {ResourceLock} annotation, the
+When access to shared resources is declared using the `{ResourceLock}` annotation, the
 JUnit Jupiter engine uses this information to ensure that no conflicting tests are run in
 parallel.
+
+[NOTE]
+.Running tests in isolation
+====
+If most of your test classes can be run in parallel without any synchronization but you
+have a some test classes that need to run in isolation, you can mark the latter with the
+`{Isolated}` annotation. Tests in such classes are executed sequentially without any other
+tests running at the same time.
+====
 
 In addition to the `String` that uniquely identifies the shared resource, you may specify
 an access mode. Two tests that require `READ` access to a shared resource may run in

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Execution.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Execution.java
@@ -27,6 +27,7 @@ import org.apiguardian.api.API;
  * <p>Since JUnit Jupiter 5.4, this annotation is {@linkplain Inherited inherited}
  * within class hierarchies.
  *
+ * @see Isolated
  * @see ResourceLock
  * @since 5.3
  */

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.parallel;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+@API(status = EXPERIMENTAL, since = "5.7")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Inherited
+@ResourceLock("__global__")
+public @interface Isolated {
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
@@ -20,6 +20,19 @@ import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
 
+/**
+ * {@code @Isolated} is used to declare that the annotated test class should be
+ * executed in isolation from other test classes.
+ *
+ * <p>When a test class is run in isolation, no other test class is executed
+ * concurrently. This can be used to enable parallel test execution for the
+ * entire test suite while running some tests in isolation (e.g. if they modify
+ * some global resource).
+ *
+ * @since 5.7
+ * @see ExecutionMode
+ * @see ResourceLock
+ */
 @API(status = EXPERIMENTAL, since = "5.7")
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
@@ -22,7 +22,7 @@ import org.apiguardian.api.API;
 
 @API(status = EXPERIMENTAL, since = "5.7")
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target(ElementType.TYPE)
 @Inherited
 @ResourceLock("__global__")
 public @interface Isolated {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
@@ -37,6 +37,6 @@ import org.apiguardian.api.API;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
-@ResourceLock("__global__")
+@ResourceLock("org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY")
 public @interface Isolated {
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLock.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLock.java
@@ -40,6 +40,7 @@ import org.apiguardian.api.API;
  * <p>Since JUnit Jupiter 5.4, this annotation is {@linkplain Inherited inherited}
  * within class hierarchies.
  *
+ * @see Isolated
  * @see Resources
  * @see ResourceAccessMode
  * @see ResourceLocks

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
@@ -29,6 +29,8 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = EXPERIMENTAL, since = "1.3")
 public class ExclusiveResource {
 
+	static final String GLOBAL_RESOURCE_LOCK_KEY = "__global__";
+
 	private final String key;
 	private final LockMode lockMode;
 	private int hash;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
@@ -18,6 +18,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ToStringBuilder;
+import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
 
 /**
  * An exclusive resource identified by a key with a lock mode that is used to
@@ -30,9 +31,15 @@ import org.junit.platform.commons.util.ToStringBuilder;
 public class ExclusiveResource {
 
 	/**
-	 * The key for the global resource lock that all direct children of the
-	 * engine descriptor acquire in {@linkplain LockMode#READ read} mode by
-	 * default.
+	 * Key of the global resource lock that all direct children of the engine
+	 * descriptor acquire in {@linkplain LockMode#READ read mode} by default.
+	 *
+	 * <p>If any node {@linkplain Node#getExclusiveResources() requires} an
+	 * exclusive resource with the same key in
+	 * {@linkplain LockMode#READ_WRITE read-write mode}, the lock will be
+	 * coarsened to be acquired by the node's ancestor that is a direct child of
+	 * the engine descriptor and all of the ancestor's descendants will be
+	 * forced to run in the {@linkplain ExecutionMode#SAME_THREAD same thread}.
 	 *
 	 * @since 1.7
 	 */

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
@@ -29,7 +29,18 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = EXPERIMENTAL, since = "1.3")
 public class ExclusiveResource {
 
-	static final String GLOBAL_RESOURCE_LOCK_KEY = "__global__";
+	/**
+	 * The key for the global resource lock that all direct children of the
+	 * engine descriptor acquire in {@linkplain LockMode#READ read} mode by
+	 * default.
+	 *
+	 * @since 1.7
+	 */
+	@API(status = EXPERIMENTAL, since = "1.7")
+	public static final String GLOBAL_KEY = "org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY";
+
+	static final ExclusiveResource GLOBAL_READ = new ExclusiveResource(GLOBAL_KEY, LockMode.READ);
+	static final ExclusiveResource GLOBAL_READ_WRITE = new ExclusiveResource(GLOBAL_KEY, LockMode.READ_WRITE);
 
 	private final String key;
 	private final LockMode lockMode;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -34,10 +34,10 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 class LockManager {
 
 	private static final Comparator<ExclusiveResource> COMPARATOR //
-		= comparing(ExclusiveResource::getKey, globalLockFirst().thenComparing(naturalOrder())) //
+		= comparing(ExclusiveResource::getKey, globalKeyFirst().thenComparing(naturalOrder())) //
 				.thenComparing(ExclusiveResource::getLockMode);
 
-	private static Comparator<String> globalLockFirst() {
+	private static Comparator<String> globalKeyFirst() {
 		return comparing(key -> !GLOBAL_KEY.equals(key));
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -75,14 +75,14 @@ class LockManager {
 	}
 
 	private ResourceLock toResourceLock(List<Lock> locks) {
-		int size = locks.size();
-		if (size == 0) {
-			return NopLock.INSTANCE;
+		switch (locks.size()) {
+			case 0:
+				return NopLock.INSTANCE;
+			case 1:
+				return new SingleLock(locks.get(0));
+			default:
+				return new CompositeLock(locks);
 		}
-		if (size == 1) {
-			return new SingleLock(locks.get(0));
-		}
-		return new CompositeLock(locks);
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine.support.hierarchical;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_RESOURCE_LOCK_KEY;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ;
 
 import java.util.Collection;
@@ -30,8 +31,15 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 class LockManager {
 
-	private static final Comparator<ExclusiveResource> COMPARATOR = comparing(ExclusiveResource::getKey).thenComparing(
-		ExclusiveResource::getLockMode);
+	private static final Comparator<ExclusiveResource> COMPARATOR = comparing(ExclusiveResource::getKey, (a, b) -> {
+		if (a.equals(GLOBAL_RESOURCE_LOCK_KEY)) {
+			return b.equals(GLOBAL_RESOURCE_LOCK_KEY) ? 0 : -1;
+		}
+		if (b.equals(GLOBAL_RESOURCE_LOCK_KEY)) {
+			return 1;
+		}
+		return a.compareTo(b);
+	}).thenComparing(ExclusiveResource::getLockMode);
 
 	private final Map<String, ReadWriteLock> locksByKey = new ConcurrentHashMap<>();
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -14,7 +14,7 @@ import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
-import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_RESOURCE_LOCK_KEY;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ;
 
 import java.util.Collection;
@@ -37,7 +37,7 @@ class LockManager {
 				.thenComparing(ExclusiveResource::getLockMode);
 
 	private static Comparator<String> globalLockFirst() {
-		return comparing(key -> !GLOBAL_RESOURCE_LOCK_KEY.equals(key));
+		return comparing(key -> !GLOBAL_KEY.equals(key));
 	}
 
 	private final Map<String, ReadWriteLock> locksByKey = new ConcurrentHashMap<>();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -14,6 +14,7 @@ import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
+import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ;
 
@@ -43,8 +44,15 @@ class LockManager {
 	private final Map<String, ReadWriteLock> locksByKey = new ConcurrentHashMap<>();
 
 	ResourceLock getLockForResources(Collection<ExclusiveResource> resources) {
+		if (resources.size() == 1) {
+			return getLockForResource(getOnlyElement(resources));
+		}
 		List<Lock> locks = getDistinctSortedLocks(resources);
 		return toResourceLock(locks);
+	}
+
+	ResourceLock getLockForResource(ExclusiveResource resource) {
+		return new SingleLock(toLock(resource));
 	}
 
 	private List<Lock> getDistinctSortedLocks(Collection<ExclusiveResource> resources) {
@@ -56,13 +64,14 @@ class LockManager {
 
 		return resourcesByKey.values().stream()
 				.map(resourcesWithSameKey -> resourcesWithSameKey.get(0))
-				.map(resource -> {
-					ReadWriteLock lock = this.locksByKey.computeIfAbsent(resource.getKey(),
-							key -> new ReentrantReadWriteLock());
-					return resource.getLockMode() == READ ? lock.readLock() : lock.writeLock();
-				})
+				.map(this::toLock)
 				.collect(toList());
 		// @formatter:on
+	}
+
+	private Lock toLock(ExclusiveResource resource) {
+		ReadWriteLock lock = this.locksByKey.computeIfAbsent(resource.getKey(), key -> new ReentrantReadWriteLock());
+		return resource.getLockMode() == READ ? lock.readLock() : lock.writeLock();
 	}
 
 	private ResourceLock toResourceLock(List<Lock> locks) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
@@ -26,7 +26,15 @@ import org.junit.platform.engine.TestDescriptor;
  */
 class NodeTreeWalker {
 
-	private final LockManager lockManager = new LockManager();
+	private final LockManager lockManager;
+
+	NodeTreeWalker() {
+		this(new LockManager());
+	}
+
+	NodeTreeWalker(LockManager lockManager) {
+		this.lockManager = lockManager;
+	}
 
 	NodeExecutionAdvisor walk(TestDescriptor rootDescriptor) {
 		Preconditions.condition(getExclusiveResources(rootDescriptor).isEmpty(),

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
@@ -46,12 +46,12 @@ class NodeTreeWalker {
 	private void walk(TestDescriptor globalLockDescriptor, TestDescriptor testDescriptor,
 			NodeExecutionAdvisor advisor) {
 		Set<ExclusiveResource> exclusiveResources = getExclusiveResources(testDescriptor);
-		Set<ExclusiveResource> allResources = new HashSet<>(exclusiveResources);
 		if (exclusiveResources.isEmpty()) {
 			advisor.useResourceLock(testDescriptor, lockManager.getLockForResources(singleton(GLOBAL_READ_LOCK)));
 			testDescriptor.getChildren().forEach(child -> walk(globalLockDescriptor, child, advisor));
 		}
 		else {
+			Set<ExclusiveResource> allResources = new HashSet<>(exclusiveResources);
 			advisor.forceDescendantExecutionMode(testDescriptor, SAME_THREAD);
 			doForChildrenRecursively(testDescriptor, child -> {
 				allResources.addAll(getExclusiveResources(child));

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static java.util.Collections.singleton;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
 import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.SAME_THREAD;
@@ -41,7 +40,7 @@ class NodeTreeWalker {
 			NodeExecutionAdvisor advisor) {
 		Set<ExclusiveResource> exclusiveResources = getExclusiveResources(testDescriptor);
 		if (exclusiveResources.isEmpty()) {
-			advisor.useResourceLock(testDescriptor, lockManager.getLockForResources(singleton(GLOBAL_READ)));
+			advisor.useResourceLock(testDescriptor, lockManager.getLockForResource(GLOBAL_READ));
 			testDescriptor.getChildren().forEach(child -> walk(globalLockDescriptor, child, advisor));
 		}
 		else {
@@ -55,8 +54,7 @@ class NodeTreeWalker {
 				advisor.forceDescendantExecutionMode(globalLockDescriptor, SAME_THREAD);
 				doForChildrenRecursively(globalLockDescriptor,
 					child -> advisor.forceDescendantExecutionMode(child, SAME_THREAD));
-				advisor.useResourceLock(globalLockDescriptor,
-					lockManager.getLockForResources(singleton(GLOBAL_READ_WRITE)));
+				advisor.useResourceLock(globalLockDescriptor, lockManager.getLockForResource(GLOBAL_READ_WRITE));
 			}
 			advisor.useResourceLock(testDescriptor, lockManager.getLockForResources(allResources));
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
@@ -29,9 +29,9 @@ class NodeTreeWalker {
 	private final LockManager lockManager = new LockManager();
 
 	NodeExecutionAdvisor walk(TestDescriptor rootDescriptor) {
-		NodeExecutionAdvisor advisor = new NodeExecutionAdvisor();
 		Preconditions.condition(getExclusiveResources(rootDescriptor).isEmpty(),
 			"Engine descriptor must not declare exclusive resources");
+		NodeExecutionAdvisor advisor = new NodeExecutionAdvisor();
 		rootDescriptor.getChildren().forEach(child -> walk(child, child, advisor));
 		return advisor;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
@@ -10,12 +10,15 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import static java.util.Collections.singleton;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_RESOURCE_LOCK_KEY;
 import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.SAME_THREAD;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.TestDescriptor;
 
 /**
@@ -23,26 +26,46 @@ import org.junit.platform.engine.TestDescriptor;
  */
 class NodeTreeWalker {
 
+	private static final ExclusiveResource GLOBAL_WRITE_LOCK = new ExclusiveResource(GLOBAL_RESOURCE_LOCK_KEY,
+		ExclusiveResource.LockMode.READ_WRITE);
+	private static final ExclusiveResource GLOBAL_READ_LOCK = new ExclusiveResource(GLOBAL_RESOURCE_LOCK_KEY,
+		ExclusiveResource.LockMode.READ);
+
 	private final LockManager lockManager = new LockManager();
 
-	NodeExecutionAdvisor walk(TestDescriptor testDescriptor) {
+	NodeExecutionAdvisor walk(TestDescriptor rootDescriptor) {
 		NodeExecutionAdvisor advisor = new NodeExecutionAdvisor();
-		walk(testDescriptor, advisor);
+		Preconditions.condition(getExclusiveResources(rootDescriptor).isEmpty(),
+			"Engine descriptor must not declare exclusive resources");
+		rootDescriptor.getChildren().forEach(child -> {
+			walk(child, child, advisor);
+		});
 		return advisor;
 	}
 
-	private void walk(TestDescriptor testDescriptor, NodeExecutionAdvisor advisor) {
+	private void walk(TestDescriptor globalLockDescriptor, TestDescriptor testDescriptor,
+			NodeExecutionAdvisor advisor) {
 		Set<ExclusiveResource> exclusiveResources = getExclusiveResources(testDescriptor);
+		Set<ExclusiveResource> allResources = new HashSet<>(exclusiveResources);
 		if (exclusiveResources.isEmpty()) {
-			testDescriptor.getChildren().forEach(child -> walk(child, advisor));
+			advisor.useResourceLock(testDescriptor, lockManager.getLockForResources(singleton(GLOBAL_READ_LOCK)));
+			testDescriptor.getChildren().forEach(child -> walk(globalLockDescriptor, child, advisor));
 		}
 		else {
-			Set<ExclusiveResource> allResources = new HashSet<>(exclusiveResources);
 			advisor.forceDescendantExecutionMode(testDescriptor, SAME_THREAD);
 			doForChildrenRecursively(testDescriptor, child -> {
 				allResources.addAll(getExclusiveResources(child));
 				advisor.forceDescendantExecutionMode(child, SAME_THREAD);
 			});
+			if (allResources.contains(GLOBAL_WRITE_LOCK)) {
+				if (!globalLockDescriptor.equals(testDescriptor)) {
+					advisor.forceDescendantExecutionMode(globalLockDescriptor, SAME_THREAD);
+					doForChildrenRecursively(globalLockDescriptor,
+						child -> advisor.forceDescendantExecutionMode(child, SAME_THREAD));
+					advisor.useResourceLock(globalLockDescriptor,
+						lockManager.getLockForResources(singleton(GLOBAL_WRITE_LOCK)));
+				}
+			}
 			advisor.useResourceLock(testDescriptor, lockManager.getLockForResources(allResources));
 		}
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
@@ -16,7 +16,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_RESOURCE_LOCK_KEY;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ_WRITE;
 
@@ -103,13 +103,13 @@ class LockManagerTests {
 		Collection<ExclusiveResource> resources = asList( //
 			new ExclusiveResource("___foo", READ), //
 			new ExclusiveResource("foo", READ_WRITE), //
-			new ExclusiveResource(GLOBAL_RESOURCE_LOCK_KEY, globalLockMode), //
+			new ExclusiveResource(GLOBAL_KEY, globalLockMode), //
 			new ExclusiveResource("bar", READ_WRITE));
 
 		List<Lock> locks = getLocks(resources, CompositeLock.class);
 
 		assertThat(locks).hasSize(4);
-		assertThat(locks.get(0)).isEqualTo(getSingleLock(GLOBAL_RESOURCE_LOCK_KEY, globalLockMode));
+		assertThat(locks.get(0)).isEqualTo(getSingleLock(GLOBAL_KEY, globalLockMode));
 		assertThat(locks.get(1)).isEqualTo(getSingleLock("___foo", READ));
 		assertThat(locks.get(2)).isEqualTo(getSingleLock("bar", READ_WRITE));
 		assertThat(locks.get(3)).isEqualTo(getSingleLock("foo", READ_WRITE));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
@@ -11,10 +11,8 @@
 package org.junit.platform.engine.support.hierarchical;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ;
@@ -122,16 +120,7 @@ class LockManagerTests {
 	private List<Lock> getLocks(Collection<ExclusiveResource> resources, Class<? extends ResourceLock> type) {
 		ResourceLock lock = lockManager.getLockForResources(resources);
 		assertThat(lock).isInstanceOf(type);
-		return getLocks(lock);
+		return ResourceLockSupport.getLocks(lock);
 	}
 
-	private List<Lock> getLocks(ResourceLock resourceLock) {
-		if (resourceLock instanceof NopLock) {
-			return emptyList();
-		}
-		if (resourceLock instanceof SingleLock) {
-			return singletonList(((SingleLock) resourceLock).getLock());
-		}
-		return ((CompositeLock) resourceLock).getLocks();
-	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
@@ -103,7 +103,8 @@ class LockManagerTests {
 		Collection<ExclusiveResource> resources = asList( //
 			new ExclusiveResource("___foo", READ), //
 			new ExclusiveResource("foo", READ_WRITE), //
-			new ExclusiveResource(GLOBAL_RESOURCE_LOCK_KEY, globalLockMode), new ExclusiveResource("bar", READ_WRITE));
+			new ExclusiveResource(GLOBAL_RESOURCE_LOCK_KEY, globalLockMode), //
+			new ExclusiveResource("bar", READ_WRITE));
 
 		List<Lock> locks = getLocks(resources, CompositeLock.class);
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_RESOURCE_LOCK_KEY;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ_WRITE;
 
@@ -26,6 +27,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode;
 
 /**
  * @since 1.3
@@ -91,6 +95,27 @@ class LockManagerTests {
 		assertThat(locks).hasSize(2);
 		assertThat(locks.get(0)).isInstanceOf(WriteLock.class);
 		assertThat(locks.get(1)).isInstanceOf(WriteLock.class);
+	}
+
+	@ParameterizedTest
+	@EnumSource
+	void globalLockComesFirst(LockMode globalLockMode) {
+		Collection<ExclusiveResource> resources = asList( //
+			new ExclusiveResource("___foo", READ), //
+			new ExclusiveResource("foo", READ_WRITE), //
+			new ExclusiveResource(GLOBAL_RESOURCE_LOCK_KEY, globalLockMode), new ExclusiveResource("bar", READ_WRITE));
+
+		List<Lock> locks = getLocks(resources, CompositeLock.class);
+
+		assertThat(locks).hasSize(4);
+		assertThat(locks.get(0)).isEqualTo(getSingleLock(GLOBAL_RESOURCE_LOCK_KEY, globalLockMode));
+		assertThat(locks.get(1)).isEqualTo(getSingleLock("___foo", READ));
+		assertThat(locks.get(2)).isEqualTo(getSingleLock("bar", READ_WRITE));
+		assertThat(locks.get(3)).isEqualTo(getSingleLock("foo", READ_WRITE));
+	}
+
+	private Lock getSingleLock(String globalResourceLockKey, LockMode read) {
+		return getLocks(singleton(new ExclusiveResource(globalResourceLockKey, read)), SingleLock.class).get(0);
 	}
 
 	private List<Lock> getLocks(Collection<ExclusiveResource> resources, Class<? extends ResourceLock> type) {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalkerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalkerIntegrationTests.java
@@ -10,12 +10,20 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ_WRITE;
+import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.SAME_THREAD;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,7 +31,6 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.engine.JupiterTestEngine;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 
 /**
@@ -31,42 +38,85 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
  */
 class NodeTreeWalkerIntegrationTests {
 
+	LockManager lockManager = new LockManager();
+	NodeTreeWalker nodeTreeWalker = new NodeTreeWalker(lockManager);
+
 	@Test
 	void pullUpExclusiveChildResourcesToTestClass() {
 		TestDescriptor engineDescriptor = discover(TestCaseWithResourceLock.class);
-		NodeExecutionAdvisor advisor = new NodeTreeWalker().walk(engineDescriptor);
+
+		NodeExecutionAdvisor advisor = nodeTreeWalker.walk(engineDescriptor);
 
 		TestDescriptor testClassDescriptor = getOnlyElement(engineDescriptor.getChildren());
-		assertThat(advisor.getResourceLock(testClassDescriptor)).isInstanceOf(CompositeLock.class);
+		assertThat(advisor.getResourceLock(testClassDescriptor)).extracting(allLocks()) //
+				.isEqualTo(List.of(getReadWriteLock("a"), getReadWriteLock("b")));
 		assertThat(advisor.getForcedExecutionMode(testClassDescriptor)).isEmpty();
 
 		TestDescriptor testMethodDescriptor = getOnlyElement(testClassDescriptor.getChildren());
-		assertThat(advisor.getResourceLock(testMethodDescriptor)).isInstanceOf(NopLock.class);
-		assertThat(advisor.getForcedExecutionMode(testMethodDescriptor)).contains(ExecutionMode.SAME_THREAD);
+		assertThat(advisor.getResourceLock(testMethodDescriptor)).extracting(allLocks()).isEqualTo(emptyList());
+		assertThat(advisor.getForcedExecutionMode(testMethodDescriptor)).contains(SAME_THREAD);
 	}
 
 	@Test
 	void leavesResourceLockOnTestMethodWhenClassDoesNotUseResource() {
 		TestDescriptor engineDescriptor = discover(TestCaseWithoutResourceLock.class);
-		NodeExecutionAdvisor advisor = new NodeTreeWalker().walk(engineDescriptor);
+
+		NodeExecutionAdvisor advisor = nodeTreeWalker.walk(engineDescriptor);
 
 		TestDescriptor testClassDescriptor = getOnlyElement(engineDescriptor.getChildren());
-		assertThat(advisor.getResourceLock(testClassDescriptor)).isInstanceOf(SingleLock.class);
+		assertThat(advisor.getResourceLock(testClassDescriptor)).extracting(allLocks()) //
+				.isEqualTo(List.of(getLock(GLOBAL_READ)));
 		assertThat(advisor.getForcedExecutionMode(testClassDescriptor)).isEmpty();
 
 		assertThat(testClassDescriptor.getChildren()).hasSize(2);
 		Iterator<? extends TestDescriptor> children = testClassDescriptor.getChildren().iterator();
 		TestDescriptor testMethodDescriptor = children.next();
-		assertThat(advisor.getResourceLock(testMethodDescriptor)).isInstanceOf(SingleLock.class);
+		assertThat(advisor.getResourceLock(testMethodDescriptor)).extracting(allLocks()) //
+				.isEqualTo(List.of(getReadWriteLock("a")));
 		assertThat(advisor.getForcedExecutionMode(testMethodDescriptor)).isEmpty();
 
 		TestDescriptor nestedTestClassDescriptor = children.next();
-		assertThat(advisor.getResourceLock(nestedTestClassDescriptor)).isInstanceOf(CompositeLock.class);
+		assertThat(advisor.getResourceLock(nestedTestClassDescriptor)).extracting(allLocks()) //
+				.isEqualTo(List.of(getReadWriteLock("b"), getReadWriteLock("c")));
 		assertThat(advisor.getForcedExecutionMode(nestedTestClassDescriptor)).isEmpty();
 
 		TestDescriptor nestedTestMethodDescriptor = getOnlyElement(nestedTestClassDescriptor.getChildren());
-		assertThat(advisor.getResourceLock(nestedTestMethodDescriptor)).isInstanceOf(NopLock.class);
-		assertThat(advisor.getForcedExecutionMode(nestedTestMethodDescriptor)).contains(ExecutionMode.SAME_THREAD);
+		assertThat(advisor.getResourceLock(nestedTestMethodDescriptor)).extracting(allLocks()).isEqualTo(emptyList());
+		assertThat(advisor.getForcedExecutionMode(nestedTestMethodDescriptor)).contains(SAME_THREAD);
+	}
+
+	@Test
+	void coarsensGlobalLockToEngineDescriptorChild() {
+		TestDescriptor engineDescriptor = discover(TestCaseWithGlobalLockRequiringChild.class);
+
+		NodeExecutionAdvisor advisor = nodeTreeWalker.walk(engineDescriptor);
+
+		TestDescriptor testClassDescriptor = getOnlyElement(engineDescriptor.getChildren());
+		assertThat(advisor.getResourceLock(testClassDescriptor)).extracting(allLocks()) //
+				.isEqualTo(List.of(getLock(GLOBAL_READ_WRITE)));
+		assertThat(advisor.getForcedExecutionMode(testClassDescriptor)).isEmpty();
+
+		TestDescriptor nestedTestClassDescriptor = getOnlyElement(testClassDescriptor.getChildren());
+		assertThat(advisor.getResourceLock(nestedTestClassDescriptor)).extracting(allLocks()) //
+				.isEqualTo(List.of(getLock(GLOBAL_READ)));
+		assertThat(advisor.getForcedExecutionMode(nestedTestClassDescriptor)).contains(SAME_THREAD);
+
+		TestDescriptor testMethodDescriptor = getOnlyElement(nestedTestClassDescriptor.getChildren());
+		assertThat(advisor.getResourceLock(testMethodDescriptor)).extracting(allLocks()) //
+				.isEqualTo(List.of(getLock(GLOBAL_READ_WRITE)));
+		assertThat(advisor.getForcedExecutionMode(testMethodDescriptor)).contains(SAME_THREAD);
+	}
+
+	private static Function<org.junit.platform.engine.support.hierarchical.ResourceLock, List<Lock>> allLocks() {
+		return ResourceLockSupport::getLocks;
+	}
+
+	private Lock getReadWriteLock(String key) {
+		return getLock(new ExclusiveResource(key, READ_WRITE));
+	}
+
+	private Lock getLock(ExclusiveResource exclusiveResource) {
+		return getOnlyElement(ResourceLockSupport.getLocks(lockManager.getLockForResource(exclusiveResource)));
 	}
 
 	private TestDescriptor discover(Class<?> testClass) {
@@ -93,6 +143,16 @@ class NodeTreeWalkerIntegrationTests {
 		class NestedTestCaseWithResourceLock {
 			@Test
 			@ResourceLock("b")
+			void test() {
+			}
+		}
+	}
+
+	static class TestCaseWithGlobalLockRequiringChild {
+		@Nested
+		class NestedTestCaseWithResourceLock {
+			@Test
+			@ResourceLock(ExclusiveResource.GLOBAL_KEY)
 			void test() {
 			}
 		}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalkerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalkerIntegrationTests.java
@@ -51,7 +51,7 @@ class NodeTreeWalkerIntegrationTests {
 		NodeExecutionAdvisor advisor = new NodeTreeWalker().walk(engineDescriptor);
 
 		TestDescriptor testClassDescriptor = getOnlyElement(engineDescriptor.getChildren());
-		assertThat(advisor.getResourceLock(testClassDescriptor)).isInstanceOf(NopLock.class);
+		assertThat(advisor.getResourceLock(testClassDescriptor)).isInstanceOf(SingleLock.class);
 		assertThat(advisor.getForcedExecutionMode(testClassDescriptor)).isEmpty();
 
 		assertThat(testClassDescriptor.getChildren()).hasSize(2);

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
@@ -244,6 +244,7 @@ class ParallelExecutionIntegrationTests {
 		assertThat(events.stream().filter(event(test(), finishedWithFailure())::matches)).isEmpty();
 	}
 
+	@Isolated
 	static class IsolatedTestCase {
 		static AtomicInteger sharedResource;
 		static CountDownLatch countDownLatch;
@@ -255,7 +256,6 @@ class ParallelExecutionIntegrationTests {
 		}
 
 		@Test
-		@Isolated
 		void a() throws Exception {
 			incrementBlockAndCheck(sharedResource, countDownLatch);
 		}
@@ -300,10 +300,10 @@ class ParallelExecutionIntegrationTests {
 			}
 
 			@Nested
+			@Isolated
 			class InnerInner {
 
 				@Test
-				@Isolated
 				void a() throws Exception {
 					incrementBlockAndCheck(sharedResource, countDownLatch);
 				}
@@ -331,9 +331,10 @@ class ParallelExecutionIntegrationTests {
 				storeAndBlockAndCheck(sharedResource, countDownLatch);
 			}
 		}
+
+		@Isolated
 		static class B {
 			@Test
-			@Isolated
 			void a() throws Exception {
 				incrementBlockAndCheck(sharedResource, countDownLatch);
 			}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockSupport.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockSupport.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.hierarchical;
+
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+
+class ResourceLockSupport {
+
+	static List<Lock> getLocks(ResourceLock resourceLock) {
+		if (resourceLock instanceof NopLock) {
+			return List.of();
+		}
+		if (resourceLock instanceof SingleLock) {
+			return List.of(((SingleLock) resourceLock).getLock());
+		}
+		return ((CompositeLock) resourceLock).getLocks();
+	}
+}


### PR DESCRIPTION
This commit introduces a new global resource lock "__global__" that all
test descriptors that are children of the engine descriptor acquire by
default in READ mode. Using the `@Isolated` annotation in the Jupiter
API causes the mode to be changed to READ_WRITE.

Will eventually resolve #2142.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
  - [x] Add tests for `@Isolated` on test classes and in `@Nested` tests
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
