### PR TITLE
Introduce support for class ordering

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -74,6 +74,10 @@ on GitHub.
 * Allow rows in `@CsvSource` to start with a number sign (#)
 * New `ignoreLeadingAndTrailingWhitespace` attribute to control whether or not to trim
   whitespaces in `@CsvSource` and `@CsvFileSource` (set to `true` by default).
+* Top-level test classes can now be ordered by passing the fully-qualified name of a
+  class implementing `ClassOrderer` as value of the new
+  `junit.jupiter.testclass.order.default` configuration property.
+
 
 [[release-notes-5.8.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -511,11 +511,15 @@ custom annotations for tags.
 [[writing-tests-test-execution-order]]
 === Test Execution Order
 
-By default, test methods will be ordered using an algorithm that is deterministic but
-intentionally nonobvious. This ensures that subsequent runs of a test suite execute test
-methods in the same order, thereby allowing for repeatable builds.
+By default, test classes and methods will be ordered using an algorithm that is
+deterministic but intentionally nonobvious. This ensures that subsequent runs of several
+test suites execute test methods in the same order, thereby allowing for repeatable
+builds.
 
-NOTE: See <<writing-tests-classes-and-methods>> for a definition of _test method_.
+NOTE: See <<writing-tests-classes-and-methods>> for a definition of _test method_ and
+_test class_.
+
+==== Method Order
 
 Although true _unit tests_ typically should not rely on the order in which they are
 executed, there are times when it is necessary to enforce a specific test method execution
@@ -551,7 +555,7 @@ include::{testDir}/example/OrderedTestsDemo.java[tags=user_guide]
 ----
 
 [[writing-tests-test-execution-order-default]]
-==== Setting the Default Method Orderer
+===== Setting the Default Method Orderer
 
 You can use the `junit.jupiter.testmethod.order.default` <<running-tests-config-params,
 configuration parameter>> to specify the fully qualified class name of the
@@ -572,6 +576,43 @@ junit.jupiter.testmethod.order.default = \
 
 Similarly, you can specify the fully qualified name of any custom class that implements
 `MethodOrderer`.
+
+==== Class Order
+
+For build optimization purposes, it can be helpful to run _test classes_ in a specific
+order.
+For example:
+* previously failed tests and faster tests first: fail fast
+* with parallelism enabled, longer tests first: shortest test execution duration
+* etc.
+
+You can use the `junit.jupiter.testclass.order.default`
+<<running-tests-config-params, configuration parameter>> to specify the fully qualified
+class name of the `{ClassOrderer}` you would like to use. The supplied class has to
+implement the `ClassOrderer` interface.
+
+You can implement your own custom `ClassOrderer` or use one of the
+following built-in `ClassOrderer` implementations.
+
+* `{DisplayName}`: sorts test classes _alphanumerically_ based on their display names
+  (see <<writing-tests-display-name-generator-precedence-rules, display name generation
+  precedence rules>>).
+* `{ClassName}`: sorts test classes _alphanumerically_ based on their class name.
+* `{OrderAnnotation}`: sorts test classes _numerically_ based on values specified via the
+  `{Order}` annotation.
+* `{Random}`: orders test classes _pseudo-randomly_ and supports configuration of a
+  custom _seed_.
+
+For example for the `@Order` annotation to be honored on _test classes_, you should set
+the `{OrderAnnotation}` class orderer, using the configuration parameter with the
+corresponding fully qualified class name (e.g., in
+`src/test/resources/junit-platform.properties`):
+
+[source,properties,indent=0]
+----
+junit.jupiter.testclass.order.default = \
+    org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+----
 
 [[writing-tests-test-instance-lifecycle]]
 === Test Instance Lifecycle

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassDescriptor.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassDescriptor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code ClassDescriptor} encapsulates functionality for a given {@link Class}.
+ *
+ * @since 5.8
+ * @see ClassOrdererContext
+ */
+@API(status = EXPERIMENTAL, since = "5.8")
+public interface ClassDescriptor {
+
+	/**
+	 * Get the class for this descriptor.
+	 *
+	 * @return the class; never {@code null}
+	 */
+	Class<?> getTestClass();
+
+	/**
+	 * Get the display name for this descriptor's {@link #getClass()} () class}.
+	 *
+	 * @return the display name for this descriptor's class; never {@code null}
+	 * or blank
+	 */
+	String getDisplayName();
+
+	/**
+	 * Determine if an annotation of {@code annotationType} is either
+	 * <em>present</em> or <em>meta-present</em> on the {@link Class} for
+	 * this descriptor.
+	 *
+	 * @param annotationType the annotation type to search for; never {@code null}
+	 * @return {@code true} if the annotation is present or meta-present
+	 * @see #findAnnotation(Class)
+	 * @see #findRepeatableAnnotations(Class)
+	 */
+	boolean isAnnotated(Class<? extends Annotation> annotationType);
+
+	/**
+	 * Find the first annotation of {@code annotationType} that is either
+	 * <em>present</em> or <em>meta-present</em> on the {@link Class} for
+	 * this descriptor.
+	 *
+	 * @param <A> the annotation type
+	 * @param annotationType the annotation type to search for; never {@code null}
+	 * @return an {@code Optional} containing the annotation; never {@code null} but
+	 * potentially empty
+	 * @see #isAnnotated(Class)
+	 * @see #findRepeatableAnnotations(Class)
+	 */
+	<A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType);
+
+	/**
+	 * Find all <em>repeatable</em> {@linkplain Annotation annotations} of
+	 * {@code annotationType} that are either <em>present</em> or
+	 * <em>meta-present</em> on the {@link Class} for this descriptor.
+	 *
+	 * @param <A> the annotation type
+	 * @param annotationType the repeatable annotation type to search for; never
+	 * {@code null}
+	 * @return the list of all such annotations found; neither {@code null} nor
+	 * mutable, but potentially empty
+	 * @see #isAnnotated(Class)
+	 * @see #findAnnotation(Class)
+	 * @see java.lang.annotation.Repeatable
+	 */
+	<A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType);
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static java.util.Comparator.comparingInt;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+
+/**
+ * {@code ClassOrderer} defines the API for ordering the <em>top-level test classes</em>,
+ * without considering nested test classes.
+ *
+ * <p>In this context, the term "test class" refers to any class containing methods annotated with
+ * {@code @Test}, {@code @RepeatedTest}, {@code @ParameterizedTest},
+ * {@code @TestFactory}, or {@code @TestTemplate} and not being annotated with {@code @Nested}.
+ *
+ * <h4>Built-in Implementations</h4>
+ *
+ * <p>JUnit Jupiter provides the following built-in {@code ClassOrderer}
+ * implementations.
+ *
+ * <ul>
+ * <li>{@link ClassOrderer.ClassName}</li>
+ * <li>{@link ClassOrderer.DisplayName}</li>
+ * <li>{@link ClassOrderer.OrderAnnotation}</li>
+ * <li>{@link ClassOrderer.Random}</li>
+ * </ul>
+ *
+ * @see ClassOrdererContext
+ * @see #orderClasses(ClassOrdererContext)
+ * @since 5.8
+ */
+@API(status = EXPERIMENTAL, since = "5.8")
+public interface ClassOrderer {
+
+	/**
+	 * Order the classes encapsulated in the supplied {@link ClassOrdererContext}.
+	 *
+	 * <p>The classes to order or sort are made indirectly available via
+	 * {@link ClassOrdererContext#getClassDescriptors()} ()}. Since this method
+	 * has a {@code void} return type, the list of class descriptors must be
+	 * modified directly.
+	 *
+	 * <p>For example, a simplified implementation of the {@link ClassOrderer.Random}
+	 * {@code ClassOrderer} might look like the following.
+	 *
+	 * <pre class="code">
+	 * public void orderClasses(ClassOrdererContext context) {
+	 *     Collections.shuffle(context.getClassDescriptors());
+	 * }
+	 * </pre>
+	 *
+	 * @param context the {@code ClassOrdererContext} containing the
+	 *                {@link ClassDescriptor class descriptors} to order; never {@code null}
+	 */
+	void orderClasses(ClassOrdererContext context);
+
+	/**
+	 * {@code ClassOrderer} that sorts classes alphanumerically based on their
+	 * qualified names using {@link String#compareTo(String)}.
+	 *
+	 * @since 5.8
+	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
+	class ClassName implements ClassOrderer {
+
+		/**
+		 * Sort the classes encapsulated in the supplied
+		 * {@link ClassOrdererContext} alphanumerically based on their qualified names.
+		 */
+		@Override
+		public void orderClasses(ClassOrdererContext context) {
+			context.getClassDescriptors().sort(comparator);
+		}
+
+		private static final Comparator<ClassDescriptor> comparator = Comparator. //
+				comparing(descriptor -> descriptor.getTestClass().getName());
+	}
+
+	/**
+	 * {@code ClassOrderer} that sorts classes alphanumerically based on their
+	 * display names using {@link String#compareTo(String)}
+	 *
+	 * @since 5.8
+	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
+	class DisplayName implements ClassOrderer {
+
+		/**
+		 * Sort the classes encapsulated in the supplied
+		 * {@link ClassOrdererContext} alphanumerically based on their display
+		 * names.
+		 */
+		@Override
+		public void orderClasses(ClassOrdererContext context) {
+			context.getClassDescriptors().sort(comparator);
+		}
+
+		private static final Comparator<ClassDescriptor> comparator = Comparator.comparing(
+			ClassDescriptor::getDisplayName);
+	}
+
+	/**
+	 * {@code ClassOrderer} that sorts classes based on the {@link Order @Order}
+	 * annotation.
+	 *
+	 * <p>Any classes that are assigned the same order value will be sorted
+	 * arbitrarily adjacent to each other.
+	 *
+	 * <p>Any classes not annotated with {@code @Order} will be assigned the
+	 * {@link org.junit.jupiter.api.Order#DEFAULT default order} value which will
+	 * effectively cause them to appear at the end of the sorted list, unless
+	 * certain classes are assigned an explicit order value greater than the default
+	 * order value. Any classes assigned an explicit order value greater than the
+	 * default order value will appear after non-annotated classes in the sorted
+	 * list.
+	 */
+	class OrderAnnotation implements ClassOrderer {
+
+		/**
+		 * Sort the classes encapsulated in the supplied
+		 * {@link ClassOrdererContext} based on the {@link Order @Order}
+		 * annotation.
+		 */
+		@Override
+		public void orderClasses(ClassOrdererContext context) {
+			context.getClassDescriptors().sort(comparingInt(OrderAnnotation::getOrder));
+		}
+
+		private static int getOrder(ClassDescriptor descriptor) {
+			return descriptor.findAnnotation(Order.class).map(Order::value).orElse(Order.DEFAULT);
+		}
+	}
+
+	/**
+	 * {@code ClassOrderer} that orders classes pseudo-randomly.
+	 *
+	 * <h4>Custom Seed</h4>
+	 *
+	 * <p>By default, the random <em>seed</em> used for ordering classes is the
+	 * value returned by {@link System#nanoTime()} during static initialization
+	 * of this class. In order to support repeatable builds, the value of the
+	 * default random seed is logged at {@code INFO} level. In addition, a
+	 * custom seed (potentially the default seed from the previous test plan
+	 * execution) may be specified via the {@link Random#RANDOM_SEED_PROPERTY_NAME
+	 * junit.jupiter.execution.class.order.random.seed} <em>configuration parameter</em>
+	 * which can be supplied via the {@code Launcher} API, build tools (e.g.,
+	 * Gradle and Maven), a JVM system property, or the JUnit Platform configuration
+	 * file (i.e., a file named {@code junit-platform.properties} in the root of
+	 * the class path). Consult the User Guide for further information.
+	 *
+	 * @see Random#RANDOM_SEED_PROPERTY_NAME
+	 * @see java.util.Random
+	 */
+	class Random implements ClassOrderer {
+
+		private static final Logger logger = LoggerFactory.getLogger(Random.class);
+
+		/**
+		 * Default seed, which is generated during initialization of this class
+		 * via {@link System#nanoTime()} for reproducibility of tests.
+		 */
+		private static final long DEFAULT_SEED;
+
+		static {
+			DEFAULT_SEED = System.nanoTime();
+			logger.info(() -> "ClassOrderer.Random default seed: " + DEFAULT_SEED);
+		}
+
+		/**
+		 * Property name used to set the random seed used by this
+		 * {@code ClassOrderer}: {@value}
+		 *
+		 * The same property is used by {@link MethodOrderer.Random} for consistency
+		 * between the two random orderers.
+		 *
+		 * <h3>Supported Values</h3>
+		 *
+		 * <p>Supported values include any string that can be converted to a
+		 * {@link Long} via {@link Long#valueOf(String)}.
+		 *
+		 * <p>If not specified or if the specified value cannot be converted to
+		 * a {@link Long}, the default random seed will be used (see the
+		 * {@linkplain Random class-level Javadoc} for details).
+		 *
+		 * @see MethodOrderer.Random
+		 */
+		public static final String RANDOM_SEED_PROPERTY_NAME = MethodOrderer.Random.RANDOM_SEED_PROPERTY_NAME;
+
+		/**
+		 * Order the classes encapsulated in the supplied
+		 * {@link ClassOrdererContext} pseudo-randomly.
+		 */
+		@Override
+		public void orderClasses(ClassOrdererContext context) {
+			Collections.shuffle(context.getClassDescriptors(),
+				new java.util.Random(getCustomSeed(context).orElse(DEFAULT_SEED)));
+		}
+
+		private Optional<Long> getCustomSeed(ClassOrdererContext context) {
+			return context.getConfigurationParameter(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
+				Long seed = null;
+				try {
+					seed = Long.valueOf(configurationParameter);
+					logger.config(
+						() -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
+							RANDOM_SEED_PROPERTY_NAME, configurationParameter));
+				}
+				catch (NumberFormatException ex) {
+					logger.warn(ex,
+						() -> String.format(
+							"Failed to convert configuration parameter [%s] with value [%s] to a long. "
+									+ "Using default seed [%s] as fallback.",
+							RANDOM_SEED_PROPERTY_NAME, configurationParameter, DEFAULT_SEED));
+				}
+				return seed;
+			});
+		}
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrdererContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrdererContext.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code ClassOrdererContext} encapsulates the <em>context</em> in which
+ * a {@link ClassOrderer} will be invoked.
+ *
+ * @since 5.8
+ * @see ClassOrderer
+ * @see ClassDescriptor
+ */
+@API(status = EXPERIMENTAL, since = "5.8")
+public interface ClassOrdererContext {
+
+	/**
+	 * Get the list of {@linkplain ClassDescriptor class descriptors} to
+	 * order.
+	 *
+	 * @return the list of class descriptors; never {@code null}
+	 */
+	List<? extends ClassDescriptor> getClassDescriptors();
+
+	/**
+	 * Get the configuration parameter stored under the specified {@code key}.
+	 *
+	 * <p>If no such key is present in the {@code ConfigurationParameters} for
+	 * the JUnit Platform, an attempt will be made to look up the value as a
+	 * JVM system property. If no such system property exists, an attempt will
+	 * be made to look up the value in the JUnit Platform properties file.
+	 *
+	 * @param key the key to look up; never {@code null} or blank
+	 * @return an {@code Optional} containing the value; never {@code null}
+	 * but potentially empty
+	 *
+	 * @see System#getProperty(String)
+	 * @see org.junit.platform.engine.ConfigurationParameters
+	 */
+	Optional<String> getConfigurationParameter(String key);
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -260,6 +260,9 @@ public interface MethodOrderer {
 		 * Property name used to set the random seed used by this
 		 * {@code MethodOrderer}: {@value}
 		 *
+		 * The same property is used by {@link ClassOrderer.Random} for consistency
+		 * between the two random orderers.
+		 *
 		 * <h3>Supported Values</h3>
 		 *
 		 * <p>Supported values include any string that can be converted to a
@@ -268,6 +271,8 @@ public interface MethodOrderer {
 		 * <p>If not specified or if the specified value cannot be converted to
 		 * a {@link Long}, the default random seed will be used (see the
 		 * {@linkplain Random class-level Javadoc} for details).
+		 *
+		 * @see ClassOrderer.Random
 		 */
 		public static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Order.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Order.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
 /**
  * {@code @Order} is an annotation that is used to configure the
- * {@linkplain #value order} in which the annotated element (i.e., field or
- * method) should be evaluated or executed relative to other elements of the
- * same category.
+ * {@linkplain #value order} in which the annotated element (i.e., field,
+ * method or class) should be evaluated or executed relative to other elements
+ * of the same category.
  *
  * <p>When used with
  * {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension},
@@ -36,11 +36,15 @@ import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
  * <p>If {@code @Order} is not explicitly declared on an element, the
  * {@link #DEFAULT} order value will be assigned to the element.
  *
+ * <p>If {@code @Order} is used on classes, ordering is performed only if
+ * the matching {@link ClassOrderer.OrderAnnotation} is configured.
+ *
  * @since 5.4
  * @see MethodOrderer.OrderAnnotation
+ * @see ClassOrderer.OrderAnnotation
  * @see org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension
  */
-@Target({ ElementType.FIELD, ElementType.METHOD })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(status = EXPERIMENTAL, since = "5.4")

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -463,6 +463,17 @@ public final class Constants {
 	@API(status = EXPERIMENTAL, since = "5.7")
 	public static final String DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME;
 
+	/**
+	 * Property name used to set the class orderer class name: {@value}
+	 *
+	 * <h3>Supported Values</h3>
+	 *
+	 * <p>Supported values include fully qualified class names for types that
+	 * implement {@link org.junit.jupiter.api.ClassOrderer}.
+	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
+	public static final String DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME;
+
 	private Constants() {
 		/* no-op */
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance;
@@ -97,5 +98,12 @@ public class CachingJupiterConfiguration implements JupiterConfiguration {
 	public Optional<MethodOrderer> getDefaultTestMethodOrderer() {
 		return (Optional<MethodOrderer>) cache.computeIfAbsent(DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME,
 			key -> delegate.getDefaultTestMethodOrderer());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Optional<ClassOrderer> getTestClassOrderer() {
+		return (Optional<ClassOrderer>) cache.computeIfAbsent(DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME,
+			key -> delegate.getTestClassOrderer());
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -45,6 +46,9 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 
 	private static final InstantiatingConfigurationParameterConverter<MethodOrderer> methodOrdererConverter = //
 		new InstantiatingConfigurationParameterConverter<>(MethodOrderer.class, "method orderer");
+
+	private static final InstantiatingConfigurationParameterConverter<ClassOrderer> classOrdererConverter = //
+		new InstantiatingConfigurationParameterConverter<>(ClassOrderer.class, "class orderer");
 
 	private final ConfigurationParameters configurationParameters;
 
@@ -108,4 +112,8 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 		return methodOrdererConverter.get(configurationParameters, DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME);
 	}
 
+	@Override
+	public Optional<ClassOrderer> getTestClassOrderer() {
+		return classOrdererConverter.get(configurationParameters, DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME);
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance;
@@ -39,6 +40,7 @@ public interface JupiterConfiguration {
 	String DEACTIVATE_ALL_CONDITIONS_PATTERN = ClassNamePatternFilterUtils.DEACTIVATE_ALL_PATTERN;
 	String DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME = "junit.jupiter.displayname.generator.default";
 	String DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME = "junit.jupiter.testmethod.order.default";
+	String DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME = "junit.jupiter.testclass.order.default";
 
 	String DEFAULT_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.default";
 	String DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testable.method.default";
@@ -71,4 +73,6 @@ public interface JupiterConfiguration {
 	DisplayNameGenerator getDefaultDisplayNameGenerator();
 
 	Optional<MethodOrderer> getDefaultTestMethodOrderer();
+
+	Optional<ClassOrderer> getTestClassOrderer();
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractAnnotatedElementDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractAnnotatedElementDescriptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.discovery;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.TestDescriptor;
+
+abstract class AbstractAnnotatedElementDescriptor<E extends AnnotatedElement> {
+
+	private final TestDescriptor testDescriptor;
+	private final E annotatedElement;
+
+	AbstractAnnotatedElementDescriptor(TestDescriptor testDescriptor, E annotatedElement) {
+		this.testDescriptor = testDescriptor;
+		this.annotatedElement = annotatedElement;
+	}
+
+	protected E getAnnotatedElement() {
+		return annotatedElement;
+	}
+
+	TestDescriptor getTestDescriptor() {
+		return testDescriptor;
+	}
+
+	public final String getDisplayName() {
+		return this.testDescriptor.getDisplayName();
+	}
+
+	public boolean isAnnotated(Class<? extends Annotation> annotationType) {
+		Preconditions.notNull(annotationType, "annotationType must not be null");
+		return AnnotationUtils.isAnnotated(getAnnotatedElement(), annotationType);
+	}
+
+	public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
+		Preconditions.notNull(annotationType, "annotationType must not be null");
+		return AnnotationUtils.findAnnotation(getAnnotatedElement(), annotationType);
+	}
+
+	public <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
+		Preconditions.notNull(annotationType, "annotationType must not be null");
+		return AnnotationUtils.findRepeatableAnnotations(getAnnotatedElement(), annotationType);
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractOrderingVisitor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.discovery;
+
+import static java.util.stream.Collectors.toCollection;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
+import org.junit.platform.engine.TestDescriptor;
+
+class AbstractOrderingVisitor {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractOrderingVisitor.class);
+
+	@SuppressWarnings({ "unchecked" })
+	protected <T extends TestDescriptor> void doWithMatchingDescriptor(Class<T> descriptorSubType,
+			TestDescriptor testDescriptor, Consumer<T> action, Function<T, String> errorMessageBuilder) {
+		if (descriptorSubType.isAssignableFrom(testDescriptor.getClass())) {
+			T specificTestDescriptor = (T) testDescriptor;
+			try {
+				action.accept(specificTestDescriptor);
+			}
+			catch (Throwable t) {
+				UnrecoverableExceptions.rethrowIfUnrecoverable(t);
+				logger.error(t, () -> errorMessageBuilder.apply(specificTestDescriptor));
+			}
+		}
+	}
+
+	protected <T extends TestDescriptor, D extends AbstractAnnotatedElementDescriptor<?>> void orderChildrenTestDescriptors(
+			TestDescriptor parentTestDescriptor, Class<T> matchingChildrenType, Function<T, D> descriptorWrapperBuilder,
+			Consumer<List<D>> orderingAction, IntFunction<String> descriptorAdditionLogger,
+			IntFunction<String> descriptorDeletionLogger) {
+		Set<? extends TestDescriptor> children = parentTestDescriptor.getChildren();
+
+		List<TestDescriptor> nonMatchingTestDescriptors = children.stream()//
+				.filter(childTestDescriptor -> !(matchingChildrenType.isAssignableFrom(childTestDescriptor.getClass())))//
+				.collect(Collectors.toList());
+
+		List<D> matchingDescriptorWrappers = children.stream()//
+				.filter(matchingChildrenType::isInstance)//
+				.map(matchingChildrenType::cast)//
+				.map(descriptorWrapperBuilder)//
+				.collect(toCollection(ArrayList::new));
+
+		// Make a local copy for later validation
+		Set<D> originalDescriptors = new LinkedHashSet<>(matchingDescriptorWrappers);
+
+		orderingAction.accept(matchingDescriptorWrappers);
+
+		int difference = matchingDescriptorWrappers.size() - originalDescriptors.size();
+
+		if (difference > 0) {
+			logger.warn(() -> descriptorAdditionLogger.apply(difference));
+		}
+		else if (difference < 0) {
+			logger.warn(() -> descriptorDeletionLogger.apply(difference));
+		}
+
+		Set<TestDescriptor> sortedTestDescriptors = matchingDescriptorWrappers.stream()//
+				.filter(originalDescriptors::contains)//
+				.map(AbstractAnnotatedElementDescriptor::getTestDescriptor)//
+				.collect(toCollection(LinkedHashSet::new));
+
+		// Currently no way to removeAll or addAll children at once.
+		Stream.concat(sortedTestDescriptors.stream(), nonMatchingTestDescriptors.stream())//
+				.forEach(parentTestDescriptor::removeChild);
+		Stream.concat(sortedTestDescriptors.stream(), nonMatchingTestDescriptors.stream())//
+				.forEach(parentTestDescriptor::addChild);
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.discovery;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
+import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
+import org.junit.platform.engine.TestDescriptor;
+
+/**
+ * @since 5.8
+ */
+class ClassOrderingVisitor extends AbstractOrderingVisitor implements TestDescriptor.Visitor {
+
+	private final JupiterConfiguration configuration;
+
+	public ClassOrderingVisitor(JupiterConfiguration configuration) {
+		this.configuration = configuration;
+	}
+
+	@Override
+	public void visit(TestDescriptor testDescriptor) {
+		Optional<ClassOrderer> testClassOrderer = configuration.getTestClassOrderer();
+		if (!testClassOrderer.isPresent()) {
+			return;
+		}
+		doWithMatchingDescriptor(JupiterEngineDescriptor.class, testDescriptor,
+			descriptor -> orderContainedClasses(descriptor, testClassOrderer.get()),
+			descriptor -> "Failed to order classes");
+	}
+
+	private void orderContainedClasses(JupiterEngineDescriptor jupiterEngineDescriptor, ClassOrderer classOrderer) {
+		orderChildrenTestDescriptors(jupiterEngineDescriptor, ClassBasedTestDescriptor.class,
+			DefaultClassDescriptor::new,
+			descriptorWrappers -> classOrderer.orderClasses(
+				new DefaultClassOrdererContext(descriptorWrappers, this.configuration)),
+			difference -> String.format("ClassOrderer [%s] added %s ClassDescriptor(s) which will be ignored.",
+				classOrderer.getClass().getName(), difference),
+			difference -> String.format(
+				"ClassOrderer [%s] removed %s ClassDescriptor(s) which will be retained with arbitrary ordering.",
+				classOrderer.getClass().getName(), -difference));
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DefaultClassDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DefaultClassDescriptor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.discovery;
+
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
+import org.junit.platform.commons.util.ToStringBuilder;
+
+/**
+ * Default implementation of {@link ClassDescriptor}, backed by
+ * a {@link ClassBasedTestDescriptor}.
+ *
+ * @since 5.8
+ */
+class DefaultClassDescriptor extends AbstractAnnotatedElementDescriptor<Class<?>> implements ClassDescriptor {
+
+	DefaultClassDescriptor(ClassBasedTestDescriptor testDescriptor) {
+		super(testDescriptor, testDescriptor.getTestClass());
+	}
+
+	@Override
+	public final Class<?> getTestClass() {
+		return getAnnotatedElement();
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).append("class", getTestClass().toGenericString()).toString();
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DefaultClassOrdererContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DefaultClassOrdererContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.discovery;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrdererContext;
+import org.junit.jupiter.engine.config.JupiterConfiguration;
+
+/**
+ * Default implementation of {@link ClassOrdererContext}.
+ *
+ * @since 5.8
+ */
+class DefaultClassOrdererContext implements ClassOrdererContext {
+
+	private final List<? extends ClassDescriptor> classDescriptors;
+	private final JupiterConfiguration configuration;
+
+	DefaultClassOrdererContext(List<? extends ClassDescriptor> classDescriptors, JupiterConfiguration configuration) {
+		this.classDescriptors = classDescriptors;
+		this.configuration = configuration;
+	}
+
+	@Override
+	public List<? extends ClassDescriptor> getClassDescriptors() {
+		return classDescriptors;
+	}
+
+	@Override
+	public Optional<String> getConfigurationParameter(String key) {
+		return this.configuration.getRawConfigurationParameter(key);
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DefaultMethodDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DefaultMethodDescriptor.java
@@ -10,15 +10,10 @@
 
 package org.junit.jupiter.engine.discovery;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.MethodDescriptor;
 import org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor;
-import org.junit.platform.commons.util.AnnotationUtils;
-import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
@@ -27,49 +22,19 @@ import org.junit.platform.commons.util.ToStringBuilder;
  *
  * @since 5.4
  */
-class DefaultMethodDescriptor implements MethodDescriptor {
-
-	private final MethodBasedTestDescriptor testDescriptor;
+class DefaultMethodDescriptor extends AbstractAnnotatedElementDescriptor<Method> implements MethodDescriptor {
 
 	DefaultMethodDescriptor(MethodBasedTestDescriptor testDescriptor) {
-		this.testDescriptor = testDescriptor;
-	}
-
-	MethodBasedTestDescriptor getTestDescriptor() {
-		return testDescriptor;
+		super(testDescriptor, testDescriptor.getTestMethod());
 	}
 
 	@Override
 	public final Method getMethod() {
-		return this.testDescriptor.getTestMethod();
-	}
-
-	@Override
-	public final String getDisplayName() {
-		return this.testDescriptor.getDisplayName();
-	}
-
-	@Override
-	public boolean isAnnotated(Class<? extends Annotation> annotationType) {
-		Preconditions.notNull(annotationType, "annotationType must not be null");
-		return AnnotationUtils.isAnnotated(getMethod(), annotationType);
-	}
-
-	@Override
-	public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
-		Preconditions.notNull(annotationType, "annotationType must not be null");
-		return AnnotationUtils.findAnnotation(getMethod(), annotationType);
-	}
-
-	@Override
-	public <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
-		Preconditions.notNull(annotationType, "annotationType must not be null");
-		return AnnotationUtils.findRepeatableAnnotations(getMethod(), annotationType);
+		return getAnnotatedElement();
 	}
 
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this).append("method", getMethod().toGenericString()).toString();
 	}
-
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -36,6 +36,7 @@ public class DiscoverySelectorResolver {
 			.addClassContainerSelectorResolver(new IsTestClassWithTests())
 			.addSelectorResolver(context -> new ClassSelectorResolver(context.getClassNameFilter(), context.getEngineDescriptor().getConfiguration()))
 			.addSelectorResolver(context -> new MethodSelectorResolver(context.getEngineDescriptor().getConfiguration()))
+			.addTestDescriptorVisitor(context -> new ClassOrderingVisitor(context.getEngineDescriptor().getConfiguration()))
 			.addTestDescriptorVisitor(context -> new MethodOrderingVisitor(context.getEngineDescriptor().getConfiguration()))
 			.addTestDescriptorVisitor(context -> TestDescriptor::prune)
 			.build();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
@@ -10,16 +10,9 @@
 
 package org.junit.jupiter.engine.discovery;
 
-import static java.util.stream.Collectors.toCollection;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -27,18 +20,13 @@ import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
 import org.junit.jupiter.engine.descriptor.JupiterTestDescriptor;
 import org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.ReflectionUtils;
-import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.junit.platform.engine.TestDescriptor;
 
 /**
  * @since 5.5
  */
-class MethodOrderingVisitor implements TestDescriptor.Visitor {
-
-	private static final Logger logger = LoggerFactory.getLogger(MethodOrderingVisitor.class);
+class MethodOrderingVisitor extends AbstractOrderingVisitor implements TestDescriptor.Visitor {
 
 	private final JupiterConfiguration configuration;
 
@@ -48,16 +36,9 @@ class MethodOrderingVisitor implements TestDescriptor.Visitor {
 
 	@Override
 	public void visit(TestDescriptor testDescriptor) {
-		if (testDescriptor instanceof ClassBasedTestDescriptor) {
-			ClassBasedTestDescriptor classBasedTestDescriptor = (ClassBasedTestDescriptor) testDescriptor;
-			try {
-				orderContainedMethods(classBasedTestDescriptor, classBasedTestDescriptor.getTestClass());
-			}
-			catch (Throwable t) {
-				UnrecoverableExceptions.rethrowIfUnrecoverable(t);
-				logger.error(t, () -> "Failed to order methods for " + classBasedTestDescriptor.getTestClass());
-			}
-		}
+		doWithMatchingDescriptor(ClassBasedTestDescriptor.class, testDescriptor,
+			descriptor -> orderContainedMethods(descriptor, descriptor.getTestClass()),
+			descriptor -> "Failed to order methods for " + descriptor.getTestClass());
 	}
 
 	/**
@@ -70,48 +51,16 @@ class MethodOrderingVisitor implements TestDescriptor.Visitor {
 				.map(Optional::of)//
 				.orElseGet(configuration::getDefaultTestMethodOrderer)//
 				.ifPresent(methodOrderer -> {
-
-					Set<? extends TestDescriptor> children = classBasedTestDescriptor.getChildren();
-
-					List<TestDescriptor> nonMethodTestDescriptors = children.stream()//
-							.filter(testDescriptor -> !(testDescriptor instanceof MethodBasedTestDescriptor))//
-							.collect(Collectors.toList());
-
-					List<DefaultMethodDescriptor> methodDescriptors = children.stream()//
-							.filter(MethodBasedTestDescriptor.class::isInstance)//
-							.map(MethodBasedTestDescriptor.class::cast)//
-							.map(DefaultMethodDescriptor::new)//
-							.collect(toCollection(ArrayList::new));
-
-					// Make a local copy for later validation
-					Set<DefaultMethodDescriptor> originalMethodDescriptors = new LinkedHashSet<>(methodDescriptors);
-
-					methodOrderer.orderMethods(
-						new DefaultMethodOrdererContext(methodDescriptors, testClass, this.configuration));
-
-					int difference = methodDescriptors.size() - originalMethodDescriptors.size();
-
-					if (difference > 0) {
-						logger.warn(() -> String.format(
+					orderChildrenTestDescriptors(classBasedTestDescriptor, MethodBasedTestDescriptor.class,
+						DefaultMethodDescriptor::new,
+						descriptorWrappers -> methodOrderer.orderMethods(
+							new DefaultMethodOrdererContext(descriptorWrappers, testClass, this.configuration)),
+						difference -> String.format(
 							"MethodOrderer [%s] added %s MethodDescriptor(s) for test class [%s] which will be ignored.",
-							methodOrderer.getClass().getName(), difference, testClass.getName()));
-					}
-					else if (difference < 0) {
-						logger.warn(() -> String.format(
+							methodOrderer.getClass().getName(), difference, testClass.getName()),
+						difference -> String.format(
 							"MethodOrderer [%s] removed %s MethodDescriptor(s) for test class [%s] which will be retained with arbitrary ordering.",
 							methodOrderer.getClass().getName(), -difference, testClass.getName()));
-					}
-
-					Set<TestDescriptor> sortedMethodTestDescriptors = methodDescriptors.stream()//
-							.filter(originalMethodDescriptors::contains)//
-							.map(DefaultMethodDescriptor::getTestDescriptor)//
-							.collect(toCollection(LinkedHashSet::new));
-
-					// Currently no way to removeAll or addAll children at once.
-					Stream.concat(sortedMethodTestDescriptors.stream(), nonMethodTestDescriptors.stream())//
-							.forEach(classBasedTestDescriptor::removeChild);
-					Stream.concat(sortedMethodTestDescriptors.stream(), nonMethodTestDescriptors.stream())//
-							.forEach(classBasedTestDescriptor::addChild);
 
 					// Note: MethodOrderer#getDefaultExecutionMode() is guaranteed
 					// to be invoked after MethodOrderer#orderMethods().

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/OrderedClassTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/OrderedClassTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+class OrderedClassTests {
+
+	private static final Set<String> callSequence = Collections.synchronizedSet(new LinkedHashSet<>());
+
+	@BeforeEach
+	void clearCallSequence() {
+		callSequence.clear();
+	}
+
+	@Test
+	void className() {
+		var tests = executeTests(ClassOrderer.ClassName.class);
+
+		tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
+
+		assertThat(callSequence)//
+				.containsExactly("A_TestCase", "B_TestCase", "C_TestCase");
+	}
+
+	@Test
+	void displayName() {
+		var tests = executeTests(ClassOrderer.DisplayName.class);
+
+		tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
+
+		assertThat(callSequence)//
+				.containsExactly("C_TestCase", "B_TestCase", "A_TestCase");
+	}
+
+	@Test
+	void orderAnnotation() {
+		var tests = executeTests(ClassOrderer.OrderAnnotation.class);
+
+		tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
+
+		assertThat(callSequence)//
+				.containsExactly("A_TestCase", "C_TestCase", "B_TestCase");
+	}
+
+	@Test
+	void random() {
+		var tests = executeTests(ClassOrderer.Random.class);
+
+		tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
+	}
+
+	private Events executeTests(Class<? extends ClassOrderer> classOrderer) {
+		// @formatter:off
+        return EngineTestKit
+                .engine("junit-jupiter")
+                .configurationParameter(DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME, classOrderer.getName())
+                .selectors(selectClass(A_TestCase.class), selectClass(B_TestCase.class), selectClass(C_TestCase.class))
+                .execute()
+                .testEvents();
+        // @formatter:on
+	}
+
+	abstract static class BaseTestCase {
+
+		@BeforeEach
+		void trackInvocations(TestInfo testInfo) {
+			var testClass = testInfo.getTestClass().get();
+
+			callSequence.add(testClass.getSimpleName());
+		}
+
+		@Test
+		void a() {
+		}
+	}
+
+	@Order(2)
+	@DisplayName("Z")
+	static class A_TestCase extends BaseTestCase {
+	}
+
+	static class B_TestCase extends BaseTestCase {
+	}
+
+	@Order(10)
+	@DisplayName("A")
+	static class C_TestCase extends BaseTestCase {
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/RandomlyOrderedTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/RandomlyOrderedTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME;
+import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Events;
+
+class RandomlyOrderedTests {
+
+	private static final Set<String> callSequence = Collections.synchronizedSet(new LinkedHashSet<>());
+
+	@Test
+	void randomSeedForClassAndMethodOrderingIsDeterministic() {
+		IntStream.range(0, 20).forEach(i -> {
+			callSequence.clear();
+			var tests = executeTests(1618034L);
+
+			tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
+			assertThat(callSequence).containsExactlyInAnyOrder("B_TestCase#b", "B_TestCase#c", "B_TestCase#a",
+				"C_TestCase#b", "C_TestCase#c", "C_TestCase#a", "A_TestCase#b", "A_TestCase#c", "A_TestCase#a");
+		});
+	}
+
+	private Events executeTests(long randomSeed) {
+		// @formatter:off
+		return EngineTestKit
+				.engine("junit-jupiter")
+				.configurationParameter(DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME, ClassOrderer.Random.class.getName())
+				.configurationParameter(DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME, MethodOrderer.Random.class.getName())
+				.configurationParameter(MethodOrderer.Random.RANDOM_SEED_PROPERTY_NAME, String.valueOf(randomSeed))
+				.selectors(selectClass(A_TestCase.class), selectClass(B_TestCase.class), selectClass(C_TestCase.class))
+				.execute()
+				.testEvents();
+		// @formatter:on
+	}
+
+	abstract static class BaseTestCase {
+
+		@BeforeEach
+		void trackInvocations(TestInfo testInfo) {
+			var testClass = testInfo.getTestClass().get();
+			var testMethod = testInfo.getTestMethod().get();
+
+			callSequence.add(testClass.getSimpleName() + "#" + testMethod.getName());
+		}
+
+		@Test
+		void a() {
+		}
+
+		@Test
+		void b() {
+		}
+
+		@Test
+		void c() {
+		}
+	}
+
+	static class A_TestCase extends BaseTestCase {
+	}
+
+	static class B_TestCase extends BaseTestCase {
+	}
+
+	static class C_TestCase extends BaseTestCase {
+	}
+}


### PR DESCRIPTION
Issue: #1948

## Overview

Introduce support for class ordering through the addition of a new configuration parameter:
* `junit.jupiter.testclass.order.default` accepting a fully-qualified class-name implementing the newly introduced `org.junit.jupiter.api.ClassOrderer` interface

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
