### PR TITLE
Add 'class' URI scheme for dynamic test sources

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -50,6 +50,8 @@ on GitHub.
 
 * New `named()` static factory method in the `Named` interface that serves as an
   _alias_ for `Named.of()`. `named()` is intended to be used via `import static`.
+* New `class` URI scheme added for dynamic test sources. This allows tests to be located
+  using the information available in a `StackTraceElement`.
 
 
 [[release-notes-5.8.0-M2-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1832,7 +1832,7 @@ implementations.
 
 `ClassSource` ::
   If the `URI` contains the `class` scheme and the fully qualified class name --
-  for example, `class:/org.junit.Foo?line=42`.
+  for example, `class:org.junit.Foo?line=42`.
 
 `UriSource` ::
   If none of the above `TestSource` implementations are applicable.

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1830,6 +1830,10 @@ implementations.
   refer to the Javadoc for `DiscoverySelectors.selectMethod(String)` for the supported
   formats for a FQMN.
 
+`ClassSource` ::
+  If the `URI` contains the `class` scheme and the fully qualified class name --
+  for example, `class:/org.junit.Foo?line=42`.
+
 `UriSource` ::
   If none of the above `TestSource` implementations are applicable.
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.descriptor;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.MethodSourceSupport.METHOD_SCHEME;
+import static org.junit.platform.engine.support.descriptor.ClassSource.CLASS_SCHEME;
 import static org.junit.platform.engine.support.descriptor.ClasspathResourceSource.CLASSPATH_SCHEME;
 
 import java.lang.reflect.Method;
@@ -39,6 +40,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
 import org.junit.platform.engine.support.descriptor.UriSource;
 
@@ -168,6 +170,9 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 		Preconditions.notNull(uri, "URI must not be null");
 		if (CLASSPATH_SCHEME.equals(uri.getScheme())) {
 			return ClasspathResourceSource.from(uri);
+		}
+		if (CLASS_SCHEME.equals(uri.getScheme())) {
+			return ClassSource.from(uri);
 		}
 		if (METHOD_SCHEME.equals(uri.getScheme())) {
 			return MethodSourceSupport.from(uri);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -97,9 +97,9 @@ public class ClassSource implements TestSource {
 	 * Create a new {@code ClassSource} from the supplied {@link URI}.
 	 * <p>
 	 * URIs should be formatted as <code>class:fully.qualified.class.Name</code>. An
-	 * optional query can be appended detailing <code>line</code> and
+	 * optional query can be appended detailing <code>line</code> and/or
 	 * <code>column</code> numbers, e.g.
-	 * <code>class:com.foo.Bar?line=42&column=13</code>. The URI fragment, if
+	 * <code>class:com.foo.Bar?line=42&amp;column=13</code>. The URI fragment, if
 	 * present, is ignored.
 	 *
 	 * @param uri the {@code URI} for the class source; never {@code null}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -115,17 +115,17 @@ public class ClassSource implements TestSource {
 		Preconditions.condition(CLASS_SCHEME.equals(uri.getScheme()),
 			() -> "URI [" + uri + "] must have [" + CLASS_SCHEME + "] scheme");
 
-		String classSource = uri.getSchemeSpecificPart();
+		String className = uri.getSchemeSpecificPart();
 		FilePosition filePosition = null;
-		int qi = classSource.indexOf('?');
+		int qi = className.indexOf('?');
 		if (qi >= 0) {
-			filePosition = FilePosition.fromQuery(classSource.substring(qi + 1)).orElse(null);
-			classSource = classSource.substring(0, qi);
+			filePosition = FilePosition.fromQuery(className.substring(qi + 1)).orElse(null);
+			className = className.substring(0, qi);
 		}
 
-		Preconditions.condition(!classSource.isEmpty(), () -> "Class name cannot be empty");
+		Preconditions.condition(!className.isEmpty(), () -> "Class name cannot be empty");
 
-		return ClassSource.from(classSource, filePosition);
+		return ClassSource.from(className, filePosition);
 	}
 
 	private final String className;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.support.descriptor;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -43,6 +44,14 @@ import org.junit.platform.engine.TestSource;
 public class ClassSource implements TestSource {
 
 	private static final long serialVersionUID = 1L;
+
+	/**
+	 * {@link URI} {@linkplain URI#getScheme() scheme} for class
+	 * sources: {@value}
+	 *
+	 * @since 1.3
+	 */
+	public static final String CLASS_SCHEME = "class";
 
 	/**
 	 * Create a new {@code ClassSource} using the supplied class name.
@@ -82,6 +91,33 @@ public class ClassSource implements TestSource {
 	 */
 	public static ClassSource from(Class<?> javaClass, FilePosition filePosition) {
 		return new ClassSource(javaClass, filePosition);
+	}
+
+	/**
+	 * Create a new {@code ClassSource} from the supplied {@link URI}.
+	 *
+	 * <p>The {@link URI#getPath() path} component of the {@code URI} (excluding
+	 * the query) will be used as the class name. The
+	 * {@linkplain URI#getQuery() query} component of the {@code URI}, if present,
+	 * will be used to retrieve the {@link FilePosition} via
+	 * {@link FilePosition#fromQuery(String)}.
+	 *
+	 * @param uri the {@code URI} for the class source; never {@code null}
+	 * @return a new {@code ClassSource}; never {@code null}
+	 * @throws PreconditionViolationException if the supplied {@code URI} is
+	 * {@code null} or if the scheme of the supplied {@code URI} is not equal
+	 * to the {@link #CLASS_SCHEME}
+	 * @since 1.3
+	 * @see #CLASS_SCHEME
+	 */
+	public static ClassSource from(URI uri) {
+		Preconditions.notNull(uri, "URI must not be null");
+		Preconditions.condition(CLASS_SCHEME.equals(uri.getScheme()),
+			() -> "URI [" + uri + "] must have [" + CLASS_SCHEME + "] scheme");
+
+		String classSource = ResourceUtils.stripQueryComponent(uri).getPath().substring(1);
+		FilePosition filePosition = FilePosition.fromQuery(uri.getQuery()).orElse(null);
+		return ClassSource.from(classSource, filePosition);
 	}
 
 	private final String className;

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -44,6 +46,8 @@ class ClassSourceTests extends AbstractTestSourceTests {
 		assertThrows(PreconditionViolationException.class, () -> ClassSource.from("    ", null));
 		assertThrows(PreconditionViolationException.class, () -> ClassSource.from((Class<?>) null));
 		assertThrows(PreconditionViolationException.class, () -> ClassSource.from((Class<?>) null, null));
+		assertThrows(PreconditionViolationException.class, () -> ClassSource.from((URI) null));
+		assertThrows(PreconditionViolationException.class, () -> ClassSource.from(new URI("badscheme:/com.foo.Bar")));
 	}
 
 	@Test
@@ -87,6 +91,15 @@ class ClassSourceTests extends AbstractTestSourceTests {
 		assertThat(source.getJavaClass()).isEqualTo(testClass);
 		assertThat(source.getPosition()).isNotEmpty();
 		assertThat(source.getPosition()).hasValue(position);
+	}
+
+	@Test
+	void classSourceFromURI() throws URISyntaxException {
+		var source = ClassSource.from(new URI("class:/java.lang.Object?line=42"));
+
+		assertThat(source.getJavaClass()).isEqualTo(Object.class);
+		assertThat(source.getPosition()).isNotEmpty();
+		assertThat(source.getPosition().get().getLine()).isEqualTo(42);
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
@@ -48,6 +48,7 @@ class ClassSourceTests extends AbstractTestSourceTests {
 		assertThrows(PreconditionViolationException.class, () -> ClassSource.from((Class<?>) null, null));
 		assertThrows(PreconditionViolationException.class, () -> ClassSource.from((URI) null));
 		assertThrows(PreconditionViolationException.class, () -> ClassSource.from(new URI("badscheme:/com.foo.Bar")));
+		assertThrows(PreconditionViolationException.class, () -> ClassSource.from(new URI("class:?line=1")));
 	}
 
 	@Test
@@ -95,7 +96,7 @@ class ClassSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void classSourceFromURI() throws URISyntaxException {
-		var source = ClassSource.from(new URI("class:/java.lang.Object?line=42"));
+		var source = ClassSource.from(new URI("class:java.lang.Object?line=42"));
 
 		assertThat(source.getJavaClass()).isEqualTo(Object.class);
 		assertThat(source.getPosition()).isNotEmpty();

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
@@ -96,11 +96,27 @@ class ClassSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void classSourceFromURI() throws URISyntaxException {
-		var source = ClassSource.from(new URI("class:java.lang.Object?line=42"));
+		var source = ClassSource.from( new URI( "class:java.lang.Object" ) );
 
-		assertThat(source.getJavaClass()).isEqualTo(Object.class);
-		assertThat(source.getPosition()).isNotEmpty();
-		assertThat(source.getPosition().get().getLine()).isEqualTo(42);
+		assertThat( source.getJavaClass() ).isEqualTo( Object.class );
+		assertThat( source.getPosition() ).isEmpty();
+	}
+
+	@Test
+	void classSourceFromURIWithLineQuery() throws URISyntaxException {
+		var source = ClassSource.from( new URI( "class:java.lang.Object?line=42" ) );
+
+		assertThat( source.getJavaClass() ).isEqualTo( Object.class );
+		assertThat( source.getPosition() ).isNotEmpty();
+		assertThat( source.getPosition().get().getLine() ).isEqualTo( 42 );
+	}
+
+	@Test
+	void classSourceFromURIWithMalformedQuery() throws URISyntaxException {
+		var source = ClassSource.from( new URI( "class:java.lang.Object?foo=42" ) );
+
+		assertThat( source.getJavaClass() ).isEqualTo( Object.class );
+		assertThat( source.getPosition() ).isEmpty();
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ClassSourceTests.java
@@ -96,27 +96,27 @@ class ClassSourceTests extends AbstractTestSourceTests {
 
 	@Test
 	void classSourceFromURI() throws URISyntaxException {
-		var source = ClassSource.from( new URI( "class:java.lang.Object" ) );
+		var source = ClassSource.from(new URI("class:java.lang.Object"));
 
-		assertThat( source.getJavaClass() ).isEqualTo( Object.class );
-		assertThat( source.getPosition() ).isEmpty();
+		assertThat(source.getJavaClass()).isEqualTo(Object.class);
+		assertThat(source.getPosition()).isEmpty();
 	}
 
 	@Test
 	void classSourceFromURIWithLineQuery() throws URISyntaxException {
-		var source = ClassSource.from( new URI( "class:java.lang.Object?line=42" ) );
+		var source = ClassSource.from(new URI("class:java.lang.Object?line=42"));
 
-		assertThat( source.getJavaClass() ).isEqualTo( Object.class );
-		assertThat( source.getPosition() ).isNotEmpty();
-		assertThat( source.getPosition().get().getLine() ).isEqualTo( 42 );
+		assertThat(source.getJavaClass()).isEqualTo(Object.class);
+		assertThat(source.getPosition()).isNotEmpty();
+		assertThat(source.getPosition().get().getLine()).isEqualTo(42);
 	}
 
 	@Test
 	void classSourceFromURIWithMalformedQuery() throws URISyntaxException {
-		var source = ClassSource.from( new URI( "class:java.lang.Object?foo=42" ) );
+		var source = ClassSource.from(new URI("class:java.lang.Object?foo=42"));
 
-		assertThat( source.getJavaClass() ).isEqualTo( Object.class );
-		assertThat( source.getPosition() ).isEmpty();
+		assertThat(source.getJavaClass()).isEqualTo(Object.class);
+		assertThat(source.getPosition()).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

 * Adding `ClassSource.from(URI)` method, which accepts URIs with a new `class` scheme. The URI details the fully qualified class name and optional `line` and `column` query parameters.
 * Hooking that new scheme into `TestFactoryTestDescriptor.fromUri(URI)`, so that such URIs can be supplied when creating dynamic tests
 *  Associated unit test and documentation updates

This enables dynamic tests instances to be located using the information available in a StackTraceElement, so it becomes possible to automatically provide test locations by walking the call stack.

These changes are largely a subset of #2431. To the extent that they work, credit goes to @ST-DDT. To the extent that they're broken, blame falls upon me.

Resolves issue: #2635

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
