### PR TITLE
Report containers as JFR events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,11 +98,15 @@ allprojects {
 	}
 
 	repositories {
-		// mavenLocal()
 		mavenCentral()
 		maven(url = "https://oss.sonatype.org/content/repositories/snapshots") {
 			mavenContent {
 				snapshotsOnly()
+			}
+		}
+		maven(url = "https://jitpack.io") {
+			mavenContent {
+				includeModule("com.github.gunnarmorling", "jfrunit")
 			}
 		}
 	}

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -33,5 +33,6 @@ dependencies {
 		api("org.mockito:mockito-junit-jupiter:${versions["mockito"]}")
 		api("biz.aQute.bnd:biz.aQute.bndlib:${versions["bnd"]}")
 		api("org.spockframework:spock-core:${versions["spock"]}")
+		api("com.github.gunnarmorling:jfrunit:${versions["jfrunit"]}")
 	}
 }

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -30,6 +30,8 @@ on GitHub.
   nested container events when using the `EngineTestKit`. For example,
   `test(displayName("my test"))` can be used to match against a test whose display name is
   `my test`.
+* The `junit-platform-jfr` module now also reports events for containers, e.g. test
+  classes.
 
 
 [[release-notes-5.8.0-M1-junit-jupiter]]

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,7 @@ log4j.version=2.13.3
 mockito.version=3.5.0
 slf4j.version=1.7.30
 spock.version=1.3-groovy-2.5
+jfrunit.version=main-SNAPSHOT
 
 # Tools
 checkstyle.version=8.36.2

