### PR TITLE
Optionally import org.apiguardian.api in OSGi metadata

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,1 +1,7 @@
-// intentionally left blank
+dependencyResolutionManagement {
+	versionCatalogs {
+		create("libs") {
+			from(files("../gradle/libs.versions.toml"))
+		}
+	}
+}

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -25,7 +25,7 @@ tasks.jar {
 		bnd("""
 			# Import JUnit4 packages with a version
 			Import-Package: \
-				!org.apiguardian.api,\
+				${extra["importAPIGuardian"]},\
 				org.junit;version="[${libs.versions.junit4Min.get()},5)",\
 				org.junit.platform.commons.logging;status=INTERNAL,\
 				org.junit.rules;version="[${libs.versions.junit4Min.get()},5)",\

--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
@@ -44,7 +44,7 @@ tasks {
 			bnd("""
 				# Customize the imports because this is an aggregate jar
 				Import-Package: \
-					!org.apiguardian.api,\
+					${extra["importAPIGuardian"]},\
 					kotlin.*;resolution:="optional",\
 					*
 				# Disable the APIGuardian plugin since everything was already

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -25,7 +25,7 @@ tasks.jar {
 		bnd("""
 			# Import JUnit4 packages with a version
 			Import-Package: \
-				!org.apiguardian.api,\
+				${extra["importAPIGuardian"]},\
 				org.junit.platform.commons.logging;status=INTERNAL,\
 				org.junit.runner.*;version="[${libs.versions.junit4Min.get()},5)",\
 				*

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -38,7 +38,7 @@ tasks {
 			bnd("""
 				# Import JUnit4 packages with a version
 				Import-Package: \
-					!org.apiguardian.api,\
+					${extra["importAPIGuardian"]},\
 					junit.runner;version="[${junit4Min},5)",\
 					org.junit;version="[${junit4Min},5)",\
 					org.junit.experimental.categories;version="[${junit4Min},5)",\


### PR DESCRIPTION
## Overview

Fixes #2547.

A "regression" in the context of this issue (compared with the current situation) would be if importing API Guardian suddenly became required, as that would break existing systems. To guard against such a regression, I modified the `verifyOSGi` task so that it excludes the API Guardian jar/bundle from consideration by the resolver. Thus the test will prove that API Guardian is not required for resolving JUnit 5 bundles.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
