### PR TITLE
Issue #2401 adding custom dokka test with configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,6 +106,7 @@ allprojects {
 	repositories {
 		// mavenLocal()
 		mavenCentral()
+		jcenter() // doka dependency
 		maven(url = "https://oss.sonatype.org/content/repositories/snapshots") {
 			mavenContent {
 				snapshotsOnly()

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -4,8 +4,10 @@ import org.junit.gradle.exec.ClasspathSystemPropertyProvider
 import org.junit.gradle.javadoc.ModuleSpecificJavadocFileOption
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
+import java.net.URL
 
 plugins {
+	id("org.jetbrains.dokka")
 	id("org.asciidoctor.jvm.convert")
 	id("org.asciidoctor.jvm.pdf")
 	id("org.ajoberstar.git-publish")
@@ -306,6 +308,25 @@ tasks {
 		doFirst {
 			(options as CoreJavadocOptions).modulePath = classpath.files.toList()
 		}
+	}
+
+	val customDokkaTask by creating(org.jetbrains.dokka.gradle.DokkaTask::class) {
+		dependencies {
+			plugins("org.jetbrains.dokka:kotlin-as-java-plugin:1.4.10")
+		}
+		dokkaSourceSets {
+			configureEach {
+				sourceRoot("src/test")
+				sourceLink{
+					localDirectory.set(File("src/test"))
+
+					remoteUrl.set(URL("https://github.com/junit-team/junit5/tree/main/documentation/src/test/kotlin/example"))
+					// Suffix which is used to append the line number to the URL. Use #L for GitHub
+					remoteLineSuffix.set("#L")
+				}
+			}
+		}
+		dependsOn(javadoc)
 	}
 
 	val fixJavadoc by registering(Copy::class) {

--- a/documentation/src/test/java/example/AssumptionsDemo.java
+++ b/documentation/src/test/java/example/AssumptionsDemo.java
@@ -21,10 +21,29 @@ import example.util.Calculator;
 
 import org.junit.jupiter.api.Test;
 
+
+/**
+ * Assumptions demo
+ * @author      John Doe
+ * @version     1.6 (current version number of program)
+ * @since       1.2 (the version of the package this class was first added to)
+ */
 class AssumptionsDemo {
 
 	private final Calculator calculator = new Calculator();
 
+	/**
+	 * Short one line description.                           (1)
+	 * <p>
+	 * Longer description. If there were any, it would be    (2)
+	 * here.
+	 * <p>
+	 * And even more explanations to follow in consecutive
+	 * paragraphs separated by HTML paragraph breaks.
+	 *
+	 * @param  variable Description text text text.          (3)
+	 * @return Description text text text.
+	 */
 	@Test
 	void testOnlyOnCiServer() {
 		assumeTrue("CI".equals(System.getenv("ENV")));

--- a/documentation/src/test/kotlin/example/FibonacciCalculator.kt
+++ b/documentation/src/test/kotlin/example/FibonacciCalculator.kt
@@ -9,6 +9,9 @@
  */
 package example
 
+/**
+ * A calculator for Fibonacci numbers
+ */
 class FibonacciCalculator {
 
     private val fibonacci = sequence {
@@ -24,6 +27,11 @@ class FibonacciCalculator {
         }
     }
 
+    /**
+     * Runs the fibonacci calculator
+     * @param fibonacciNumber the number to start from
+     * @return fibonacci numbers
+     */
     fun fib(fibonacciNumber: Int) =
         fibonacci.elementAt(fibonacciNumber)
 }

--- a/documentation/src/test/kotlin/example/KotlinAssertionsDemo.kt
+++ b/documentation/src/test/kotlin/example/KotlinAssertionsDemo.kt
@@ -54,6 +54,16 @@ class KotlinAssertionsDemo {
         )
     }
 
+    /**
+     * Test for grouping assertions from a stream:
+     * ```kotlin
+     * val exception = assertThrows<IllegalArgumentException>({ "Should throw an Exception" }) {
+     *     throw IllegalArgumentException("Talk to a duck")
+     * }
+     * assertEquals("Talk to a duck", exception.message)
+     * ```
+     * @since 5.0
+     */
     @Test
     fun `grouped assertions from a stream`() {
         assertAll("People with first name starting with J",

--- a/documentation/src/test/kotlin/example/registration/KotlinWebServerDemo.kt
+++ b/documentation/src/test/kotlin/example/registration/KotlinWebServerDemo.kt
@@ -14,6 +14,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
 // tag::user_guide[]
+/**
+ * Demo for a Web server implemented with Kotlin
+ *
+ * This class is used for documentation purposes and serves as an example
+ *
+ * @param parameter Some parameter
+ * @property name the name of KotlinWebServerDemo.
+ * @constructor Creates a KotlinWebServerDemo.
+ */
 class KotlinWebServerDemo {
 
     companion object {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ pluginManagement {
 		id("org.asciidoctor.jvm.pdf") version settings.extra["asciidoctor.plugin.version"] as String
 		id("me.champeau.gradle.jmh") version settings.extra["jmh.plugin.version"] as String
 		id("io.spring.nohttp") version settings.extra["nohttp.plugin.version"] as String
+		id("org.jetbrains.dokka") version "1.4.10"
 	}
 }
 


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
I have attempted to take a look at dokka for Kotlin. 

I have created a custom task, added dependencies, added some javadoc to Kotlin and tried to generate an html file.

Running the new custom task ends up with an html file as expected. I also updated properties and made it depend on javadoc 
task.
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
