### PR TITLE
Clarify intended usage of assert{Not}Equals

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -34,6 +34,17 @@ import org.opentest4j.MultipleFailuresError;
  * <p>Unless otherwise noted, a <em>failed</em> assertion will throw an
  * {@link org.opentest4j.AssertionFailedError} or a subclass thereof.
  *
+ * <p>Assertion methods comparing two values for equality, such as {@code assertEquals},
+ * are <em>only</em> intended to test equality for an (un-)expected and an actual result
+ * value. They are not designed for testing whether a class correctly implements
+ * {@code equals(Object)}. For example {@code assertEquals} might return fast when
+ * provided with the same object as expected and actual value without calling
+ * {@code equals(Object)} at all. Such tests trying to verify the {@code equals(Object)}
+ * implementation should instead be written explicitly and
+ * {@link #assertTrue(boolean) assertTrue} or {@link #assertFalse(boolean) assertFalse}
+ * should be used to verify the result, e.g.: {@code assertTrue(obj.equals(obj))},
+ * {@code assertFalse(obj.equals(null))}.
+ *
  * <h3>Kotlin Support</h3>
  *
  * <p>Additional <a href="https://kotlinlang.org/">Kotlin</a> assertions can be


### PR DESCRIPTION
## Overview
Resolves #2567

See https://github.com/junit-team/junit5/issues/2567#issuecomment-806626091.

The changes currently only adjust the `Assertions` documentation. Should the user guide be adjusted as well?
And should this also be mentioned in the release notes? It is not a behavior change, so I am not sure how relevant it is for the release notes.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
