### PR TITLE
Block parallel tests longer on CI

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
@@ -766,7 +766,7 @@ class ParallelExecutionIntegrationTests {
 			throws InterruptedException {
 		var value = sharedResource.incrementAndGet();
 		countDownLatch.countDown();
-		countDownLatch.await(100, MILLISECONDS);
+		countDownLatch.await(estimateSimulatedTestDurationInMiliseconds(), MILLISECONDS);
 		return value;
 	}
 
@@ -774,8 +774,23 @@ class ParallelExecutionIntegrationTests {
 			throws InterruptedException {
 		var value = sharedResource.get();
 		countDownLatch.countDown();
-		countDownLatch.await(100, MILLISECONDS);
+		countDownLatch.await(estimateSimulatedTestDurationInMiliseconds(), MILLISECONDS);
 		assertEquals(value, sharedResource.get());
+	}
+
+	/**
+	 * To simulate tests running in parallel tests will modify a shared
+	 * resource, simulate work by waiting, then check if the shared resource was
+	 * not modified by any other thread.
+	 *
+	 * Depending on system performance the simulation of work needs to be longer
+	 * on slower systems to ensure tests can run in parallel.
+	 *
+	 * Currently CI is known to be slow.
+	 */
+	private static long estimateSimulatedTestDurationInMiliseconds() {
+		var runningInCi = Boolean.valueOf(System.getenv("CI"));
+		return runningInCi ? 1000 : 100;
 	}
 
 	static class ThreadReporter implements AfterTestExecutionCallback {


### PR DESCRIPTION
## Overview

Various tests in `ParallelExecutionIntegrationTests` verify that different
tests were indeed executed by different threads. To ensure that an incorrect
implementation does not block the test suite indefinitely these tests contain
an intentional race condition.

This race condition assumes awaiting at most 100ms will be sufficient to schedule
another thread. This assumption is hardware dependent and does not hold on
Github CI[1]. Increasing the maximum time spend waiting by a factor 10 while in CI
is hopefully sufficient.

1. https://github.com/junit-team/junit5/pull/2416/checks?check_run_id=1712237454
```
2021-01-16T02:00:44.8166959Z > Task :platform-tests:test
2021-01-16T02:00:44.8167430Z
2021-01-16T02:00:44.8168932Z ParallelExecutionIntegrationTests > customContextClassLoader() FAILED
2021-01-16T02:00:44.8177847Z     java.lang.AssertionError:
2021-01-16T02:00:44.8178812Z     Expected size:<3> but was:<2> in:
2021-01-16T02:00:44.8179762Z     <["ForkJoinPool-19-worker-3", "ForkJoinPool-19-worker-5"]>
2021-01-16T02:00:44.8183737Z         at org.junit.platform.engine.support.hierarchical.ParallelExecutionIntegrationTests.customContextClassLoader(ParallelExecutionIntegrationTests.java:135)
2021-01-16T02:01:05.6171111Z
2021-01-16T02:01:05.6173697Z ParallelExecutionIntegrationTests > customContextClassLoader() FAILED
2021-01-16T02:01:05.6175991Z     java.lang.AssertionError:
2021-01-16T02:01:05.6177743Z     Expected size:<3> but was:<2> in:
2021-01-16T02:01:05.6178859Z     <["ForkJoinPool-1-worker-3", "ForkJoinPool-1-worker-5"]>
2021-01-16T02:01:05.6183298Z         at org.junit.platform.engine.support.hierarchical.ParallelExecutionIntegrationTests.customContextClassLoader(ParallelExecutionIntegrationTests.java:135)
2021-01-16T02:01:09.0267715Z
2021-01-16T02:01:09.0280937Z
2021-01-16T02:01:09.0282574Z ParallelExecutionIntegrationTests > customContextClassLoader() FAILED
2021-01-16T02:01:09.0283978Z 1534 tests completed, 3 failed, 7 skipped
2021-01-16T02:01:09.0284818Z     java.lang.AssertionError:
2021-01-16T02:01:09.0290826Z     Expected size:<3> but was:<2> in:
2021-01-16T02:01:09.0291728Z     <["ForkJoinPool-1-worker-3", "ForkJoinPool-1-worker-5"]>
2021-01-16T02:01:09.0295567Z         at org.junit.platform.engine.support.hierarchical.ParallelExecutionIntegrationTests.customContextClassLoader(ParallelExecutionIntegrationTests.java:135)
```
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [X] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [X] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
