### PR TITLE
@Disabled javadoc - use better wording to be more precise about actua…

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Disabled.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Disabled.java
@@ -22,7 +22,7 @@ import org.apiguardian.api.API;
 
 /**
  * {@code @Disabled} is used to signal that the annotated test class or
- * test method is currently <em>disabled</em> and should not be executed.
+ * test method is currently <em>disabled</em> and shall not be executed.
  *
  * <p>{@code @Disabled} may optionally be declared with a {@linkplain #value
  * reason} to document why the annotated test class or test method is disabled.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExecutionCondition.java
@@ -57,7 +57,7 @@ public interface ExecutionCondition extends Extension {
 	 * <p>An {@linkplain ConditionEvaluationResult#enabled enabled} result
 	 * indicates that the container or test should be executed; whereas, a
 	 * {@linkplain ConditionEvaluationResult#disabled disabled} result
-	 * indicates that the container or test should not be executed.
+	 * indicates that the container or test shall not be executed.
 	 *
 	 * @param context the current extension context; never {@code null}
 	 * @return the result of evaluating this condition; never {@code null}


### PR DESCRIPTION
## Overview

@Disabled use word "should" in "should not be executed"

Word "should" can be interpreted as something which may happen, but it's not 100% sure. Like they say in https://tools.ietf.org/html/rfc2119. In context of JUnit5 this actually means "shall not be executed"

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).