--- a/junit-platform-jfr/src/main/java/org/junit/platform/jfr/FlightRecordingListener.java
+++ b/junit-platform-jfr/src/main/java/org/junit/platform/jfr/FlightRecordingListener.java
@@ -17,7 +17,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -52,7 +51,7 @@ public class FlightRecordingListener implements TestExecutionListener {
 
 	@Override
 	public void testPlanExecutionStarted(TestPlan plan) {
-		TestPlanExecutionEvent event = new TestPlanExecutionEvent();
+		var event = new TestPlanExecutionEvent();
 		event.containsTests = plan.containsTests();
 		event.engineNames = plan.getRoots().stream().map(TestIdentifier::getDisplayName).collect(
 			Collectors.joining(", "));
@@ -62,13 +61,13 @@ public class FlightRecordingListener implements TestExecutionListener {
 
 	@Override
 	public void testPlanExecutionFinished(TestPlan plan) {
-		TestPlanExecutionEvent event = testPlanExecutionEvent.get();
+		var event = testPlanExecutionEvent.get();
 		event.commit();
 	}
 
 	@Override
 	public void executionSkipped(TestIdentifier test, String reason) {
-		SkippedTestEvent event = new SkippedTestEvent();
+		var event = new SkippedTestEvent();
 		event.initialize(test);
 		event.reason = reason;
 		event.commit();
@@ -76,7 +75,7 @@ public class FlightRecordingListener implements TestExecutionListener {
 
 	@Override
 	public void executionStarted(TestIdentifier test) {
-		TestExecutionEvent event = new TestExecutionEvent();
+		var event = new TestExecutionEvent();
 		testExecutionEventMap.put(test.getUniqueId(), event);
 		event.initialize(test);
 		event.begin();
@@ -84,11 +83,8 @@ public class FlightRecordingListener implements TestExecutionListener {
 
 	@Override
 	public void executionFinished(TestIdentifier test, TestExecutionResult result) {
-		if (test.isContainer() && result.getStatus().equals(TestExecutionResult.Status.SUCCESSFUL)) {
-			return;
-		}
-		Optional<Throwable> throwable = result.getThrowable();
-		TestExecutionEvent event = testExecutionEventMap.get(test.getUniqueId()); // TODO Remove?
+		var throwable = result.getThrowable();
+		var event = testExecutionEventMap.remove(test.getUniqueId());
 		event.end();
 		event.result = result.getStatus().toString();
 		event.exceptionClass = throwable.map(Throwable::getClass).orElse(null);
@@ -98,8 +94,8 @@ public class FlightRecordingListener implements TestExecutionListener {
 
 	@Override
 	public void reportingEntryPublished(TestIdentifier test, ReportEntry reportEntry) {
-		for (Map.Entry<String, String> entry : reportEntry.getKeyValuePairs().entrySet()) {
-			ReportEntryEvent event = new ReportEntryEvent();
+		for (var entry : reportEntry.getKeyValuePairs().entrySet()) {
+			var event = new ReportEntryEvent();
 			event.uniqueId = test.getUniqueId();
 			event.key = entry.getKey();
 			event.value = entry.getValue();

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 	testImplementation(project(":junit-platform-commons"))
 	testImplementation(project(":junit-platform-console"))
 	testImplementation(project(":junit-platform-engine"))
+	testImplementation(project(":junit-platform-jfr"))
 	testImplementation(project(":junit-platform-launcher"))
 
 	// --- Things we are testing with ---------------------------------------------
@@ -21,6 +22,7 @@ dependencies {
 	testImplementation(testFixtures(project(":junit-platform-launcher")))
 	testImplementation(project(":junit-jupiter-engine"))
 	testImplementation("org.apiguardian:apiguardian-api")
+	testImplementation("com.github.gunnarmorling:jfrunit")
 
 	// --- Test run-time dependencies ---------------------------------------------
 	testRuntimeOnly(project(":junit-vintage-engine"))

--- a/platform-tests/src/test/java/org/junit/platform/jfr/FlightRecordingListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/jfr/FlightRecordingListenerIntegrationTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.jfr;
+
+import static dev.morling.jfrunit.ExpectedEvent.event;
+import static dev.morling.jfrunit.JfrEventsAssert.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import dev.morling.jfrunit.EnableEvent;
+import dev.morling.jfrunit.JfrEventTest;
+import dev.morling.jfrunit.JfrEvents;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.engine.JupiterTestEngine;
+import org.junit.platform.launcher.core.LauncherConfig;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+@JfrEventTest
+public class FlightRecordingListenerIntegrationTests {
+
+	public JfrEvents jfrEvents = new JfrEvents();
+
+	@Test
+	@EnableEvent("org.junit.*")
+	void reportsEvents() {
+		var config = LauncherConfig.builder() //
+				.enableTestExecutionListenerAutoRegistration(false) //
+				.enableTestEngineAutoRegistration(false) //
+				.addTestEngines(new JupiterTestEngine()) //
+				.build();
+		var request = request() //
+				.selectors(selectClass(TestCase.class)) //
+				.build();
+
+		LauncherFactory.create(config).execute(request, new FlightRecordingListener());
+		jfrEvents.awaitEvents();
+
+		assertThat(jfrEvents) //
+				.contains(event("org.junit.TestPlan") //
+						.with("engineNames", "JUnit Jupiter")) //
+				.contains(event("org.junit.TestExecution") //
+						.with("displayName", "JUnit Jupiter") //
+						.with("type", "CONTAINER")) //
+				.contains(event("org.junit.TestExecution") //
+						.with("displayName", FlightRecordingListenerIntegrationTests.class.getSimpleName() + "$"
+								+ TestCase.class.getSimpleName()) //
+						.with("type", "CONTAINER")) //
+				.contains(event("org.junit.TestExecution") //
+						.with("displayName", "test(TestReporter)") //
+						.with("type", "TEST") //
+						.with("result", "SUCCESSFUL")) //
+				.contains(event("org.junit.ReportEntry") //
+						.with("key", "message") //
+						.with("value", "Hello JFR!")) //
+				.contains(event("org.junit.SkippedTest") //
+						.with("displayName", "skipped()") //
+						.with("type", "TEST") //
+						.with("reason", "for demonstration purposes"));
+	}
+
+	static class TestCase {
+		@Test
+		void test(TestReporter reporter) {
+			reporter.publishEntry("message", "Hello JFR!");
+		}
+
+		@Test
+		@Disabled("for demonstration purposes")
+		void skipped() {
+		}
+	}
+}


### PR DESCRIPTION
Prior to this commit only tests were reported as JFR events. However,
it's also useful to see events for containers, e.g. test classes, in
particular when they require expensive setup that causes other JFR
events such as garbage collection.

Moreover, this commit adds an integration test using the new JfrUnit
Jupiter extension.

<img width="1617" alt="Screenshot 2020-12-21 at 10 21 06" src="https://user-images.githubusercontent.com/214207/102763027-69cbcd80-4379-11eb-9050-25869969be31.png">
