### PR TITLE
Introduce @CombineTestTemplates support

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1848,6 +1848,49 @@ method with full support for the same lifecycle callbacks and extensions. Please
 NOTE: <<writing-tests-repeated-tests>> and <<writing-tests-parameterized-tests>> are
 built-in specializations of test templates.
 
+Usually if there is more than one `{TestTemplateInvocationContextProvider}` that applies
+to a method, each set is concatonated togther. This means that the extensions registered
+by each will not be available to the other. The best example is this test method
+
+[source:java]
+---
+@RepeatedTest(2)
+@ParameterizedTest
+@ValueSource(string={"a", "b"})
+public void testMethod(String value) {
+}
+---
+
+In this example the test method will be run four times; twice from the `RepeatedTest`
+annotation and twice from the `ParameterizedTest` annotation. This may not be desirable
+though since it means two of the runs will not have anything that populates the `value`
+parameter.
+
+If this is a case you need to deal with; there is an annotation `{CombineTestTemplates}`
+which changes this behaviour.
+
+[source:java]
+---
+@RepeatedTest(2)
+@ParameterizedTest
+@CombineTestTemplates
+@ValueSource(string={"a", "b"})
+public void testMethod(String value) {
+}
+---
+
+Adding this annotation causes the test runner to combine the contexts from all of the
+providers. In this example the context from the first repeated test run will be combined
+with each of the one from the parameterized test. This result in executions that can be
+described like this:
+
+{[Run 1, Parameter A], [Run 1, Parameter B], [Run 2, Parameter A], [Run 2, Parameter B]}
+
+For more details see the Javadoc on the `{CombineTestTemplates}` annotation.
+
+NOTE: Not all `{TestTemplateInvocationContextProvider}` instances will be compatible with
+this annotation.
+
 [[writing-tests-dynamic-tests]]
 === Dynamic Tests
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/CombineTestTemplates.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/CombineTestTemplates.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.platform.commons.annotation.Testable;
+
+/**
+ * Opt this test method into combining {@link TestTemplateInvocationContextProvider} instances together into a single
+ * one. This means that the product of the tests will be run. This allows combining tests such as the
+ * {@link RepeatedTest} and {@code ParameterizedTest} annotations.
+ * <p>
+ *     <b>Note:</b> Not all {@link TestTemplateInvocationContextProvider} instances may be compatible with this.
+ *     Specifically: any implementation of {@link TestTemplateInvocationContextProvider} which does complex initilization
+ *     logic in the {@link TestTemplateInvocationContextProvider#provideTestTemplateInvocationContexts(ExtensionContext)}
+ *     method may not work. Extenstions that wish to support this option should instead to their work in an extension
+ *     that is created, new, each time {@link TestTemplateInvocationContext#getAdditionalExtensions()} is called.
+ * </p>
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = EXPERIMENTAL, since = "5.8")
+@Testable
+public @interface CombineTestTemplates {
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/CombineTestTemplates.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/CombineTestTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -16,11 +16,16 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.ExtensionUtils.populateNewExtensionRegistryFromExtendWithAnnotation;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.CombineTestTemplates;
+import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
@@ -29,6 +34,7 @@ import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
@@ -98,9 +104,21 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 		List<TestTemplateInvocationContextProvider> providers = validateProviders(extensionContext,
 			context.getExtensionRegistry());
 		AtomicInteger invocationIndex = new AtomicInteger();
+
+		boolean productTestTemplates = AnnotationSupport.isAnnotated(extensionContext.getElement(),
+			CombineTestTemplates.class);
+		Stream<TestTemplateInvocationContext> invocationContexts;
+		if (productTestTemplates) {
+			invocationContexts = productOfTestTemplateContexts(providers, extensionContext).map(
+				AdaptingTestTemplateExecutionContext::new);
+		}
+		else {
+			invocationContexts = providers.stream().flatMap(
+				provider -> provider.provideTestTemplateInvocationContexts(extensionContext));
+		}
+
 		// @formatter:off
-		providers.stream()
-				.flatMap(provider -> provider.provideTestTemplateInvocationContexts(extensionContext))
+		invocationContexts
 				.map(invocationContext -> createInvocationTestDescriptor(invocationContext, invocationIndex.incrementAndGet()))
 				.filter(Optional::isPresent)
 				.map(Optional::get)
@@ -147,6 +165,69 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 					+ providers.stream().map(provider -> provider.getClass().getSimpleName()).collect(
 						joining(", ", "[", "]"))
 					+ " provided a non-empty stream");
+	}
+
+	/**
+	 * Allows the creation of a product of {@link TestTemplateInvocationContext TestTemplateInvocationContext} from a
+	 * list of providers. Each provider will be asked for execution contexts and those will be combined.
+	 * <p>
+	 * 		If there are two Executors (for example the {@code RepeatedTestExtension} and the
+	 * 		{@code ParameterizedTestExtension} and they provide templates [1, 2, 3] and [A, B] respectively; then this
+	 * 		method will return a stream of the following items:
+	 * </p>
+	 * <ul>
+	 *     <li>[1, A]</li>
+	 *     <li>[1, B]</li>
+	 *     <li>[2, A]</li>
+	 *     <li>[2, B]</li>
+	 *     <li>[3, A<]</li>
+	 *     <li>[3, B]</li>
+	 * </ul>
+	 * <p>
+	 *     The intention here is that this can then be passed to {@link AdaptingTestTemplateExecutionContext} to be executed.
+	 * </p>
+	 *
+	 * @param providers the providers to use to generate the template contexts
+	 * @param extensionContext the extension context to use when generating the test contexts
+	 * @return a stream of test invocation context combinations
+	 */
+	private static Stream<List<TestTemplateInvocationContext>> productOfTestTemplateContexts(
+			List<TestTemplateInvocationContextProvider> providers, ExtensionContext extensionContext) {
+		if (providers.isEmpty()) {
+			return Stream.of(Collections.emptyList());
+		}
+
+		TestTemplateInvocationContextProvider firstProvider = providers.get(0);
+		List<TestTemplateInvocationContextProvider> tail = providers.subList(1, providers.size());
+
+		return firstProvider.provideTestTemplateInvocationContexts(extensionContext).flatMap(
+			context -> productOfTestTemplateContexts(tail, extensionContext).map(
+				contexts -> Stream.concat(Stream.of(context), contexts.stream()).collect(toList())));
+	}
+
+	/**
+	 * Adapt a List of {@link TestTemplateInvocationContext TestTemplateInvocationContexts} into a single one for
+	 * execution. The methods on {@link TestTemplateInvocationContext} delegate to each of the wrapped elements in turn.
+	 */
+	private static class AdaptingTestTemplateExecutionContext implements TestTemplateInvocationContext {
+		private final List<TestTemplateInvocationContext> delegates;
+
+		private AdaptingTestTemplateExecutionContext(List<TestTemplateInvocationContext> delegates) {
+			this.delegates = delegates;
+		}
+
+		@Override
+		public List<Extension> getAdditionalExtensions() {
+			return delegates.stream().flatMap(context -> context.getAdditionalExtensions().stream()).collect(
+				Collectors.toList());
+		}
+
+		@Override
+		public String getDisplayName(int invocationIndex) {
+			return delegates.stream().map(context -> context.getDisplayName(invocationIndex)).collect(
+				Collectors.joining(", ")) + " [Combined " + this.delegates.size() + " contexts. Execution "
+					+ invocationIndex + "]";
+		}
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
@@ -12,19 +12,38 @@ package org.junit.jupiter.engine.descriptor;
 
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.api.CombineTestTemplates;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
+import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.hierarchical.Node;
+import org.mockito.Answers;
 
 /**
  * Unit tests for {@link TestTemplateTestDescriptor}.
@@ -86,6 +105,87 @@ class TestTemplateTestDescriptorTests {
 		assertThat(testDescriptor.getDisplayName()).isEqualTo("testTemplate()");
 	}
 
+	@Test
+	public void standardTestExecutionModeExecutesTheTestInTheContextOfTheTestTemplate() throws Exception {
+		UniqueId rootUniqueId = UniqueId.root("segment", "template");
+		UniqueId parentUniqueId = rootUniqueId.append("class", "myClass");
+		AbstractTestDescriptor parent = containerTestDescriptorWithTags(parentUniqueId,
+			singleton(TestTag.create("foo")));
+
+		when(jupiterConfiguration.getDefaultDisplayNameGenerator()).thenReturn(new DisplayNameGenerator.Standard());
+
+		Method testMethod = MyTestCase.class.getDeclaredMethod("testTemplate");
+		TestTemplateTestDescriptor testDescriptor = new TestTemplateTestDescriptor(
+			parentUniqueId.append("tmp", "testTemplate()"), MyTestCase.class, testMethod, jupiterConfiguration);
+		parent.addChild(testDescriptor);
+
+		ExtensionContext extensionContext = mock(ExtensionContext.class, Answers.RETURNS_MOCKS);
+		when(extensionContext.getElement()).thenReturn(Optional.of(testMethod));
+		MutableExtensionRegistry extensionRegistry = MutableExtensionRegistry.createRegistryWithDefaultExtensions(
+			mock(JupiterConfiguration.class));
+		extensionRegistry.registerExtension(new MyTestTemplateProvider(), new Object());
+		extensionRegistry.registerExtension(new MyOtherTestTemplateProvider(), new Object());
+		JupiterEngineExecutionContext context = new JupiterEngineExecutionContext(mock(EngineExecutionListener.class),
+			mock(JupiterConfiguration.class)).extend().withExtensionContext(extensionContext).withExtensionRegistry(
+				extensionRegistry).build();
+
+		Node.DynamicTestExecutor executor = mock(Node.DynamicTestExecutor.class);
+		List<MutableExtensionRegistry> registriedForTests = new ArrayList<>();
+		doAnswer(invocation -> {
+			MutableExtensionRegistry registry = invocation.getArgument(0,
+				TestTemplateInvocationTestDescriptor.class).populateNewExtensionRegistry(context);
+			registriedForTests.add(registry);
+			return registry;
+		}).when(executor).execute(any());
+
+		testDescriptor.execute(context, executor);
+
+		List<Extension> extensions = registriedForTests.get(0).getExtensions(Extension.class);
+		assertThat(extensions).contains(MyTestTemplateProvider.EXTENSION);
+
+		List<Extension> extensions2 = registriedForTests.get(1).getExtensions(Extension.class);
+		assertThat(extensions2).contains(MyOtherTestTemplateProvider.EXTENSION);
+	}
+
+	@Test
+	public void combinedTestExecutionModeExecutesTheTestInTheContextOfTheTestTemplate() throws Exception {
+		UniqueId rootUniqueId = UniqueId.root("segment", "template");
+		UniqueId parentUniqueId = rootUniqueId.append("class", "myClass");
+		AbstractTestDescriptor parent = containerTestDescriptorWithTags(parentUniqueId,
+			singleton(TestTag.create("foo")));
+
+		when(jupiterConfiguration.getDefaultDisplayNameGenerator()).thenReturn(new DisplayNameGenerator.Standard());
+
+		Method testMethod = MyCombinedTestCase.class.getDeclaredMethod("testTemplate");
+		TestTemplateTestDescriptor testDescriptor = new TestTemplateTestDescriptor(
+			parentUniqueId.append("tmp", "testTemplate()"), MyCombinedTestCase.class, testMethod, jupiterConfiguration);
+		parent.addChild(testDescriptor);
+
+		ExtensionContext extensionContext = mock(ExtensionContext.class, Answers.RETURNS_MOCKS);
+		when(extensionContext.getElement()).thenReturn(Optional.of(testMethod));
+		MutableExtensionRegistry extensionRegistry = MutableExtensionRegistry.createRegistryWithDefaultExtensions(
+			mock(JupiterConfiguration.class));
+		extensionRegistry.registerExtension(new MyTestTemplateProvider(), new Object());
+		extensionRegistry.registerExtension(new MyOtherTestTemplateProvider(), new Object());
+		JupiterEngineExecutionContext context = new JupiterEngineExecutionContext(mock(EngineExecutionListener.class),
+			mock(JupiterConfiguration.class)).extend().withExtensionContext(extensionContext).withExtensionRegistry(
+				extensionRegistry).build();
+
+		Node.DynamicTestExecutor executor = mock(Node.DynamicTestExecutor.class);
+		List<MutableExtensionRegistry> registriedForTests = new ArrayList<>();
+		doAnswer(invocation -> {
+			MutableExtensionRegistry registry = invocation.getArgument(0,
+				TestTemplateInvocationTestDescriptor.class).populateNewExtensionRegistry(context);
+			registriedForTests.add(registry);
+			return registry;
+		}).when(executor).execute(any());
+
+		testDescriptor.execute(context, executor);
+
+		List<Extension> extensions = registriedForTests.get(0).getExtensions(Extension.class);
+		assertThat(extensions).contains(MyTestTemplateProvider.EXTENSION, MyOtherTestTemplateProvider.EXTENSION);
+	}
+
 	private AbstractTestDescriptor containerTestDescriptorWithTags(UniqueId uniqueId, Set<TestTag> tags) {
 		return new AbstractTestDescriptor(uniqueId, "testDescriptor with tags") {
 
@@ -106,8 +206,70 @@ class TestTemplateTestDescriptorTests {
 		@Tag("bar")
 		@Tag("baz")
 		@TestTemplate
+		@ExtendWith(MyTestTemplateProvider.class)
+		@ExtendWith(MyOtherTestTemplateProvider.class)
 		void testTemplate() {
 		}
 	}
 
+	static class MyCombinedTestCase {
+		@Tag("bar")
+		@Tag("baz")
+		@TestTemplate
+		@ExtendWith(MyTestTemplateProvider.class)
+		@ExtendWith(MyOtherTestTemplateProvider.class)
+		@CombineTestTemplates
+		void testTemplate() {
+		}
+	}
+
+	static class MyTestTemplateProvider implements TestTemplateInvocationContextProvider {
+		public static final Extension EXTENSION = new Extension() {
+		};
+
+		@Override
+		public boolean supportsTestTemplate(ExtensionContext context) {
+			return true;
+		}
+
+		@Override
+		public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+			return Stream.of(new TestTemplateInvocationContext() {
+				@Override
+				public String getDisplayName(int invocationIndex) {
+					return "Test";
+				}
+
+				@Override
+				public List<Extension> getAdditionalExtensions() {
+					return Collections.singletonList(EXTENSION);
+				}
+			});
+		}
+	}
+
+	static class MyOtherTestTemplateProvider implements TestTemplateInvocationContextProvider {
+		public static final Extension EXTENSION = new Extension() {
+		};
+
+		@Override
+		public boolean supportsTestTemplate(ExtensionContext context) {
+			return true;
+		}
+
+		@Override
+		public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+			return Stream.of(new TestTemplateInvocationContext() {
+				@Override
+				public String getDisplayName(int invocationIndex) {
+					return "Test2";
+				}
+
+				@Override
+				public List<Extension> getAdditionalExtensions() {
+					return Collections.singletonList(EXTENSION);
+				}
+			});
+		}
+	}
 }


### PR DESCRIPTION
This adds support for combining multiple TestTemplate providers
together, in a product style, so that an implementer can use the
benefits of multiple extensions together.

Issue: #1224

## Overview

This is a fix for #1224. I had some free time so I thought I would take a look at how hard it would be. This will almost certainly not work for everyone so I have made it opt-in with a new annotation, @CombineTestTemplates. This will allow those who need this feature to use it, and everything will be normal for others.

Using the Maven test sample as a quick test we get the following test output (happy to hear suggestions for better test names): 
![image](https://user-images.githubusercontent.com/1029558/93200151-f2b1e800-f73e-11ea-8c15-a5c863e1a099.png)

I have not yet had a chance to write test cases but I'm gonna have a crack at that later in the week if this seems interesting.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
