### PR TITLE
Provide ability to disable test based on OS and environment variable

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -56,6 +56,8 @@ on GitHub.
 * Numeric literals used with `@CsvSource` or `CsvFileSource` can now be expressed using
   underscores as in some JVM languages, to improve readability of long numbers like
   `700_000_000`.
+* Add `@DisabledOnOsWithEnvironmentVariable` annotation that can disabled test class or
+  test method based on operation system and environment variable.
 
 
 [[release-notes-5.8.0-M1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
  * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
@@ -64,6 +64,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
@@ -64,6 +64,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOSWithEnvironmentVariables.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOSWithEnvironmentVariables.java
@@ -1,0 +1,36 @@
+package org.junit.jupiter.api.condition;
+
+import org.apiguardian.api.API;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.apiguardian.api.API.Status.STABLE;
+
+/**
+ * {@code @DisabledOnOSWithEnvironmentVariable} is a container for one or more
+ * {@link DisabledOnOsWithEnvironmentVariable @DisabledOnOSWithEnvironmentVariable} declarations.
+ *
+ * <p>Note, however, that use of the {@code @DisabledOnOSWithEnvironmentVariable} container
+ * is completely optional since {@code @DisabledOnOSWithEnvironmentVariable} is a {@linkplain
+ * java.lang.annotation.Repeatable repeatable} annotation.
+ *
+ * @see DisabledOnOsWithEnvironmentVariable
+ * @see java.lang.annotation.Repeatable
+ * @since 5.6
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = STABLE, since = "5.6")
+public @interface DisabledOnOSWithEnvironmentVariables {
+
+    /**
+     * An array of one or more {@link DisabledOnOsWithEnvironmentVariable @DisabledOnOSWithEnvironmentVariable}
+     * declarations.
+     */
+    DisabledOnOsWithEnvironmentVariable[] value();
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOSWithEnvironmentVariables.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOSWithEnvironmentVariables.java
@@ -1,6 +1,16 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
 package org.junit.jupiter.api.condition;
 
-import org.apiguardian.api.API;
+import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -8,7 +18,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.apiguardian.api.API.Status.STABLE;
+import org.apiguardian.api.API;
 
 /**
  * {@code @DisabledOnOSWithEnvironmentVariable} is a container for one or more
@@ -22,15 +32,15 @@ import static org.apiguardian.api.API.Status.STABLE;
  * @see java.lang.annotation.Repeatable
  * @since 5.6
  */
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(status = STABLE, since = "5.6")
 public @interface DisabledOnOSWithEnvironmentVariables {
 
-    /**
-     * An array of one or more {@link DisabledOnOsWithEnvironmentVariable @DisabledOnOSWithEnvironmentVariable}
-     * declarations.
-     */
-    DisabledOnOsWithEnvironmentVariable[] value();
+	/**
+	 * An array of one or more {@link DisabledOnOsWithEnvironmentVariable @DisabledOnOSWithEnvironmentVariable}
+	 * declarations.
+	 */
+	DisabledOnOsWithEnvironmentVariable[] value();
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOs.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOs.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariable.java
@@ -1,6 +1,16 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
 package org.junit.jupiter.api.condition;
 
-import org.apiguardian.api.API;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -9,7 +19,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import org.apiguardian.api.API;
 
 /**
  * {@code DisabledOnOsWithEnvironmentVariable} is used to signal that the test class or
@@ -29,6 +39,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
  * custom <em>composed annotation</em> that inherits the semantics of this
  * annotation.
  *
+ * @since 5.8
  * @see org.junit.jupiter.api.condition.EnabledOnOs
  * @see org.junit.jupiter.api.condition.EnabledOnJre
  * @see org.junit.jupiter.api.condition.DisabledOnJre
@@ -41,43 +52,42 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
- * @since 5.8
  */
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Repeatable(DisabledOnOSWithEnvironmentVariables.class)
 @API(status = EXPERIMENTAL, since = "5.8")
 public @interface DisabledOnOsWithEnvironmentVariable {
 
-    /**
-     * Operating systems on which the annotated class or method should be
-     * disabled.
-     *
-     * @see OS
-     */
-    OS[] value();
+	/**
+	 * Operating systems on which the annotated class or method should be
+	 * disabled.
+	 *
+	 * @see OS
+	 */
+	OS[] value();
 
-    /**
-     * The name of the environment variable to retrieve.
-     *
-     * @return the environment variable name; never <em>blank</em>
-     * @see System#getenv(String)
-     */
-    String named();
+	/**
+	 * The name of the environment variable to retrieve.
+	 *
+	 * @return the environment variable name; never <em>blank</em>
+	 * @see System#getenv(String)
+	 */
+	String named();
 
-    /**
-     * A regular expression that will be used to match against the retrieved
-     * value of the {@link #named} environment variable.
-     *
-     * @return the regular expression; never <em>blank</em>
-     * @see String#matches(String)
-     * @see java.util.regex.Pattern
-     */
-    String matches();
+	/**
+	 * A regular expression that will be used to match against the retrieved
+	 * value of the {@link #named} environment variable.
+	 *
+	 * @return the regular expression; never <em>blank</em>
+	 * @see String#matches(String)
+	 * @see java.util.regex.Pattern
+	 */
+	String matches();
 
-    /**
-     * Reason to provide if the test of container ends up being disabled.
-     */
-    String disabledReason() default "";
+	/**
+	 * Reason to provide if the test of container ends up being disabled.
+	 */
+	String disabledReason() default "";
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariable.java
@@ -1,0 +1,83 @@
+package org.junit.jupiter.api.condition;
+
+import org.apiguardian.api.API;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+/**
+ * {@code DisabledOnOsWithEnvironmentVariable} is used to signal that the test class or
+ * test method is <em>disabled</em> on one or more specified {@linkplain #value operating systems}
+ * only if specified {@linkplain #named() environment variable} matches the specified
+ * {@linkplain #matches() regular expression}.
+ *
+ * <p>When applied at the class level, all test methods within that class
+ * will be disabled on the same specified operating systems.
+ *
+ * <p>If a test method is disabled via this annotation, that does not prevent
+ * the test class from being instantiated. Rather, it prevents the execution of
+ * the test method and method-level lifecycle callbacks such as {@code @BeforeEach}
+ * methods, {@code @AfterEach} methods, and corresponding extension APIs.
+ *
+ * <p>This annotation may be used as a meta-annotation in order to create a
+ * custom <em>composed annotation</em> that inherits the semantics of this
+ * annotation.
+ *
+ * @see org.junit.jupiter.api.condition.EnabledOnOs
+ * @see org.junit.jupiter.api.condition.EnabledOnJre
+ * @see org.junit.jupiter.api.condition.DisabledOnJre
+ * @see org.junit.jupiter.api.condition.EnabledForJreRange
+ * @see org.junit.jupiter.api.condition.DisabledForJreRange
+ * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+ * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
+ * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
+ * @see org.junit.jupiter.api.condition.EnabledIf
+ * @see org.junit.jupiter.api.condition.DisabledIf
+ * @see org.junit.jupiter.api.Disabled
+ * @since 5.8
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Repeatable(DisabledOnOSWithEnvironmentVariables.class)
+@API(status = EXPERIMENTAL, since = "5.8")
+public @interface DisabledOnOsWithEnvironmentVariable {
+
+    /**
+     * Operating systems on which the annotated class or method should be
+     * disabled.
+     *
+     * @see OS
+     */
+    OS[] value();
+
+    /**
+     * The name of the environment variable to retrieve.
+     *
+     * @return the environment variable name; never <em>blank</em>
+     * @see System#getenv(String)
+     */
+    String named();
+
+    /**
+     * A regular expression that will be used to match against the retrieved
+     * value of the {@link #named} environment variable.
+     *
+     * @return the regular expression; never <em>blank</em>
+     * @see String#matches(String)
+     * @see java.util.regex.Pattern
+     */
+    String matches();
+
+    /**
+     * Reason to provide if the test of container ends up being disabled.
+     */
+    String disabledReason() default "";
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableCondition.java
@@ -1,72 +1,80 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
 package org.junit.jupiter.api.condition;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+
+import java.util.Arrays;
 
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.platform.commons.util.Preconditions;
 
-import java.util.Arrays;
-
-import static java.lang.String.format;
-import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
-
 /**
  * {@link ExecutionCondition} for {@link DisabledOnOsWithEnvironmentVariable @DisabledOnOSWithEnvironmentVariable}.
  *
- * @see DisabledOnOsWithEnvironmentVariable
  * @since 5.8
+ * @see DisabledOnOsWithEnvironmentVariable
  */
-public class DisabledOnOsWithEnvironmentVariableCondition
-        extends AbstractRepeatableAnnotationCondition<DisabledOnOsWithEnvironmentVariable> {
+class DisabledOnOsWithEnvironmentVariableCondition
+		extends AbstractRepeatableAnnotationCondition<DisabledOnOsWithEnvironmentVariable> {
 
-    private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
-            "No @DisabledOnOsWithEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+	private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
+		"No @DisabledOnOsWithEnvironmentVariable conditions resulting in 'disabled' execution encountered");
 
-    DisabledOnOsWithEnvironmentVariableCondition() {
-        super(DisabledOnOsWithEnvironmentVariable.class);
-    }
+	DisabledOnOsWithEnvironmentVariableCondition() {
+		super(DisabledOnOsWithEnvironmentVariable.class);
+	}
 
-    @Override
-    protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
-        return ENABLED;
-    }
+	@Override
+	protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
+		return ENABLED;
+	}
 
-    @Override
-    protected ConditionEvaluationResult evaluate(final DisabledOnOsWithEnvironmentVariable annotation) {
-        final OS[] operatingSystems = annotation.value();
-        Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @DisabledOnOs");
-        final boolean isDisabled = Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs);
-        if (isDisabled) {
-            final String name = annotation.named();
-            final String regex = annotation.matches();
-            Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);
-            Preconditions.notBlank(regex, () -> "The 'matches' attribute must not be blank in " + annotation);
+	@Override
+	protected ConditionEvaluationResult evaluate(final DisabledOnOsWithEnvironmentVariable annotation) {
+		final OS[] operatingSystems = annotation.value();
+		Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @DisabledOnOs");
+		final boolean isDisabled = Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs);
+		if (isDisabled) {
+			final String name = annotation.named();
+			final String regex = annotation.matches();
+			Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);
+			Preconditions.notBlank(regex, () -> "The 'matches' attribute must not be blank in " + annotation);
 
-            String actual = getEnvironmentVariable(name);
-            if (actual == null) {
-                return ENABLED;
-            }
+			String actual = getEnvironmentVariable(name);
+			if (actual == null) {
+				return ENABLED;
+			}
 
-            final boolean matches = actual.matches(regex);
-            if (matches) {
-                return disabled(
-                        format(
-                                "Disabled on operating system: [%s] with Environment variable [%s] with " +
-                                        "value [%s] matches regular expression [%s]",
-                                System.getProperty("os.name"), name, actual, regex
-                        ), annotation.disabledReason());
-            }
-        }
-        return ENABLED;
-    }
+			final boolean matches = actual.matches(regex);
+			if (matches) {
+				return disabled(format(
+					"Disabled on operating system: [%s] with Environment variable [%s] with "
+							+ "value [%s] matches regular expression [%s]",
+					System.getProperty("os.name"), name, actual, regex), annotation.disabledReason());
+			}
+		}
+		return ENABLED;
+	}
 
