### PR TITLE
Document array of dynamic tests in the User Guide

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1766,8 +1766,8 @@ and dynamic tests.
 The first method returns an invalid return type. Since an invalid return type cannot be
 detected at compile time, a `JUnitException` is thrown when it is detected at runtime.
 
-The next five methods are very simple examples that demonstrate the generation of a
-`Collection`, `Iterable`, `Iterator`, or `Stream` of `DynamicTest` instances. Most of
+The next six methods are very simple examples that demonstrate the generation of a
+`Collection`, `Iterable`, `Iterator`, array, or `Stream` of `DynamicTest` instances. Most of
 these examples do not really exhibit dynamic behavior but merely demonstrate the
 supported return types in principle. However, `dynamicTestsFromStream()` and
 `dynamicTestsFromIntStream()` demonstrate how easy it is to generate dynamic tests for a


### PR DESCRIPTION
## Overview

Currently the [JUnit 5 User Guide - 2.17.1. Dynamic Test Examples](https://junit.org/junit5/docs/current/user-guide/#writing-tests-dynamic-tests) includes several examples, but the documentation forgets to mention one of those:

```java
DynamicTest[] dynamicTestsFromArray() { ... }
```

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

