### PR TITLE
Allow rows in @CsvSource to start with a number sign (#)

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -66,6 +66,7 @@ on GitHub.
   provide better error messages comparable to those of `assertThrows`.
 * Dynamic tests now require less memory thanks to a number of improvements to internal
   data structures.
+* Allow rows in `@CsvSource` to start with a number sign (#)
 
 [[release-notes-5.8.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvParserFactory.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvParserFactory.java
@@ -27,17 +27,19 @@ class CsvParserFactory {
 	private static final char SINGLE_QUOTE = '\'';
 	private static final char DOUBLE_QUOTE = '"';
 	private static final char EMPTY_CHAR = '\0';
+	private static final boolean COMMENT_PROCESSING_FOR_CSV_SOURCE = false;
+	private static final boolean COMMENT_PROCESSING_FOR_CSV_FILE_SOURCE = true;
 
 	static CsvParser createParserFor(CsvSource annotation) {
 		String delimiter = selectDelimiter(annotation, annotation.delimiter(), annotation.delimiterString());
 		return createParser(delimiter, LINE_SEPARATOR, SINGLE_QUOTE, annotation.emptyValue(),
-			annotation.maxCharsPerColumn());
+			annotation.maxCharsPerColumn(), COMMENT_PROCESSING_FOR_CSV_SOURCE);
 	}
 
 	static CsvParser createParserFor(CsvFileSource annotation) {
 		String delimiter = selectDelimiter(annotation, annotation.delimiter(), annotation.delimiterString());
 		return createParser(delimiter, annotation.lineSeparator(), DOUBLE_QUOTE, annotation.emptyValue(),
-			annotation.maxCharsPerColumn());
+			annotation.maxCharsPerColumn(), COMMENT_PROCESSING_FOR_CSV_FILE_SOURCE);
 	}
 
 	private static String selectDelimiter(Annotation annotation, char delimiter, String delimiterString) {
@@ -54,12 +56,13 @@ class CsvParserFactory {
 	}
 
 	private static CsvParser createParser(String delimiter, String lineSeparator, char quote, String emptyValue,
-			int maxCharsPerColumn) {
-		return new CsvParser(createParserSettings(delimiter, lineSeparator, quote, emptyValue, maxCharsPerColumn));
+			int maxCharsPerColumn, boolean commentProcessingEnabled) {
+		return new CsvParser(createParserSettings(delimiter, lineSeparator, quote, emptyValue, maxCharsPerColumn,
+			commentProcessingEnabled));
 	}
 
 	private static CsvParserSettings createParserSettings(String delimiter, String lineSeparator, char quote,
-			String emptyValue, int maxCharsPerColumn) {
+			String emptyValue, int maxCharsPerColumn, boolean commentProcessingEnabled) {
 
 		CsvParserSettings settings = new CsvParserSettings();
 		settings.getFormat().setDelimiter(delimiter);
@@ -67,6 +70,7 @@ class CsvParserFactory {
 		settings.getFormat().setQuote(quote);
 		settings.getFormat().setQuoteEscape(quote);
 		settings.setEmptyValue(emptyValue);
+		settings.setCommentProcessingEnabled(commentProcessingEnabled);
 		settings.setAutoConfigurationEnabled(false);
 		Preconditions.condition(maxCharsPerColumn > 0,
 			() -> "maxCharsPerColumn must be a positive number: " + maxCharsPerColumn);

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -221,6 +221,15 @@ class CsvArgumentsProviderTests {
 				.withMessageStartingWith("maxCharsPerColumn must be a positive number: -1");
 	}
 
+	@Test
+	void doesNotMindSoCalledCommentCharacters() {
+		var annotation = csvSource("#foo", "#bar,baz", "baz,#quux");
+
+		var arguments = provideArguments(annotation);
+
+		assertThat(arguments).containsExactly(array("#foo"), array("#bar", "baz"), array("baz", "#quux"));
+	}
+
 	private Stream<Object[]> provideArguments(CsvSource annotation) {
 		var provider = new CsvArgumentsProvider();
 		provider.accept(annotation);


### PR DESCRIPTION
Issue: #2527

## Overview

This change relates to the `@CsvSource` annotation and how its rows are parsed. The underlying library supports comments, by default with the number sign (#), and the support for them was left enabled for the `@CsvSource`. This does not make sense in that the tests just throw a `PreconditionViolationException` in case the number sign is used at the start of a row. So, this pull request disables comment processing for  `@CsvSource` but leaves it enabled for  `@CsvFileSource`, as not to disturb existing, documented functionality.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- ✓ There are no TODOs left in the code
- (N/A) Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- ✓ [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- ✓ Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- (N/A) Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- (Release notes: ✓) Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- (✓) All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