-    /**
-     * Get the value of the named environment variable.
-     *
-     * <p>The default implementation simply delegates to
-     * {@link System#getenv(String)}. Can be overridden in a subclass for
-     * testing purposes.
-     */
-    protected String getEnvironmentVariable(String name) {
-        return System.getenv(name);
-    }
+	/**
+	 * Get the value of the named environment variable.
+	 *
+	 * <p>The default implementation simply delegates to
+	 * {@link System#getenv(String)}. Can be overridden in a subclass for
+	 * testing purposes.
+	 */
+	protected String getEnvironmentVariable(String name) {
+		return System.getenv(name);
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableCondition.java
@@ -1,0 +1,72 @@
+package org.junit.jupiter.api.condition;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.platform.commons.util.Preconditions;
+
+import java.util.Arrays;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+
+/**
+ * {@link ExecutionCondition} for {@link DisabledOnOsWithEnvironmentVariable @DisabledOnOSWithEnvironmentVariable}.
+ *
+ * @see DisabledOnOsWithEnvironmentVariable
+ * @since 5.8
+ */
+public class DisabledOnOsWithEnvironmentVariableCondition
+        extends AbstractRepeatableAnnotationCondition<DisabledOnOsWithEnvironmentVariable> {
+
+    private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
+            "No @DisabledOnOsWithEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+
+    DisabledOnOsWithEnvironmentVariableCondition() {
+        super(DisabledOnOsWithEnvironmentVariable.class);
+    }
+
+    @Override
+    protected ConditionEvaluationResult getNoDisabledConditionsEncounteredResult() {
+        return ENABLED;
+    }
+
+    @Override
+    protected ConditionEvaluationResult evaluate(final DisabledOnOsWithEnvironmentVariable annotation) {
+        final OS[] operatingSystems = annotation.value();
+        Preconditions.condition(operatingSystems.length > 0, "You must declare at least one OS in @DisabledOnOs");
+        final boolean isDisabled = Arrays.stream(operatingSystems).anyMatch(OS::isCurrentOs);
+        if (isDisabled) {
+            final String name = annotation.named();
+            final String regex = annotation.matches();
+            Preconditions.notBlank(name, () -> "The 'named' attribute must not be blank in " + annotation);
+            Preconditions.notBlank(regex, () -> "The 'matches' attribute must not be blank in " + annotation);
+
+            String actual = getEnvironmentVariable(name);
+            if (actual == null) {
+                return ENABLED;
+            }
+
+            final boolean matches = actual.matches(regex);
+            if (matches) {
+                return disabled(
+                        format(
+                                "Disabled on operating system: [%s] with Environment variable [%s] with " +
+                                        "value [%s] matches regular expression [%s]",
+                                System.getProperty("os.name"), name, actual, regex
+                        ), annotation.disabledReason());
+            }
+        }
+        return ENABLED;
+    }
+
+    /**
+     * Get the value of the named environment variable.
+     *
+     * <p>The default implementation simply delegates to
+     * {@link System#getenv(String)}. Can be overridden in a subclass for
+     * testing purposes.
+     */
+    protected String getEnvironmentVariable(String name) {
+        return System.getenv(name);
+    }
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
  * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOs.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOs.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see org.junit.jupiter.api.condition.EnabledIf
  * @see org.junit.jupiter.api.condition.DisabledIf
  * @see org.junit.jupiter.api.Disabled
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExecutionCondition.java
@@ -13,7 +13,6 @@ package org.junit.jupiter.api.extension;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
-import org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable;
 
 /**
  * {@code ExecutionCondition} defines the {@link Extension} API for

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExecutionCondition.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.api.extension;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable;
 
 /**
  * {@code ExecutionCondition} defines the {@link Extension} API for
@@ -46,6 +47,7 @@ import org.apiguardian.api.API;
  * @see org.junit.jupiter.api.condition.DisabledForJreRange
  * @see org.junit.jupiter.api.condition.EnabledOnOs
  * @see org.junit.jupiter.api.condition.DisabledOnOs
+ * @see org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariable
  */
 @FunctionalInterface
 @API(status = STABLE, since = "5.0")

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableConditionTests.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.condition.DisabledIfEnvironmentVariableIntegrationTests.ENIGMA;
+import static org.junit.jupiter.api.condition.DisabledIfEnvironmentVariableIntegrationTests.KEY1;
+import static org.junit.jupiter.api.condition.DisabledOnOsWithEnvironmentVariableIntegrationTests.KEY2;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.platform.commons.PreconditionViolationException;
+
+/**
+ * Unit tests for {@link DisabledOnOsWithEnvironmentVariableCondition}.
+ *
+ * <p>Note that test method names MUST match the test method names in
+ * {@link DisabledOnOsWithEnvironmentVariableConditionTests}.
+ *
+ * @since 5.1
+ */
+final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractExecutionConditionTests {
+
+	private static final String OS_NAME = System.getProperty("os.name");
+
+	/**
+	 * Stubbed subclass of {@link DisabledIfEnvironmentVariableCondition}.
+	 */
+	private ExecutionCondition condition = new DisabledOnOsWithEnvironmentVariableCondition() {
+
+		protected String getEnvironmentVariable(String name) {
+			return KEY1.equals(name) ? ENIGMA : null;
+		}
+	};
+
+	@Override
+	protected ExecutionCondition getExecutionCondition() {
+		return this.condition;
+	}
+
+	@Override
+	protected Class<?> getTestClass() {
+		return DisabledOnOsWithEnvironmentVariableIntegrationTests.class;
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#enabledBecauseAnnotationIsNotPresent()
+	 */
+	@Test
+	void enabledBecauseAnnotationIsNotPresent() {
+		evaluateCondition();
+		assertEnabled();
+		assertReasonContains(
+			"No @DisabledOnOsWithEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#missingOsDeclaration()
+	 */
+	@Test
+	void missingOsDeclaration() {
+		Exception exception = assertThrows(PreconditionViolationException.class, this::evaluateCondition);
+		assertThat(exception).hasMessageContaining("You must declare at least one OS");
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#disabledOnEveryOs()
+	 */
+	@Test
+	void disabledOnEveryOs() {
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("matches regular expression");
+		assertReasonContains("Disabled on operating system");
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#enabledOnLinuxWithoutEnvironmentVariablesMatches()
+	 */
+	@Test
+	void enabledOnLinuxWithoutEnvironmentVariablesMatches() {
+		evaluateCondition();
+		assertEnabled();
+		assertReasonContains(
+			"No @DisabledOnOsWithEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#disableOnOsWithEnvironmentVariableMatches()
+	 */
+	@Test
+	void disableOnOsWithEnvironmentVariableMatches() {
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("Disabled on operating system: " + OS_NAME);
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#disableOnMultipleOsWithEnvironmentVariableMatches()
+	 */
+	@Test
+	void disableOnMultipleOsWithEnvironmentVariableMatches() {
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("Disabled on operating system: " + OS_NAME);
+	}
+
+	/**
+	 * This method is coupled with the usage of the LINUX API annotation on the test level. It is done only in this
+	 * test since it is hard to get the information about the type of OS at the level of this test.
+	 *
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#blankNamedAttribute()
+	 */
+	@Test
+	void blankNamedAttribute() {
+		if (onLinux()) {
+			Exception exception = assertThrows(PreconditionViolationException.class, this::evaluateCondition);
+			assertThat(exception).hasMessageContaining("The 'named' attribute must not be blank");
+		}
+	}
+
+	/**
+	 * This method is coupled with the usage of the SOLARIS API annotation on the test level. It is done only in this
+	 * test since it is hard to get the information about the type of OS at the level of this test.
+	 *
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#blankMatchesAttribute()
+	 */
+	@Test
+	void blankMatchesAttribute() {
+		if (onSolaris()) {
+			Exception exception = assertThrows(PreconditionViolationException.class, this::evaluateCondition);
+			assertThat(exception).hasMessageContaining("The 'matches' attribute must not be blank");
+		}
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#macOs()
+	 */
+	@Test
+	void macOs() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onMac());
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#macOsWithComposedAnnotation()
+	 */
+	@Test
+	void macOsWithComposedAnnotation() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onMac());
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#windows()
+	 */
+	@Test
+	void windows() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onWindows());
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#solaris()
+	 */
+	@Test
+	void solaris() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onSolaris());
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#other()
+	 */
+	@Test
+	void other() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(!(onLinux() || onMac() || onSolaris() || onWindows()));
+	}
+
+	private void assertDisabledOnCurrentOsIf(boolean condition) {
+		if (condition) {
+			assertDisabled();
+			assertReasonContains("Disabled on operating system: " + OS_NAME);
+		}
+		else {
+			assertEnabled();
+			assertReasonContains(
+				"No @DisabledOnOsWithEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+		}
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#disabledBecauseEnvironmentVariableForComposedAnnotationMatchesExactly()
+	 */
+	@Test
+	void disabledBecauseEnvironmentVariableForComposedAnnotationMatchesExactly() {
+		this.condition = new DisabledOnOsWithEnvironmentVariableCondition() {
+			@Override
+			protected String getEnvironmentVariable(String name) {
+				return KEY1.equals(name) || KEY2.equals(name) ? ENIGMA : null;
+			}
+		};
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("matches regular expression");
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#disabledBecauseEnvironmentVariableMatchesExactly()
+	 */
+	@Test
+	void disabledBecauseEnvironmentVariableMatchesExactly() {
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("matches regular expression");
+		assertCustomDisabledReasonIs("That's an enigma");
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#disabledBecauseEnvironmentVariableMatchesPattern()
+	 */
+	@Test
+	void disabledBecauseEnvironmentVariableMatchesPattern() {
+		evaluateCondition();
+		assertDisabled();
+		assertReasonContains("matches regular expression");
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#enabledBecauseEnvironmentVariableDoesNotMatch()
+	 */
+	@Test
+	void enabledBecauseEnvironmentVariableDoesNotMatch() {
+		evaluateCondition();
+		assertEnabled();
+		assertReasonContains(
+			"No @DisabledOnOsWithEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+	}
+
+	/**
+	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#enabledBecauseEnvironmentVariableDoesNotExist()
+	 */
+	@Test
+	void enabledBecauseEnvironmentVariableDoesNotExist() {
+		evaluateCondition();
+		assertEnabled();
+		assertReasonContains(
+			"No @DisabledOnOsWithEnvironmentVariable conditions resulting in 'disabled' execution encountered");
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableConditionTests.java
@@ -34,8 +34,6 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractExecutionConditionTests {
 
-	private static final String OS_NAME = System.getProperty("os.name");
-
 	/**
 	 * Stubbed subclass of {@link DisabledIfEnvironmentVariableCondition}.
 	 */
@@ -84,7 +82,6 @@ final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractEx
 		evaluateCondition();
 		assertDisabled();
 		assertReasonContains("matches regular expression");
-		assertReasonContains("Disabled on operating system");
 	}
 
 	/**
@@ -104,18 +101,7 @@ final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractEx
 	@Test
 	void disableOnOsWithEnvironmentVariableMatches() {
 		evaluateCondition();
-		assertDisabled();
-		assertReasonContains("Disabled on operating system: " + OS_NAME);
-	}
-
-	/**
-	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#disableOnMultipleOsWithEnvironmentVariableMatches()
-	 */
-	@Test
-	void disableOnMultipleOsWithEnvironmentVariableMatches() {
-		evaluateCondition();
-		assertDisabled();
-		assertReasonContains("Disabled on operating system: " + OS_NAME);
+		assertDisabledOnCurrentOsIf(onLinux());
 	}
 
 	/**
@@ -156,15 +142,6 @@ final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractEx
 	}
 
 	/**
-	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#macOsWithComposedAnnotation()
-	 */
-	@Test
-	void macOsWithComposedAnnotation() {
-		evaluateCondition();
-		assertDisabledOnCurrentOsIf(onMac());
-	}
-
-	/**
 	 * @see DisabledOnOsWithEnvironmentVariableIntegrationTests#windows()
 	 */
 	@Test
@@ -194,7 +171,7 @@ final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractEx
 	private void assertDisabledOnCurrentOsIf(boolean condition) {
 		if (condition) {
 			assertDisabled();
-			assertReasonContains("Disabled on operating system: " + OS_NAME);
+			assertReasonContains("matches regular expression");
 		}
 		else {
 			assertEnabled();
@@ -215,8 +192,7 @@ final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractEx
 			}
 		};
 		evaluateCondition();
-		assertDisabled();
-		assertReasonContains("matches regular expression");
+		assertDisabledOnCurrentOsIf(onLinux());
 	}
 
 	/**
@@ -225,9 +201,7 @@ final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractEx
 	@Test
 	void disabledBecauseEnvironmentVariableMatchesExactly() {
 		evaluateCondition();
-		assertDisabled();
-		assertReasonContains("matches regular expression");
-		assertCustomDisabledReasonIs("That's an enigma");
+		assertDisabledOnCurrentOsIf(onLinux());
 	}
 
 	/**
@@ -236,8 +210,7 @@ final class DisabledOnOsWithEnvironmentVariableConditionTests extends AbstractEx
 	@Test
 	void disabledBecauseEnvironmentVariableMatchesPattern() {
 		evaluateCondition();
-		assertDisabled();
-		assertReasonContains("matches regular expression");
+		assertDisabledOnCurrentOsIf(onLinux());
 	}
 
 	/**

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableIntegrationTests.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@Disabled("Only used in a unit test via reflection")
 final class DisabledOnOsWithEnvironmentVariableIntegrationTests {
 
 	static final String KEY1 = "DisabledIfEnvironmentVariableTests.key1";
@@ -69,20 +70,8 @@ final class DisabledOnOsWithEnvironmentVariableIntegrationTests {
 	}
 
 	@Test
-	@DisabledOnOsWithEnvironmentVariable(value = { LINUX, MAC, WINDOWS, SOLARIS,
-			OTHER }, named = KEY1, matches = ENIGMA)
-	void disableOnMultipleOsWithEnvironmentVariableMatches() {
-	}
-
-	@Test
 	@DisabledOnOsWithEnvironmentVariable(value = MAC, named = KEY1, matches = ENIGMA)
 	void macOs() {
-		assertFalse(onMac());
-	}
-
-	@Test
-	@DisabledOnMac
-	void macOsWithComposedAnnotation() {
 		assertFalse(onMac());
 	}
 
@@ -102,12 +91,6 @@ final class DisabledOnOsWithEnvironmentVariableIntegrationTests {
 	@DisabledOnOsWithEnvironmentVariable(value = OTHER, named = KEY1, matches = ENIGMA)
 	void other() {
 		assertTrue(onLinux() || onMac() || onSolaris() || onWindows());
-	}
-
-	@Target(ElementType.METHOD)
-	@Retention(RetentionPolicy.RUNTIME)
-	@DisabledOnOs(MAC)
-	@interface DisabledOnMac {
 	}
 
 	// -------------------------------------------------------------------------

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsWithEnvironmentVariableIntegrationTests.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.OTHER;
+import static org.junit.jupiter.api.condition.OS.SOLARIS;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+final class DisabledOnOsWithEnvironmentVariableIntegrationTests {
+
+	static final String KEY1 = "DisabledIfEnvironmentVariableTests.key1";
+	static final String KEY2 = "DisabledIfEnvironmentVariableTests.key2";
+	static final String ENIGMA = "enigma";
+	static final String BOGUS = "bogus";
+
+	@Test
+	void enabledBecauseAnnotationIsNotPresent() {
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledOnOsWithEnvironmentVariable(value = {}, named = "", matches = "")
+	void missingOsDeclaration() {
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = { LINUX, MAC, WINDOWS, SOLARIS,
+			OTHER }, named = KEY1, matches = ENIGMA, disabledReason = "Disabled on every OS")
+	void disabledOnEveryOs() {
+		fail("should be disabled");
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = KEY1, matches = BOGUS)
+	void enabledOnLinuxWithoutEnvironmentVariablesMatches() {
+		assertFalse(onLinux());
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = KEY1, matches = ENIGMA)
+	void disableOnOsWithEnvironmentVariableMatches() {
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = { LINUX, MAC, WINDOWS, SOLARIS,
+			OTHER }, named = KEY1, matches = ENIGMA)
+	void disableOnMultipleOsWithEnvironmentVariableMatches() {
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = MAC, named = KEY1, matches = ENIGMA)
+	void macOs() {
+		assertFalse(onMac());
+	}
+
+	@Test
+	@DisabledOnMac
+	void macOsWithComposedAnnotation() {
+		assertFalse(onMac());
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = WINDOWS, named = KEY1, matches = ENIGMA)
+	void windows() {
+		assertFalse(onWindows());
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = SOLARIS, named = KEY1, matches = ENIGMA)
+	void solaris() {
+		assertFalse(onSolaris());
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = OTHER, named = KEY1, matches = ENIGMA)
+	void other() {
+		assertTrue(onLinux() || onMac() || onSolaris() || onWindows());
+	}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@DisabledOnOs(MAC)
+	@interface DisabledOnMac {
+	}
+
+	// -------------------------------------------------------------------------
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = "  ", matches = ENIGMA)
+	void blankNamedAttribute() {
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = SOLARIS, named = KEY1, matches = "  ")
+	void blankMatchesAttribute() {
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = KEY1, matches = ENIGMA, disabledReason = "That's an enigma")
+	void disabledBecauseEnvironmentVariableMatchesExactly() {
+		fail("should be disabled");
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = KEY1, matches = BOGUS)
+	@CustomDisabled
+	void disabledBecauseEnvironmentVariableForComposedAnnotationMatchesExactly() {
+		fail("should be disabled");
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = KEY1, matches = ".*e.+gma$")
+	void disabledBecauseEnvironmentVariableMatchesPattern() {
+		fail("should be disabled");
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = KEY1, matches = BOGUS)
+	void enabledBecauseEnvironmentVariableDoesNotMatch() {
+		assertNotEquals(BOGUS, System.getenv(KEY1));
+	}
+
+	@Test
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = BOGUS, matches = "doesn't matter")
+	void enabledBecauseEnvironmentVariableDoesNotExist() {
+		assertNull(System.getenv(BOGUS));
+	}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@DisabledOnOsWithEnvironmentVariable(value = LINUX, named = KEY2, matches = ENIGMA)
+	@interface CustomDisabled {
+	}
+}


### PR DESCRIPTION
## Overview

I have created an annotation that is capable of disabling test class or test method based on OS and environment variables. In order to disable the test, both conditions must be satisfied (OS and env variable). 
- In the case of missing the env variable test will be executed. 
- In the case of a different OS but env variable is present the test will be executed

This PR is a proposition and the API is under the discussion.
This is my first PR in this project so I may be missing some obvious things to do, please let me know.

Resolved [#2487](https://github.com/junit-team/junit5/issues/2487)
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
