### PR TITLE
Add `assertThrowsExactly` assertion method

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -90,6 +90,9 @@ on GitHub.
 * `DynamicTests.stream()` can now consume `Named` input and will use each name-value pair
   as the display name and value for each generated dynamic test (see
   <<../user-guide/index.adoc#writing-tests-dynamic-tests-examples,User Guide>> for details).
+* New `assertThrowsExactly` method is introduced as a more strict version of the `assertThrows`
+  allowing you to assert that the thrown exception has the exact specified class.
+
 
 
 [[release-notes-5.8.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -90,7 +90,7 @@ on GitHub.
 * `DynamicTests.stream()` can now consume `Named` input and will use each name-value pair
   as the display name and value for each generated dynamic test (see
   <<../user-guide/index.adoc#writing-tests-dynamic-tests-examples,User Guide>> for details).
-* New `assertThrowsExactly` method is introduced as a more strict version of the `assertThrows`
+* New `assertThrowsExactly` method is introduced as a more strict version of `assertThrows`
   allowing you to assert that the thrown exception has the exact specified class.
 
 

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -90,8 +90,8 @@ on GitHub.
 * `DynamicTests.stream()` can now consume `Named` input and will use each name-value pair
   as the display name and value for each generated dynamic test (see
   <<../user-guide/index.adoc#writing-tests-dynamic-tests-examples,User Guide>> for details).
-* New `assertThrowsExactly` method is introduced as a more strict version of `assertThrows`
-  allowing you to assert that the thrown exception has the exact specified class.
+* New `assertThrowsExactly` method which is a more strict version of `assertThrows`
+  that allows you to assert that the thrown exception has the exact specified class.
 
 
 

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M1.adoc
@@ -90,9 +90,6 @@ on GitHub.
 * `DynamicTests.stream()` can now consume `Named` input and will use each name-value pair
   as the display name and value for each generated dynamic test (see
   <<../user-guide/index.adoc#writing-tests-dynamic-tests-examples,User Guide>> for details).
-* New `assertThrowsExactly` method which is a more strict version of `assertThrows`
-  that allows you to assert that the thrown exception has the exact specified class.
-
 
 
 [[release-notes-5.8.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -67,6 +67,8 @@ on GitHub.
   the information available in a `StackTraceElement`.
 * `@TempDir` cleanup resets readable and executable permissions of the root temporary
   directory and any contained directories instead of failing to delete them.
+* New `assertThrowsExactly` method which is a more strict version of `assertThrows`
+  that allows you to assert that the thrown exception has the exact specified class.
 
 
 [[release-notes-5.8.0-M2-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
+import static org.junit.jupiter.api.AssertionUtils.format;
+import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
+import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.function.Executable;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * {@code AssertThrowsExactly} is a collection of utility methods that support asserting
+ * an exception of an expected type is thrown.
+ *
+ * @since 5.0
+ */
+class AssertThrowsExactly {
+
+	private AssertThrowsExactly() {
+		/* no-op */
+	}
+
+	static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable) {
+		return assertThrowsExactly(expectedType, executable, (Object) null);
+	}
+
+	static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable, String message) {
+		return assertThrowsExactly(expectedType, executable, (Object) message);
+	}
+
+	static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable,
+			Supplier<String> messageSupplier) {
+
+		return assertThrowsExactly(expectedType, executable, (Object) messageSupplier);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable,
+			Object messageOrSupplier) {
+
+		try {
+			executable.execute();
+		}
+		catch (Throwable actualException) {
+			if (expectedType.equals(actualException.getClass())) {
+				return (T) actualException;
+			}
+			else {
+				UnrecoverableExceptions.rethrowIfUnrecoverable(actualException);
+				String message = buildPrefix(nullSafeGet(messageOrSupplier))
+						+ format(expectedType, actualException.getClass(), "Unexpected exception type thrown");
+				throw new AssertionFailedError(message, actualException);
+			}
+		}
+
+		String message = buildPrefix(nullSafeGet(messageOrSupplier))
+				+ String.format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType));
+		throw new AssertionFailedError(message);
+	}
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
@@ -25,7 +25,7 @@ import org.opentest4j.AssertionFailedError;
  * {@code AssertThrowsExactly} is a collection of utility methods that support asserting
  * an exception of an expected type is thrown.
  *
- * @since 5.0
+ * @since 5.8
  */
 class AssertThrowsExactly {
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
@@ -23,7 +23,7 @@ import org.opentest4j.AssertionFailedError;
 
 /**
  * {@code AssertThrowsExactly} is a collection of utility methods that support asserting
- * an exception of an expected type is thrown.
+ * an exception of an exact type is thrown.
  *
  * @since 5.8
  */

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3019,7 +3019,10 @@ public class Assertions {
 	 *
 	 * <p>If you do not want to perform additional checks on the exception instance,
 	 * ignore the return value.
+	 *
+	 * @since 5.8
 	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
 	public static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable) {
 		return AssertThrowsExactly.assertThrowsExactly(expectedType, executable);
 	}
@@ -3035,7 +3038,10 @@ public class Assertions {
 	 * ignore the return value.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @since 5.8
 	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
 	public static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable,
 			String message) {
 		return AssertThrowsExactly.assertThrowsExactly(expectedType, executable, message);
@@ -3053,7 +3059,10 @@ public class Assertions {
 	 *
 	 * <p>If you do not want to perform additional checks on the exception instance,
 	 * ignore the return value.
+	 *
+	 * @since 5.8
 	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
 	public static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable,
 			Supplier<String> messageSupplier) {
 		return AssertThrowsExactly.assertThrowsExactly(expectedType, executable, messageSupplier);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3012,6 +3012,55 @@ public class Assertions {
 
 	/**
 	 * <em>Assert</em> that execution of the supplied {@code executable} throws
+	 * an exception of exactly the {@code expectedType} and return the exception.
+	 *
+	 * <p>If no exception is thrown, or if an exception of a different type is
+	 * thrown, this method will fail.
+	 *
+	 * <p>If you do not want to perform additional checks on the exception instance,
+	 * ignore the return value.
+	 */
+	public static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable) {
+		return AssertThrowsExactly.assertThrowsExactly(expectedType, executable);
+	}
+
+	/**
+	 * <em>Assert</em> that execution of the supplied {@code executable} throws
+	 * an exception of exactly the {@code expectedType} and return the exception.
+	 *
+	 * <p>If no exception is thrown, or if an exception of a different type is
+	 * thrown, this method will fail.
+	 *
+	 * <p>If you do not want to perform additional checks on the exception instance,
+	 * ignore the return value.
+	 *
+	 * <p>Fails with the supplied failure {@code message}.
+	 */
+	public static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable,
+			String message) {
+		return AssertThrowsExactly.assertThrowsExactly(expectedType, executable, message);
+	}
+
+	/**
+	 * <em>Assert</em> that execution of the supplied {@code executable} throws
+	 * an exception of exactly the {@code expectedType} and return the exception.
+	 *
+	 * <p>If no exception is thrown, or if an exception of a different type is
+	 * thrown, this method will fail.
+	 *
+	 * <p>If necessary, the failure message will be retrieved lazily from the
+	 * supplied {@code messageSupplier}.
+	 *
+	 * <p>If you do not want to perform additional checks on the exception instance,
+	 * ignore the return value.
+	 */
+	public static <T extends Throwable> T assertThrowsExactly(Class<T> expectedType, Executable executable,
+			Supplier<String> messageSupplier) {
+		return AssertThrowsExactly.assertThrowsExactly(expectedType, executable, messageSupplier);
+	}
+
+	/**
+	 * <em>Assert</em> that execution of the supplied {@code executable} throws
 	 * an exception of the {@code expectedType} and return the exception.
 	 *
 	 * <p>If no exception is thrown, or if an exception of a different type is

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
@@ -247,7 +247,7 @@ class AssertThrowsExactlyAssertionsTests {
 			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			// As of the time of this writing, the class name of the above anonymous inner
-			// class is org.junit.jupiter.api.AssertionsAssertThrowsTests$2; however, hard
+			// class is org.junit.jupiter.api.AssertThrowsExactlyAssertionsTests$2; however, hard
 			// coding "$2" is fragile. So we just check for the presence of the "$"
 			// appended to this class's name.
 			assertMessageContains(ex, "but was: <" + getClass().getName() + "$");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.jupiter.api.AssertThrowsExactly.assertThrowsExactly;
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
+import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+
+import org.junit.jupiter.api.function.Executable;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * Unit tests for JUnit Jupiter {@link Assertions}.
+ *
+ * @since 5.0
+ */
+class AssertThrowsExactlyAssertionsTests {
+
+	private static final Executable nix = () -> {
+	};
+
+	@Test
+	void assertThrowsExactlyTheSpecifiedExceptionClass() {
+		var actual = assertThrowsExactly(EnigmaThrowable.class, (Executable) () -> {
+			throw new EnigmaThrowable();
+		});
+		assertNotNull(actual);
+	}
+
+	@Test
+	void assertThrowsExactlyWithTheExpectedChildException() {
+		try {
+			assertThrowsExactly(RuntimeException.class, (Executable) () -> {
+				throw new Exception();
+			});
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "expected: <java.lang.RuntimeException>");
+			assertMessageContains(ex, "but was: <java.lang.Exception>");
+		}
+	}
+
+	@Test
+	void assertThrowsExactlyWithTheExpectedParentException() {
+		try {
+			assertThrowsExactly(RuntimeException.class, (Executable) () -> {
+				throw new NumberFormatException();
+			});
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "expected: <java.lang.RuntimeException>");
+			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+		}
+	}
+
+	@Test
+	void assertThrowsWithMethodReferenceForNonVoidReturnType() {
+		FutureTask<String> future = new FutureTask<>(() -> {
+			throw new RuntimeException("boom");
+		});
+		future.run();
+
+		ExecutionException exception = assertThrowsExactly(ExecutionException.class, future::get);
+		assertEquals("boom", exception.getCause().getMessage());
+	}
+
+	@Test
+	void assertThrowsWithMethodReferenceForVoidReturnType() {
+		var object = new Object();
+		IllegalMonitorStateException exception;
+
+		exception = assertThrowsExactly(IllegalMonitorStateException.class, object::notify);
+		assertNotNull(exception);
+
+		// Note that Object.wait(...) is an overloaded method with a void return type
+		exception = assertThrowsExactly(IllegalMonitorStateException.class, object::wait);
+		assertNotNull(exception);
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsThrowable() {
+		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, (Executable) () -> {
+			throw new EnigmaThrowable();
+		});
+		assertNotNull(enigmaThrowable);
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsThrowableWithMessage() {
+		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, (Executable) () -> {
+			throw new EnigmaThrowable();
+		}, "message");
+		assertNotNull(enigmaThrowable);
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsThrowableWithMessageSupplier() {
+		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, (Executable) () -> {
+			throw new EnigmaThrowable();
+		}, () -> "message");
+		assertNotNull(enigmaThrowable);
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsCheckedException() {
+		IOException exception = assertThrowsExactly(IOException.class, (Executable) () -> {
+			throw new IOException();
+		});
+		assertNotNull(exception);
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsRuntimeException() {
+		IllegalStateException illegalStateException = assertThrowsExactly(IllegalStateException.class,
+			(Executable) () -> {
+				throw new IllegalStateException();
+			});
+		assertNotNull(illegalStateException);
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsError() {
+		StackOverflowError stackOverflowError = assertThrowsExactly(StackOverflowError.class,
+			(Executable) AssertionTestUtils::recurseIndefinitely);
+		assertNotNull(stackOverflowError);
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatDoesNotThrowAnException() {
+		try {
+			assertThrowsExactly(IllegalStateException.class, nix);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.");
+		}
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatDoesNotThrowAnExceptionWithMessageString() {
+		try {
+			assertThrowsExactly(IOException.class, nix, "Custom message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionError ex) {
+			assertMessageEquals(ex,
+				"Custom message ==> Expected java.io.IOException to be thrown, but nothing was thrown.");
+		}
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatDoesNotThrowAnExceptionWithMessageSupplier() {
+		try {
+			assertThrowsExactly(IOException.class, nix, () -> "Custom message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionError ex) {
+			assertMessageEquals(ex,
+				"Custom message ==> Expected java.io.IOException to be thrown, but nothing was thrown.");
+		}
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsAnUnexpectedException() {
+		try {
+			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+				throw new NumberFormatException();
+			});
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
+			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+		}
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsAnUnexpectedExceptionWithMessageString() {
+		try {
+			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+				throw new NumberFormatException();
+			}, "Custom message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			// Should look something like this:
+			// Custom message ==> Unexpected exception type thrown ==> expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
+			assertMessageStartsWith(ex, "Custom message ==> ");
+			assertMessageContains(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
+			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+		}
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsAnUnexpectedExceptionWithMessageSupplier() {
+		try {
+			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+				throw new NumberFormatException();
+			}, () -> "Custom message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			// Should look something like this:
+			// Custom message ==> Unexpected exception type thrown ==> expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
+			assertMessageStartsWith(ex, "Custom message ==> ");
+			assertMessageContains(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
+			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+		}
+	}
+
+	@Test
+	@SuppressWarnings("serial")
+	void assertThrowsWithExecutableThatThrowsInstanceOfAnonymousInnerClassAsUnexpectedException() {
+		try {
+			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+				throw new NumberFormatException() {
+				};
+			});
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
+			// As of the time of this writing, the class name of the above anonymous inner
+			// class is org.junit.jupiter.api.AssertionsAssertThrowsTests$2; however, hard
+			// coding "$2" is fragile. So we just check for the presence of the "$"
+			// appended to this class's name.
+			assertMessageContains(ex, "but was: <" + getClass().getName() + "$");
+		}
+	}
+
+	@Test
+	void assertThrowsWithExecutableThatThrowsInstanceOfStaticNestedClassAsUnexpectedException() {
+		try {
+			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+				throw new LocalException();
+			});
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
+			// The following verifies that the canonical name is used (i.e., "." instead of "$").
+			assertMessageContains(ex, "but was: <" + LocalException.class.getName().replace("$", ".") + ">");
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void assertThrowsWithExecutableThatThrowsSameExceptionTypeFromDifferentClassLoader() throws Exception {
+		try (EnigmaClassLoader enigmaClassLoader = new EnigmaClassLoader()) {
+
+			// Load expected exception type from different class loader
+			Class<? extends Throwable> enigmaThrowableClass = (Class<? extends Throwable>) enigmaClassLoader.loadClass(
+				EnigmaThrowable.class.getName());
+
+			try {
+				assertThrowsExactly(enigmaThrowableClass, (Executable) () -> {
+					throw new EnigmaThrowable();
+				});
+				expectAssertionFailedError();
+			}
+			catch (AssertionFailedError ex) {
+				// Example Output:
+				//
+				// Unexpected exception type thrown ==>
+				// expected: <org.junit.jupiter.api.EnigmaThrowable@5d3411d>
+				// but was: <org.junit.jupiter.api.EnigmaThrowable@2471cca7>
+
+				assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+				// The presence of the "@" sign is sufficient to indicate that the hash was
+				// generated to disambiguate between the two identical class names.
+				assertMessageContains(ex, "expected: <org.junit.jupiter.api.EnigmaThrowable@");
+				assertMessageContains(ex, "but was: <org.junit.jupiter.api.EnigmaThrowable@");
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	@SuppressWarnings("serial")
+	private static class LocalException extends RuntimeException {
+	}
+
+	private static class EnigmaClassLoader extends URLClassLoader {
+
+		EnigmaClassLoader() {
+			super(new URL[] { EnigmaClassLoader.class.getProtectionDomain().getCodeSource().getLocation() },
+				getSystemClassLoader());
+		}
+
+		@Override
+		public Class<?> loadClass(String name) throws ClassNotFoundException {
+			return (EnigmaThrowable.class.getName().equals(name) ? findClass(name) : super.loadClass(name));
+		}
+
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
@@ -30,7 +30,7 @@ import org.opentest4j.AssertionFailedError;
 /**
  * Unit tests for JUnit Jupiter {@link Assertions}.
  *
- * @since 5.0
+ * @since 5.8
  */
 class AssertThrowsExactlyAssertionsTests {
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
@@ -10,13 +10,13 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertThrowsExactly.assertThrowsExactly;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import java.io.IOException;
 import java.net.URL;


### PR DESCRIPTION
## Overview

Continuation of #2543.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
