### PR TITLE
osgi: Use Bnd macro processing to avoid gradle afterEvaluate

### DIFF
--- a/buildSrc/src/main/kotlin/osgi-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/osgi-conventions.gradle.kts
@@ -23,6 +23,9 @@ tasks.withType<Jar>().matching {
 			# in the default Bundle-SymbolicName value.
 			Bundle-SymbolicName: ${'$'}{task.archiveBaseName}
 
+			# Set the Bundle-Name from the project description
+			Bundle-Name: ${'$'}{project.description}
+
 			# These are the general rules for package imports.
 			Import-Package: \
 				!org.apiguardian.api,\
@@ -105,13 +108,4 @@ val verifyOSGi by tasks.registering(Resolve::class) {
 
 tasks.check {
 	dependsOn(verifyOSGi)
-}
-
-// The ${project.description}, for some odd reason, is only available
-// after evaluation.
-afterEvaluate {
-	tasks.withType<Jar>().configureEach {
-		convention.findPlugin(BundleTaskConvention::class.java)
-				?.bnd("Bundle-Name: ${project.description}")
-	}
 }


### PR DESCRIPTION
We use late-binding to get the project description via Bnd's macro
support instead of having to use afterEvaluate to early-bind to the
project description in the gradle script. 

(I forgot to include this change in the build updates for Bnd 5.2.0.)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---
