### PR TITLE
junit-platform-commons 1.7.0 does not contain MANIFEST.MF as first JAR entry (#2438)

### DIFF
--- a/buildSrc/src/main/kotlin/java-repackage-jars.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-repackage-jars.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.Calendar
-import java.util.GregorianCalendar
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
@@ -19,10 +17,21 @@ afterEvaluate {
 			val newJarStream = JarOutputStream(os)
 			val oldJar = JarFile(originalOutput)
 
+			fun sortAlwaysFirst(name: String): Comparator<JarEntry> =
+				Comparator { a, b ->
+					when {
+						a.name == name -> -1
+						b.name == name -> 1
+						else -> 0
+					}
+				}
+
 			oldJar.entries()
 					.toList()
 					.distinctBy { it.name }
-					.sortedBy { it.name }
+					.sortedWith(sortAlwaysFirst("META-INF/")
+							.then(sortAlwaysFirst("META-INF/MANIFEST.MF"))
+							.thenBy { it.name })
 					.forEach { entry ->
 						val jarEntry = JarEntry(entry.name)
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JarContainsManifestFirstTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JarContainsManifestFirstTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static platform.tooling.support.Helper.createJarPath;
+
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.util.jar.JarInputStream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @since 1.8
+ */
+class JarContainsManifestFirstTests {
+
+	@ParameterizedTest
+	@MethodSource("platform.tooling.support.Helper#loadModuleDirectoryNames")
+	void manifestFirst(String module) throws Exception {
+		var modulePath = createJarPath(module);
+
+		if (Files.notExists(modulePath)) {
+			fail("No such file: " + modulePath);
+		}
+
+		// JarInputStream expects the META-INF/MANIFEST.MF to be at the start of the JAR archive
+		try (final JarInputStream jarInputStream = new JarInputStream(new FileInputStream(modulePath.toFile()))) {
+			assertNotNull(jarInputStream.getManifest(), "MANIFEST.MF should be available via JarInputStream");
+		}
+	}
+}


### PR DESCRIPTION
Resolves  #2438

## Overview

- always sort "META-INF/" and "META-INF/MANIFEST.MF" entries first

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
