### PR TITLE
additional arguments source example

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1349,7 +1349,7 @@ the parameters in the method, in this example `testWithArgumentsSource2` above.
 
 [source,java,indent=0]
 ----
-include::{testDir}/example/ParameterizedTestDemo.java[tags=My2ndArgumentsProvider_example]
+include::{testDir}/example/ParameterizedTestDemo.java[tags=LambdaArgumentsProvider_example]
 ----
 
 Note that the example shows the Lambda expressions to be assigned to values of the appropriate type, like `IntBinaryOperation plus`. This 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1334,6 +1334,26 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsSource_examp
 include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsProvider_example]
 ----
 
+[[writing-tests-parameterized-tests-sources-multi-valued-arguments-source]]
+A bit more interesting example shows ArgumentsSource can do a similar parameter interpretation as
+CsvSource. As such it is even more powerful than CsvSource, because it can pass values that are not easily
+converted from String into the Java code domain, such as  *Lambda expressions*.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsSource2_example]
+----
+
+NOTE: You have to pay attention to the fact that the order of the values in the arrays below matches the order of
+the parameters in the method, in this example `testWithArgumentsSource2` above.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=My2ndArgumentsProvider_example]
+----
+
+Note that the example shows the Lambda expressions to be assigned to values of the appropriate type, like `IntBinaryOperation plus`. This 
+avoids to have to do an ugly cast before each of the expressions in the Object arrays.
 
 [[writing-tests-parameterized-tests-argument-conversion]]
 ==== Argument Conversion

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -258,7 +258,7 @@ class ParameterizedTestDemo {
 
 	// tag::ArgumentsSource2_example[]
 	@ParameterizedTest
-	@ArgumentsSource(My2ndArgumentsProvider.class)
+	@ArgumentsSource(LambdaArgumentsProvider.class)
 	void testWithArgumentsSource2( String opName, IntBinaryOperator op, 
 					int a, int b, int expected) {
 		assertEquals( expected, op.applyAsInt(a,b), "with opname " + opName );
@@ -266,8 +266,8 @@ class ParameterizedTestDemo {
 	// end::ArgumentsSource2_example[]
 
 	
-	// tag::My2ndArgumentsProvider_example[]
-	public static class My2ndArgumentsProvider implements ArgumentsProvider {
+	// tag::LambdaArgumentsProvider_example[]
+	public static class LambdaArgumentsProvider implements ArgumentsProvider {
 
 		@Override
 		public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
@@ -283,7 +283,7 @@ class ParameterizedTestDemo {
 				).map(Arguments::of);
 		}
 	}
-	// end::My2ndArgumentsProvider_example[]
+	// end::LambdaArgumentsProvider_example[]
 	
 
 	// tag::ParameterResolver_example[]

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -31,6 +31,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.function.IntBinaryOperator;
 
 import example.domain.Person;
 import example.domain.Person.Gender;
@@ -254,6 +255,36 @@ class ParameterizedTestDemo {
 		}
 	}
 	// end::ArgumentsProvider_example[]
+
+	// tag::ArgumentsSource2_example[]
+	@ParameterizedTest
+	@ArgumentsSource(My2ndArgumentsProvider.class)
+	void testWithArgumentsSource2( String opName, IntBinaryOperator op, 
+					int a, int b, int expected) {
+		assertEquals( expected, op.applyAsInt(a,b), "with opname " + opName );
+	}
+	// end::ArgumentsSource2_example[]
+
+	
+	// tag::My2ndArgumentsProvider_example[]
+	public static class My2ndArgumentsProvider implements ArgumentsProvider {
+
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+			IntBinaryOperator plus = ( a, b ) -> a + b;
+			IntBinaryOperator times = ( a,b ) -> a + b;
+			IntBinaryOperator minus = ( a, b ) -> a + b;
+			IntBinaryOperator divideBy = ( a, b ) -> a + b;
+			return Stream.of(
+				new Object[]{ "plus",   plus, 2, 3, 5 } ,
+				new Object[]{ "times",  times, 2, 3, 6 },
+				new Object[]{ "minus",  minus, 3, 6, -3 },
+				new Object[]{ "divideBy", divideBy, 12, 4, 3}
+				).map(Arguments::of);
+		}
+	}
+	// end::My2ndArgumentsProvider_example[]
+	
 
 	// tag::ParameterResolver_example[]
 	@BeforeEach


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

The example provided with ArgumentsSources uses only **one** parameter, which is a pity because that does not show the full potential of ArgumentsSources. This additional example shows that ArgumentsSources can be used as CsvSource on steroids, because it stays inside the domain of Java code, so that conversions that are impossible from text to java code is easy.
The example shows that for instance lambda expressions can be used as parameters in parameterized test without much extra coding.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
