### PR TITLE
Improve Javadoc for Assumptions.assumingThat

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -212,11 +212,12 @@ public class Assumptions {
 	 * Execute the supplied {@link Executable}, but only if the supplied
 	 * assumption is valid.
 	 *
-	 * <p>If the assumption is invalid, this method does nothing.
-	 *
-	 * <p>If the {@code executable} throws an exception, it will be rethrown
-	 * <em>as is</em> but  {@link ExceptionUtils#throwAsUncheckedException masked}
-	 * as an unchecked exception.
+	 * <p>Unlike the other assumption methods, this method will not abort the test.
+	 * If the assumption is invalid, this method does nothing. If the assumption is
+	 * valid and the {@code executable} throws an exception, it will be treated like
+	 * a regular test <em>error</em>. That exception will be rethrown <em>as is</em>
+	 * but {@link ExceptionUtils#throwAsUncheckedException masked} as an unchecked
+	 * exception.
 	 *
 	 * @param assumptionSupplier the supplier of the assumption to validate
 	 * @param executable the block of code to execute if the assumption is valid
@@ -230,11 +231,12 @@ public class Assumptions {
 	 * Execute the supplied {@link Executable}, but only if the supplied
 	 * assumption is valid.
 	 *
-	 * <p>If the assumption is invalid, this method does nothing.
-	 *
-	 * <p>If the {@code executable} throws an exception, it will be rethrown
-	 * <em>as is</em> but  {@link ExceptionUtils#throwAsUncheckedException masked}
-	 * as an unchecked exception.
+	 * <p>Unlike the other assumption methods, this method will not abort the test.
+	 * If the assumption is invalid, this method does nothing. If the assumption is
+	 * valid and the {@code executable} throws an exception, it will be treated like
+	 * a regular test <em>error</em>. That exception will be rethrown <em>as is</em>
+	 * but {@link ExceptionUtils#throwAsUncheckedException masked} as an unchecked
+	 * exception.
 	 *
 	 * @param assumption the assumption to validate
 	 * @param executable the block of code to execute if the assumption is valid


### PR DESCRIPTION
## Overview

As discussed in https://github.com/junit-team/junit5/discussions/2553, improves the documentation of the `Assumptions.assumingThat(...)` methods by clarifying that, unlike the other assumptions methods, they do not cause a test to be aborted.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).