### PR TITLE
Provide access to ConfigurationParameters via the TestPlan

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -23,6 +23,11 @@ on GitHub.
 
 ==== New Features and Improvements
 
+* New `getConfigurationParameters()` method in the `TestPlan` which allows a
+  `TestExecutionListener` to access
+  <<../user-guide/index.adoc#running-tests-config-params, configuration parameters>>. See
+  <<../user-guide/index.adoc#launcher-api-listeners-config, Configuring an Execution
+  Listener>> for details.
 * New `UniqueIdTrackingListener` which is a `TestExecutionListener` that tracks the unique
   IDs of all tests that were executed during the `TestPlan` and generates a file
   containing the unique IDs. The generated file can be used to rerun those tests -- for

--- a/documentation/src/docs/asciidoc/user-guide/launcher-api.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/launcher-api.adoc
@@ -120,7 +120,7 @@ declared within the `/META-INF/services/org.junit.platform.launcher.PostDiscover
 file is loaded and applied automatically.
 
 [[launcher-api-launcher-session-listeners-custom]]
-==== Plugging in your own Launcher Sessions Listeners
+==== Plugging in your own Launcher Session Listeners
 
 Registered implementations of `{LauncherSessionListener}` are notified when a
 `{LauncherSession}` is opened, i.e. before a `{Launcher}` first discovers and executes
@@ -160,6 +160,20 @@ For example, an `example.CustomTestExecutionListener` class implementing
 `{TestExecutionListener}` and declared within the
 `/META-INF/services/org.junit.platform.launcher.TestExecutionListener` file is loaded and
 registered automatically.
+
+[[launcher-api-listeners-config]]
+==== Configuring an Execution Listener
+
+When a `{TestExecutionListener}` is registered programmatically via the `{Launcher}` API,
+the listener may provide programmatic ways for it to be configured -- for example, via its
+constructor, setter methods, etc. However, when a `TestExecutionListener` is registered
+automatically via Java's `ServiceLoader` mechanism (see
+<<launcher-api-listeners-custom>>), there is no way for the user to directly configure the
+listener. In such cases, the author of a `TestExecutionListener` may choose to make the
+listener configurable via <<running-tests-config-params, configuration parameters>>. The
+listener can then access the configuration parameters via the `TestPlan` supplied to the
+`testPlanExecutionStarted(TestPlan)` and `testPlanExecutionFinished(TestPlan)` callback
+methods. See the `{UniqueIdTrackingListener}` for an example.
 
 [[launcher-api-listeners-custom-deactivation]]
 ==== Deactivating Execution Listeners

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -699,8 +699,8 @@ infrastructure.
 
 In addition to instructing the platform which test classes and test engines to include,
 which packages to scan, etc., it is sometimes necessary to provide additional custom
-configuration parameters that are specific to a particular test engine or registered
-extension. For example, the JUnit Jupiter `TestEngine` supports _configuration
+configuration parameters that are specific to a particular test engine, listener, or
+registered extension. For example, the JUnit Jupiter `TestEngine` supports _configuration
 parameters_ for the following use cases.
 
 - <<writing-tests-test-instance-lifecycle-changing-default>>

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/ConfigurationParameters.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/ConfigurationParameters.java
@@ -26,6 +26,10 @@ import org.junit.platform.commons.util.Preconditions;
  * <p>For example, the JUnit Jupiter engine uses a configuration parameter to
  * enable IDEs and build tools to deactivate conditional test execution.
  *
+ * <p>As of JUnit Platform 1.8, configuration parameters are also made available to
+ * implementations of the {@link org.junit.platform.launcher.TestExecutionListener}
+ * API via the {@link org.junit.platform.launcher.TestPlan}.
+ *
  * @see TestEngine
  * @see EngineDiscoveryRequest
  * @see ExecutionRequest

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestExecutionListener.java
@@ -39,6 +39,13 @@ import org.junit.platform.engine.reporting.ReportEntry;
  * Jupiter engines comply with this contract, there is no way to guarantee this for
  * third-party engines.
  *
+ * <p>As of JUnit Platform 1.8, a {@code TestExecutionListener} can access
+ * {@linkplain org.junit.platform.engine.ConfigurationParameters configuration
+ * parameters} via the {@link TestPlan#getConfigurationParameters()
+ * getConfigurationParameters()} method in the {@code TestPlan} supplied to
+ * {@link #testPlanExecutionStarted(TestPlan)} and
+ * {@link #testPlanExecutionFinished(TestPlan)}.
+ *
  * @since 1.0
  * @see Launcher
  * @see TestPlan

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -15,6 +15,7 @@ import static java.util.Collections.synchronizedSet;
 import static java.util.Collections.unmodifiableSet;
 import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.Collection;
@@ -28,6 +29,7 @@ import java.util.function.Predicate;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestDescriptor.Visitor;
 import org.junit.platform.engine.UniqueId;
@@ -66,6 +68,8 @@ public class TestPlan {
 
 	private final boolean containsTests;
 
+	private final ConfigurationParameters configurationParameters;
+
 	/**
 	 * Construct a new {@code TestPlan} from the supplied collection of
 	 * {@link TestDescriptor TestDescriptors}.
@@ -75,20 +79,26 @@ public class TestPlan {
 	 *
 	 * @param engineDescriptors the engine test descriptors from which the test
 	 * plan should be created; never {@code null}
+	 * @param configurationParameters the {@code ConfigurationParameters} for
+	 * this test plan; never {@code null}
 	 * @return a new test plan
 	 */
 	@API(status = INTERNAL, since = "1.0")
-	public static TestPlan from(Collection<TestDescriptor> engineDescriptors) {
+	public static TestPlan from(Collection<TestDescriptor> engineDescriptors,
+			ConfigurationParameters configurationParameters) {
 		Preconditions.notNull(engineDescriptors, "Cannot create TestPlan from a null collection of TestDescriptors");
-		TestPlan testPlan = new TestPlan(engineDescriptors.stream().anyMatch(TestDescriptor::containsTests));
+		Preconditions.notNull(configurationParameters, "Cannot create TestPlan from null ConfigurationParameters");
+		TestPlan testPlan = new TestPlan(engineDescriptors.stream().anyMatch(TestDescriptor::containsTests),
+			configurationParameters);
 		Visitor visitor = descriptor -> testPlan.add(TestIdentifier.from(descriptor));
 		engineDescriptors.forEach(engineDescriptor -> engineDescriptor.accept(visitor));
 		return testPlan;
 	}
 
 	@API(status = INTERNAL, since = "1.4")
-	protected TestPlan(boolean containsTests) {
+	protected TestPlan(boolean containsTests, ConfigurationParameters configurationParameters) {
 		this.containsTests = containsTests;
+		this.configurationParameters = configurationParameters;
 	}
 
 	/**
@@ -220,6 +230,17 @@ public class TestPlan {
 	 */
 	public boolean containsTests() {
 		return containsTests;
+	}
+
+	/**
+	 * Get the {@link ConfigurationParameters} for this test plan.
+	 *
+	 * @return the configuration parameters; never {@code null}
+	 * @since 1.8
+	 */
+	@API(status = MAINTAINED, since = "1.8")
+	public ConfigurationParameters getConfigurationParameters() {
+		return this.configurationParameters;
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
@@ -34,12 +34,13 @@ class InternalTestPlan extends TestPlan {
 	private final TestPlan delegate;
 
 	static InternalTestPlan from(LauncherDiscoveryResult discoveryResult) {
-		TestPlan delegate = TestPlan.from(discoveryResult.getEngineTestDescriptors());
+		TestPlan delegate = TestPlan.from(discoveryResult.getEngineTestDescriptors(),
+			discoveryResult.getConfigurationParameters());
 		return new InternalTestPlan(discoveryResult, delegate);
 	}
 
 	private InternalTestPlan(LauncherDiscoveryResult discoveryResult, TestPlan delegate) {
-		super(delegate.containsTests());
+		super(delegate.containsTests(), delegate.getConfigurationParameters());
 		this.discoveryResult = discoveryResult;
 		this.delegate = delegate;
 	}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
@@ -11,15 +11,19 @@
 package org.junit.platform.launcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 
 class TestPlanTests {
+
+	private final ConfigurationParameters configParams = mock(ConfigurationParameters.class);
 
 	private EngineDescriptor engineDescriptor = new EngineDescriptor(UniqueId.forEngine("foo"), "Foo");
 
@@ -33,7 +37,7 @@ class TestPlanTests {
 				}
 			});
 
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		assertThat(testPlan.containsTests()).as("contains tests").isFalse();
 	}
@@ -48,7 +52,7 @@ class TestPlanTests {
 				}
 			});
 
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		assertThat(testPlan.containsTests()).as("contains tests").isTrue();
 	}
@@ -68,8 +72,9 @@ class TestPlanTests {
 				}
 			});
 
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		assertThat(testPlan.containsTests()).as("contains tests").isTrue();
 	}
+
 }

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/CompositeTestExecutionListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/CompositeTestExecutionListenerTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
@@ -91,7 +92,8 @@ class CompositeTestExecutionListenerTests {
 			LogRecordListener logRecordListener) {
 		var testDescriptor = getDemoMethodTestDescriptor();
 
-		compositeTestExecutionListener().testPlanExecutionStarted(TestPlan.from(Set.of(testDescriptor)));
+		compositeTestExecutionListener().testPlanExecutionStarted(
+			TestPlan.from(Set.of(testDescriptor), mock(ConfigurationParameters.class)));
 
 		assertThatTestListenerErrorLogged(logRecordListener, ThrowingTestExecutionListener.class,
 			"testPlanExecutionStarted");
@@ -102,7 +104,8 @@ class CompositeTestExecutionListenerTests {
 			LogRecordListener logRecordListener) {
 		var testDescriptor = getDemoMethodTestDescriptor();
 
-		compositeTestExecutionListener().testPlanExecutionFinished(TestPlan.from(Set.of(testDescriptor)));
+		compositeTestExecutionListener().testPlanExecutionFinished(
+			TestPlan.from(Set.of(testDescriptor), mock(ConfigurationParameters.class)));
 
 		assertThatTestListenerErrorLogged(logRecordListener, ThrowingTestExecutionListener.class,
 			"testPlanExecutionFinished");

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/ExecutionListenerAdapterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/ExecutionListenerAdapterTests.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
@@ -35,7 +36,8 @@ class ExecutionListenerAdapterTests {
 	void testReportingEntryPublished() {
 		var testDescriptor = getSampleMethodTestDescriptor();
 
-		var discoveryResult = new LauncherDiscoveryResult(Map.of(mock(TestEngine.class), testDescriptor), null);
+		var discoveryResult = new LauncherDiscoveryResult(Map.of(mock(TestEngine.class), testDescriptor),
+			mock(ConfigurationParameters.class));
 		var testPlan = InternalTestPlan.from(discoveryResult);
 		var testIdentifier = testPlan.getTestIdentifier(testDescriptor.getUniqueId().toString());
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/SummaryGenerationTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.commons.test.ConcurrencyTestingUtils.executeConcurrently;
+import static org.mockito.Mockito.mock;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -24,6 +25,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
@@ -38,7 +40,7 @@ import org.junit.platform.launcher.TestPlan;
 class SummaryGenerationTests {
 
 	private final SummaryGeneratingListener listener = new SummaryGeneratingListener();
-	private final TestPlan testPlan = TestPlan.from(List.of());
+	private final TestPlan testPlan = TestPlan.from(List.of(), mock(ConfigurationParameters.class));
 
 	@Test
 	void emptyReport() {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/LegacyReportingUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/LegacyReportingUtilsTests.java
@@ -11,10 +11,12 @@
 package org.junit.platform.reporting.legacy;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
@@ -70,13 +72,13 @@ class LegacyReportingUtilsTests {
 	}
 
 	private String getClassName(UniqueId uniqueId) {
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), mock(ConfigurationParameters.class));
 		return LegacyReportingUtils.getClassName(testPlan, testPlan.getTestIdentifier(uniqueId.toString()));
 	}
 
 	@SuppressWarnings("deprecation")
 	private String getClassNameFromOldLocation(UniqueId uniqueId) {
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), mock(ConfigurationParameters.class));
 		return org.junit.platform.launcher.listeners.LegacyReportingUtils.getClassName(testPlan,
 			testPlan.getTestIdentifier(uniqueId.toString()));
 	}

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
@@ -20,6 +20,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqu
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
 import static org.junit.platform.reporting.legacy.xml.XmlReportAssertions.assertValidAccordingToJenkinsSchema;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -41,6 +42,7 @@ import java.util.Set;
 import org.joox.Match;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
@@ -368,7 +370,7 @@ class LegacyXmlReportGeneratingListenerTests {
 		var out = new StringWriter();
 		var listener = new LegacyXmlReportGeneratingListener(reportsDir, new PrintWriter(out));
 
-		listener.testPlanExecutionStarted(TestPlan.from(Set.of()));
+		listener.testPlanExecutionStarted(TestPlan.from(Set.of(), mock(ConfigurationParameters.class)));
 
 		assertThat(out.toString()).containsSubsequence("Could not create reports directory",
 			"FileAlreadyExistsException", "at ");
@@ -384,7 +386,7 @@ class LegacyXmlReportGeneratingListenerTests {
 		var out = new StringWriter();
 		var listener = new LegacyXmlReportGeneratingListener(tempDirectory, new PrintWriter(out));
 
-		listener.testPlanExecutionStarted(TestPlan.from(Set.of(engineDescriptor)));
+		listener.testPlanExecutionStarted(TestPlan.from(Set.of(engineDescriptor), mock(ConfigurationParameters.class)));
 		listener.executionFinished(TestIdentifier.from(engineDescriptor), successful());
 
 		assertThat(out.toString()).containsSubsequence("Could not write XML report", "Exception", "at ");
@@ -394,7 +396,7 @@ class LegacyXmlReportGeneratingListenerTests {
 	void writesReportEntriesToSystemOutElement() throws Exception {
 		var engineDescriptor = new EngineDescriptor(UniqueId.forEngine("engine"), "Engine");
 		engineDescriptor.addChild(new TestDescriptorStub(UniqueId.root("child", "test"), "test"));
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), mock(ConfigurationParameters.class));
 
 		var out = new StringWriter();
 		var listener = new LegacyXmlReportGeneratingListener(tempDirectory, new PrintWriter(out));

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportDataTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportDataTests.java
@@ -13,11 +13,13 @@ package org.junit.platform.reporting.legacy.xml;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.TestExecutionResult.failed;
 import static org.junit.platform.engine.TestExecutionResult.successful;
+import static org.mockito.Mockito.mock;
 
 import java.time.Clock;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.fakes.TestDescriptorStub;
@@ -28,11 +30,13 @@ import org.junit.platform.launcher.TestPlan;
  */
 class XmlReportDataTests {
 
+	private final ConfigurationParameters configParams = mock(ConfigurationParameters.class);
+
 	@Test
 	void resultsOfTestIdentifierWithoutAnyReportedEventsAreEmpty() {
 		var engineDescriptor = new EngineDescriptor(UniqueId.forEngine("engine"), "Engine");
 		engineDescriptor.addChild(new TestDescriptorStub(UniqueId.root("child", "test"), "test"));
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		var results = reportData.getResults(testPlan.getTestIdentifier("[child:test]"));
@@ -44,7 +48,7 @@ class XmlReportDataTests {
 	void resultsOfTestIdentifierWithoutReportedEventsContainsOnlyFailureOfAncestor() {
 		var engineDescriptor = new EngineDescriptor(UniqueId.forEngine("engine"), "Engine");
 		engineDescriptor.addChild(new TestDescriptorStub(UniqueId.root("child", "test"), "test"));
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		var failureOfAncestor = failed(new RuntimeException("failed!"));
@@ -59,7 +63,7 @@ class XmlReportDataTests {
 	void resultsOfTestIdentifierWithoutReportedEventsContainsOnlySuccessOfAncestor() {
 		var engineDescriptor = new EngineDescriptor(UniqueId.forEngine("engine"), "Engine");
 		engineDescriptor.addChild(new TestDescriptorStub(UniqueId.root("child", "test"), "test"));
-		var testPlan = TestPlan.from(Set.of(engineDescriptor));
+		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		reportData.markFinished(testPlan.getTestIdentifier("[engine:engine]"), successful());
@@ -68,4 +72,5 @@ class XmlReportDataTests {
 
 		assertThat(results).containsExactly(successful());
 	}
+
 }

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
@@ -432,7 +433,7 @@ class JUnitPlatformRunnerTests {
 			TestDescriptor container2 = new TestDescriptorStub(UniqueId.root("root", "container2"), "container2");
 			container2.addChild(new TestDescriptorStub(UniqueId.root("root", "test2a"), "test2a"));
 			container2.addChild(new TestDescriptorStub(UniqueId.root("root", "test2b"), "test2b"));
-			var testPlan = TestPlan.from(List.of(container1, container2));
+			var testPlan = TestPlan.from(List.of(container1, container2), mock(ConfigurationParameters.class));
 
 			var launcher = mock(Launcher.class);
 			when(launcher.discover(any())).thenReturn(testPlan);
@@ -461,6 +462,8 @@ class JUnitPlatformRunnerTests {
 	@Nested
 	class Filtering {
 
+		private final ConfigurationParameters configParams = mock(ConfigurationParameters.class);
+
 		@Test
 		void appliesFilter() throws Exception {
 
@@ -469,11 +472,11 @@ class JUnitPlatformRunnerTests {
 			TestDescriptor originalParent2 = new TestDescriptorStub(UniqueId.root("root", "parent2"), "parent2");
 			originalParent2.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2a"), "leaf2a"));
 			originalParent2.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2b"), "leaf2b"));
-			var fullTestPlan = TestPlan.from(List.of(originalParent1, originalParent2));
+			var fullTestPlan = TestPlan.from(List.of(originalParent1, originalParent2), configParams);
 
 			TestDescriptor filteredParent = new TestDescriptorStub(UniqueId.root("root", "parent2"), "parent2");
 			filteredParent.addChild(new TestDescriptorStub(UniqueId.root("root", "leaf2b"), "leaf2b"));
-			var filteredTestPlan = TestPlan.from(Set.of(filteredParent));
+			var filteredTestPlan = TestPlan.from(Set.of(filteredParent), configParams);
 
 			var launcher = mock(Launcher.class);
 			var captor = ArgumentCaptor.forClass(LauncherDiscoveryRequest.class);
@@ -495,7 +498,8 @@ class JUnitPlatformRunnerTests {
 
 		@Test
 		void throwsNoTestsRemainExceptionWhenNoTestIdentifierMatchesFilter() {
-			var testPlan = TestPlan.from(Set.of(new TestDescriptorStub(UniqueId.root("root", "test"), "test")));
+			var testPlan = TestPlan.from(Set.of(new TestDescriptorStub(UniqueId.root("root", "test"), "test")),
+				configParams);
 
 			var launcher = mock(Launcher.class);
 			when(launcher.discover(any())).thenReturn(testPlan);
@@ -733,7 +737,8 @@ class JUnitPlatformRunnerTests {
 	private LauncherDiscoveryRequest instantiateRunnerAndCaptureGeneratedRequest(Class<?> testClass) {
 		var launcher = mock(Launcher.class);
 		var captor = ArgumentCaptor.forClass(LauncherDiscoveryRequest.class);
-		when(launcher.discover(captor.capture())).thenReturn(TestPlan.from(Set.of()));
+		when(launcher.discover(captor.capture())).thenReturn(
+			TestPlan.from(Set.of(), mock(ConfigurationParameters.class)));
 
 		new JUnitPlatform(testClass, launcher);
 


### PR DESCRIPTION
This is a PR for #2631.

Once approved, I will document the new feature in the user guide and release notes.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
