### PR TITLE
Introduce Named.named() as an alias for Named.of()

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -1,0 +1,61 @@
+// TODO: replace all occurrences of ⚠️ with appropriate values, delete this comment, and
+// 'include:' this new file in index.adoc.
+[[release-notes-⚠️]]
+== ⚠️
+
+*Date of Release:* ❓
+
+*Scope:* ❓
+
+For a complete list of all _closed_ issues and pull requests for this release, consult the
+link:{junit5-repo}+/milestone/⚠️?closed=1+[⚠️] milestone page in the JUnit repository on
+GitHub.
+
+
+[[release-notes-⚠️-junit-platform]]
+=== JUnit Platform
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓
+
+
+[[release-notes-⚠️-junit-jupiter]]
+=== JUnit Jupiter
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* New `named()` static factory method in the `Named` interface that serves as an
+  _alias_ for `Named.of()`. `named()` is intended to be used via `import static`.
+
+
+[[release-notes-⚠️-junit-vintage]]
+=== JUnit Vintage
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
@@ -18,6 +18,8 @@ import org.apiguardian.api.API;
  * {@code Named} is used to wrap an object and give it a name.
  *
  * @param <T> the type of the payload
+ *
+ * @since 5.8
  */
 @API(status = STABLE, since = "5.8")
 public interface Named<T> {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
@@ -42,7 +42,7 @@ public interface Named<T> {
 	}
 
 	static <T> Named<T> named(String name, T payload) {
-		return of(named, payload);
+		return of(name, payload);
 	}
 
 	String getName();

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
@@ -41,6 +41,10 @@ public interface Named<T> {
 		};
 	}
 
+	static <T> Named<T> named(String name, T payload) {
+		return of(named, payload);
+	}
+
 	String getName();
 
 	T getPayload();

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
@@ -14,6 +14,8 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
 
