### PR TITLE
Provide a way to run tests only if ports are available

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfPortsAvailable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfPortsAvailable.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to use for running tests only when the specified ports are available.
+ *
+ * If the ports are not available then the test is skipped with an appropriate message.
+ */
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(EnabledIfPortsAvailableCondition.class)
+public @interface EnabledIfPortsAvailable {
+  /**
+   * Returns the ports that should be available, in order to run the test.
+   */
+  int[] value();
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfPortsAvailableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfPortsAvailableCondition.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+/**
+ * JUnit Jupiter extension to selectively enable tests when certain ports are available.
+ *
+ * @see EnabledIfPortsAvailable
+ */
+class EnabledIfPortsAvailableCondition implements ExecutionCondition {
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    return findAnnotation(context.getElement(), EnabledIfPortsAvailable.class) //
+        .map(annotation -> {
+          for (int port : annotation.value()) {
+            if (!isPortAvailable(port)) {
+              return ConditionEvaluationResult.disabled("Port " + port + " is not available.");
+            }
+          }
+          return ConditionEvaluationResult.enabled("All required ports are free");
+        }).orElse(ConditionEvaluationResult.enabled(""));
+  }
+
+  private static boolean isPortAvailable(int port) {
+    try (ServerSocket ss = new ServerSocket()) {
+      ss.bind(new InetSocketAddress(port));
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfPortsAvailableConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledIfPortsAvailableConditionTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+/**
+ * Unit tests for {@link EnabledIfPortsAvailable}.
+ */
+public class EnabledIfPortsAvailableConditionTests {
+
+  private static ServerSocket server;
+
+  @BeforeAll
+  static void setupSocket2000() {
+    try {
+      // Best effort to force some tests to be skipped.
+      server = new ServerSocket(2000);
+    } catch (IOException exception) {
+      // It is fine if we don't manage to bind the socket
+      // tests should not fail cause of it.
+    }
+  }
+
+  @AfterAll
+  static void tearDownSocket2000() throws IOException {
+    if (server != null) {
+      server.close();
+      server = null;
+    }
+  }
+
+  @Test
+  @EnabledIfPortsAvailable(2000)
+  void testPortMostLikelyInUse() throws IOException {
+    // Most of the time the test should be skipped since we are explicitly binding the port with server.
+    // If we fail to bind the server to the given port:
+    // - due to the port that is already taken; in that case the test should be skipped via the annotation
+    // - due to another reason (port is free); in that case the test should pass
+    try (ServerSocket s = new ServerSocket()) {
+      s.bind(new InetSocketAddress(2000));
+    }
+  }
+
+  @Test
+  @EnabledIfPortsAvailable(2001)
+  void testPortMostLikelyAvailableV1() throws IOException {
+    // Most of the time the test should pass. In some cases it may happen that the port 2001
+    // is bound by somebody else so the test should be skipped.
+    try (ServerSocket s = new ServerSocket()) {
+      s.bind(new InetSocketAddress(2001));
+    }
+  }
+
+  @Test
+  @EnabledIfPortsAvailable(5050)
+  void testPortMostLikelyAvailableV2() throws IOException {
+    // Most of the time the test should pass. In some cases it may happen that the port 5050
+    // is bound by somebody else so the test should be skipped.
+    try (ServerSocket s = new ServerSocket()) {
+      s.bind(new InetSocketAddress(5050));
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview

Add `EnabledIfPortsAvailable`annotation for running tests only if ports are available.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
