### PR TITLE
Support underscores for numeric in CSV sources

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -44,7 +44,9 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* Numeric literals used with `@CsvSource` or `CsvFileSource` can now be expressed using
+  underscores as in some JVM languages, to improve readability of long numbers like
+  `700_000_000`.
 
 
 [[release-notes-5.8.0-M1-junit-vintage]]

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -210,7 +210,8 @@ class ParameterizedTestDemo {
 	@CsvSource({
 		"apple,         1",
 		"banana,        2",
-		"'lemon, lime', 0xF1"
+		"'lemon, lime', 0xF1",
+		"strawberry,    700_000"
 	})
 	void testWithCsvSource(String fruit, int rank) {
 		assertNotNull(fruit);

--- a/documentation/src/test/resources/two-column.csv
+++ b/documentation/src/test/resources/two-column.csv
@@ -2,3 +2,4 @@ Country, reference
 Sweden, 1
 Poland, 2
 "United States of America", 3
+France, 700_000

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -76,7 +76,8 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 	public static final DefaultArgumentConverter INSTANCE = new DefaultArgumentConverter();
 
 	private static final List<StringToObjectConverter> stringToObjectConverters = unmodifiableList(asList( //
-		new StringToPrimitiveConverter(), //
+		new StringToBooleanAndCharPrimitiveConverter(), //
+		new StringToNumericPrimitiveConverter(), //
 		new StringToEnumConverter(), //
 		new StringToJavaTimeConverter(), //
 		new StringToCommonJavaTypesConverter(), //
@@ -140,7 +141,7 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 
 	}
 
-	private static class StringToPrimitiveConverter implements StringToObjectConverter {
+	private static class StringToBooleanAndCharPrimitiveConverter implements StringToObjectConverter {
 
 		private static final Map<Class<?>, Function<String, ?>> CONVERTERS;
 		static {
@@ -150,6 +151,25 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 				Preconditions.condition(source.length() == 1, () -> "String must have length of 1: " + source);
 				return source.charAt(0);
 			});
+			CONVERTERS = unmodifiableMap(converters);
+		}
+
+		@Override
+		public boolean canConvert(Class<?> targetType) {
+			return CONVERTERS.containsKey(targetType);
+		}
+
+		@Override
+		public Object convert(String source, Class<?> targetType) {
+			return CONVERTERS.get(targetType).apply(source);
+		}
+	}
+
+	private static class StringToNumericPrimitiveConverter implements StringToObjectConverter {
+
+		private static final Map<Class<?>, Function<String, ?>> CONVERTERS;
+		static {
+			Map<Class<?>, Function<String, ?>> converters = new HashMap<>();
 			converters.put(Byte.class, Byte::decode);
 			converters.put(Short.class, Short::decode);
 			converters.put(Integer.class, Integer::decode);
@@ -166,7 +186,7 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 
 		@Override
 		public Object convert(String source, Class<?> targetType) {
-			return CONVERTERS.get(targetType).apply(source);
+			return CONVERTERS.get(targetType).apply(source.replace("_", ""));
 		}
 	}
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -83,13 +83,19 @@ class DefaultArgumentConverterTests {
 	@Test
 	void convertsStringsToPrimitiveTypes() {
 		assertConverts("true", boolean.class, true);
-		assertConverts("1", byte.class, (byte) 1);
 		assertConverts("o", char.class, 'o');
+		assertConverts("1", byte.class, (byte) 1);
+		assertConverts("1_0", byte.class, (byte) 10);
 		assertConverts("1", short.class, (short) 1);
+		assertConverts("1_2", short.class, (short) 12);
 		assertConverts("42", int.class, 42);
+		assertConverts("700_050_000", int.class, 700_050_000);
 		assertConverts("42", long.class, 42L);
+		assertConverts("4_2", long.class, 42L);
 		assertConverts("42.23", float.class, 42.23f);
+		assertConverts("42.2_3", float.class, 42.23f);
 		assertConverts("42.23", double.class, 42.23);
+		assertConverts("42.2_3", double.class, 42.23);
 	}
 
 	/**


### PR DESCRIPTION
## Overview

Hello,

This change adds support for underscores in long numeric literals such as `700_000_000` in `CsvSource` and `CsvFileSource`.

This kind of notation was introduced in Java 1.7 to improve readability of long numbers (https://docs.oracle.com/javase/7/docs/technotes/guides/language/underscores-literals.html).
It is also available in Groovy and Kotlin.

This is the kind of thing that can be done with an `ArgumentConverter`, however it adds a lot of boilerplate code and loose the benefit of better readability / maintability.

Let me know if this is something that you would consider integrating to JUnit-Jupiter.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
