### PR TITLE
Discover suite tests using parent configuration parameters

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -107,4 +107,6 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* Suites executed by the `junit-platform-suite` module will inherit the
+  configuration parameters from the parent discovery request. This behaviour can
+  be disabled by the `DisableParentConfigurationParameters` annotation.

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -107,6 +107,6 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* Suites executed by the `junit-platform-suite` module will inherit the
+* Suites executed by the `junit-platform-suite` module will now inherit the
   configuration parameters from the parent discovery request. This behaviour can
-  be disabled by the `DisableParentConfigurationParameters` annotation.
+  be disabled via the `@DisableParentConfigurationParameters` annotation.

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -30,6 +30,7 @@ import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.core.LauncherConfigurationParameters.Builder;
 import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListeners;
 
 /**
@@ -101,6 +102,7 @@ public final class LauncherDiscoveryRequestBuilder {
 	private final Map<String, String> configurationParameters = new HashMap<>();
 	private final List<LauncherDiscoveryListener> discoveryListeners = new ArrayList<>();
 	private boolean implicitConfigurationParametersEnabled = true;
+	private ConfigurationParameters parentConfigurationParameters;
 
 	/**
 	 * Create a new {@code LauncherDiscoveryRequestBuilder}.
@@ -198,6 +200,11 @@ public final class LauncherDiscoveryRequestBuilder {
 		return this;
 	}
 
+	public void parentConfigurationParameters(ConfigurationParameters configurationParameters) {
+		Preconditions.notNull(configurationParameters, "parent configuration parameters must not be null");
+		this.parentConfigurationParameters = configurationParameters;
+	}
+
 	/**
 	 * Add all of the supplied discovery listeners to the request.
 	 *
@@ -269,10 +276,15 @@ public final class LauncherDiscoveryRequestBuilder {
 	}
 
 	private LauncherConfigurationParameters buildLauncherConfigurationParameters() {
-		return LauncherConfigurationParameters.builder() //
+		Builder builder = LauncherConfigurationParameters.builder() //
 				.explicitParameters(this.configurationParameters) //
-				.enableImplicitProviders(this.implicitConfigurationParametersEnabled) //
-				.build();
+				.enableImplicitProviders(this.implicitConfigurationParametersEnabled);
+
+		if (parentConfigurationParameters != null) {
+			builder.parentConfigurationParameters(this.parentConfigurationParameters);
+		}
+
+		return builder.build();
 	}
 
 	private LauncherDiscoveryListener getLauncherDiscoveryListener(ConfigurationParameters configurationParameters) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -11,6 +11,7 @@
 package org.junit.platform.launcher.core;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.ArrayList;
@@ -110,19 +111,15 @@ public final class LauncherDiscoveryRequestBuilder {
 	 * @return a new builder
 	 */
 	public static LauncherDiscoveryRequestBuilder request() {
-		return new LauncherDiscoveryRequestBuilder(null);
+		return new LauncherDiscoveryRequestBuilder();
 	}
 
 	/**
 	 * @deprecated Use {@link #request()}
 	 */
-	@API(status = DEPRECATED, since = "5.8")
+	@API(status = DEPRECATED, since = "1.8")
 	@Deprecated
 	public LauncherDiscoveryRequestBuilder() {
-		this(null);
-	}
-
-	private LauncherDiscoveryRequestBuilder(@SuppressWarnings("unused") Object ignored) {
 	}
 
 	/**
@@ -200,9 +197,27 @@ public final class LauncherDiscoveryRequestBuilder {
 		return this;
 	}
 
-	public void parentConfigurationParameters(ConfigurationParameters configurationParameters) {
+	/**
+	 * Set the parent configuration parameters to use for the request.
+	 *
+	 * <p>Any explicit configuration parameters configured via
+	 * {@link #configurationParameter(String, String)} or
+	 * {@link #configurationParameters(Map)} takes precedence over the supplied
+	 * configuration parameters.
+	 *
+	 * @param configurationParameters the parent instance to be used for looking
+	 * up configuration parameters that have not been explicitly configured;
+	 * never {@code null}
+	 * @see #configurationParameter(String, String)
+	 * @see #configurationParameters(Map)
+	 * @since 1.8
+	 */
+	@API(status = EXPERIMENTAL, since = "1.8")
+	public LauncherDiscoveryRequestBuilder parentConfigurationParameters(
+			ConfigurationParameters configurationParameters) {
 		Preconditions.notNull(configurationParameters, "parent configuration parameters must not be null");
 		this.parentConfigurationParameters = configurationParameters;
+		return this;
 	}
 
 	/**
@@ -220,8 +235,9 @@ public final class LauncherDiscoveryRequestBuilder {
 	 * @see LauncherDiscoveryListener
 	 * @see LauncherDiscoveryListeners
 	 * @see LauncherDiscoveryRequestBuilder#DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME
+	 * @since 1.6
 	 */
