### PR TITLE
Remove spurious usage of the word simply

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -639,14 +639,14 @@ You need the following artifacts and their dependencies on the classpath. See
 ==== Display Names vs. Technical Names
 
 To define a custom _display name_ for the class run via `@RunWith(JUnitPlatform.class)`
-simply annotate the class with `@SuiteDisplayName` and provide a custom value.
+annotate the class with `@SuiteDisplayName` and provide a custom value.
 
 By default, _display names_ will be used for test artifacts; however, when the
 `JUnitPlatform` runner is used to execute tests with a build tool such as Gradle or
 Maven, the generated test report often needs to include the _technical names_ of test
 artifacts — for example, fully qualified class names — instead of shorter display names
 like the simple name of a test class or a custom display name containing special
-characters. To enable technical names for reporting purposes, simply declare the
+characters. To enable technical names for reporting purposes, declare the
 `@UseTechnicalNames` annotation alongside `@RunWith(JUnitPlatform.class)`.
 
 Note that the presence of `@UseTechnicalNames` overrides any custom display name
@@ -808,7 +808,7 @@ expressions can be useful.
 === Capturing Standard Output/Error
 
 Since version 1.3, the JUnit Platform provides opt-in support for capturing output
-printed to `System.out` and `System.err`. To enable it, simply set the
+printed to `System.out` and `System.err`. To enable it, set the
 `junit.platform.output.capture.stdout` and/or `junit.platform.output.capture.stderr`
 <<running-tests-config-params, configuration parameter>> to `true`. In addition, you may
 configure the maximum number of buffered bytes to be used per executed test or container

