### PR TITLE
Ensure consistent top-level test class legacy reporting names

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.7.1.adoc
@@ -61,7 +61,8 @@ GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* The legacy reporting name of top-level test classes is now always their fully-qualified
+  class name. Previously, a textual description was returned for JUnit 3 suites.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.engine.UniqueId;
@@ -48,6 +49,12 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 	public RunnerTestDescriptor(UniqueId uniqueId, Class<?> testClass, Runner runner) {
 		super(uniqueId, runner.getDescription(), testClass.getSimpleName(), ClassSource.from(testClass));
 		this.runner = runner;
+	}
+
+	@Override
+	public String getLegacyReportingName() {
+		return getSource().map(source -> ((ClassSource) source).getClassName()) //
+				.orElseThrow(() -> new JUnitException("source should have been present"));
 	}
 
 	public Request toRequest() {

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
@@ -167,6 +167,10 @@ class VintageTestEngineDiscoveryTests {
 
 		var suiteDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		assertRunnerTestDescriptor(suiteDescriptor, suiteClass);
+		assertThat(suiteDescriptor.getDisplayName()).describedAs("display name") //
+				.startsWith(suiteClass.getSimpleName());
+		assertThat(suiteDescriptor.getLegacyReportingName()).describedAs("legacy reporting name") //
+				.isEqualTo(suiteClass.getName());
 
 		var testClassDescriptor = getOnlyElement(suiteDescriptor.getChildren());
 		assertContainerTestDescriptor(testClassDescriptor, suiteClass, testClass);


### PR DESCRIPTION
Prior to this commit, legacy reporting names of JUnit 3 suites were not
the fully-qualified test class name but rather some textual description
of the test suite (e.g. "TestSuite with 42 tests [example: ...]"). Now,
the legacy reporting name of top-level test classes reported by the
Vintage engine is always the fully-qualified test class name.