### PR TITLE
Adds assertInstanceOf (proof of concept)

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertInstanceOf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertInstanceOf.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.jupiter.api.AssertionUtils.*;
+
+import java.util.function.Supplier;
+
+import org.opentest4j.AssertionFailedError;
+
+class AssertInstanceOf {
+
+	private AssertInstanceOf() {
+		/* no-op */
+	}
+
+	static void assertInstanceOf(Class<?> expectedType, Object actualValue) {
+		assertInstanceOf(expectedType, actualValue, (Object) null);
+	}
+
+	static void assertInstanceOf(Class<?> expectedType, Object actualValue, String message) {
+		assertInstanceOf(expectedType, actualValue, (Object) message);
+	}
+
+	static void assertInstanceOf(Class<?> expectedType, Object actualValue, Supplier<String> messageSupplier) {
+		assertInstanceOf(expectedType, actualValue, (Object) messageSupplier);
+	}
+
+	private static void assertInstanceOf(Class<?> expectedType, Object actualValue, Object messageOrSupplier) {
+		if (!expectedType.isInstance(actualValue)) {
+			String template = actualValue instanceof Throwable ? "Unexpected exception type"
+					: "Unexpected instance type";
+			if (actualValue == null)
+				template = "Unexpected null value";
+			String message = buildPrefix(nullSafeGet(messageOrSupplier))
+					+ format(expectedType, actualValue == null ? null : actualValue.getClass(), template);
+			throw new AssertionFailedError(message);
+		}
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3448,4 +3448,15 @@ public class Assertions {
 		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier, messageSupplier);
 	}
 
+	public static void assertInstanceOf(Class<?> expectedType, Object actualValue) {
+		AssertInstanceOf.assertInstanceOf(expectedType, actualValue);
+	}
+
+	static void assertInstanceOf(Class<?> expectedType, Object actualValue, String message) {
+		AssertInstanceOf.assertInstanceOf(expectedType, actualValue, message);
+	}
+
+	static void assertInstanceOf(Class<?> expectedType, Object actualValue, Supplier<String> messageSupplier) {
+		AssertInstanceOf.assertInstanceOf(expectedType, actualValue, messageSupplier);
+	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertInstanceOfAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertInstanceOfAssertionsTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * Unit tests for JUnit Jupiter {@link Assertions#assertInstanceOf(Class, Object)}.
+ *
+ * @since 5.6.4
+ */
+class AssertInstanceOfAssertionsTests {
+
+	@Test
+	void assertInstanceOfFailsNullValue() {
+		assertInstanceOfFails(String.class, null, "null value");
+	}
+
+	@Test
+	void assertInstanceOfFailsWrongTypeValue() {
+		assertInstanceOfFails(String.class, 1, "instance type");
+	}
+
+	@Test
+	void assertInstanceOfWrongExceptionValue() {
+		assertInstanceOfFails(RuntimeException.class, new IOException(), "exception type");
+	}
+
+	private static class SuperClass {
+	}
+
+	private static class ExpectedClass extends SuperClass {
+
+	}
+
+	@Test
+	void assertInstanceOfFailsSuperTypeValue() {
+		assertInstanceOfFails(ExpectedClass.class, new SuperClass(), "instance type");
+	}
+
+	@Test
+	void assertInstanceOfSucceedsSameTypeValue() {
+		assertInstanceOfSucceeds(String.class, "indeed a String");
+	}
+
+	@Test
+	void assertInstanceOfSucceedsExpectSuperClassOfValue() {
+		assertInstanceOfSucceeds(CharSequence.class, "indeed a CharSequence");
+	}
+
+	@Test
+	void assertInstanceOfSucceedsSameTypeExceptionValue() {
+		assertInstanceOfSucceeds(UnsupportedOperationException.class, new UnsupportedOperationException());
+	}
+
+	@Test
+	void assertInstanceOfSucceedsExpectSuperClassOfExceptionValue() {
+		assertInstanceOfSucceeds(RuntimeException.class, new IllegalArgumentException("is a RuntimeException"));
+	}
+
+	private void assertInstanceOfSucceeds(Class<?> expectedType, Object actualValue) {
+		assertInstanceOf(expectedType, actualValue);
+	}
+
+	private void assertInstanceOfFails(Class<?> expectedType, Object actualValue, String unexpectedType) {
+		Error error = assertThrows(AssertionFailedError.class, () -> assertInstanceOf(expectedType, actualValue));
+		String valueType = actualValue == null ? "null" : actualValue.getClass().getCanonicalName();
+		String expectedMessage = String.format("Unexpected %s ==> expected: <%s> but was: <%s>", unexpectedType,
+			expectedType.getCanonicalName(), valueType);
+		assertEquals(expectedMessage, error.getMessage());
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
