### PR TITLE
Use JDK 11 to run Gradle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,11 +82,18 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 15
+    - name: Prepare JDK15 env var
+      shell: bash
+      run: echo "JDK15=$JAVA_HOME" >> $GITHUB_ENV
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - name: Test
       shell: bash
       run: |
         ./gradlew --version
-        ./gradlew --no-parallel --stacktrace -Dplatform.tooling.support.tests.enabled=true -Porg.gradle.java.installations.fromEnv=JDK8 build
+        ./gradlew --no-parallel --stacktrace -Dplatform.tooling.support.tests.enabled=true -Porg.gradle.java.installations.fromEnv=JDK8,JDK15 build
         ./gradlew --stop
 
   mac:
@@ -112,19 +119,34 @@ jobs:
         key: test-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           test-${{ runner.os }}-maven-
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Prepare JDK8 env var
+      shell: bash
+      run: echo "JDK8=$JAVA_HOME" >> $GITHUB_ENV
     - name: Set up JDK 15
       uses: actions/setup-java@v1
       with:
         java-version: 15
+    - name: Prepare JDK15 env var
+      shell: bash
+      run: echo "JDK15=$JAVA_HOME" >> $GITHUB_ENV
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - name: 'Test'
       run: |
         ./gradlew --version
-        ./gradlew --no-parallel --stacktrace -Dplatform.tooling.support.tests.enabled=true build
+        ./gradlew --no-parallel --stacktrace -Dplatform.tooling.support.tests.enabled=true -Porg.gradle.java.installations.fromEnv=JDK8,JDK15 build
 
   publish_artifacts:
     name: Publish Snapshot Artifacts
     needs: linux
     runs-on: ubuntu-latest
+    container: ghcr.io/junit-team/build
     if: github.event_name == 'push' && github.repository == 'junit-team/junit5' && (startsWith(github.ref, 'refs/heads/releases/') || github.ref == 'refs/heads/main')
     steps:
     - uses: actions/checkout@v2
@@ -139,10 +161,6 @@ jobs:
         key: assemble-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
         restore-keys: |
           assemble-${{ runner.os }}-gradle-
-    - name: Set up JDK 15
-      uses: actions/setup-java@v1
-      with:
-        java-version: 15
     - name: Publish
       env:
         ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -153,6 +171,7 @@ jobs:
     name: Update Snapshot Documentation
     needs: linux
     runs-on: ubuntu-latest
+    container: ghcr.io/junit-team/build
     if: github.event_name == 'push' && github.repository == 'junit-team/junit5' && github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v2
@@ -167,10 +186,6 @@ jobs:
         key: assemble-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
         restore-keys: |
           assemble-${{ runner.os }}-gradle-
-    - name: Set up JDK 15
-      uses: actions/setup-java@v1
-      with:
-        java-version: 15
     - name: Upload Documentation
       env:
         GRGIT_USER: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -11,13 +11,13 @@ on:
 
 env:
   ORG_GRADLE_PROJECT_org.gradle.java.installations.auto-download: 'false'
+  ORG_GRADLE_PROJECT_org.gradle.java.installations.fromEnv: 'JDK15'
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 jobs:
   check_build_reproducibility:
     name: 'Check build reproducibility'
     runs-on: ubuntu-latest
-    container: ghcr.io/junit-team/build
     steps:
     - uses: actions/checkout@v2
       with:
@@ -31,6 +31,17 @@ jobs:
         key: assemble-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
         restore-keys: |
           assemble-${{ runner.os }}-gradle-
+    - name: Set up JDK 15
+      uses: actions/setup-java@v1
+      with:
+        java-version: 15
+    - name: Prepare JDK15 env var
+      shell: bash
+      run: echo "JDK15=$JAVA_HOME" >> $GITHUB_ENV
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - name: Build and compare checksums
       shell: bash
       run: |

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -17,6 +17,7 @@ jobs:
   check_build_reproducibility:
     name: 'Check build reproducibility'
     runs-on: ubuntu-latest
