### PR TITLE
Introduce utility method for processing all destroyed test instances

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.1.adoc
@@ -54,6 +54,8 @@ GitHub.
 ==== New Features and Improvements
 
 * The user guide now explains Nested Tests in more detail.
+* New utility method in `TestInstancePreDestroyCallback` helps to ensure all test
+  instances are processed when used in conjunction with `@Nested` tests.
 
 
 [[release-notes-5.7.1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstancePreDestroyCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstancePreDestroyCallback.java
@@ -10,9 +10,18 @@
 
 package org.junit.jupiter.api.extension;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 /**
  * {@code TestInstancePreDestroyCallback} defines the API for {@link Extension
@@ -24,9 +33,9 @@ import org.apiguardian.api.API;
  *
  * <p>Extensions that implement {@code TestInstancePreDestroyCallback} must be
  * registered at the class level if the test class is configured with
- * {@link org.junit.jupiter.api.TestInstance.Lifecycle @TestInstance(Lifecycle.PER_CLASS)}
+ * {@link Lifecycle @TestInstance(Lifecycle.PER_CLASS)}
  * semantics. If the test class is configured with
- * {@link org.junit.jupiter.api.TestInstance.Lifecycle @TestInstance(Lifecycle.PER_METHOD)}
+ * {@link Lifecycle @TestInstance(Lifecycle.PER_METHOD)}
  * semantics, {@code TestInstancePreDestroyCallback} extensions may be registered
  * at the class level or at the method level. In the latter case, the
  * {@code TestInstancePreDestroyCallback} extension will only be applied to the
@@ -48,12 +57,64 @@ import org.apiguardian.api.API;
 public interface TestInstancePreDestroyCallback extends Extension {
 
 	/**
-	 * Callback for processing a test instance before it is destroyed.
+	 * Callback for processing test instances before they are destroyed.
+	 *
+	 * <p>Contrary to {@link TestInstancePostProcessor#postProcessTestInstance}
+	 * this method is only called once for each {@link ExtensionContext} even if
+	 * there are multiple test instances about to be destroyed in case of
+	 * {@link Nested @Nested} tests. Please use the provided
+	 * {@link #preDestroyTestInstances(ExtensionContext, Consumer)} utility
+	 * method to ensure that all test instances are handled.
 	 *
 	 * @param context the current extension context; never {@code null}
 	 * @see ExtensionContext#getTestInstance()
 	 * @see ExtensionContext#getRequiredTestInstance()
+	 * @see ExtensionContext#getTestInstances()
+	 * @see ExtensionContext#getRequiredTestInstances()
+	 * @see #preDestroyTestInstances(ExtensionContext, Consumer)
 	 */
 	void preDestroyTestInstance(ExtensionContext context) throws Exception;
+
+	/**
+	 * Utility method for processing <em>all</em> test instances of an
+	 * {@link ExtensionContext} that are not present in any of its parent
+	 * contexts.
+	 *
+	 * <p>This method should be called in order to implement this interface
+	 * correctly since it ensures that the right test instances are processed
+	 * regardless of the used {@linkplain Lifecycle lifecycle}. The supplied
+	 * callback is called once per test instance that is about to be destroyed
+	 * starting with the innermost one.
+	 *
+	 * <p>This method is intended to be called from an implementation of
+	 * {@link #preDestroyTestInstance(ExtensionContext)} like this:
+	 *
+	 * <pre>{@code
+	 * class MyExtension implements TestInstancePreDestroyCallback {
+	 *     @Override
+	 *     public void preDestroyTestInstance(ExtensionContext context) {
+	 *         TestInstancePreDestroyCallback.preDestroyTestInstances(context, testInstance -> {
+	 *             // custom logic that processes testInstance
+	 *         });
+	 *     }
+	 * }
+	 * }</pre>
+	 *
+	 * @param context the current extension context; never {@code null}
+	 * @param callback the callback to be invoked for every test instance of the
+	 * current extension context that is about to be destroyed; never
+	 * {@code null}
+	 * @since 5.7.1
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7.1")
+	static void preDestroyTestInstances(ExtensionContext context, Consumer<Object> callback) {
+		List<Object> destroyedInstances = new ArrayList<>(context.getRequiredTestInstances().getAllInstances());
+		for (Optional<ExtensionContext> current = context.getParent(); current.isPresent(); current = current.get().getParent()) {
+			current.get().getTestInstances().map(TestInstances::getAllInstances).ifPresent(
+				destroyedInstances::removeAll);
+		}
+		Collections.reverse(destroyedInstances);
+		destroyedInstances.forEach(callback);
+	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/extension/ExtensionComposabilityTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/extension/ExtensionComposabilityTests.java
@@ -14,8 +14,10 @@ import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.platform.commons.util.FunctionUtils.where;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import java.util.List;
@@ -51,6 +53,7 @@ class ExtensionComposabilityTests {
 				.map(Class::getDeclaredMethods)
 				.flatMap(Arrays::stream)
 				.filter(not(Method::isSynthetic))
+				.filter(not(where(Method::getModifiers, Modifier::isStatic)))
 				.collect(toList());
 
 		List<String> expectedMethodSignatures = expectedMethods.stream()

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleTests.java
@@ -455,6 +455,7 @@ class TestInstanceLifecycleTests extends AbstractJupiterTestEngineTests {
 		assertSame(nestedInstance, instanceMap.get(nestedPreDestroyCallbackTestInstanceKey).getInnermostInstance());
 
 		Object outerInstance = instanceMap.get(nestedExecutionConditionKey1).findInstance(testClass).get();
+		assertSame(outerInstance, instance);
 		assertSame(outerInstance, instanceMap.get(postProcessTestInstanceKey).getInnermostInstance());
 		assertSame(outerInstance, instanceMap.get(preDestroyCallbackTestInstanceKey).getInnermostInstance());
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestInstancePreDestroyCallbackUtilityMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestInstancePreDestroyCallbackUtilityMethodTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.reportEntry;
+import static org.junit.platform.testkit.engine.EventConditions.started;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.junit.jupiter.api.extension.TestInstancePreDestroyCallback;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+
+public class TestInstancePreDestroyCallbackUtilityMethodTests extends AbstractJupiterTestEngineTests {
+
+	@TestFactory
+	Stream<DynamicTest> destroysWhatWasPostProcessed() {
+		var testClasses = Stream.of(PerMethodLifecycleOnAllLevels.class, PerMethodWithinPerClassLifecycle.class,
+			PerClassWithinPerMethodLifecycle.class, PerClassLifecycleOnAllLevels.class);
+		return testClasses.map(testClass -> dynamicTest( //
+			testClass.getSimpleName(), //
+			() -> executeTestsForClass(testClass).allEvents().debug() //
+					.assertStatistics(stats -> stats.reportingEntryPublished(4)) //
+					.assertEventsMatchLooselyInOrder( //
+						reportEntry(Map.of("post-process", testClass.getSimpleName())),
+						reportEntry(Map.of("post-process", "Inner")), //
+						event(test(), started()), //
+						reportEntry(Map.of("pre-destroy", "Inner")), //
+						reportEntry(Map.of("pre-destroy", testClass.getSimpleName())) //
+					)));
+	}
+
+	@ExtendWith(TestInstanceLifecycleExtension.class)
+	static class PerMethodLifecycleOnAllLevels {
+		@Nested
+		class Inner {
+			@Test
+			void test() {
+			}
+		}
+	}
+
+	@ExtendWith(TestInstanceLifecycleExtension.class)
+	@TestInstance(PER_CLASS)
+	static class PerMethodWithinPerClassLifecycle {
+		@Nested
+		class Inner {
+			@Test
+			void test() {
+			}
+		}
+	}
+
+	@ExtendWith(TestInstanceLifecycleExtension.class)
+	static class PerClassWithinPerMethodLifecycle {
+		@Nested
+		@TestInstance(PER_CLASS)
+		class Inner {
+			@Test
+			void test() {
+			}
+		}
+	}
+
+	@ExtendWith(TestInstanceLifecycleExtension.class)
+	@TestInstance(PER_CLASS)
+	static class PerClassLifecycleOnAllLevels {
+		@Nested
+		@TestInstance(PER_CLASS)
+		class Inner {
+			@Test
+			void test() {
+			}
+		}
+	}
+
+	private static class TestInstanceLifecycleExtension
+			implements TestInstancePostProcessor, TestInstancePreDestroyCallback {
+
+		@Override
+		public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+			context.publishReportEntry("post-process", testInstance.getClass().getSimpleName());
+		}
+
+		@Override
+		public void preDestroyTestInstance(ExtensionContext context) {
+			TestInstancePreDestroyCallback.preDestroyTestInstances(context,
+				testInstance -> context.publishReportEntry("pre-destroy", testInstance.getClass().getSimpleName()));
+		}
+	}
+}


### PR DESCRIPTION
The new utility method helps to ensure all test instances are processed
by a `TestInstancePreDestroyCallback` when used in conjunction with
`@Nested` tests.

Resolves #2430.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
