### PR TITLE
Support parallelization in junit-vintage-engine

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -62,4 +62,6 @@ on GitHub.
 
 ==== New Features and Improvements
 
+* Tests can now be run in parallel by setting the appropriate `junit.jupiter.execution.parallel`
+  parameters. This is compatible with the Maven Surefire and Failsafe plugins.
 * ❓

--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics.adoc
@@ -19,7 +19,7 @@ implementations out of the box: `dynamic` and `fixed`. Alternatively, you may im
 `custom` strategy.
 
 To select a strategy, set the `junit.<engine>.execution.parallel.config.strategy`
-configuration parameter to one of the following options. Replace "engine" with either
+configuration parameter to one of the following options. Replace `<engine>` with either
 `jupiter` or `vintage`.
 
 `dynamic`::
@@ -41,10 +41,10 @@ strategy with a factor of `1`. Consequently, the desired parallelism will be equ
 number of available processors/cores.
 
 .Parallelism does not imply maximum number of concurrent threads
-NOTE: JUnit Jupiter does not guarantee that the number of concurrently executing tests
-will not exceed the configured parallelism. For example, when using one of the
-synchronization mechanisms described in the
-<<writing-tests-parallel-execution-synchronization,Jupiter Synchronization>>
+NOTE: JUnit does not guarantee that the number of concurrently executing tests
+will not exceed the configured parallelism. For example, when using one of
+Jupiter's synchronization mechanisms described in the
+<<writing-tests-parallel-execution-synchronization, Synchronization>>
 section, the `ForkJoinPool` that is used behind the scenes may spawn additional threads to
 ensure execution continues with sufficient parallelism. Thus, if you require such
 guarantees in a test class, please use your own means of controlling concurrency.

--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics.adoc
@@ -8,3 +8,43 @@ include::testkit.adoc[]
 ////
 include::engines.adoc[]
 ////
+
+[[advanced-topics-parallel-execution-config]]
+=== Parallel Execution Configuration
+
+When enabling parallel test execution using either the Jupiter or Vintage engines,
+properties such as the desired parallelism and the maximum pool size can be configured
+using a `{ParallelExecutionConfigurationStrategy}`. The JUnit Platform provides two
+implementations out of the box: `dynamic` and `fixed`. Alternatively, you may implement a
+`custom` strategy.
+
+To select a strategy, set the `junit.<engine>.execution.parallel.config.strategy`
+configuration parameter to one of the following options. Replace "engine" with either
+`jupiter` or `vintage`.
+
+`dynamic`::
+  Computes the desired parallelism based on the number of available processors/cores
+  multiplied by the `junit.<engine>.execution.parallel.config.dynamic.factor`
+  configuration parameter (defaults to `1`).
+
+`fixed`::
+  Uses the mandatory `junit.<engine>.execution.parallel.config.fixed.parallelism`
+  configuration parameter as the desired parallelism.
+
+`custom`::
+  Allows you to specify a custom `{ParallelExecutionConfigurationStrategy}`
+  implementation via the mandatory `junit.<engine>.execution.parallel.config.custom.class`
+  configuration parameter to determine the desired configuration.
+
+If no configuration strategy is set, JUnit uses the `dynamic` configuration
+strategy with a factor of `1`. Consequently, the desired parallelism will be equal to the
+number of available processors/cores.
+
+.Parallelism does not imply maximum number of concurrent threads
+NOTE: JUnit Jupiter does not guarantee that the number of concurrently executing tests
+will not exceed the configured parallelism. For example, when using one of the
+synchronization mechanisms described in the
+<<writing-tests-parallel-execution-synchronization,Jupiter Synchronization>>
+section, the `ForkJoinPool` that is used behind the scenes may spawn additional threads to
+ensure execution continues with sufficient parallelism. Thus, if you require such
+guarantees in a test class, please use your own means of controlling concurrency.

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -129,14 +129,7 @@ feature. Consult the table in <<api-evolution-experimental-apis>> for detail.
 === Limited Parallel Execution Support
 
 As of 5.8, limited parallel execution is supported by setting the
