### PR TITLE
Removed an unnecessary "a" in the documentation

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2031,7 +2031,7 @@ parallel.
 .Running tests in isolation
 ====
 If most of your test classes can be run in parallel without any synchronization but you
-have a some test classes that need to run in isolation, you can mark the latter with the
+have some test classes that need to run in isolation, you can mark the latter with the
 `{Isolated}` annotation. Tests in such classes are executed sequentially without any other
 tests running at the same time.
 ====


### PR DESCRIPTION
## Overview

I removed an unnecessary "a" in the documentation

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x ] There are no TODOs left in the code
- [x ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
