### PR TITLE
dump timezone and offset for junit reporter xml timestamp

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine.reporting;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,7 +33,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = STABLE, since = "1.0")
 public final class ReportEntry {
 
-	private final LocalDateTime timestamp = LocalDateTime.now();
+	private final ZonedDateTime timestamp = ZonedDateTime.now();
 	private final Map<String, String> keyValuePairs = new LinkedHashMap<>();
 
 	/**
@@ -86,6 +87,17 @@ public final class ReportEntry {
 	 * @return when this entry was created; never {@code null}
 	 */
 	public final LocalDateTime getTimestamp() {
+		return this.timestamp.toLocalDateTime();
+	}
+
+	/**
+	 * Get the zoned timestamp for when and where this {@code ReportEntry} was created.
+	 *
+	 * <p>Can be used, for example, to order entries.
+	 *
+	 * @return when this entry was created; never {@code null}
+	 */
+	public final ZonedDateTime getZonedTimestamp() {
 		return this.timestamp;
 	}
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -11,7 +11,7 @@
 package org.junit.platform.reporting.legacy.xml;
 
 import static java.text.MessageFormat.format;
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.util.ExceptionUtils.readStackTrace;
 import static org.junit.platform.commons.util.StringUtils.isNotBlank;
@@ -23,7 +23,7 @@ import java.io.Writer;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.NumberFormat;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -116,7 +116,7 @@ class XmlReportWriter {
 		writeTestCounts(tests, writer);
 		writeAttributeSafely(writer, "time", getTime(testIdentifier, numberFormat));
 		writeAttributeSafely(writer, "hostname", getHostname().orElse("<unknown host>"));
-		writeAttributeSafely(writer, "timestamp", ISO_LOCAL_DATE_TIME.format(getCurrentDateTime()));
+		writeAttributeSafely(writer, "timestamp", ISO_ZONED_DATE_TIME.format(getCurrentDateTime()));
 	}
 
 	private void writeTestCounts(List<TestIdentifier> tests, XMLStreamWriter writer) throws XMLStreamException {
@@ -236,7 +236,7 @@ class XmlReportWriter {
 					systemOutElementsForCapturedOutput);
 				removeIfPresentAndAddAsSeparateElement(keyValuePairs, STDERR_REPORT_ENTRY_KEY, systemErrElements);
 				if (!keyValuePairs.isEmpty()) {
-					buildReportEntryDescription(reportEntry.getTimestamp(), keyValuePairs, i + 1,
+					buildReportEntryDescription(reportEntry.getZonedTimestamp(), keyValuePairs, i + 1,
 						formattedReportEntries);
 				}
 			}
@@ -253,10 +253,10 @@ class XmlReportWriter {
 		}
 	}
 
-	private void buildReportEntryDescription(LocalDateTime timestamp, Map<String, String> keyValuePairs,
+	private void buildReportEntryDescription(ZonedDateTime timestamp, Map<String, String> keyValuePairs,
 			int entryNumber, StringBuilder result) {
 		result.append(
-			format("Report Entry #{0} (timestamp: {1})\n", entryNumber, ISO_LOCAL_DATE_TIME.format(timestamp)));
+			format("Report Entry #{0} (timestamp: {1})\n", entryNumber, ISO_ZONED_DATE_TIME.format(timestamp)));
 		keyValuePairs.forEach((key, value) -> result.append(format("\t- {0}: {1}\n", key, value)));
 	}
 
@@ -273,8 +273,8 @@ class XmlReportWriter {
 		}
 	}
 
-	private LocalDateTime getCurrentDateTime() {
-		return LocalDateTime.now(this.reportData.getClock()).withNano(0);
+	private ZonedDateTime getCurrentDateTime() {
+		return ZonedDateTime.now(this.reportData.getClock()).withNano(0);
 	}
 
 	private String formatNonStandardAttributesAsString(TestIdentifier testIdentifier) {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.Year;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -317,10 +316,11 @@ class LegacyXmlReportGeneratingListenerTests {
 		engine.addTest("test", () -> {
 		});
 
-		LocalDateTime now = LocalDateTime.parse("2016-01-28T14:02:59.123");
-		ZoneId zone = ZoneId.systemDefault();
+		String timestamp = "2016-01-28T14:02:59Z[Europe/London]";
+		ZonedDateTime now = ZonedDateTime.parse(timestamp);
+		ZoneId zone = now.getZone();
 
-		executeTests(engine, tempDirectory, Clock.fixed(ZonedDateTime.of(now, zone).toInstant(), zone));
+		executeTests(engine, tempDirectory, Clock.fixed(now.toInstant(), zone));
 
 		String content = readValidXmlFile(tempDirectory.resolve("TEST-dummy.xml"));
 
@@ -329,7 +329,7 @@ class LegacyXmlReportGeneratingListenerTests {
 			.containsSubsequence(
 				"<testsuite",
 				"hostname=\"" + InetAddress.getLocalHost().getHostName() + "\"",
-				"timestamp=\"2016-01-28T14:02:59\"",
+				"timestamp=\"" + timestamp + "\"",
 				"<testcase",
 				"</testsuite>");
 		// @formatter:on


### PR DESCRIPTION
## Overview
related to https://github.com/pytest-dev/pytest/issues/7662

> It looks like pytest (and Junit) just takes the system time from OS, and save it to test report.
Unfortunately, this timestamp doesn't have any timezone information, Our CI system will treat this timestamp as a UTC time, even the timestamp is actually from another time zone.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