-	@API(status = API.Status.EXPERIMENTAL, since = "1.6")
+	@API(status = EXPERIMENTAL, since = "1.6")
 	public LauncherDiscoveryRequestBuilder listeners(LauncherDiscoveryListener... listeners) {
 		Preconditions.notNull(listeners, "discovery listener array must not be null");
 		Preconditions.containsNoNullElements(listeners, "individual discovery listeners must not be null");
@@ -240,8 +256,9 @@ public final class LauncherDiscoveryRequestBuilder {
 	 *
 	 * @see #configurationParameter(String, String)
 	 * @see #configurationParameters(Map)
+	 * @since 1.7
 	 */
-	@API(status = API.Status.EXPERIMENTAL, since = "1.7")
+	@API(status = EXPERIMENTAL, since = "1.7")
 	public LauncherDiscoveryRequestBuilder enableImplicitConfigurationParameters(boolean enabled) {
 		this.implicitConfigurationParametersEnabled = enabled;
 		return this;

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/ConfigurationParameter.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/ConfigurationParameter.java
@@ -28,6 +28,7 @@ import org.apiguardian.api.API.Status;
  * a test suite on the JUnit Platform.
  *
  * @since 1.8
+ * @see DisableParentConfigurationParameters
  * @see Suite
  * @see org.junit.platform.runner.JUnitPlatform
  * @see org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder#configurationParameter(String, String)

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/DisableParentConfigurationParameters.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/DisableParentConfigurationParameters.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * Disable parent configuration parameters.
+ *
+ * <p>By default a suite discovers tests using the configuration parameters
+ * explicitly configured by {@link ConfigurationParameter @ConfigurationParameter}
+ * and the configuration parameters from the discovery request that discovered
+ * the suite.
+ *
+ * <p>Annotating a suite with this annotation disables the latter source so
+ * that only explicit configuration parameters are taken into account.
+ *
+ * @see ConfigurationParameter
+ * @see Suite
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@Documented
+@API(status = Status.EXPERIMENTAL, since = "1.8")
+public @interface DisableParentConfigurationParameters {
+
+}

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/Suite.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/Suite.java
@@ -35,6 +35,14 @@ import org.junit.platform.commons.annotation.Testable;
  * org.junit.platform.engine.discovery.ClassNameFilter#STANDARD_INCLUDE_PATTERN
  * ClassNameFilter#STANDARD_INCLUDE_PATTERN}).
  *
+ * <p>By default a suite discovers tests using the configuration parameters
+ * explicitly configured by {@link ConfigurationParameter @ConfigurationParameter}
+ * and the configuration parameters from the discovery request that discovered
+ * the suite. Annotating a suite with
+ * {@link DisableParentConfigurationParameters @DisableParentConfigurationParameters}
+ * annotation disables the latter as a source of parameters so that only explicit
+ * configuration parameters are taken into account.
+ *
  * @since 1.8
  * @see SelectClasses
  * @see SelectClasspathResource
@@ -53,7 +61,9 @@ import org.junit.platform.commons.annotation.Testable;
  * @see ExcludeTags
  * @see SuiteDisplayName
  * @see ConfigurationParameter
+ * @see DisableParentConfigurationParameters
  * @see org.junit.platform.launcher.LauncherDiscoveryRequest
+ * @see org.junit.platform.launcher.LauncherDiscoveryRequestBuilder
  * @see org.junit.platform.launcher.Launcher
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-platform-suite-commons/src/main/java/org/junit/platform/suite/commons/SuiteLauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-suite-commons/src/main/java/org/junit/platform/suite/commons/SuiteLauncherDiscoveryRequestBuilder.java
@@ -122,11 +122,6 @@ public final class SuiteLauncherDiscoveryRequestBuilder {
 		return this;
 	}
 
-	public SuiteLauncherDiscoveryRequestBuilder enableParentConfigurationParameters(boolean enabled) {
-		this.enableParentConfigurationParameters = enabled;
-		return this;
-	}
-
 	public SuiteLauncherDiscoveryRequestBuilder suite(Class<?> suiteClass) {
 		Preconditions.notNull(suiteClass, "Suite class must not be null");
 
@@ -135,8 +130,7 @@ public final class SuiteLauncherDiscoveryRequestBuilder {
 		findRepeatableAnnotations(suiteClass, ConfigurationParameter.class)
 				.forEach(configuration -> configurationParameter(configuration.key(), configuration.value()));
 		findAnnotation(suiteClass, DisableParentConfigurationParameters.class)
-				.map(disableParentConfigurationParameters -> false)
-				.ifPresent(this::enableParentConfigurationParameters);
+				.ifPresent(__ -> enableParentConfigurationParameters = false);
 		findAnnotationValues(suiteClass, ExcludeClassNamePatterns.class, ExcludeClassNamePatterns::value)
 				.flatMap(SuiteLauncherDiscoveryRequestBuilder::trimmed)
 				.map(ClassNameFilter::excludeClassNamePatterns)

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/ClassSelectorResolver.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/ClassSelectorResolver.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.UniqueId.Segment;
@@ -33,10 +34,13 @@ final class ClassSelectorResolver implements SelectorResolver {
 
 	private final Predicate<String> classNameFilter;
 	private final SuiteEngineDescriptor suiteEngineDescriptor;
+	private final ConfigurationParameters configurationParameters;
 
-	ClassSelectorResolver(Predicate<String> classNameFilter, SuiteEngineDescriptor suiteEngineDescriptor) {
+	ClassSelectorResolver(Predicate<String> classNameFilter, SuiteEngineDescriptor suiteEngineDescriptor,
+			ConfigurationParameters configurationParameters) {
 		this.classNameFilter = classNameFilter;
 		this.suiteEngineDescriptor = suiteEngineDescriptor;
+		this.configurationParameters = configurationParameters;
 	}
 
 	@Override
@@ -88,9 +92,9 @@ final class ClassSelectorResolver implements SelectorResolver {
 		return suite.map(Match::exact).map(Resolution::match).orElseGet(Resolution::unresolved);
 	}
 
-	private static Optional<SuiteTestDescriptor> newSuiteDescriptor(Class<?> suiteClass, TestDescriptor parent) {
+	private Optional<SuiteTestDescriptor> newSuiteDescriptor(Class<?> suiteClass, TestDescriptor parent) {
 		UniqueId id = parent.getUniqueId().append(SuiteTestDescriptor.SEGMENT_TYPE, suiteClass.getName());
-		return Optional.of(new SuiteTestDescriptor(id, suiteClass));
+		return Optional.of(new SuiteTestDescriptor(id, suiteClass, configurationParameters));
 	}
 
 }

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/DiscoverySelectorResolver.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/DiscoverySelectorResolver.java
@@ -22,7 +22,10 @@ final class DiscoverySelectorResolver {
 	// @formatter:off
 	private static final EngineDiscoveryRequestResolver<SuiteEngineDescriptor> resolver = EngineDiscoveryRequestResolver.<SuiteEngineDescriptor>builder()
 			.addClassContainerSelectorResolver(new IsSuiteClass())
-			.addSelectorResolver(context -> new ClassSelectorResolver(context.getClassNameFilter(), context.getEngineDescriptor()))
+			.addSelectorResolver(context -> new ClassSelectorResolver(
+					context.getClassNameFilter(),
+					context.getEngineDescriptor(),
+					context.getDiscoveryRequest().getConfigurationParameters()))
 			.build();
 	// @formatter:on
 

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
@@ -48,12 +49,14 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 	static final String SEGMENT_TYPE = "suite";
 
 	private final SuiteLauncherDiscoveryRequestBuilder discoveryRequestBuilder = request();
+	private final ConfigurationParameters configurationParameters;
 
 	private LauncherDiscoveryResult launcherDiscoveryResult;
 	private SuiteLauncher launcher;
 
-	SuiteTestDescriptor(UniqueId id, Class<?> suiteClass) {
+	SuiteTestDescriptor(UniqueId id, Class<?> suiteClass, ConfigurationParameters configurationParameters) {
 		super(requireNoCycles(id), getSuiteDisplayName(suiteClass), ClassSource.from(suiteClass));
+		this.configurationParameters = configurationParameters;
 	}
 
 	private static UniqueId requireNoCycles(UniqueId id) {
@@ -94,6 +97,8 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 		// @formatter:off
 		LauncherDiscoveryRequest request = discoveryRequestBuilder
 				.filterStandardClassNamePatterns(true)
+				.enableImplicitConfigurationParameters(false)
+				.parentConfigurationParameters(configurationParameters)
 				.build();
 		// @formatter:on
 		this.launcher = SuiteLauncher.create();

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteTestDescriptorTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
@@ -41,7 +43,8 @@ class SuiteTestDescriptorTests {
 	UniqueId testClassId = jupiterEngineId.append(ClassTestDescriptor.SEGMENT_TYPE, SingleTestTestCase.class.getName());
 	UniqueId methodId = testClassId.append(TestMethodTestDescriptor.SEGMENT_TYPE, "test()");
 
-	SuiteTestDescriptor suite = new SuiteTestDescriptor(suiteId, Object.class);
+	ConfigurationParameters configurationParameters = new EmptyConfigurationParameters();
+	SuiteTestDescriptor suite = new SuiteTestDescriptor(suiteId, Object.class, configurationParameters);
 
 	@Test
 	void suiteIsEmptyBeforeDiscovery() {
@@ -94,6 +97,24 @@ class SuiteTestDescriptorTests {
 		JUnitException exception = assertThrows(JUnitException.class, suite::discover);
 		assertEquals("Configuration error: The suite configuration may not contain a cycle [" + expectedCycle + "]",
 			exception.getCause().getCause().getCause().getMessage());
+	}
+
+	private static class EmptyConfigurationParameters implements ConfigurationParameters {
+		@Override
+		public Optional<String> get(String key) {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<Boolean> getBoolean(String key) {
+			return Optional.empty();
+		}
+
+		@Override
+		public int size() {
+			return 0;
+		}
+
 	}
 
 }


### PR DESCRIPTION
## Overview

From a practical perspective the expectation is that a `@Suite` annotated class uses the same configuration parameters when discovering tests as the discovery request used to discover the suite.

For example:

When executing a suite with the the `ConsoleLauncher` providing a configuration via `--config=key=value` should have the same effect as configuring this value implicitly as an environment variable via `-Dvalue=key`. However when suites are involved this is not the case. Rather implicit variables are considered while explicit values are ignored.

This surprising to say the least.

This behavior occurs because the `junit-platform-suite-engine` creates a new discovery request - and this includes the implicit configuration by default.

There is also a use case where the suite should neither inherit configuration nor use any implicit configuration values. (e.g. the execution of tcks  #2594).

This PR changes the `junit-platform-suite-engine` so as to only discover tests using the explicitly provided parameters and the parameters from the discovery request used to discover the the suite engine. 

This behaviour can be disabled by `@DisableParentConfigurationParameters`. If disabled, only the explicitly provided parameters will be used. 

This also means that a suite will never use implicit parameters (unless of course the parent discovery request used them).

Note this replaces: https://github.com/junit-team/junit5/pull/2618

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
