### PR TITLE
Evaluate argument length only when argument is not null

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -103,7 +103,7 @@ class ParameterizedTestNameFormatter {
 	}
 
 	private String truncateIfExceedsMaxLength(String argument) {
-		if (argument.length() > argumentMaxLength) {
+		if (argument != null && argument.length() > argumentMaxLength) {
 			return argument.substring(0, argumentMaxLength - 1) + ELLIPSIS;
 		}
 		return argument;

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -45,7 +45,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
  */
 class ParameterizedTestNameFormatterTests {
 
-	private Locale originalLocale = Locale.getDefault();
+	private final Locale originalLocale = Locale.getDefault();
 
 	@AfterEach
 	void restoreLocale() {
@@ -163,10 +163,19 @@ class ParameterizedTestNameFormatterTests {
 	void formattingDoesNotFailIfArgumentToStringImplementationThrowsAnException() {
 		ParameterizedTestNameFormatter formatter = formatter(ARGUMENTS_PLACEHOLDER, "enigma");
 
-		String formattedName = formatter.format(1, new Object[] { new ToStringThrowsException(), "foo" });
+		String formattedName = formatter.format(1, new ToStringThrowsException(), "foo");
 
 		assertThat(formattedName).startsWith(ToStringThrowsException.class.getName() + "@");
 		assertThat(formattedName).endsWith("foo");
+	}
+
+	@Test
+	void formattingDoesNotFailIfArgumentToStringImplementationReturnsNull() {
+		ParameterizedTestNameFormatter formatter = formatter(ARGUMENTS_PLACEHOLDER, "enigma");
+
+		String formattedName = formatter.format(1, new ToStringReturnsNull(), "foo");
+
+		assertThat(formattedName).isEqualTo("null, foo");
 	}
 
 	@ParameterizedTest(name = "{0}")
@@ -244,6 +253,14 @@ class ParameterizedTestNameFormatterTests {
 		@Override
 		public String toString() {
 			throw new RuntimeException("Boom!");
+		}
+	}
+
+	private static class ToStringReturnsNull {
+
+		@Override
+		public String toString() {
+			return null;
 		}
 	}
 


### PR DESCRIPTION
## Overview

Fixes #2405.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] ~Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc~
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] ~Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)~
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
