### PR TITLE
Make SummaryGeneratingListener thread-safe

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -15,7 +15,8 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* `SummaryGeneratingListener` is now thread-safe and can handle concurrently failing
+  tests.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
+++ b/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 	testImplementation(project(":junit-platform-launcher"))
 	testImplementation(project(":junit-platform-runner"))
 	testImplementation(project(":junit-platform-testkit"))
+	testImplementation(testFixtures(project(":junit-platform-commons")))
 	testImplementation("org.jetbrains.kotlin:kotlin-stdlib")
 	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 	testImplementation("org.codehaus.groovy:groovy")

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionValuesStoreTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/execution/ExtensionValuesStoreTests.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContextException;
-import org.junit.platform.commons.test.ConcurrencyTestingUtils;
 
 /**
  * Unit tests for {@link ExtensionValuesStore}.

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	`java-library-conventions`
 	`java-multi-release-sources`
 	`java-repackage-jars`
+	`java-test-fixtures`
 }
 
 description = "JUnit Platform Commons"

--- a/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java
+++ b/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ConcurrencyTestingUtils {
+
+	public static void executeConcurrently(int threads, Runnable action) throws Exception {
+		executeConcurrently(threads, () -> {
+			action.run();
+			return null;
+		});
+	}
+
+	public static <T> List<T> executeConcurrently(int threads, Callable<T> action) throws Exception {
+		ExecutorService executorService = Executors.newFixedThreadPool(threads);
+		try {
+			CountDownLatch latch = new CountDownLatch(threads);
+			List<CompletableFuture<T>> futures = new ArrayList<>();
+			for (int i = 0; i < threads; i++) {
+				futures.add(CompletableFuture.supplyAsync(() -> {
+					try {
+						latch.countDown();
+						latch.await();
+						return action.call();
+					}
+					catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new CompletionException(e);
+					}
+					catch (Exception e) {
+						throw new CompletionException("Action failed", e);
+					}
+				}, executorService));
+			}
+			List<T> list = new ArrayList<>();
+			for (CompletableFuture<T> future : futures) {
+				list.add(future.get(5, SECONDS));
+			}
+			return list;
+		}
+		finally {
+			executorService.shutdownNow();
+			var terminated = executorService.awaitTermination(5, SECONDS);
+			if (!terminated) {
+				//noinspection ThrowFromFinallyBlock
+				throw new AssertionError("ExecutorService did not cleanly shut down");
+			}
+		}
+	}
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
@@ -11,6 +11,7 @@
 package org.junit.platform.launcher.listeners;
 
 import static java.lang.String.join;
+import static java.util.Collections.synchronizedList;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -54,7 +55,7 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 	final AtomicLong testsFailed = new AtomicLong();
 
 	private final TestPlan testPlan;
-	private final List<Failure> failures = new ArrayList<>();
+	private final List<Failure> failures = synchronizedList(new ArrayList<>());
 	private final long timeStarted;
 	long timeFinished;
 

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 	// --- Things we are testing with ---------------------------------------------
 	testImplementation(project(":junit-platform-runner"))
 	testImplementation(project(":junit-platform-testkit"))
+	testImplementation(testFixtures(project(":junit-platform-commons")))
 	testImplementation(testFixtures(project(":junit-platform-engine")))
 	testImplementation(testFixtures(project(":junit-platform-launcher")))
 	testImplementation(project(":junit-jupiter-engine"))

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.launcher.listeners;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,15 +21,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.test.ConcurrencyTestingUtils;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
@@ -10,18 +10,27 @@
 
 package org.junit.platform.launcher.listeners;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.commons.test.ConcurrencyTestingUtils.executeConcurrently;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.test.ConcurrencyTestingUtils;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
@@ -218,6 +227,27 @@ class SummaryGenerationTests {
 			() -> assertFalse(failuresString.contains("Caused by: "),
 				"'Caused by: ' omitted because of Circular reference") //
 		);
+	}
+
+	@RepeatedTest(10)
+	void reportingConcurrentlyFinishedTests() throws Exception {
+		var numThreads = 250;
+		var testIdentifier = TestIdentifier.from(new TestDescriptorStub(UniqueId.root("root", "2"), "failingTest") {
+			@Override
+			public Optional<TestSource> getSource() {
+				return Optional.of(ClassSource.from(Object.class));
+			}
+		});
+		var result = TestExecutionResult.failed(new RuntimeException());
+
+		listener.testPlanExecutionStarted(testPlan);
+		executeConcurrently(numThreads, () -> {
+			listener.executionStarted(testIdentifier);
+			listener.executionFinished(testIdentifier, result);
+		});
+		listener.testPlanExecutionFinished(testPlan);
+
+		assertThat(listener.getSummary().getFailures()).hasSize(numThreads);
 	}
 
 	@SuppressWarnings("deprecation")


### PR DESCRIPTION
Prior to this commit, concurrently reported failures were stored in an
unguarded `ArrayList` which caused a race condition that sometimes
caused failures to get lost and hence not reported. Now the list of
failures is wrapped in `synchronizedList` to make it thread-safe.

Fixes #2546.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
