### PR TITLE
Fix compiler warnings

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
 	`kotlin-dsl`
 }
@@ -13,4 +15,14 @@ dependencies {
 	implementation("biz.aQute.bnd:biz.aQute.bnd.gradle:5.2.0")
 	implementation("com.github.jengelman.gradle.plugins:shadow:6.1.0")
 	implementation("org.gradle:test-retry-gradle-plugin:1.2.0")
+}
+
+kotlinDslPluginOptions {
+	experimentalWarning.set(false)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+	kotlinOptions {
+		allWarningsAsErrors = true
+	}
 }

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -155,9 +155,9 @@ val compileModule by tasks.registering(JavaCompile::class) {
 	classpath = files()
 	options.release.set(9)
 	options.compilerArgs.addAll(listOf(
-			// "-verbose",
 			// Suppress warnings for automatic modules: org.apiguardian.api, org.opentest4j
 			"-Xlint:all,-requires-automatic,-requires-transitive-automatic",
+			"-Werror", // Terminates compilation when warnings occur.
 			"--module-version", "${project.version}",
 			"--module-source-path", files(modularProjects.map { "${it.projectDir}/src/module" }).asPath
 	))

--- a/buildSrc/src/main/kotlin/java-repackage-jars.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-repackage-jars.gradle.kts
@@ -2,6 +2,7 @@ import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
 import org.gradle.api.internal.file.archive.ZipCopyAction
+import java.nio.file.Files
 
 // This registers a `doLast` action to rewrite the timestamps of the project's output JAR
 afterEvaluate {
@@ -9,8 +10,8 @@ afterEvaluate {
 
 	jarTask.doLast {
 
-		val newFile = createTempFile("rewrite-timestamp")
-		val originalOutput = jarTask.archiveFile.get().getAsFile()
+		val newFile = Files.createTempFile("rewrite-timestamp", null).toFile()
+		val originalOutput = jarTask.archiveFile.get().asFile
 
 		newFile.outputStream().use { os ->
 

--- a/buildSrc/src/main/kotlin/kotlin-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-library-conventions.gradle.kts
@@ -10,5 +10,6 @@ tasks.withType<KotlinCompile>().configureEach {
 		jvmTarget = Versions.jvmTarget.toString()
 		apiVersion = "1.3"
 		languageVersion = "1.3"
+		allWarningsAsErrors = true
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -92,6 +92,9 @@ public interface DisplayNameGenerator {
 
 		static final DisplayNameGenerator INSTANCE = new Standard();
 
+		public Standard() {
+		}
+
 		@Override
 		public String generateDisplayNameForClass(Class<?> testClass) {
 			String name = testClass.getName();
@@ -122,6 +125,9 @@ public interface DisplayNameGenerator {
 
 		static final DisplayNameGenerator INSTANCE = new Simple();
 
+		public Simple() {
+		}
+
 		@Override
 		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
 			String displayName = testMethod.getName();
@@ -147,6 +153,9 @@ public interface DisplayNameGenerator {
 	class ReplaceUnderscores extends Simple {
 
 		static final DisplayNameGenerator INSTANCE = new ReplaceUnderscores();
+
+		public ReplaceUnderscores() {
+		}
 
 		@Override
 		public String generateDisplayNameForClass(Class<?> testClass) {
@@ -184,6 +193,9 @@ public interface DisplayNameGenerator {
 	class IndicativeSentences implements DisplayNameGenerator {
 
 		static final DisplayNameGenerator INSTANCE = new IndicativeSentences();
+
+		public IndicativeSentences() {
+		}
 
 		@Override
 		public String generateDisplayNameForClass(Class<?> testClass) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -123,6 +123,8 @@ public interface MethodOrderer {
 	@Deprecated
 	class Alphanumeric extends MethodName {
 
+		public Alphanumeric() {
+		}
 	}
 	/**
 	 * {@code MethodOrderer} that sorts methods alphanumerically based on their
@@ -135,6 +137,9 @@ public interface MethodOrderer {
 	 */
 	@API(status = EXPERIMENTAL, since = "5.7")
 	class MethodName implements MethodOrderer {
+
+		public MethodName() {
+		}
 
 		/**
 		 * Sort the methods encapsulated in the supplied
@@ -163,6 +168,9 @@ public interface MethodOrderer {
 	 */
 	@API(status = EXPERIMENTAL, since = "5.7")
 	class DisplayName implements MethodOrderer {
+
+		public DisplayName() {
+		}
 
 		/**
 		 * Sort the methods encapsulated in the supplied
@@ -194,6 +202,9 @@ public interface MethodOrderer {
 	 * list.
 	 */
 	class OrderAnnotation implements MethodOrderer {
+
+		public OrderAnnotation() {
+		}
 
 		/**
 		 * Sort the methods encapsulated in the supplied
@@ -259,6 +270,9 @@ public interface MethodOrderer {
 		 * {@linkplain Random class-level Javadoc} for details).
 		 */
 		public static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
+
+		public Random() {
+		}
 
 		/**
 		 * Order the methods encapsulated in the supplied

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
@@ -100,7 +100,7 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 	@Override
 	public DisplayNameGenerator getDefaultDisplayNameGenerator() {
 		return displayNameGeneratorConverter.get(configurationParameters, DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME) //
-				.orElseGet(DisplayNameGenerator.Standard::new);
+				.orElseGet(() -> DisplayNameGenerator.getDisplayNameGenerator(DisplayNameGenerator.Standard.class));
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -46,22 +46,26 @@ final class DisplayNameUtils {
 	/**
 	 * Pre-defined standard display name generator instance.
 	 */
-	private static final DisplayNameGenerator standardGenerator = new Standard();
+	private static final DisplayNameGenerator standardGenerator = DisplayNameGenerator.getDisplayNameGenerator(
+		Standard.class);
 
 	/**
 	 * Pre-defined simple display name generator instance.
 	 */
-	private static final DisplayNameGenerator simpleGenerator = new Simple();
+	private static final DisplayNameGenerator simpleGenerator = DisplayNameGenerator.getDisplayNameGenerator(
+		Simple.class);
 
 	/**
 	 * Pre-defined display name generator instance replacing underscores.
 	 */
-	private static final DisplayNameGenerator replaceUnderscoresGenerator = new ReplaceUnderscores();
+	private static final DisplayNameGenerator replaceUnderscoresGenerator = DisplayNameGenerator.getDisplayNameGenerator(
+		ReplaceUnderscores.class);
 
 	/**
 	 * Pre-defined display name generator instance producing indicative sentences.
 	 */
-	private static final DisplayNameGenerator indicativeSentencesGenerator = new IndicativeSentences();
+	private static final DisplayNameGenerator indicativeSentencesGenerator = DisplayNameGenerator.getDisplayNameGenerator(
+		IndicativeSentences.class);
 
 	static String determineDisplayName(AnnotatedElement element, Supplier<String> displayNameSupplier) {
 		Preconditions.notNull(element, "Annotated element must not be null");

--- a/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/engine/kotlin/ArbitraryNamingKotlinTestCase.kt
+++ b/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/engine/kotlin/ArbitraryNamingKotlinTestCase.kt
@@ -17,6 +17,7 @@ class ArbitraryNamingKotlinTestCase {
         val METHOD_NAME = "\uD83E\uDD86 ~|~test with a really, (really) terrible name & that needs to be changed!~|~"
     }
 
+    @Suppress("DANGEROUS_CHARACTERS")
     @Test
     fun `🦆 ~|~test with a really, (really) terrible name & that needs to be changed!~|~`() { }
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine.reporting;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.time.LocalDateTime;
@@ -34,6 +35,14 @@ public final class ReportEntry {
 
 	private final LocalDateTime timestamp = LocalDateTime.now();
 	private final Map<String, String> keyValuePairs = new LinkedHashMap<>();
+
+	/**
+	 * @deprecated Use {@link #from(String, String)} or {@link #from(Map)}
+	 */
+	@API(status = DEPRECATED, since = "5.8")
+	@Deprecated
+	public ReportEntry() {
+	}
 
 	/**
 	 * Factory for creating a new {@code ReportEntry} from a map of key-value pairs.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestEngine.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/HierarchicalTestEngine.java
@@ -29,6 +29,9 @@ import org.junit.platform.engine.TestEngine;
 @API(status = MAINTAINED, since = "1.0")
 public abstract class HierarchicalTestEngine<C extends EngineExecutionContext> implements TestEngine {
 
+	public HierarchicalTestEngine() {
+	}
+
 	/**
 	 * Create an {@linkplain #createExecutorService(ExecutionRequest) executor
 	 * service}; create an initial {@linkplain #createExecutionContext execution

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SameThreadHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SameThreadHierarchicalTestExecutorService.java
@@ -27,6 +27,9 @@ import org.apiguardian.api.API;
 @API(status = EXPERIMENTAL, since = "1.3")
 public class SameThreadHierarchicalTestExecutorService implements HierarchicalTestExecutorService {
 
+	public SameThreadHierarchicalTestExecutorService() {
+	}
+
 	@Override
 	public Future<Void> submit(TestTask testTask) {
 		testTask.execute();


### PR DESCRIPTION
## Overview

Fixes existing Java/Kotlin compiler warnings and makes all compile tasks fail on warnings from now on.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
