### PR TITLE
Fix enclosing class bug in `IndicativeSentences`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -46,7 +46,9 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* The `IndicativeSentences` `DisplayNameGenerator` no longer includes the display name of
+  the enclosing class when generating an _indicative sentence_ if the enclosing class is
+  not configured to use the `IndicativeSentences` display name generator as well.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static java.util.function.Predicate.not;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.support.ModifierSupport.isStatic;
@@ -236,7 +237,7 @@ public interface DisplayNameGenerator {
 				}
 				Class<? extends DisplayNameGenerator> generatorClass = findDisplayNameGeneration(testClass)//
 						.map(DisplayNameGeneration::value)//
-						.filter(clazz -> clazz != IndicativeSentences.class)//
+						.filter(not(IndicativeSentences.class::equals))//
 						.orElse(null);
 				if (generatorClass != null) {
 					return getDisplayNameGenerator(generatorClass).generateDisplayNameForClass(testClass);
@@ -290,7 +291,7 @@ public interface DisplayNameGenerator {
 		private static DisplayNameGenerator getGeneratorFor(Class<?> testClass) {
 			return findIndicativeSentencesGeneration(testClass)//
 					.map(IndicativeSentencesGeneration::generator)//
-					.filter(clazz -> clazz != IndicativeSentences.class)//
+					.filter(not(IndicativeSentences.class::equals))//
 					.map(DisplayNameGenerator::getDisplayNameGenerator)//
 					.orElseGet(() -> getDisplayNameGenerator(IndicativeSentencesGeneration.DEFAULT_GENERATOR));
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api;
 
-import static java.util.function.Predicate.not;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.support.ModifierSupport.isStatic;
@@ -18,6 +17,7 @@ import static org.junit.platform.commons.support.ModifierSupport.isStatic;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.support.AnnotationSupport;
@@ -237,7 +237,7 @@ public interface DisplayNameGenerator {
 				}
 				Class<? extends DisplayNameGenerator> generatorClass = findDisplayNameGeneration(testClass)//
 						.map(DisplayNameGeneration::value)//
-						.filter(not(IndicativeSentences.class::equals))//
+						.filter(not(IndicativeSentences.class))//
 						.orElse(null);
 				if (generatorClass != null) {
 					return getDisplayNameGenerator(generatorClass).generateDisplayNameForClass(testClass);
@@ -291,7 +291,7 @@ public interface DisplayNameGenerator {
 		private static DisplayNameGenerator getGeneratorFor(Class<?> testClass) {
 			return findIndicativeSentencesGeneration(testClass)//
 					.map(IndicativeSentencesGeneration::generator)//
-					.filter(not(IndicativeSentences.class::equals))//
+					.filter(not(IndicativeSentences.class))//
 					.map(DisplayNameGenerator::getDisplayNameGenerator)//
 					.orElseGet(() -> getDisplayNameGenerator(IndicativeSentencesGeneration.DEFAULT_GENERATOR));
 		}
@@ -342,6 +342,10 @@ public interface DisplayNameGenerator {
 				candidate = candidate.getEnclosingClass();
 			} while (candidate != null);
 			return Optional.empty();
+		}
+
+		private static Predicate<Class<?>> not(Class<?> clazz) {
+			return ((Predicate<Class<?>>) clazz::equals).negate();
 		}
 
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/IndicativeSentencesGeneration.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/IndicativeSentencesGeneration.java
@@ -20,18 +20,24 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.DisplayNameGenerator.IndicativeSentences;
 
 /**
- * {@code @IndicativeSentencesGeneration} is used to declare a custom parameters
- * by {@code IndicativeSentences}, if this notation has some not declared
- * parameters, it will use the default values instead.
+ * {@code @IndicativeSentencesGeneration} is used to register the
+ * {@link IndicativeSentences} display name generator and configure it.
+ *
+ * <p>The {@link #separator} for sentence fragments and the display name
+ * {@link #generator} for sentence fragments are configurable. If this annotation
+ * is declared without any attributes &mdash; for example,
+ * {@code @IndicativeSentencesGeneration} or {@code @IndicativeSentencesGeneration()}
+ * &mdash; the default configuration will be used.
  *
  * @since 5.7
  * @see DisplayName
  * @see DisplayNameGenerator
  * @see DisplayNameGenerator.IndicativeSentences
  */
-@DisplayNameGeneration(DisplayNameGenerator.IndicativeSentences.class)
+@DisplayNameGeneration(IndicativeSentences.class)
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
@@ -40,15 +46,21 @@ import org.apiguardian.api.API;
 public @interface IndicativeSentencesGeneration {
 
 	String DEFAULT_SEPARATOR = ", ";
+
 	Class<? extends DisplayNameGenerator> DEFAULT_GENERATOR = DisplayNameGenerator.Standard.class;
 
 	/**
-	 * Custom separator for indicative sentences generator.
+	 * Custom separator for sentence fragments.
+	 *
+	 * <p>Defaults to {@value #DEFAULT_SEPARATOR}.
 	 */
-	String separator() default "";
+	String separator() default DEFAULT_SEPARATOR;
 
 	/**
-	 * Custom display name generator.
+	 * Custom display name generator to use for sentence fragments.
+	 *
+	 * <p>Defaults to {@link DisplayNameGenerator.Standard}.
 	 */
 	Class<? extends DisplayNameGenerator> generator() default DisplayNameGenerator.Standard.class;
+
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.engine.descriptor;
 
-import static org.junit.jupiter.api.DisplayNameGenerator.IndicativeSentences;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 
 import java.lang.reflect.AnnotatedElement;
@@ -21,6 +20,7 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.DisplayNameGenerator.IndicativeSentences;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.DisplayNameGenerator.Simple;
 import org.junit.jupiter.api.DisplayNameGenerator.Standard;
@@ -128,7 +128,7 @@ final class DisplayNameUtils {
 
 	/**
 	 * Find the first {@code DisplayNameGeneration} annotation that is either
-	 * <em>directly present</em>, <em>meta-present</em>, <em>indirectly present</em>
+	 * <em>directly present</em>, <em>meta-present</em>, or <em>indirectly present</em>
 	 * on the supplied {@code testClass} or on an enclosing class.
 	 */
 	private static Optional<DisplayNameGeneration> getDisplayNameGeneration(Class<?> testClass) {
@@ -142,4 +142,5 @@ final class DisplayNameUtils {
 		} while (candidate != null);
 		return Optional.empty();
 	}
+
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -82,7 +82,7 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
-	void indicativeSentencesGenerator() {
+	void indicativeSentencesGeneratorOnStaticNestedClass() {
 		var expectedDisplayNames = List.of( //
 			"CONTAINER: DisplayNameGenerationTests$IndicativeStyleTestCase", //
 			"TEST: @DisplayName prevails", //
@@ -94,6 +94,26 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 			"TEST: DisplayNameGenerationTests$IndicativeStyleTestCase -> testUsingCamelCaseStyle" //
 		);
 		check(IndicativeStyleTestCase.class, expectedDisplayNames);
+	}
+
+	@Test
+	void indicativeSentencesGeneratorOnTopLevelClass() {
+		var expectedDisplayNames = List.of( //
+			"CONTAINER: A year is a leap year", //
+			"CONTAINER: IndicativeSentencesTopLevelTestCase", //
+			"TEST: A year is a leap year -> if it is divisible by 4 but not by 100" //
+		);
+		check(IndicativeSentencesTopLevelTestCase.class, expectedDisplayNames);
+	}
+
+	@Test
+	void indicativeSentencesGeneratorOnNestedClass() {
+		var expectedDisplayNames = List.of( //
+			"CONTAINER: A year is a leap year", //
+			"CONTAINER: IndicativeSentencesNestedTestCase", //
+			"TEST: A year is a leap year -> if it is divisible by 4 but not by 100" //
+		);
+		check(IndicativeSentencesNestedTestCase.class, expectedDisplayNames);
 	}
 
 	@Test
@@ -130,11 +150,11 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	void checkDisplayNameGeneratedForIndicativeGeneratorTestCase() {
 		check(IndicativeGeneratorTestCase.class, List.of( //
 			"CONTAINER: A stack", //
-			"CONTAINER: A stack, when is new", //
-			"CONTAINER: A stack, when is new, after pushing an element to an empty stack", //
+			"CONTAINER: A stack, when new", //
+			"CONTAINER: A stack, when new, after pushing an element to an empty stack", //
 			"TEST: A stack, is instantiated with new constructor", //
-			"TEST: A stack, when is new, after pushing an element to an empty stack, is no longer empty", //
-			"TEST: A stack, when is new, throws EmptyStackException when peeked" //
+			"TEST: A stack, when new, after pushing an element to an empty stack, is no longer empty", //
+			"TEST: A stack, when new, throws EmptyStackException when peeked" //
 		));
 	}
 
@@ -319,7 +339,7 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Nested
-		class when_is_new {
+		class when_new {
 
 			@BeforeEach
 			void create_with_new_stack() {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -99,9 +99,9 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void indicativeSentencesGeneratorOnTopLevelClass() {
 		var expectedDisplayNames = List.of( //
-			"CONTAINER: A year is a leap year", //
 			"CONTAINER: IndicativeSentencesTopLevelTestCase", //
-			"TEST: A year is a leap year -> if it is divisible by 4 but not by 100" //
+			"CONTAINER: IndicativeSentencesTopLevelTestCase -> A year is a leap year", //
+			"TEST: IndicativeSentencesTopLevelTestCase -> A year is a leap year -> if it is divisible by 4 but not by 100" //
 		);
 		check(IndicativeSentencesTopLevelTestCase.class, expectedDisplayNames);
 	}
@@ -162,11 +162,11 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	void checkDisplayNameGeneratedForIndicativeGeneratorWithCustomSeparatorTestCase() {
 		check(IndicativeGeneratorWithCustomSeparatorTestCase.class, List.of( //
 			"CONTAINER: A stack", //
-			"CONTAINER: A stack >> when is new", //
-			"CONTAINER: A stack >> when is new >> after pushing an element to an empty stack", //
+			"CONTAINER: A stack >> when new", //
+			"CONTAINER: A stack >> when new >> after pushing an element to an empty stack", //
 			"TEST: A stack >> is instantiated with new constructor", //
-			"TEST: A stack >> when is new >> after pushing an element to an empty stack >> is no longer empty", //
-			"TEST: A stack >> when is new >> throws EmptyStackException when peeked"//
+			"TEST: A stack >> when new >> after pushing an element to an empty stack >> is no longer empty", //
+			"TEST: A stack >> when new >> throws EmptyStackException when peeked"//
 		));
 	}
 
@@ -383,7 +383,7 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Nested
-		class when_is_new {
+		class when_new {
 
 			@BeforeEach
 			void create_with_new_stack() {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/IndicativeSentencesNestedTestCase.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/IndicativeSentencesNestedTestCase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+/**
+ * This test case declares {@link IndicativeSentencesGeneration} on a test class
+ * that is nested directly within a top-level test class.
+ *
+ * @see IndicativeSentencesTopLevelTestCase
+ */
+class IndicativeSentencesNestedTestCase {
+
+	@Nested
+	@IndicativeSentencesGeneration(separator = " -> ", generator = ReplaceUnderscores.class)
+	class A_year_is_a_leap_year {
+
+		@Test
+		void if_it_is_divisible_by_4_but_not_by_100() {
+		}
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/IndicativeSentencesTopLevelTestCase.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/IndicativeSentencesTopLevelTestCase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+/**
+ * This test case declares {@link IndicativeSentencesGeneration} on a top-level
+ * test class that contains a nested test class.
+ *
+ * @see IndicativeSentencesNestedTestCase
+ */
+@IndicativeSentencesGeneration(separator = " -> ", generator = ReplaceUnderscores.class)
+class IndicativeSentencesTopLevelTestCase {
+
+	@Nested
+	class A_year_is_a_leap_year {
+
+		@Test
+		void if_it_is_divisible_by_4_but_not_by_100() {
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes #2645

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
