### PR TITLE
Fix for currently disabled test in ReflectionUtilsWithGenericTypeHierarchiesTests

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -1502,6 +1502,8 @@ public final class ReflectionUtils {
 	 * @since 5.8
 	 */
 	private static List<Class<?>> getInterfaces(Class<?> clazz) {
+		Preconditions.notNull(clazz, "Class must not be null");
+
 		Class<?>[] interfaces = clazz.getInterfaces();
 		Arrays.sort(interfaces, comparing(Class::getName));
 		return Arrays.asList(interfaces);

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsWithGenericTypeHierarchiesTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsWithGenericTypeHierarchiesTests.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("TypeParameterExplicitlyExtendsObject")
 class ReflectionUtilsWithGenericTypeHierarchiesTests {
 	@Test
-	@Disabled("Describes a new case that does not yet yield the expected result.")
 	void findsMethodsIndependentlyFromOrderOfImplementationsOfInterfaces() {
 
 		class AB implements InterfaceDouble, InterfaceGenericNumber<Number> {


### PR DESCRIPTION
## Overview

If accepted, this PR will address part of the outstanding work in issue 981.

It addresses `@Test findsMethodsIndependentlyFromOrderOfImplementationsOfInterfaces()` by
ensuring a consistent ordering of returned Class objects when getting the implemented
interfaces for a type. This is handled by a new method, `ReflectionUtils.getInterfaces(Class)`.

I wanted a consistent ordering of the results and arbitrarily went for alphanumeric sorting by implemented interface name.
I did not add a specific test case for `ReflectionUtils.getInterfaces` in `ReflectionUtilsTest` because
my new method is private and because it is covered by the re-enabled test in
`ReflectionUtilsWithGenericTypeHierarchiesTests`. I'd be happy to add a specific test, if you want.

I also went further than was necessary to fix the failing test by ensuring that all calls to
clazz.getInterfaces() in ReflectionUtils used this method. I did this for consistency within that class.

Issue: #981

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
