### PR TITLE
Introduce SHORT_DISPLAY_NAME and LONG_DISPLAY_NAME in @ParameterizedTest

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1010,6 +1010,15 @@ palindromes(String) ✔
 └─ [3] candidate=able was I ere I saw elba ✔
 ....
 
+If you want ot make the display name of the @ParameterizedTest include the method name, you can define your own custom
+pattern or use the predefined ParameterizedTest.LONG_DISPLAY_NAME pattern. The following example demonstrates a
+parameterized test with ParameterizedTest.LONG_DISPLAY_NAME.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=long_display_name_example]
+----
+
 [[writing-tests-parameterized-tests-setup]]
 ==== Required Setup
 

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -74,6 +74,14 @@ class ParameterizedTestDemo {
 	}
 	// end::first_example[]
 
+	// tag::long_display_name_example[]
+	@ParameterizedTest(name = ParameterizedTest.LONG_DISPLAY_NAME)
+	@ValueSource(strings = { "racecar", "radar", "able was I ere I saw elba" })
+	void palindromesWithLongPattern(String candidate) {
+		assertTrue(StringUtils.isPalindrome(candidate));
+	}
+	// end::long_display_name_example[]
+
 	// tag::ValueSource_example[]
 	@ParameterizedTest
 	@ValueSource(ints = { 1, 2, 3 })

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -163,6 +163,22 @@ public @interface ParameterizedTest {
 	String ARGUMENTS_WITH_NAMES_PLACEHOLDER = "{argumentsWithNames}";
 
 	/**
+	 * <em>Short</em> display name pattern for a parameterized test: {@value}
+	 *
+	 * @see #INDEX_PLACEHOLDER
+	 * @see #ARGUMENTS_WITH_NAMES_PLACEHOLDER
+	 */
+	String SHORT_DISPLAY_NAME = "[" + INDEX_PLACEHOLDER + "] " + ARGUMENTS_WITH_NAMES_PLACEHOLDER;
+
+	/**
+	 * <em>Long</em> display name pattern for a parameterized test: {@value}
+	 *
+	 * @see #DISPLAY_NAME_PLACEHOLDER
+	 * @see #SHORT_DISPLAY_NAME
+	 */
+	String LONG_DISPLAY_NAME = DISPLAY_NAME_PLACEHOLDER + " :: " + SHORT_DISPLAY_NAME;
+
+	/**
 	 * Default display name pattern for the current invocation of a
 	 * {@code @ParameterizedTest} method: {@value}
 	 *
@@ -176,7 +192,7 @@ public @interface ParameterizedTest {
 	 * @see #INDEX_PLACEHOLDER
 	 * @see #ARGUMENTS_WITH_NAMES_PLACEHOLDER
 	 */
-	String DEFAULT_DISPLAY_NAME = "[" + INDEX_PLACEHOLDER + "] " + ARGUMENTS_WITH_NAMES_PLACEHOLDER;
+	String DEFAULT_DISPLAY_NAME = SHORT_DISPLAY_NAME;
 
 	/**
 	 * The display name to be used for individual invocations of the


### PR DESCRIPTION
…rizedTest

## Overview

By default, the display name of ```ParameterizedTest``` is similar to ```RepeatedTest#SHORT_DISPLAY_NAME```. If we want to make display name include "method name", we have to write string formate like ``` "{displayName} - {arguments}"``` for all test cases. It seems to me ```RepeatedTest#LONG_DISPLAY_NAME``` is a good example and it would be better to introduce ```LONG_DISPLAY_NAME``` to ```ParameterizedTest```. The benefit is that junit 5 users can replace aforementioned string format by "standard" long display name.

Resolved #2525

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