--- a/documentation/src/test/java/example/testkit/EngineTestKitAllEventsDemo.java
+++ b/documentation/src/test/java/example/testkit/EngineTestKitAllEventsDemo.java
@@ -41,7 +41,7 @@ class EngineTestKitAllEventsDemo {
 	void verifyAllJupiterEvents() {
 		Writer writer = // create a java.io.Writer for debug output
 		// end::user_guide[]
-				// For the demo, we are simply swallowing the debug output.
+				// For the demo, we are swallowing the debug output.
 				new StringWriter();
 		// tag::user_guide[]
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -127,7 +127,7 @@ class AssertLinesMatch {
 				}
 
 				String actualLine = actualDeque.peek();
-				// trivial case: take the fast path when they simply match
+				// trivial case: take the fast path when they match
 				if (matches(expectedLine, actualLine)) {
 					actualDeque.pop();
 					continue; // main

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3002,7 +3002,7 @@ public class Assertions {
 	 * thrown, this method will fail.
 	 *
 	 * <p>If you do not want to perform additional checks on the exception instance,
-	 * simply ignore the return value.
+	 * ignore the return value.
 	 */
 	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
 		return AssertThrows.assertThrows(expectedType, executable);
@@ -3016,7 +3016,7 @@ public class Assertions {
 	 * thrown, this method will fail.
 	 *
 	 * <p>If you do not want to perform additional checks on the exception instance,
-	 * simply ignore the return value.
+	 * ignore the return value.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 */
@@ -3035,7 +3035,7 @@ public class Assertions {
 	 * supplied {@code messageSupplier}.
 	 *
 	 * <p>If you do not want to perform additional checks on the exception instance,
-	 * simply ignore the return value.
+	 * ignore the return value.
 	 */
 	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable,
 			Supplier<String> messageSupplier) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableCondition.java
@@ -64,7 +64,7 @@ class DisabledIfEnvironmentVariableCondition
 	/**
 	 * Get the value of the named environment variable.
 	 *
-	 * <p>The default implementation simply delegates to
+	 * <p>The default implementation delegates to
 	 * {@link System#getenv(String)}. Can be overridden in a subclass for
 	 * testing purposes.
 	 */

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableCondition.java
@@ -63,7 +63,7 @@ class EnabledIfEnvironmentVariableCondition
 	/**
 	 * Get the value of the named environment variable.
 	 *
-	 * <p>The default implementation simply delegates to
+	 * <p>The default implementation delegates to
 	 * {@link System#getenv(String)}. Can be overridden in a subclass for
 	 * testing purposes.
 	 */

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/InvocationInterceptor.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/InvocationInterceptor.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.TestTemplate;
  * Invocation#skip()} exactly once on the supplied invocation. Otherwise, the
  * enclosing test or container will be reported as failed.
  *
- * <p>The default implementation simply calls {@link Invocation#proceed()
+ * <p>The default implementation calls {@link Invocation#proceed()
  * proceed()} on the supplied {@linkplain Invocation invocation}.
  *
  * <h3>Constructor Requirements</h3>

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestInstanceFactoryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestInstanceFactoryTests.java
@@ -642,7 +642,7 @@ class TestInstanceFactoryTests extends AbstractJupiterTestEngineTests {
 	}
 
 	/**
-	 * This does not actually create a proxy. Rather, it simply simulates what
+	 * This does not actually create a proxy. Rather, it simulates what
 	 * a proxy-based implementation might do, by loading the class from a
 	 * different {@link ClassLoader}.
 	 */

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -177,8 +177,8 @@ public final class AnnotationSupport {
 	 * discovered within the class hierarchy, this method will additionally
 	 * search on interfaces implemented by each class in the hierarchy.
 	 *
-	 * <p>If the supplied {@code element} is {@code null}, this method simply
-	 * returns an empty list.
+	 * <p>If the supplied {@code element} is {@code null}, this method returns
+	 * an empty list.
 	 *
 	 * <p>As of JUnit Platform 1.5, the search algorithm will also find
 	 * repeatable annotations used as meta-annotations on other repeatable

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -108,7 +108,7 @@ public final class ReflectionUtils {
 	 * <p>The pattern intentionally captures the last bracket with the
 	 * capital letter so that the combination can be looked up via
 	 * {@link #classNameToTypeMap}. For example, the last matched group
-	 * will contain {@code "[I"} instead of simply {@code "I"}.
+	 * will contain {@code "[I"} instead of {@code "I"}.
 	 *
 	 * @see Class#getName()
 	 */
@@ -891,8 +891,8 @@ public final class ReflectionUtils {
 	 * Get the outermost instance of the required type, searching recursively
 	 * through enclosing instances.
 	 *
-	 * <p>If the supplied inner object is of the required type, it will simply
-	 * be returned.
+	 * <p>If the supplied inner object is of the required type, it will be
+	 * returned.
 	 *
 	 * @param inner the inner object from which to begin the search; never {@code null}
 	 * @param requiredType the required type of the outermost instance; never {@code null}
@@ -1705,8 +1705,7 @@ public final class ReflectionUtils {
 	 * {@link InvocationTargetException}, this method will be invoked
 	 * recursively with the underlying
 	 * {@linkplain InvocationTargetException#getTargetException() target
-	 * exception}; otherwise, this method simply returns the supplied
-	 * {@code Throwable}.
+	 * exception}; otherwise, this method returns the supplied {@code Throwable}.
 	 */
 	private static Throwable getUnderlyingCause(Throwable t) {
 		if (t instanceof InvocationTargetException) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -60,7 +60,7 @@ public interface TestDescriptor {
 	 * reporting infrastructure &mdash; for example, for reporting systems built
 	 * on the Ant-based XML reporting format for JUnit 4.
 	 *
-	 * <p>The default implementation simply delegates to {@link #getDisplayName()}.
+	 * <p>The default implementation delegates to {@link #getDisplayName()}.
 	 *
 	 * @return the legacy reporting name; never {@code null} or blank
 	 */

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestEngine.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestEngine.java
@@ -91,7 +91,7 @@ public interface TestEngine {
 	 *
 	 * <p>This information is used solely for debugging and reporting purposes.
 	 *
-	 * <p>The default implementation simply returns an empty {@link Optional},
+	 * <p>The default implementation returns an empty {@link Optional},
 	 * signaling that the group ID is unknown.
 	 *
 	 * <p>Concrete test engine implementations may override this method in
@@ -121,7 +121,7 @@ public interface TestEngine {
 	 * {@link Package} instance with the attributes from the manifest.
 	 *
 	 * <p>If the implementation title cannot be queried from the package
-	 * attributes, the default implementation simply returns an empty
+	 * attributes, the default implementation returns an empty
 	 * {@link Optional}.
 	 *
 	 * <p>Concrete test engine implementations may override this method in

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
@@ -32,7 +32,7 @@ import org.junit.platform.engine.DiscoverySelector;
  * <p>If a Java {@link Method} is provided, the selector will return that
  * {@linkplain #getJavaMethod() method} and its method name, class name, and
  * parameter types accordingly. If a {@link Class} and method name, a class name
- * and method name, or simply a <em>fully qualified method name</em> is provided,
+ * and method name, or a <em>fully qualified method name</em> is provided,
  * this selector will only attempt to lazily load the {@link Class} and
  * {@link Method} if {@link #getJavaClass()} or {@link #getJavaMethod()} is
  * invoked.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/SelectorResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/SelectorResolver.java
@@ -74,7 +74,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link ClasspathResourceSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -93,7 +93,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link ClasspathRootSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -112,7 +112,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link ClassSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -131,7 +131,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link NestedClassSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -150,7 +150,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link DirectorySelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -169,7 +169,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link FileSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -188,7 +188,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link MethodSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -207,7 +207,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link NestedMethodSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -226,7 +226,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link ModuleSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -245,7 +245,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link PackageSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -264,7 +264,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link UniqueIdSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}
@@ -283,7 +283,7 @@ public interface SelectorResolver {
 	 * Resolve the supplied {@link UriSelector} using the supplied
 	 * {@link Context Context}.
 	 *
-	 * <p>The default implementation simply delegates to {@link
+	 * <p>The default implementation delegates to {@link
 	 * #resolve(DiscoverySelector, Context)}.
 	 *
 	 * @param selector the selector to be resolved; never {@code null}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -181,7 +181,7 @@ public final class TestIdentifier implements Serializable {
 	 * reporting infrastructure &mdash; for example, for reporting systems built
 	 * on the Ant-based XML reporting format for JUnit 4.
 	 *
-	 * <p>The default implementation simply delegates to {@link #getDisplayName()}.
+	 * <p>The default implementation delegates to {@link #getDisplayName()}.
 	 *
 	 * @return the legacy reporting name; never {@code null} or blank
 	 * @see org.junit.platform.engine.TestDescriptor#getLegacyReportingName()

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
@@ -78,11 +78,11 @@ import org.junit.runner.notification.RunNotifier;
  * package for configuration options.
  *
  * <p>If you do not use any configuration annotations from the
- * {@code org.junit.platform.suite.api} package, you can simply use this runner
- * on a test class whose programming model is supported on the JUnit Platform
- * &mdash; for example, a JUnit Jupiter test class. Note, however, that any test
- * class run with this runner must be {@code public} in order to be picked up by
- * IDEs and build tools.
+ * {@code org.junit.platform.suite.api} package, you can use this runner on a
+ * test class whose programming model is supported on the JUnit Platform &mdash;
+ * for example, a JUnit Jupiter test class. Note, however, that any test class
+ * run with this runner must be {@code public} in order to be picked up by IDEs
+ * and build tools.
  *
  * <p>When used on a class that serves as a test suite and the
  * {@link IncludeClassNamePatterns @IncludeClassNamePatterns} annotation is not
@@ -147,7 +147,7 @@ public class JUnitPlatform extends Runner implements Filterable {
 	private LauncherDiscoveryRequest createDiscoveryRequest() {
 		List<DiscoverySelector> selectors = getSelectorsFromAnnotations();
 
-		// Allows to simply add @RunWith(JUnitPlatform.class) to any test case
+		// Allows @RunWith(JUnitPlatform.class) to be added to any test case
 		boolean isSuite = !selectors.isEmpty();
 		if (!isSuite) {
 			selectors.add(selectClass(this.testClass));


### PR DESCRIPTION
## Overview
The word simply is used in roughly two situations:

 * When used in instructional documentation the word simply often conveys a
   value judgement about the complexity of a task. Not only is this
   unnecessary, it makes a number of assumptions about the readers familiarity
   with the concepts involved and can come across as condescending.

 * When used to describe a default implementation, the word simply is used to
   to convey that the description is a complete description of the
   implementation. This should be unnecessary given the context.

As such nearly all usages of the world simply can be removed without a loss of
clarity.

For more context and a longer argument I found the arguments made Jim Fisher in 
his talk "Don't Say Simply" at Write the Docs Prague 2018[1] to be quite
compelling.

 1. https://www.youtube.com/watch?v=gsT2BBWBVmM
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
