### PR TITLE
Add Provide-Capability OSGi header to engine bundles

### DIFF
--- a/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
+++ b/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
@@ -1,3 +1,5 @@
+import aQute.bnd.gradle.BundleTaskConvention;
+
 plugins {
 	`kotlin-library-conventions`
 	`testing-conventions`
@@ -21,4 +23,17 @@ dependencies {
 	testImplementation("org.jetbrains.kotlin:kotlin-stdlib")
 	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 	testImplementation("org.codehaus.groovy:groovy")
+}
+
+tasks {
+	jar {
+		withConvention(BundleTaskConvention::class) {
+			bnd("""
+				Provide-Capability:\
+					org.junit.platform.engine;\
+						org.junit.platform.engine='junit-jupiter';\
+						version:Version="${'$'}{version_cleanup;${project.version}}"
+			""")
+		}
+	}
 }

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -56,6 +56,11 @@ tasks {
 					org.junit.runner.*;version="[${versions.junit4Min},5)",\
 					org.junit.runners.model;version="[${versions.junit4Min},5)",\
 					*
+
+				Provide-Capability:\
+					org.junit.platform.engine;\
+						org.junit.platform.engine='junit-vintage';\
+						version:Version="${'$'}{version_cleanup;${project.version}}"
 			""")
 		}
 	}


### PR DESCRIPTION
Adds
* `Provide-Capability: org.junit.platform.engine;org.junit.platform.engine=junit-vintage;version:Version="${project.version}"` to `junit-vintage-engine`
* `Provide-Capability: org.junit.platform.engine;org.junit.platform.engine=junit-jupiter;version:Version="${project.version}"` to `junit-jupiter-engine`

Fixes #2100.

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).