-`junit.vintage.execution.parallel.enabled` configuration parameter to `true`. In addition, the
-following properties with the `junit.vintage.execution.parallel.config.` prefix are also supported.
-
-.Parallel Configuration Properties
-|===
-| Parameter Name | Potential Values | Description |
-| `strategy` | `fixed`, `dynamic` (default), or `custom` | If `fixed`, set an explicit number of concurrent tests to run based on the `fixed.parallelism` property. If `dynamic` or not specified, use the number of processor cores multiplied by `dynamic.factor`. If `custom` provide an implementation of `ParallelExecutionConfigurationStrategy` in `custom.class` to configure the parallelism. |
-| `fixed.parallelism` | positive integer | The maximum number of concurrent tests to run. Only applicable if `strategy=fixed`. |
-| `dynamic.factor` | positive floating point number (can be less than one) | Set the number of concurrent tests to be a multiple of the number of processor cores. Only applicable if `strategy=dynamic`. |
-| `custom.class` | Fully-qualified class name that implements `ParallelExecutionConfigurationStrategy`. | Provide a custom approach to configuring parallelism. The class must implement `org.junit.platform.engine.support.hierarchical.ParallelExecutionConfigurationStrategy`. |
-|===
+`junit.vintage.execution.parallel.enabled` configuration parameter to `true`. See
+<<advanced-topics-parallel-execution-config,Parallel Execution Configuration>>
+for details on customizing the number of threads used. Be sure to specify the "vintage"
+engine in the property names (i.e. prefix with `junit.vintage`).

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -21,7 +21,9 @@ developers have plenty of time to migrate to JUnit Jupiter on their own schedule
 
 Just make sure that the `junit-vintage-engine` artifact is in your test runtime path. In
 that case JUnit 3 and JUnit 4 tests will automatically be picked up by the JUnit Platform
-launcher.
+launcher. Limited parallel execution is supported by setting the
+`junit.jupiter.execution.parallel.enabled` configuration parameter to `true`. In addition, the
+JUnit concurrency settings in `junit.jupiter.execution.parallel.config.*` are also supported.
 
 See the example projects in the {junit5-samples-repo}[`junit5-samples`] repository to
 find out how this is done with Gradle and Maven.

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -21,9 +21,7 @@ developers have plenty of time to migrate to JUnit Jupiter on their own schedule
 
 Just make sure that the `junit-vintage-engine` artifact is in your test runtime path. In
 that case JUnit 3 and JUnit 4 tests will automatically be picked up by the JUnit Platform
-launcher. Limited parallel execution is supported by setting the
-`junit.jupiter.execution.parallel.enabled` configuration parameter to `true`. In addition, the
-JUnit concurrency settings in `junit.jupiter.execution.parallel.config.*` are also supported.
+launcher. 
 
 See the example projects in the {junit5-samples-repo}[`junit5-samples`] repository to
 find out how this is done with Gradle and Maven.
@@ -126,3 +124,19 @@ include::{testDir}/example/IgnoredTestsDemo.java[tags=user_guide]
 
 WARNING: JUnit 4 `@Ignore` support in JUnit Jupiter is currently an _experimental_
 feature. Consult the table in <<api-evolution-experimental-apis>> for detail.
+
+[[migrating-from-junit4-parallel-support]]
+=== Limited Parallel Execution Support
+
+As of 5.8, limited parallel execution is supported by setting the
+`junit.vintage.execution.parallel.enabled` configuration parameter to `true`. In addition, the
+following properties with the `junit.vintage.execution.parallel.config.` prefix are also supported.
+
+.Parallel Configuration Properties
+|===
+| Parameter Name | Potential Values | Description |
+| `strategy` | `fixed`, `dynamic` (default), or `custom` | If `fixed`, set an explicit number of concurrent tests to run based on the `fixed.parallelism` property. If `dynamic` or not specified, use the number of processor cores multiplied by `dynamic.factor`. If `custom` provide an implementation of `ParallelExecutionConfigurationStrategy` in `custom.class` to configure the parallelism. |
+| `fixed.parallelism` | positive integer | The maximum number of concurrent tests to run. Only applicable if `strategy=fixed`. |
+| `dynamic.factor` | positive floating point number (can be less than one) | Set the number of concurrent tests to be a multiple of the number of processor cores. Only applicable if `strategy=dynamic`. |
+| `custom.class` | Fully-qualified class name that implements `ParallelExecutionConfigurationStrategy`. | Provide a custom approach to configuring parallelism. The class must implement `org.junit.platform.engine.support.hierarchical.ParallelExecutionConfigurationStrategy`. |
+|===

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -21,7 +21,7 @@ developers have plenty of time to migrate to JUnit Jupiter on their own schedule
 
 Just make sure that the `junit-vintage-engine` artifact is in your test runtime path. In
 that case JUnit 3 and JUnit 4 tests will automatically be picked up by the JUnit Platform