+    container: ghcr.io/junit-team/build
     steps:
     - uses: actions/checkout@v2
       with:
@@ -30,10 +31,6 @@ jobs:
         key: assemble-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', '**/gradle.properties', 'gradle/**', 'buildSrc/src/main/**') }}
         restore-keys: |
           assemble-${{ runner.os }}-gradle-
-    - name: 'Set up JDK 15'
-      uses: actions/setup-java@v1
-      with:
-        java-version: 15
     - name: Build and compare checksums
       shell: bash
       run: |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ so that local builds can reuse task outputs from previous CI builds.
 
 ## Building from Source
 
-You need [JDK 15] to build JUnit 5.
+You need [JDK 11] to build JUnit 5. [Gradle toolchains] are used to detect and
+potentially download additional JDKs for compilation and test execution.
 
 All modules can be _built_ with the [Gradle Wrapper] using the following command.
 
@@ -91,10 +92,11 @@ See also <https://repo1.maven.org/maven2/org/junit/> for releases and
 [CONTRIBUTING.md]: https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md
 [Dependency Metadata]: https://junit.org/junit5/docs/current/user-guide/#dependency-metadata
 [Gitter]: https://gitter.im/junit-team/junit5
+[Gradle toolchains]: https://docs.gradle.org/current/userguide/toolchains.html
 [Gradle Wrapper]: https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:using_wrapper
 [JaCoCo]: https://www.eclemma.org/jacoco/
 [Javadoc]: https://junit.org/junit5/docs/current/api/
-[JDK 15]: https://jdk.java.net/15/
+[JDK 11]: https://adoptopenjdk.net/archive.html?variant=openjdk11&jvmVariant=hotspot
 [Release Notes]: https://junit.org/junit5/docs/current/release-notes/
 [Samples]: https://github.com/junit-team/junit5-samples
 [StackOverflow]: https://stackoverflow.com/questions/tagged/junit5

--- a/buildSrc/src/main/kotlin/java-toolchain-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-toolchain-conventions.gradle.kts
@@ -9,7 +9,6 @@ project.pluginManager.withPlugin("java") {
 	val javaToolchainService = the<JavaToolchainService>()
 	extension.toolchain.languageVersion.set(javaLanguageVersion)
 	val compiler = javaToolchainService.compilerFor(extension.toolchain)
-	val launcher = javaToolchainService.launcherFor(extension.toolchain)
 	tasks.withType<KotlinJvmCompile>().configureEach {
 		doFirst {
 			kotlinOptions.jdkHome = compiler.get().metadata.installationPath.asFile.absolutePath
@@ -21,9 +20,12 @@ project.pluginManager.withPlugin("java") {
 		options.forkOptions.jvmArgs!!.addAll(listOf("--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"))
 	}
 	tasks.withType<GroovyCompile>().configureEach {
-		javaLauncher.set(launcher)
+		javaLauncher.set(javaToolchainService.launcherFor {
+			// Groovy does not yet support JDK 17, see https://issues.apache.org/jira/browse/GROOVY-9943
+			languageVersion.set(minOf(javaLanguageVersion, defaultLanguageVersion))
+		})
 	}
 	tasks.withType<JavaExec>().configureEach {
-		javaLauncher.set(launcher)
+		javaLauncher.set(javaToolchainService.launcherFor(extension.toolchain))
 	}
 }

--- a/buildSrc/src/main/kotlin/java-toolchain-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-toolchain-conventions.gradle.kts
@@ -9,6 +9,7 @@ project.pluginManager.withPlugin("java") {
 	val javaToolchainService = the<JavaToolchainService>()
 	extension.toolchain.languageVersion.set(javaLanguageVersion)
 	val compiler = javaToolchainService.compilerFor(extension.toolchain)
+	val launcher = javaToolchainService.launcherFor(extension.toolchain)
 	tasks.withType<KotlinJvmCompile>().configureEach {
 		doFirst {
 			kotlinOptions.jdkHome = compiler.get().metadata.installationPath.asFile.absolutePath
@@ -20,12 +21,9 @@ project.pluginManager.withPlugin("java") {
 		options.forkOptions.jvmArgs!!.addAll(listOf("--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"))
 	}
 	tasks.withType<GroovyCompile>().configureEach {
-		javaLauncher.set(javaToolchainService.launcherFor {
-			// Groovy does not yet support JDK 16, see https://issues.apache.org/jira/browse/GROOVY-9752
-			languageVersion.set(minOf(javaLanguageVersion, defaultLanguageVersion))
-		})
+		javaLauncher.set(launcher)
 	}
 	tasks.withType<JavaExec>().configureEach {
-		javaLauncher.set(javaToolchainService.launcherFor(extension.toolchain))
+		javaLauncher.set(launcher)
 	}
 }

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -20,7 +20,7 @@ tasks.jar {
 	inputs.dir(release9ClassesDir).withPathSensitivity(PathSensitivity.RELATIVE)
 	doLast {
 		exec {
-			executable = project.the<JavaToolchainService>().launcherFor(project.the<JavaPluginExtension>().toolchain).get()
+			executable = project.the<JavaToolchainService>().launcherFor(java.toolchain).get()
 				.metadata.installationPath.file("bin/jar").asFile.absolutePath
 			args(
 				"--update",

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -19,10 +19,16 @@ tasks.jar {
 	val release9ClassesDir = sourceSets.mainRelease9.get().output.classesDirs.singleFile
 	inputs.dir(release9ClassesDir).withPathSensitivity(PathSensitivity.RELATIVE)
 	doLast {
-		ToolProvider.findFirst("jar").get().run(System.out, System.err, "--update",
+		exec {
+			executable = project.the<JavaToolchainService>().launcherFor(project.the<JavaPluginExtension>().toolchain).get()
+				.metadata.installationPath.file("bin/jar").asFile.absolutePath
+			args(
+				"--update",
 				"--file", archiveFile.get().asFile.absolutePath,
 				"--release", "9",
-				"-C", release9ClassesDir.absolutePath, ".")
+				"-C", release9ClassesDir.absolutePath, "."
+			)
+		}
 	}
 }
 

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -31,7 +31,7 @@ tasks {
 		from(sourceSets.mainRelease9.get().output.classesDirs)
 		doLast {
 			exec {
-				executable = project.the<JavaToolchainService>().launcherFor(project.the<JavaPluginExtension>().toolchain).get()
+				executable = project.the<JavaToolchainService>().launcherFor(java.toolchain).get()
 					.metadata.installationPath.file("bin/jar").asFile.absolutePath
 				args(
 					"--update",

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -30,9 +30,15 @@ tasks {
 		}
 		from(sourceSets.mainRelease9.get().output.classesDirs)
 		doLast {
-			ToolProvider.findFirst("jar").get().run(System.out, System.err, "--update",
+			exec {
+				executable = project.the<JavaToolchainService>().launcherFor(project.the<JavaPluginExtension>().toolchain).get()
+					.metadata.installationPath.file("bin/jar").asFile.absolutePath
+				args(
+					"--update",
 					"--file", archiveFile.get().asFile.absolutePath,
-					"--main-class", "org.junit.platform.console.ConsoleLauncher")
+					"--main-class", "org.junit.platform.console.ConsoleLauncher"
+				)
+			}
 		}
 	}
 	jar {

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -37,6 +37,12 @@ configurations.all {
 }
 
 tasks {
+	compileTestFixturesGroovy {
+		javaLauncher.set(project.the<JavaToolchainService>().launcherFor {
+			// Groovy 2.x (used for Spock tests) does not support JDK 16
+			languageVersion.set(JavaLanguageVersion.of(11))
+		})
+	}
 	jar {
 		withConvention(BundleTaskConvention::class) {
 			bnd("""


### PR DESCRIPTION
In preparation for the toolchain upgrade to JDK 16, we now run the build with the JDK 11 LTS version again.