### PR TITLE
Bump API Guardian version to 1.1.2-SNAPSHOT

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,7 +1,1 @@
-dependencyResolutionManagement {
-	versionCatalogs {
-		create("libs") {
-			from(files("../gradle/libs.versions.toml"))
-		}
-	}
-}
+// intentionally left blank

--- a/buildSrc/src/main/kotlin/osgi-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/osgi-conventions.gradle.kts
@@ -6,11 +6,7 @@ plugins {
 	`java-library`
 }
 
-// Because the current build version of apiguardian (1.1.1) doesn't have OSGi metadata, bnd
-// cannot automatically determine the correct version to use in the Import-Package statement.
-// Fetch the current version out of the libs.versions.toml file.
-val apiguardianVersion = project.extensions.getByType(VersionCatalogsExtension::class).named("libs").findVersion("apiguardian").get()
-val importAPIGuardian = "org.apiguardian.*;version=\"\${range;[==,+);${apiguardianVersion}}\";resolution:=\"optional\""
+val importAPIGuardian = "org.apiguardian.*;resolution:=\"optional\""
 
 // This task enhances `jar` and `shadowJar` tasks with the bnd
 // `BundleTaskConvention` convention which allows for generating OSGi

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-apiguardian = "1.1.1"
+apiguardian = "1.1.2-SNAPSHOT"
 asciidoctor-pdf = "1.5.3"
 assertj = "3.19.0"
 checkstyle = "8.36.2"


### PR DESCRIPTION
## Overview

Because API Guardian 1.1.2-SNAPSHOT now has OSGi metadata, bumping to this dependency allows Bnd to automatically calculate the correct version of the package to import. This allows removing the extra gymnastics that were inserted to calculate it manually.

Fixes #2547 (again!)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
