### PR TITLE
Add tests for whitespace within CsvSource columns

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -25,6 +25,9 @@ import org.apiguardian.api.API;
  * comma-separated values (CSV) from one or more supplied
  * {@linkplain #value CSV lines}.
  *
+ * <p>The column delimiter (defaults to comma) can be customized with either
+ * {@link #delimiter()} or {@link #delimiterString()}.
+ *
  * <p>The supplied values will be provided as arguments to the
  * annotated {@code @ParameterizedTest} method.
  *

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -98,6 +98,15 @@ class CsvArgumentsProviderTests {
 	}
 
 	@Test
+	void doesNotTrimSpacesInsideQuotes() {
+		CsvSource annotation = csvSource("''", "'   '", "'blank '", "' not blank   '");
+
+		Stream<Object[]> arguments = provideArguments(annotation);
+
+		assertThat(arguments).containsExactly(array(""), array("   "), array("blank "), array(" not blank   "));
+	}
+
+	@Test
 	void providesArgumentsWithCharacterDelimiter() {
 		CsvSource annotation = csvSource().delimiter('|').lines("foo|bar", "bar|foo").build();
 


### PR DESCRIPTION
## Overview

Initially, I had intention to make `@CsvSource` support blank quoted strings. But after I made a test, it appeared that `@CsvSource` handles them already. So I just contribute you one unit test.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
