### PR TITLE
Forbid redundant TempDir declarations

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -339,6 +339,24 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 
 	}
 
+	@Nested
+	@DisplayName("reports illegal usage")
+	class IllegalUsage {
+
+		@Test
+		@DisplayName("when @TempDir with same identifier is used on multiple method parameters")
+		void doesNotSupportMultipleTempDirAnnotationsWithSameIdentifierOnOneMethod() throws NoSuchMethodException {
+			var testClass = IllegalUsageTestCase.MultipleMethodParameters.class;
+			var results = executeTestsForClass(testClass);
+			var method = testClass.getDeclaredMethod("test", Path.class, File.class);
+
+			assertSingleFailedTest(results, ParameterResolutionException.class,
+				"The same @TempDir was declared on multiple parameters of the following method: " + method
+						+ ". Please specify distinct identifiers to create different temporary directories via @TempDir(...) or remove the duplicate parameter.");
+		}
+
+	}
+
 	private static void assertSingleFailedContainer(EngineExecutionResults results, Class<? extends Throwable> clazz,
 			String message) {
 
@@ -981,6 +999,16 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 			assertTrue(Files.notExists(C));
 			assertTrue(Files.notExists(D));
 			assertTrue(Files.notExists(E));
+		}
+	}
+
+	static class IllegalUsageTestCase {
+
+		static class MultipleMethodParameters {
+			@Test
+			void test(@TempDir Path path, @TempDir File file) {
+				// never called
+			}
 		}
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -741,17 +741,17 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 	@DisplayName("resolves java.io.File injection type")
 	class FileAndPathInjection {
 
-		@TempDir
-		File fileTempDir;
+		Path path;
 
-		@TempDir
-		Path pathTempDir;
+		@BeforeEach
+		void beforeEach(@TempDir Path path) {
+			this.path = path;
+		}
 
 		@Test
 		@DisplayName("and injected File and Path reference the same temp directory")
-		void checkFile(@TempDir File tempDir, @TempDir Path ref) {
-			assertFileAndPathAreEqual(tempDir, ref);
-			assertFileAndPathAreEqual(this.fileTempDir, this.pathTempDir);
+		void checkFile(@TempDir File file) {
+			assertFileAndPathAreEqual(file, path);
 		}
 
 		private void assertFileAndPathAreEqual(File tempDir, Path ref) {


### PR DESCRIPTION
Resolves #2219.

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