-launcher. 
+launcher.
 
 See the example projects in the {junit5-samples-repo}[`junit5-samples`] repository to
 find out how this is done with Gradle and Maven.

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1971,41 +1971,10 @@ not explicitly set, the value for `junit.jupiter.execution.parallel.mode.default
 used instead.
 
 [[writing-tests-parallel-execution-config]]
-==== Configuration
-
-Properties such as the desired parallelism and the maximum pool size can be configured
-using a `{ParallelExecutionConfigurationStrategy}`. The JUnit Platform provides two
-implementations out of the box: `dynamic` and `fixed`. Alternatively, you may implement a
-`custom` strategy.
-
-To select a strategy, set the `junit.jupiter.execution.parallel.config.strategy`
-configuration parameter to one of the following options.
-
-`dynamic`::
-  Computes the desired parallelism based on the number of available processors/cores
-  multiplied by the `junit.jupiter.execution.parallel.config.dynamic.factor`
-  configuration parameter (defaults to `1`).
-
-`fixed`::
-  Uses the mandatory `junit.jupiter.execution.parallel.config.fixed.parallelism`
-  configuration parameter as the desired parallelism.
-
-`custom`::
-  Allows you to specify a custom `{ParallelExecutionConfigurationStrategy}`
-  implementation via the mandatory `junit.jupiter.execution.parallel.config.custom.class`
-  configuration parameter to determine the desired configuration.
-
-If no configuration strategy is set, JUnit Jupiter uses the `dynamic` configuration
-strategy with a factor of `1`. Consequently, the desired parallelism will be equal to the
-number of available processors/cores.
-
-.Parallelism does not imply maximum number of concurrent threads
-NOTE: JUnit Jupiter does not guarantee that the number of concurrently executing tests
-will not exceed the configured parallelism. For example, when using one of the
-synchronization mechanisms described in the next section, the `ForkJoinPool` that is used
-behind the scenes may spawn additional threads to ensure execution continues with
-sufficient parallelism. Thus, if you require such guarantees in a test class, please use
-your own means of controlling concurrency.
+See
+<<advanced-topics-parallel-execution-config,Parallel Execution Configuration>>
+for details on customizing the number of threads used. Be sure to specify the "jupiter"
+engine in the property names (i.e. prefix with `junit.jupiter`).
 
 [[writing-tests-parallel-execution-synchronization]]
 ==== Synchronization

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolFactory.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolFactory.java
@@ -16,7 +16,6 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
@@ -31,9 +30,9 @@ import org.junit.platform.commons.function.Try;
  * @see ParallelExecutionConfigurationStrategy
  */
 @API(status = Status.INTERNAL, since = "5.8")
-public class ForkJoinPoolFactory implements Function<ParallelExecutionConfiguration, ForkJoinPool> {
+public class ForkJoinPoolFactory {
 
-	public ForkJoinPool apply(ParallelExecutionConfiguration configuration) {
+	public static ForkJoinPool create(ParallelExecutionConfiguration configuration) {
 		ForkJoinWorkerThreadFactory threadFactory = new WorkerThreadFactory();
 		return Try.call(() -> {
 			// Try to use constructor available in Java >= 9

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolFactory.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.hierarchical;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.lang.reflect.Constructor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.function.Try;
+
+/**
+ * A factory for creating {@link ForkJoinPool ForkJoinPools} given a {@link ParallelExecutionConfiguration}.
+ *
+ * @since 5.8
+ * @see ParallelExecutionConfigurationStrategy
+ */
+public class ForkJoinPoolFactory implements Function<ParallelExecutionConfiguration, ForkJoinPool> {
+
+	public ForkJoinPool apply(ParallelExecutionConfiguration configuration) {
+		ForkJoinWorkerThreadFactory threadFactory = new WorkerThreadFactory();
+		return Try.call(() -> {
+			// Try to use constructor available in Java >= 9
+			Constructor<ForkJoinPool> constructor = ForkJoinPool.class.getDeclaredConstructor(Integer.TYPE,
+				ForkJoinWorkerThreadFactory.class, UncaughtExceptionHandler.class, Boolean.TYPE, Integer.TYPE,
+				Integer.TYPE, Integer.TYPE, Predicate.class, Long.TYPE, TimeUnit.class);
+			return constructor.newInstance(configuration.getParallelism(), threadFactory, null, false,
+				configuration.getCorePoolSize(), configuration.getMaxPoolSize(), configuration.getMinimumRunnable(),
+				null, configuration.getKeepAliveSeconds(), TimeUnit.SECONDS);
+		}).orElseTry(() -> {
+			// Fallback for Java 8
+			return new ForkJoinPool(configuration.getParallelism(), threadFactory, null, false);
+		}).getOrThrow(cause -> new JUnitException("Failed to create ForkJoinPool", cause));
+	}
+
+	static class WorkerThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory {
+
+		private final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+		@Override
+		public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+			return new WorkerThread(pool, contextClassLoader);
+		}
+	}
+
+	static class WorkerThread extends ForkJoinWorkerThread {
+
+		WorkerThread(ForkJoinPool pool, ClassLoader contextClassLoader) {
+			super(pool);
+			setContextClassLoader(contextClassLoader);
+		}
+	}
+
+}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolFactory.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolFactory.java
@@ -19,6 +19,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.function.Try;
 
@@ -28,6 +30,7 @@ import org.junit.platform.commons.function.Try;
  * @since 5.8
  * @see ParallelExecutionConfigurationStrategy
  */
+@API(status = Status.INTERNAL, since = "5.8")
 public class ForkJoinPoolFactory implements Function<ParallelExecutionConfiguration, ForkJoinPool> {
 
 	public ForkJoinPool apply(ParallelExecutionConfiguration configuration) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -61,7 +61,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 	 */
 	@API(status = EXPERIMENTAL, since = "1.7")
 	public ForkJoinPoolHierarchicalTestExecutorService(ParallelExecutionConfiguration configuration) {
-		this(new ForkJoinPoolFactory().apply(configuration));
+		this(ForkJoinPoolFactory.create(configuration));
 	}
 
 	/**

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
@@ -168,7 +168,7 @@ public final class VintageTestEngine implements TestEngine {
 				strategyName.toUpperCase());
 			ParallelExecutionConfiguration executionConfiguration = executionStrategy.createConfiguration(
 				prefixedParameters);
-			executorService = new ForkJoinPoolFactory().apply(executionConfiguration);
+			executorService = ForkJoinPoolFactory.create(executionConfiguration);
 		}
 
 		public void execute(Runnable command) {
@@ -185,6 +185,7 @@ public final class VintageTestEngine implements TestEngine {
 			}
 			catch (InterruptedException e) {
 				logger.warn(e, () -> "Interrupted while waiting for tests to complete.");
+				Thread.currentThread().interrupt();
 			}
 		}
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
@@ -14,15 +14,27 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.engine.TestExecutionResult.successful;
 import static org.junit.vintage.engine.descriptor.VintageTestDescriptor.ENGINE_ID;
 
+import java.util.Collection;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.config.PrefixedConfigurationParameters;
+import org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy;
+import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfiguration;
+import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfigurationStrategy;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
 import org.junit.vintage.engine.descriptor.VintageEngineDescriptor;
 import org.junit.vintage.engine.discovery.VintageDiscoverer;
@@ -35,6 +47,10 @@ import org.junit.vintage.engine.execution.RunnerExecutor;
  */
 @API(status = INTERNAL, since = "4.12")
 public final class VintageTestEngine implements TestEngine {
+
+	private static final String PARALLEL_CONFIG_PREFIX = "junit.jupiter.execution.parallel";
+	private static final String PARALLEL_ENABLED_CONFIG = PARALLEL_CONFIG_PREFIX + ".enabled";
+	private static final String PARALLEL_CONFIG = PARALLEL_CONFIG_PREFIX + ".config.";
 
 	@Override
 	public String getId() {
@@ -70,17 +86,107 @@ public final class VintageTestEngine implements TestEngine {
 		engineExecutionListener.executionStarted(engineDescriptor);
 		RunnerExecutor runnerExecutor = new RunnerExecutor(engineExecutionListener,
 			engineDescriptor.getTestSourceProvider());
-		executeAllChildren(runnerExecutor, engineDescriptor);
+
+		final ConfigurationParameters configurationParameters = request.getConfigurationParameters();
+		final boolean parallelExecutionEnabled = configurationParameters.getBoolean(PARALLEL_ENABLED_CONFIG).orElse(
+			false);
+
+		try (CloseableExecutor executor = parallelExecutionEnabled ? new ParallelExecutor(configurationParameters)
+				: new SerialExecutor()) {
+			executeAllChildren(executor, runnerExecutor, engineDescriptor);
+		}
+		catch (final InterruptedException e) {
+			throw new JUnitException("Error executing tests for engine " + getId() + ": " + e.getMessage(), e);
+		}
+
 		engineExecutionListener.executionFinished(engineDescriptor, successful());
 	}
 
-	private void executeAllChildren(RunnerExecutor runnerExecutor, TestDescriptor engineDescriptor) {
+	private void executeAllChildren(final Executor executor, RunnerExecutor runnerExecutor,
+			TestDescriptor engineDescriptor) throws InterruptedException {
+		final Collection<? extends TestDescriptor> children = engineDescriptor.getChildren();
+		final CountDownLatch latch = new CountDownLatch(children.size());
 		// @formatter:off
-		engineDescriptor.getChildren()
+		children
 				.stream()
 				.map(RunnerTestDescriptor.class::cast)
-				.forEach(runnerExecutor::execute);
+				.map(descriptor -> (Runnable)() -> {
+					runnerExecutor.execute(descriptor);
+					latch.countDown();
+				})
+				.forEach(executor::execute);
 		// @formatter:on
+		latch.await();
+	}
+
+	/**
+	 * Wrapper for {@link Executor} to allow it to be used in a try-with-resources block.
+	 */
+	@API(status = INTERNAL, since = "5.8")
+	protected interface CloseableExecutor extends Executor, AutoCloseable {
+		default public void close() throws JUnitException {
+		};
+	}
+
+	/**
+	 * {@link CloseableExecutor} that executes tasks synchronously.
+	 *
+	 * @since 5.8
+	 */
+	@API(status = INTERNAL, since = "5.8")
+	protected class SerialExecutor implements CloseableExecutor {
+		public void execute(final Runnable command) {
+			command.run();
+		}
+
+	}
+
+	/**
+	 * {@link CloseableExecutor} backed by a {@link ForkJoinPool} that executes tasks asynchronously
+	 * based on the settings in {@value #PARALLEL_CONFIG}. Clients *must* implement their own logic
+	 * to wait for tasks to complete.
+	 *
+	 * @since 5.8
+	 */
+	@API(status = INTERNAL, since = "5.8")
+	protected class ParallelExecutor implements CloseableExecutor {
+
+		private final ForkJoinPool pool;
+
+		/**
+		 * @param parameters test execution configuration
+		 */
+		public ParallelExecutor(final ConfigurationParameters parameters) {
+			final ConfigurationParameters prefixedParameters = new PrefixedConfigurationParameters(parameters,
+				PARALLEL_CONFIG);
+			final String strategyName = prefixedParameters.get("strategy").orElse("dynamic");
+			final ParallelExecutionConfigurationStrategy executionStrategy = DefaultParallelExecutionConfigurationStrategy.valueOf(
+				strategyName.toUpperCase());
+			final ParallelExecutionConfiguration executionConfiguration = executionStrategy.createConfiguration(
+				prefixedParameters);
+			pool = new ForkJoinPool(executionConfiguration.getParallelism());
+		}
+
+		public void execute(final Runnable command) {
+			getPool().execute(command);
+		}
+
+		public void close() throws JUnitException {
+			final ExecutorService executor = getPool();
+			executor.shutdown();
+			try {
+				executor.awaitTermination(1, TimeUnit.MINUTES);
+			}
+			catch (final InterruptedException ie) {
+				throw new JUnitException("Interrupted while waiting for forked tests to complete; " + ie.getMessage(),
+					ie);
+			}
+		}
+
+		protected ForkJoinPool getPool() {
+			return pool;
+		}
+
 	}
 
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineParallelismTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineParallelismTests.java
@@ -130,23 +130,21 @@ class VintageTestEngineParallelismTests {
 		}
 
 		public void executionStarted(final TestDescriptor testDescriptor) {
-			String displayName = testDescriptor.getDisplayName();
 			if (testDescriptor.isTest()) {
 				incrementTests();
 			}
-			else if (displayName.equals("A") || displayName.equals("B")) {
+			else if (!testDescriptor.isRoot()) {
 				incrementClasses();
 			}
 		}
 
 		public void executionFinished(final TestDescriptor testDescriptor,
 				final TestExecutionResult testExecutionResult) {
-			String displayName = testDescriptor.getDisplayName();
 			assertEquals(Status.SUCCESSFUL, testExecutionResult.getStatus());
 			if (testDescriptor.isTest()) {
 				decrementTests();
 			}
-			else if (displayName.equals("A") || displayName.equals("B")) {
+			else if (!testDescriptor.isRoot()) {
 				decrementClasses();
 			}
 		}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineParallelismTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineParallelismTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.util.IntSummaryStatistics;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.vintage.engine.samples.junit4.ConcurrencyTests.A;
+import org.junit.vintage.engine.samples.junit4.ConcurrencyTests.B;
+
+/**
+ * Tests to ensure that vintage JUnit tests can run in parallel.
+ * At the moment, only concurrency of top-level containers is supported.
+ *
+ * @since 5.8
+ */
+class VintageTestEngineParallelismTests {
+
+	private static final String PARALLELISM = "junit.jupiter.execution.parallel.config.fixed.parallelism";
+	private static final String PARALLEL_STRATEGY = "junit.jupiter.execution.parallel.config.strategy";
+	private static final String DEFAULT_PARALLEL_MODE = "junit.jupiter.execution.parallel.mode.default";
+	private static final String PARALLEL_EXECUTION_ENABLED = "junit.jupiter.execution.parallel.enabled";
+
+	/**
+	 * Verify that if parallel execution is enabled, tests from separate classes will run concurrently.
+	 */
+	@Test
+	void verifyTestsRunConcurrently() {
+		// given
+		final LauncherDiscoveryRequest discoveryRequest = LauncherDiscoveryRequestBuilder.request().selectors(
+			selectClass(A.class), selectClass(B.class)).configurationParameter(PARALLEL_EXECUTION_ENABLED,
+				"true").configurationParameter(DEFAULT_PARALLEL_MODE, "concurrent").configurationParameter(
+					PARALLEL_STRATEGY, "fixed").configurationParameter(PARALLELISM, "2").build();
+		final TestEngine engine = new VintageTestEngine();
+		final TestDescriptor descriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()));
+
+		final CountingListener listener = new CountingListener();
+		final ExecutionRequest executionRequest = new ExecutionRequest(descriptor, listener,
+			discoveryRequest.getConfigurationParameters());
+
+		// when
+		engine.execute(executionRequest);
+
+		// then
+		assertEquals(2, listener.getMaxConcurrentTests());
+		assertEquals(2, listener.getMaxConcurrentClasses());
+	}
+
+	/**
+	 * Verify that if parallel execution is disabled, tests will run sequentially.
+	 */
+	@Test
+	void verifyTestsRunSequentially() {
+		// given
+		final LauncherDiscoveryRequest discoveryRequest = LauncherDiscoveryRequestBuilder.request().selectors(
+			selectClass(A.class), selectClass(B.class)).configurationParameter(PARALLEL_EXECUTION_ENABLED,
+				"false").build();
+		final TestEngine engine = new VintageTestEngine();
+		final TestDescriptor descriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()));
+
+		final CountingListener listener = new CountingListener();
+		final ExecutionRequest executionRequest = new ExecutionRequest(descriptor, listener,
+			discoveryRequest.getConfigurationParameters());
+
+		// when
+		engine.execute(executionRequest);
+
+		// then
+		assertEquals(1, listener.getMaxConcurrentTests());
+		assertEquals(1, listener.getMaxConcurrentClasses());
+	}
+
+	/**
+	 * {@link EngineExecutionListener} that exposes that maximum number of concurrent classes and tests.
+	 *
+	 * @since 5.8
+	 */
+	protected class CountingListener implements EngineExecutionListener {
+
+		private final IntSummaryStatistics classSummary = new IntSummaryStatistics();
+		private final IntSummaryStatistics testSummary = new IntSummaryStatistics();
+		private final LongAdder testAdder = new LongAdder();
+		private final LongAdder classAdder = new LongAdder();
+
+		/**
+		 * @return the largest number of tests that ran at the same time.
+		 */
+		public int getMaxConcurrentTests() {
+			return testSummary.getMax();
+		}
+
+		/**
+		 * @return the largest number of classes that ran at the same time.
+		 */
+		public int getMaxConcurrentClasses() {
+			return classSummary.getMax();
+		}
+
+		public void executionStarted(final TestDescriptor testDescriptor) {
+			synchronized (this) {
+				final String displayName = testDescriptor.getDisplayName();
+				if (testDescriptor.isTest()) {
+					testAdder.increment();
+					testSummary.accept(testAdder.intValue());
+				}
+				else if (displayName.equals("A") || displayName.equals("B")) {
+					classAdder.increment();
+					classSummary.accept(classAdder.intValue());
+				}
+			}
+		}
+
+		public void executionFinished(final TestDescriptor testDescriptor,
+				final TestExecutionResult testExecutionResult) {
+			synchronized (this) {
+				final String displayName = testDescriptor.getDisplayName();
+				assertEquals(Status.SUCCESSFUL, testExecutionResult.getStatus());
+				if (testDescriptor.isTest()) {
+					testAdder.decrement();
+				}
+				else if (displayName.equals("A") || displayName.equals("B")) {
+					classAdder.decrement();
+				}
+			}
+		}
+	}
+}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineParallelismTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineParallelismTests.java
@@ -37,10 +37,10 @@ import org.junit.vintage.engine.samples.junit4.ConcurrencyTests.B;
  */
 class VintageTestEngineParallelismTests {
 
-	private static final String PARALLELISM = "junit.jupiter.execution.parallel.config.fixed.parallelism";
-	private static final String PARALLEL_STRATEGY = "junit.jupiter.execution.parallel.config.strategy";
-	private static final String DEFAULT_PARALLEL_MODE = "junit.jupiter.execution.parallel.mode.default";
-	private static final String PARALLEL_EXECUTION_ENABLED = "junit.jupiter.execution.parallel.enabled";
+	private static final String PARALLELISM = "junit.vintage.execution.parallel.config.fixed.parallelism";
+	private static final String PARALLEL_STRATEGY = "junit.vintage.execution.parallel.config.strategy";
+	private static final String DEFAULT_PARALLEL_MODE = "junit.vintage.execution.parallel.mode.default";
+	private static final String PARALLEL_EXECUTION_ENABLED = "junit.vintage.execution.parallel.enabled";
 
 	/**
 	 * Verify that if parallel execution is enabled, tests from separate classes will run concurrently.
@@ -48,15 +48,15 @@ class VintageTestEngineParallelismTests {
 	@Test
 	void verifyTestsRunConcurrently() {
 		// given
-		final LauncherDiscoveryRequest discoveryRequest = LauncherDiscoveryRequestBuilder.request().selectors(
+		LauncherDiscoveryRequest discoveryRequest = LauncherDiscoveryRequestBuilder.request().selectors(
 			selectClass(A.class), selectClass(B.class)).configurationParameter(PARALLEL_EXECUTION_ENABLED,
 				"true").configurationParameter(DEFAULT_PARALLEL_MODE, "concurrent").configurationParameter(
 					PARALLEL_STRATEGY, "fixed").configurationParameter(PARALLELISM, "2").build();
-		final TestEngine engine = new VintageTestEngine();
-		final TestDescriptor descriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()));
+		TestEngine engine = new VintageTestEngine();
+		TestDescriptor descriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()));
 
-		final CountingListener listener = new CountingListener();
-		final ExecutionRequest executionRequest = new ExecutionRequest(descriptor, listener,
+		CountingListener listener = new CountingListener();
+		ExecutionRequest executionRequest = new ExecutionRequest(descriptor, listener,
 			discoveryRequest.getConfigurationParameters());
 
 		// when
@@ -73,14 +73,14 @@ class VintageTestEngineParallelismTests {
 	@Test
 	void verifyTestsRunSequentially() {
 		// given
-		final LauncherDiscoveryRequest discoveryRequest = LauncherDiscoveryRequestBuilder.request().selectors(
+		LauncherDiscoveryRequest discoveryRequest = LauncherDiscoveryRequestBuilder.request().selectors(
 			selectClass(A.class), selectClass(B.class)).configurationParameter(PARALLEL_EXECUTION_ENABLED,
 				"false").build();
-		final TestEngine engine = new VintageTestEngine();
-		final TestDescriptor descriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()));
+		TestEngine engine = new VintageTestEngine();
+		TestDescriptor descriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()));
 
-		final CountingListener listener = new CountingListener();
-		final ExecutionRequest executionRequest = new ExecutionRequest(descriptor, listener,
+		CountingListener listener = new CountingListener();
+		ExecutionRequest executionRequest = new ExecutionRequest(descriptor, listener,
 			discoveryRequest.getConfigurationParameters());
 
 		// when
@@ -119,7 +119,7 @@ class VintageTestEngineParallelismTests {
 
 		public void executionStarted(final TestDescriptor testDescriptor) {
 			synchronized (this) {
-				final String displayName = testDescriptor.getDisplayName();
+				String displayName = testDescriptor.getDisplayName();
 				if (testDescriptor.isTest()) {
 					testAdder.increment();
 					testSummary.accept(testAdder.intValue());
@@ -134,7 +134,7 @@ class VintageTestEngineParallelismTests {
 		public void executionFinished(final TestDescriptor testDescriptor,
 				final TestExecutionResult testExecutionResult) {
 			synchronized (this) {
-				final String displayName = testDescriptor.getDisplayName();
+				String displayName = testDescriptor.getDisplayName();
 				assertEquals(Status.SUCCESSFUL, testExecutionResult.getStatus());
 				if (testDescriptor.isTest()) {
 					testAdder.decrement();

--- a/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ConcurrencyTests.java
+++ b/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ConcurrencyTests.java
@@ -21,25 +21,21 @@ public class ConcurrencyTests {
 
 	public static class A {
 		@Test
-		public final void test1() throws InterruptedException {
-			Thread.sleep(5);
+		public final void test1() {
 		}
 
 		@Test
-		public final void test2() throws InterruptedException {
-			Thread.sleep(5);
+		public final void test2() {
 		}
 	}
 
 	public static class B {
 		@Test
-		public final void test1() throws InterruptedException {
-			Thread.sleep(5);
+		public final void test1() {
 		}
 
 		@Test
-		public final void test2() throws InterruptedException {
-			Thread.sleep(5);
+		public final void test2() {
 		}
 	}
 

--- a/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ConcurrencyTests.java
+++ b/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ConcurrencyTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import org.junit.Test;
+
+/**
+ * Vintage tests to reproduce various concurrency scenarios.
+ *
+ * @since 5.8
+ */
+public class ConcurrencyTests {
+
+	public static class A {
+		@Test
+		public final void test1() throws InterruptedException {
+			Thread.sleep(5);
+		}
+
+		@Test
+		public final void test2() throws InterruptedException {
+			Thread.sleep(5);
+		}
+	}
+
+	public static class B {
+		@Test
+		public final void test1() throws InterruptedException {
+			Thread.sleep(5);
+		}
+
+		@Test
+		public final void test2() throws InterruptedException {
+			Thread.sleep(5);
+		}
+	}
+
+}


### PR DESCRIPTION
## Overview

This change updates the JUnit Vintage Test Engine to read the parallel configuration parameters, and if parallel execution is enabled, creates a thread pool for executing the test descriptors concurrently. The approach for configuring the thread pool emulates the logic used by the Jupiter Test Engine.

I tested this with the Maven Surefire plugin with the following configuration:

    ...
		<dependency>
		    <groupId>junit</groupId>
		    <artifactId>junit</artifactId>
		    <scope>test</scope>
		</dependency>
	</dependencies>
    ...
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
                <configuration>
                    <parallel>classes</parallel>
                    <threadCount>4</threadCount>
                </configuration>
                <dependencies>
                    <dependency>
                        <groupId>org.junit.vintage</groupId>
                        <artifactId>junit-vintage-engine</artifactId>
                        <version>5.8.0-SNAPSHOT</version>
                    </dependency>
                </dependencies>
            </plugin>
	</plugins>
    </build>
...

Setting `parallel` to both `classes` and `all` behave as expected.

### Open Questions

* It was not clear to me how the Maven Surefire plugin interfaces with the JUnit vintage engine. I enabled concurrency for top-level `TestDescriptor` instances. The unit test I created only tests parallelism enabled and parallelism disabled.
* ~Also, should I update the user guide and release notes within the scope of this PR?~ I included the user guide and release notes changes in this PR. If they should be separate, please let me know.

Issue: #2229

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
