### PR TITLE
Document constant value for ExclusiveResource.GLOBAL_KEY

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -38,6 +38,7 @@ on GitHub.
   and registered test engines.
 * Custom `LauncherDiscoveryListener` implementations can now be registered via Java’s
   `ServiceLoader` mechanism.
+* Documented constant value of `ExclusiveResource.GLOBAL_KEY`.
 
 
 [[release-notes-5.8.0-M1-junit-jupiter]]
@@ -56,6 +57,7 @@ on GitHub.
 * Numeric literals used with `@CsvSource` or `CsvFileSource` can now be expressed using
   underscores as in some JVM languages, to improve readability of long numbers like
   `700_000_000`.
+* Documented constant values in `Resources`.
 
 
 [[release-notes-5.8.0-M1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Isolated.java
@@ -37,7 +37,7 @@ import org.apiguardian.api.API;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
-@ResourceLock("org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY")
+@ResourceLock(Resources.GLOBAL)
 public @interface Isolated {
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Resources.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Resources.java
@@ -24,7 +24,7 @@ import org.apiguardian.api.API;
 public class Resources {
 
 	/**
-	 * Represents Java's system properties.
+	 * Represents Java's system properties: {@value}
 	 *
 	 * @see System#getProperties()
 	 * @see System#setProperties(java.util.Properties)
@@ -32,7 +32,7 @@ public class Resources {
 	public static final String SYSTEM_PROPERTIES = "java.lang.System.properties";
 
 	/**
-	 * Represents the standard output stream of the current process.
+	 * Represents the standard output stream of the current process: {@value}
 	 *
 	 * @see System#out
 	 * @see System#setOut(java.io.PrintStream)
@@ -40,7 +40,7 @@ public class Resources {
 	public static final String SYSTEM_OUT = "java.lang.System.out";
 
 	/**
-	 * Represents the standard error stream of the current process.
+	 * Represents the standard error stream of the current process: {@value}
 	 *
 	 * @see System#err
 	 * @see System#setErr(java.io.PrintStream)
@@ -48,7 +48,8 @@ public class Resources {
 	public static final String SYSTEM_ERR = "java.lang.System.err";
 
 	/**
-	 * Represents the default locale for the current instance of the JVM.
+	 * Represents the default locale for the current instance of the JVM:
+	 * {@value}
 	 *
 	 * @since 5.4
 	 * @see java.util.Locale#setDefault(java.util.Locale)
@@ -57,13 +58,24 @@ public class Resources {
 	public static final String LOCALE = "java.util.Locale.default";
 
 	/**
-	 * Represents the default time zone for the current instance of the JVM.
+	 * Represents the default time zone for the current instance of the JVM:
+	 * {@value}
 	 *
 	 * @since 5.4
 	 * @see java.util.TimeZone#setDefault(java.util.TimeZone)
 	 */
 	@API(status = EXPERIMENTAL, since = "5.4")
 	public static final String TIME_ZONE = "java.util.TimeZone.default";
+
+	/**
+	 * Represents the global resource lock: {@value}
+	 *
+	 * @since 5.8
+	 * @see Isolated
+	 * @see ExclusiveResource
+	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
+	public static final String GLOBAL = "org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY";
 
 	private Resources() {
 		/* no-op */

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
@@ -32,7 +32,8 @@ public class ExclusiveResource {
 
 	/**
 	 * Key of the global resource lock that all direct children of the engine
-	 * descriptor acquire in {@linkplain LockMode#READ read mode} by default.
+	 * descriptor acquire in {@linkplain LockMode#READ read mode} by default:
+	 * {@value}
 	 *
 	 * <p>If any node {@linkplain Node#getExclusiveResources() requires} an
 	 * exclusive resource with the same key in


### PR DESCRIPTION
## Overview

By documenting the value of `ExclusiveResource.GLOBAL_KEY` test engines that
can not reference constants from a class file may use plain text configuration
to run tests in isolation.

Additionally by documenting the constants used in `Resources` the canonical
resource names are exposed and can be consistently used elsewhere.

Fixes: #2508

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
