### PR TITLE
Close resource in inverse order of addition

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.0.adoc
@@ -31,7 +31,8 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* `CloseableResource` instances stored in `ExtensionContext.Store` are now closed in the
+  reverse order they were added in. Previously, the order was undefined and unstable.
 
 ==== Deprecations and Breaking Changes
 

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -569,8 +569,8 @@ methods available for storing and retrieving values via the `{ExtensionContext_S
 .`ExtensionContext.Store.CloseableResource`
 NOTE: An extension context store is bound to its extension context lifecycle. When an
 extension context lifecycle ends it closes its associated store. All stored values
-that are instances of `CloseableResource` are notified by
-an invocation of their `close()` method.
+that are instances of `CloseableResource` are notified by an invocation of their `close()`
+method in the inverse order they were added in.
 
 [[extensions-supported-utilities]]
 === Supported Utilities in Extensions

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -396,6 +396,9 @@ public interface ExtensionContext {
 		 * <p>Note that the {@code CloseableResource} API is only honored for
 		 * objects stored within an extension context {@link Store Store}.
 		 *
+		 * <p>The resources stored in a {@link Store Store} are closed in the
+		 * inverse order they were added in.
+		 *
 		 * @since 5.1
 		 */
 		@API(status = STABLE, since = "5.1")

--- a/junit-jupiter-api/src/testFixtures/java/org/junit/jupiter/api/extension/ExtensionContextParameterResolver.java
+++ b/junit-jupiter-api/src/testFixtures/java/org/junit/jupiter/api/extension/ExtensionContextParameterResolver.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+public class ExtensionContextParameterResolver implements ParameterResolver {
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		return ExtensionContext.class.equals(parameterContext.getParameter().getType());
+	}
+
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		return extensionContext;
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/extension/CloseableResourceIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/extension/CloseableResourceIntegrationTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.junit.platform.testkit.engine.EventConditions.reportEntry;
+
+import java.util.Map;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+
+public class CloseableResourceIntegrationTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void closesCloseableResourcesInReverseInsertOrder() {
+		executeTestsForClass(TestCase.class).allEvents().reportingEntryPublished() //
+				.assertEventsMatchExactly( //
+					reportEntry(Map.of("3", "closed")), //
+					reportEntry(Map.of("2", "closed")), //
+					reportEntry(Map.of("1", "closed")));
+	}
+
+	@ExtendWith(ExtensionContextParameterResolver.class)
+	static class TestCase {
+		@Test
+		void closesCloseableResourcesInExtensionContext(ExtensionContext extensionContext) {
+			ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL);
+			store.put("foo", reportEntryOnClose(extensionContext, "1"));
+			store.put("bar", reportEntryOnClose(extensionContext, "2"));
+			store.put("baz", reportEntryOnClose(extensionContext, "3"));
+		}
+
+		@NotNull
+		private ExtensionContext.Store.CloseableResource reportEntryOnClose(ExtensionContext extensionContext,
+				String key) {
+			return () -> extensionContext.publishReportEntry(Map.of(key, "closed"));
+		}
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionValuesStoreTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionValuesStoreTests.java
@@ -378,7 +378,7 @@ public class ExtensionValuesStoreTests {
 		}
 
 		@Test
-		void additionNamespacePartMakesADifferenc() {
+		void additionNamespacePartMakesADifference() {
 
 			Namespace ns1 = Namespace.create("part1", "part2");
 			Namespace ns2 = Namespace.create("part1");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionContextExecutionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionContextExecutionTests.java
@@ -21,9 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.ExtensionContextParameterResolver;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 
 class ExtensionContextExecutionTests extends AbstractJupiterTestEngineTests {
@@ -43,20 +41,6 @@ class ExtensionContextExecutionTests extends AbstractJupiterTestEngineTests {
 		assertThat(engineExtensionContext.orElse(null).getElement()).isEmpty();
 
 		assertThat(engineExtensionContext.orElse(null).getParent()).isEmpty();
-	}
-
-	static class ExtensionContextParameterResolver implements ParameterResolver {
-		@Override
-		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-				throws ParameterResolutionException {
-			return ExtensionContext.class.equals(parameterContext.getParameter().getType());
-		}
-
-		@Override
-		public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-				throws ParameterResolutionException {
-			return extensionContext;
-		}
 	}
 
 	@Test

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventConditions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventConditions.java
@@ -12,6 +12,7 @@ package org.junit.platform.testkit.engine;
 
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.assertj.core.api.Assertions.allOf;
 import static org.junit.platform.commons.util.FunctionUtils.where;
@@ -29,6 +30,7 @@ import static org.junit.platform.testkit.engine.EventType.STARTED;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
@@ -40,6 +42,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestExecutionResult.Status;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 
 /**
@@ -409,6 +412,17 @@ public final class EventConditions {
 	 */
 	public static Condition<Event> reason(Predicate<String> predicate) {
 		return new Condition<>(byPayload(String.class, predicate), "event with custom reason predicate");
+	}
+
+	/**
+	 * Create a new {@link Condition} that matches if and only if an
+	 * {@link Event}'s {@linkplain Event#getPayload() payload} is an instance of
+	 * {@link ReportEntry} that contains the supplied key-value pairs.
+	 */
+	@API(status = EXPERIMENTAL, since = "1.7")
+	public static Condition<Event> reportEntry(Map<String, String> keyValuePairs) {
+		return new Condition<>(byPayload(ReportEntry.class, it -> it.getKeyValuePairs().equals(keyValuePairs)),
+			"event for report entry with key-value pairs %s", keyValuePairs);
 	}
 
 }


### PR DESCRIPTION
Resolves #2211.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
