### PR TITLE
Add test case for issue #981

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsWithGenericTypeHierarchiesTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsWithGenericTypeHierarchiesTests.java
@@ -11,6 +11,8 @@
 package org.junit.platform.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.commons.util.ReflectionUtils.findMethod;
 
 import java.lang.reflect.Method;
@@ -120,6 +122,19 @@ class ReflectionUtilsWithGenericTypeHierarchiesTests {
 		// Exact Type Match
 		assertSpecificFooMethodFound(ClassImplementingGenericInterfaceWithMoreSpecificMethod.class,
 			ClassImplementingGenericInterfaceWithMoreSpecificMethod.class, Number.class);
+	}
+
+	@Test
+	void findMethodWithParameterTypeWithMultipleBounds() {
+		class A {
+			public <T extends A & InterfaceDouble> void method(T o) {
+			}
+		}
+
+		var method = findMethod(A.class, "method", A.class);
+
+		assertFalse(InterfaceDouble.class.isAssignableFrom(A.class));
+		assertTrue(method.isEmpty());
 	}
 
 	private void assertSpecificFooMethodFound(Class<?> classToSearchIn, Class<?> classWithMostSpecificMethod,

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsWithGenericTypeHierarchiesTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsWithGenericTypeHierarchiesTests.java
@@ -125,6 +125,7 @@ class ReflectionUtilsWithGenericTypeHierarchiesTests {
 	}
 
 	@Test
+	@Disabled("Describes a new case that does not yet yield the expected result.")
 	void findMethodWithParameterTypeWithMultipleBounds() {
 		class A {
 			public <T extends A & InterfaceDouble> void method(T o) {


### PR DESCRIPTION
## Overview

Adds test case for issue https://github.com/junit-team/junit5/issues/981.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
