### PR TITLE
More straightforward usage of Optional

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/DisabledCondition.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/DisabledCondition.java
@@ -13,7 +13,6 @@ package org.junit.jupiter.engine.extension;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.lang.reflect.AnnotatedElement;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
@@ -39,15 +38,14 @@ class DisabledCondition implements ExecutionCondition {
 	 */
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<AnnotatedElement> element = context.getElement();
-		Optional<Disabled> disabled = findAnnotation(element, Disabled.class);
-		if (disabled.isPresent()) {
-			String reason = disabled.map(Disabled::value).filter(StringUtils::isNotBlank).orElseGet(
-				() -> element.get() + " is @Disabled");
-			return ConditionEvaluationResult.disabled(reason);
-		}
+		AnnotatedElement element = context.getElement().orElse(null);
+		return findAnnotation(element, Disabled.class).map(annotation -> toResult(element, annotation)).orElse(ENABLED);
+	}
 
-		return ENABLED;
+	private ConditionEvaluationResult toResult(AnnotatedElement element, Disabled annotation) {
+		String value = annotation.value();
+		String reason = StringUtils.isNotBlank(value) ? value : element + " is @Disabled";
+		return ConditionEvaluationResult.disabled(reason);
 	}
 
 }

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/conditions/IgnoreCondition.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/conditions/IgnoreCondition.java
@@ -14,7 +14,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.lang.reflect.AnnotatedElement;
-import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.junit.Ignore;
@@ -45,16 +44,14 @@ public class IgnoreCondition implements ExecutionCondition {
 	 */
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		Optional<AnnotatedElement> element = context.getElement();
-		Optional<Ignore> ignoreAnnotation = findAnnotation(element, Ignore.class);
-		if (ignoreAnnotation.isPresent()) {
-			String reason = ignoreAnnotation.map(Ignore::value) //
-					.filter(StringUtils::isNotBlank) //
-					.orElseGet(() -> element.get() + " is disabled via @org.junit.Ignore");
-			return ConditionEvaluationResult.disabled(reason);
-		}
+		AnnotatedElement element = context.getElement().orElse(null);
+		return findAnnotation(element, Ignore.class).map(annotation -> toResult(element, annotation)).orElse(ENABLED);
+	}
 
-		return ENABLED;
+	private ConditionEvaluationResult toResult(AnnotatedElement element, Ignore annotation) {
+		String value = annotation.value();
+		String reason = StringUtils.isNotBlank(value) ? value : element + " is disabled via @org.junit.Ignore";
+		return ConditionEvaluationResult.disabled(reason);
 	}
 
 }


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
