### PR TITLE
Expose DynamicTest executable to InvocationInterceptors

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -21,7 +21,9 @@ on GitHub.
 
 ==== Deprecations and Breaking Changes
 
-* ❓
+* `InvocationInterceptor.interceptDynamicTest(Invocation<Void> , ExtensionContext)` has been deprecated in favor of
+  `InvocationInterceptor.interceptDynamicTest(Invocation<Void> , DynamicTestInvocationContext, ExtensionContext)` that
+  allows to access the dynamic test executable via `DynamicTestInvocationContext.getExecutable()`.
 
 ==== New Features and Improvements
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/DynamicTestInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/DynamicTestInvocationContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.function.Executable;
+
+/**
+ * {@code DynamicTestInvocationContext} represents the <em>context</em> of a
+ * single invocation of a {@linkplain org.junit.jupiter.api.DynamicTest test}.
+ *
+ * @since 5.8
+ * @see org.junit.jupiter.api.DynamicTest
+ */
+@API(status = EXPERIMENTAL, since = "5.8")
+public class DynamicTestInvocationContext {
+	private Executable executable;
+
+	public DynamicTestInvocationContext(Executable executable) {
+		this.executable = executable;
+	}
+
+	/**
+	 * Get the {@linkplain Executable} of this dynamic test invocation.
+	 *
+	 * @return the executable of the dynamic test invocation, never null.
+	 */
+	public Executable getExecutable() {
+		return executable;
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/InvocationInterceptor.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/InvocationInterceptor.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.lang.reflect.Constructor;
@@ -156,9 +157,29 @@ public interface InvocationInterceptor extends Extension {
 	 * {@code null}
 	 * @param extensionContext the current extension context; never {@code null}
 	 * @throws Throwable in case of failures
+	 * @deprecated use {@link #interceptDynamicTest(Invocation, DynamicTestInvocationContext, ExtensionContext)} instead
 	 */
+	@Deprecated
+	@API(status = DEPRECATED, since = "5.8")
 	default void interceptDynamicTest(Invocation<Void> invocation, ExtensionContext extensionContext) throws Throwable {
 		invocation.proceed();
+	}
+
+	/**
+	 * Intercept the invocation of a {@link DynamicTest}.
+	 *
+	 * @param invocation the invocation that is being intercepted; never
+	 * {@code null}
+	 * @param invocationContext the context of the invocation that is being
+	 * intercepted; never {@code null}
+	 * @param extensionContext the current extension context; never {@code null}
+	 * @throws Throwable in case of failures
+	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
+	default void interceptDynamicTest(Invocation<Void> invocation, DynamicTestInvocationContext invocationContext,
+			ExtensionContext extensionContext) throws Throwable {
+		// by default call the old interceptDynamicTest(Invocation, ExtensionContext) method so that existing extensions still work
+		interceptDynamicTest(invocation, extensionContext);
 	}
 
 	/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicTestTestDescriptor.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.descriptor;
 
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.extension.DynamicTestInvocationContext;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.function.Executable;
@@ -52,10 +53,13 @@ class DynamicTestTestDescriptor extends DynamicNodeTestDescriptor {
 			dynamicTest.getExecutable().execute();
 			return null;
 		};
+		DynamicTestInvocationContext dynamicTestInvocationContext = new DynamicTestInvocationContext(
+			dynamicTest.getExecutable());
 		ExtensionContext extensionContext = context.getExtensionContext();
 		ExtensionRegistry extensionRegistry = context.getExtensionRegistry();
 		interceptorChain.invoke(invocation, extensionRegistry, InterceptorCall.ofVoid(
-			(interceptor, wrappedInvocation) -> interceptor.interceptDynamicTest(wrappedInvocation, extensionContext)));
+			(interceptor, wrappedInvocation) -> interceptor.interceptDynamicTest(wrappedInvocation,
+				dynamicTestInvocationContext, extensionContext)));
 		return context;
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/extension/ExtensionComposabilityTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/extension/ExtensionComposabilityTests.java
@@ -60,6 +60,7 @@ class ExtensionComposabilityTests {
 
 		List<String> expectedMethodNames = expectedMethods.stream()
 				.map(Method::getName)
+				.distinct()
 				.sorted()
 				.collect(toList());
 		// @formatter:on

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.api.extension.DynamicTestInvocationContext;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -287,8 +288,9 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Override
-		public void interceptDynamicTest(Invocation<Void> invocation, ExtensionContext extensionContext)
-				throws Throwable {
+		public void interceptDynamicTest(Invocation<Void> invocation, DynamicTestInvocationContext invocationContext,
+				ExtensionContext extensionContext) throws Throwable {
+			assertThat(invocationContext.getExecutable()).isNotNull();
 			assertThat(extensionContext.getUniqueId()).isNotBlank();
 			assertThat(extensionContext.getElement()).isEmpty();
 			assertThat(extensionContext.getParent().flatMap(ExtensionContext::getTestMethod)).contains(


### PR DESCRIPTION
## Overview

Allow dynamic test invocation interceptors to access the dynamic test executable.

Fixes #2399

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
