### PR TITLE
Fix package path computation in `ClasspathScanner`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -15,7 +15,9 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Method `getRootUrisForPackage()` in class `ClasspathScanner` now returns a
+  valid list of class names when the package name is equal to the name of a
+  module on the module path and when running on Java 8.
 
 ==== Deprecations and Breaking Changes
 


### PR DESCRIPTION
## Overview

Fix `getRootUrisForPackage()` in class `ClasspathScanner` by looking for two "wordings" of a package name.

For example, package `foo.bar` is expanded to `foo/bar` and `foo/bar/`. The latter allows find package `foo.bar` in a module called `foo.bar`, and not `foo`.

Fixes #2500
Fixes #2600
Fixes #2612

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