+import java.lang.Object;
+
 /**
  * {@code Named} is used to wrap an object and give it a name.
  *
@@ -22,6 +24,15 @@ import org.apiguardian.api.API;
 @API(status = STABLE, since = "5.8")
 public interface Named<T> {
 
+    /**
+     * Factory method for creating an instance of {@code Named} based on a {@code name} and a {@code payload}
+     *
+     * @param name the name to be used for the wrapped object
+     * @param payload the object to be wrapped
+     * @param <T> the type of the payload
+     * @return an instance of {@code Named}; never {@code null}
+     * @see #named(String, java.lang.Object)
+     */
 	static <T> Named<T> of(String name, T payload) {
 		return new Named<T>() {
 			@Override
@@ -41,6 +52,18 @@ public interface Named<T> {
 		};
 	}
 
+    /**
+     * Factory method for creating an instance of {@code Named} based on a {@code name} and a {@code payload}
+     *
+     * <p>This method is an <em>alias</em> for {@link Named#of} and is
+     * intended to be used when statically imported &mdash; for example, via:
+     * {@code import static org.junit.jupiter.api.Named.named;}
+     *
+     * @param name the name to be used for the wrapped object
+     * @param payload the object to be wrapped
+     * @param <T> the type of the payload
+     * @return an instance of {@code Named}; never {@code null}
+q     */
 	static <T> Named<T> named(String name, T payload) {
 		return of(name, payload);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
@@ -26,7 +26,7 @@ public interface Named<T> {
 
 	/**
 	 * Factory method for creating an instance of {@code Named} based on a
-     * {@code name} and a {@code payload}.
+	 * {@code name} and a {@code payload}.
 	 *
 	 * @param name the name to be used for the wrapped object
 	 * @param payload the object to be wrapped
@@ -55,7 +55,7 @@ public interface Named<T> {
 
 	/**
 	 * Factory method for creating an instance of {@code Named} based on a
-     * {@code name} and a {@code payload}.
+	 * {@code name} and a {@code payload}.
 	 *
 	 * <p>This method is an <em>alias</em> for {@link Named#of} and is
 	 * intended to be used when statically imported &mdash; for example, via:

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
@@ -14,8 +14,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
 
-import java.lang.Object;
-
 /**
  * {@code Named} is used to wrap an object and give it a name.
  *
@@ -24,15 +22,15 @@ import java.lang.Object;
 @API(status = STABLE, since = "5.8")
 public interface Named<T> {
 
-    /**
-     * Factory method for creating an instance of {@code Named} based on a {@code name} and a {@code payload}
-     *
-     * @param name the name to be used for the wrapped object
-     * @param payload the object to be wrapped
-     * @param <T> the type of the payload
-     * @return an instance of {@code Named}; never {@code null}
-     * @see #named(String, java.lang.Object)
-     */
+	/**
+	 * Factory method for creating an instance of {@code Named} based on a {@code name} and a {@code payload}
+	 *
+	 * @param name the name to be used for the wrapped object
+	 * @param payload the object to be wrapped
+	 * @param <T> the type of the payload
+	 * @return an instance of {@code Named}; never {@code null}
+	 * @see #named(String, java.lang.Object)
+	 */
 	static <T> Named<T> of(String name, T payload) {
 		return new Named<T>() {
 			@Override
@@ -52,18 +50,18 @@ public interface Named<T> {
 		};
 	}
 
-    /**
-     * Factory method for creating an instance of {@code Named} based on a {@code name} and a {@code payload}
-     *
-     * <p>This method is an <em>alias</em> for {@link Named#of} and is
-     * intended to be used when statically imported &mdash; for example, via:
-     * {@code import static org.junit.jupiter.api.Named.named;}
-     *
-     * @param name the name to be used for the wrapped object
-     * @param payload the object to be wrapped
-     * @param <T> the type of the payload
-     * @return an instance of {@code Named}; never {@code null}
-q     */
+	/**
+	 * Factory method for creating an instance of {@code Named} based on a {@code name} and a {@code payload}
+	 *
+	 * <p>This method is an <em>alias</em> for {@link Named#of} and is
+	 * intended to be used when statically imported &mdash; for example, via:
+	 * {@code import static org.junit.jupiter.api.Named.named;}
+	 *
+	 * @param name the name to be used for the wrapped object
+	 * @param payload the object to be wrapped
+	 * @param <T> the type of the payload
+	 * @return an instance of {@code Named}; never {@code null}
+	 */
 	static <T> Named<T> named(String name, T payload) {
 		return of(name, payload);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
@@ -23,7 +23,8 @@ import org.apiguardian.api.API;
 public interface Named<T> {
 
 	/**
-	 * Factory method for creating an instance of {@code Named} based on a {@code name} and a {@code payload}
+	 * Factory method for creating an instance of {@code Named} based on a
+     * {@code name} and a {@code payload}.
 	 *
 	 * @param name the name to be used for the wrapped object
 	 * @param payload the object to be wrapped
@@ -51,7 +52,8 @@ public interface Named<T> {
 	}
 
 	/**
-	 * Factory method for creating an instance of {@code Named} based on a {@code name} and a {@code payload}
+	 * Factory method for creating an instance of {@code Named} based on a
+     * {@code name} and a {@code payload}.
 	 *
 	 * <p>This method is an <em>alias</em> for {@link Named#of} and is
 	 * intended to be used when statically imported &mdash; for example, via:

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -1046,11 +1046,11 @@ class ParameterizedTestIntegrationTests {
 			fail(string);
 		}
 
-        @MethodSourceTest
-        @Order(14)
-        void namedParametersAlias(String string) {
-            fail(string);
-        }
+		@MethodSourceTest
+		@Order(14)
+		void namedParametersAlias(String string) {
+			fail(string);
+		}
 
 		// ---------------------------------------------------------------------
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.params;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
@@ -646,6 +647,15 @@ class ParameterizedTestIntegrationTests {
 						event(test(), displayName("default name"), finishedWithFailure(message("default name"))));
 		}
 
+		@Test
+		void nameParametersAlias() {
+			execute("namedParametersAlias", String.class).allEvents().assertThatEvents() //
+					.haveAtLeast(1,
+						event(test(), displayName("cool name"), finishedWithFailure(message("parameter value")))) //
+					.haveAtLeast(1,
+						event(test(), displayName("default name"), finishedWithFailure(message("default name"))));
+		}
+
 	}
 
 	@Nested
@@ -1036,6 +1046,12 @@ class ParameterizedTestIntegrationTests {
 			fail(string);
 		}
 
+        @MethodSourceTest
+        @Order(14)
+        void namedParametersAlias(String string) {
+            fail(string);
+        }
+
 		// ---------------------------------------------------------------------
 
 		static Stream<Arguments> emptyMethodSource() {
@@ -1095,6 +1111,10 @@ class ParameterizedTestIntegrationTests {
 
 		static Stream<Arguments> namedParameters() {
 			return Stream.of(arguments(Named.of("cool name", "parameter value")), arguments("default name"));
+		}
+
+		static Stream<Arguments> namedParametersAlias() {
+			return Stream.of(arguments(named("cool name", "parameter value")), arguments("default name"));
 		}
 
 		// ---------------------------------------------------------------------


### PR DESCRIPTION
Issue: #2587

## Overview

This PR adds Named.named as a more static import friendly alternative to Named.of.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
