### PR TITLE
Make LauncherDiscoveryListener an interface

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -19,11 +19,8 @@ on GitHub.
 
 ==== Deprecations and Breaking Changes
 
-* `InvocationInterceptor.interceptDynamicTest(Invocation<Void> , ExtensionContext)` has
-  been deprecated in favor of
-  `InvocationInterceptor.interceptDynamicTest(Invocation<Void> , DynamicTestInvocationContext, ExtensionContext)`
-  that allows to access the dynamic test executable via
-  `DynamicTestInvocationContext.getExecutable()`.
+* For consistency with the rest of the JUnit Platform, the experimental
+  `LauncherDiscoveryListener` is now an interface instead of an abstract class.
 
 ==== New Features and Improvements
 
@@ -50,7 +47,11 @@ on GitHub.
 
 ==== Deprecations and Breaking Changes
 
-* ❓
+* `InvocationInterceptor.interceptDynamicTest(Invocation<Void> , ExtensionContext)` has
+  been deprecated in favor of
+  `InvocationInterceptor.interceptDynamicTest(Invocation<Void> , DynamicTestInvocationContext, ExtensionContext)`
+  that allows to access the dynamic test executable via
+  `DynamicTestInvocationContext.getExecutable()`.
 
 ==== New Features and Improvements
 

--- a/junit-platform-jfr/src/main/java/org/junit/platform/jfr/FlightRecordingDiscoveryListener.java
+++ b/junit-platform-jfr/src/main/java/org/junit/platform/jfr/FlightRecordingDiscoveryListener.java
@@ -37,7 +37,7 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
  * @since 1.8
  */
 @API(status = EXPERIMENTAL, since = "1.8")
-public class FlightRecordingDiscoveryListener extends LauncherDiscoveryListener {
+public class FlightRecordingDiscoveryListener implements LauncherDiscoveryListener {
 
 	private final AtomicReference<LauncherDiscoveryEvent> launcherDiscoveryEvent = new AtomicReference<>();
 	private final Map<org.junit.platform.engine.UniqueId, EngineDiscoveryEvent> engineDiscoveryEvents = new ConcurrentHashMap<>();

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherDiscoveryListener.java
@@ -17,13 +17,13 @@ import org.junit.platform.engine.EngineDiscoveryListener;
 import org.junit.platform.engine.UniqueId;
 
 /**
- * Register a concrete implementation of this class with a
+ * Register a concrete implementation of this interface with a
  * {@link org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder}
  * to be notified of events that occur during test discovery.
  *
- * <p>All methods in this class have empty <em>default</em> implementations.
- * Subclasses may therefore override one or more of these methods to be notified
- * of the selected events.
+ * <p>All methods in this interface have empty <em>default</em> implementations.
+ * Concrete implementations may therefore override one or more of these methods
+ * to be notified of the selected events.
  *
  * <p>JUnit provides default implementations that are created via the factory
  * methods in
@@ -38,16 +38,13 @@ import org.junit.platform.engine.UniqueId;
  * @since 1.6
  */
 @API(status = EXPERIMENTAL, since = "1.6")
-public abstract class LauncherDiscoveryListener implements EngineDiscoveryListener {
+public interface LauncherDiscoveryListener extends EngineDiscoveryListener {
 
 	/**
 	 * No-op implementation of {@code LauncherDiscoveryListener}
 	 */
-	public static final LauncherDiscoveryListener NOOP = new LauncherDiscoveryListener() {
+	LauncherDiscoveryListener NOOP = new LauncherDiscoveryListener() {
 	};
-
-	public LauncherDiscoveryListener() {
-	}
 
 	/**
 	 * Called when test discovery is about to be started.
@@ -56,7 +53,7 @@ public abstract class LauncherDiscoveryListener implements EngineDiscoveryListen
 	 * @since 1.8
 	 */
 	@API(status = EXPERIMENTAL, since = "1.8")
-	public void launcherDiscoveryStarted(LauncherDiscoveryRequest request) {
+	default void launcherDiscoveryStarted(LauncherDiscoveryRequest request) {
 	}
 
 	/**
@@ -66,7 +63,7 @@ public abstract class LauncherDiscoveryListener implements EngineDiscoveryListen
 	 * @since 1.8
 	 */
 	@API(status = EXPERIMENTAL, since = "1.8")
-	public void launcherDiscoveryFinished(LauncherDiscoveryRequest request) {
+	default void launcherDiscoveryFinished(LauncherDiscoveryRequest request) {
 	}
 
 	/**
@@ -74,7 +71,7 @@ public abstract class LauncherDiscoveryListener implements EngineDiscoveryListen
 	 *
 	 * @param engineId the unique ID of the engine descriptor
 	 */
-	public void engineDiscoveryStarted(UniqueId engineId) {
+	default void engineDiscoveryStarted(UniqueId engineId) {
 	}
 
 	/**
@@ -87,7 +84,7 @@ public abstract class LauncherDiscoveryListener implements EngineDiscoveryListen
 	 * @param result the discovery result of the supplied engine
 	 * @see EngineDiscoveryResult
 	 */
-	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
+	default void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
@@ -26,7 +26,7 @@ import org.junit.platform.launcher.LauncherDiscoveryListener;
  * @since 1.6
  * @see LauncherDiscoveryListeners#abortOnFailure()
  */
-class AbortOnFailureLauncherDiscoveryListener extends LauncherDiscoveryListener {
+class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	@Override
 	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
@@ -25,7 +25,7 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
  * @since 1.6
  * @see LauncherDiscoveryListeners#composite(List)
  */
-class CompositeLauncherDiscoveryListener extends LauncherDiscoveryListener {
+class CompositeLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	private final List<LauncherDiscoveryListener> listeners;
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
@@ -30,7 +30,7 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
  * @since 1.6
  * @see LauncherDiscoveryListeners#logging()
  */
-class LoggingLauncherDiscoveryListener extends LauncherDiscoveryListener {
+class LoggingLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	private static final Logger logger = LoggerFactory.getLogger(LoggingLauncherDiscoveryListener.class);
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherDiscoveryListener.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestLauncherDiscoveryListener.java
@@ -10,7 +10,7 @@
 
 package org.junit.platform.launcher;
 
-public class TestLauncherDiscoveryListener extends LauncherDiscoveryListener {
+public class TestLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	@Override
 	public boolean equals(Object obj) {


### PR DESCRIPTION
## Overview

As discussed in today's team call, we're deliberately breaking backwards compatibility of the experimental abstract `LauncherDiscoveryListener` class by changing it to be an interface. This makes it more flexible and consistent with the rest of the codebase, e.g. `TestExecutionListener`.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
