### PR TITLE
Add JUnit Platform JFR in Dependency Metadata and Diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,60 +78,22 @@ consumption in other projects via the following command.
 
 ## Dependency Metadata
 
-The following sections list the dependency metadata for the JUnit Platform, JUnit
-Jupiter, and JUnit Vintage.
+Consult the [Dependency Metadata] section of the [User Guide] for a list of all artifacts
+of the JUnit Platform, JUnit Jupiter, and JUnit Vintage.
 
-See also <https://repo1.maven.org/maven2/org/junit/> for releases and <https://oss.sonatype.org/content/repositories/snapshots/org/junit/> for snapshots.
-
-### JUnit Platform
-
-- **Group ID**: `org.junit.platform`
-- **Version**: `1.7.0` or `1.8.0-SNAPSHOT`
-- **Artifact IDs** and Java **module** name:
-  - `junit-platform-commons` (`org.junit.platform.commons`)
-  - `junit-platform-console` (`org.junit.platform.console`)
-  - `junit-platform-console-standalone` (*N/A*)
-  - `junit-platform-engine` (`org.junit.platform.engine`)
-  - `junit-platform-jfr` (`org.junit.platform.jfr`)
-  - `junit-platform-launcher` (`org.junit.platform.launcher`)
-  - `junit-platform-reporting` (`org.junit.platform.reporting`)
-  - `junit-platform-runner` (`org.junit.platform.runner`)
-  - `junit-platform-suite-api` (`org.junit.platform.suite.api`)
-  - `junit-platform-testkit` (`org.junit.platform.testkit`)
-
-### JUnit Jupiter
-
-- **Group ID**: `org.junit.jupiter`
-- **Version**: `5.7.0` or `5.8.0-SNAPSHOT`
-- **Artifact IDs** and Java **module** name:
-  - `junit-jupiter` (`org.junit.jupiter`)
-  - `junit-jupiter-api` (`org.junit.jupiter.api`)
-  - `junit-jupiter-engine` (`org.junit.jupiter.engine`)
-  - `junit-jupiter-migrationsupport` (`org.junit.jupiter.migrationsupport`)
-  - `junit-jupiter-params` (`org.junit.jupiter.params`)
-
-### JUnit Vintage
-
-- **Group ID**: `org.junit.vintage`
-- **Version**: `5.7.0` or `5.8.0-SNAPSHOT`
-- **Artifact ID** and Java **module** name:
-  - `junit-vintage-engine` (`org.junit.vintage.engine`)
-
-### Bill of Materials (BOM)
-
-- **Group ID**: `org.junit`
-- **Artifact ID** `junit-bom`
-- **Version**: `5.7.0` or `5.8.0-SNAPSHOT`
+See also <https://repo1.maven.org/maven2/org/junit/> for releases and
+<https://oss.sonatype.org/content/repositories/snapshots/org/junit/> for snapshots.
 
 
 [Codecov]: https://codecov.io/gh/junit-team/junit5
 [CONTRIBUTING.md]: https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md
+[Dependency Metadata]: https://junit.org/junit5/docs/current/user-guide/#dependency-metadata
 [Gitter]: https://gitter.im/junit-team/junit5
 [Gradle Wrapper]: https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:using_wrapper
 [JaCoCo]: https://www.eclemma.org/jacoco/
 [Javadoc]: https://junit.org/junit5/docs/current/api/
 [JDK 11]: https://jdk.java.net/11/
 [Release Notes]: https://junit.org/junit5/docs/current/release-notes/
+[Samples]: https://github.com/junit-team/junit5-samples
 [StackOverflow]: https://stackoverflow.com/questions/tagged/junit5
 [User Guide]: https://junit.org/junit5/docs/current/user-guide/
-[Samples]: https://github.com/junit-team/junit5-samples

--- a/documentation/src/docs/asciidoc/user-guide/appendix.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/appendix.adoc
@@ -39,6 +39,8 @@ artifacts are deployed to Sonatype's {snapshot-repo}[snapshots repository] under
     directory. See <<running-tests-console-launcher>> for details.
   `junit-platform-engine`::
     Public API for test engines. See <<launcher-api-engines-custom>> for details.
+  `junit-platform-jfr`::
+    Provides the JUnit Platform Flight Recording Listener. See <<running-tests-flight-recorder>> for details.
   `junit-platform-launcher`::
     Public API for configuring and launching test plans -- typically used by IDEs and
     build tools. See <<launcher-api>> for details.
@@ -142,6 +144,7 @@ package org.junit.platform {
     [junit-platform-commons] as commons
     [junit-platform-console] as console
     [junit-platform-engine] as engine
+    [junit-platform-jfr] as jfr
     [junit-platform-launcher] as launcher
     [junit-platform-reporting] as reporting
     [junit-platform-runner] as runner
@@ -184,6 +187,8 @@ console ..> launcher
 console ..> reporting
 
 launcher ..> engine
+
+jfr ..> launcher
 
 engine ..> opentest4j
 engine ..> commons

--- a/documentation/src/docs/asciidoc/user-guide/appendix.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/appendix.adoc
@@ -40,7 +40,7 @@ artifacts are deployed to Sonatype's {snapshot-repo}[snapshots repository] under
   `junit-platform-engine`::
     Public API for test engines. See <<launcher-api-engines-custom>> for details.
   `junit-platform-jfr`::
-    Provides the JUnit Platform Flight Recording Listener. See <<running-tests-flight-recorder>> for details.
+    Provides a `TestExecutionListener` for Java Flight Recorder events on the JUnit Platform. See <<running-tests-flight-recorder>> for details.
   `junit-platform-launcher`::
     Public API for configuring and launching test plans -- typically used by IDEs and
     build tools. See <<launcher-api>> for details.


### PR DESCRIPTION
## Overview

This commit also removes the dependency metadata from the `README.md` file and replaces it with a link to the user guide instead.

Closes #2403

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
