### PR TITLE
Support AutoCloseable for arguments provided to a @ParameterizedTest

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -76,7 +76,7 @@ on GitHub.
   directory and any contained directories instead of failing to delete them.
 * New `assertThrowsExactly` method which is a more strict version of `assertThrows`
   that allows you to assert that the thrown exception has the exact specified class.
-* New `autoCloseArguments` attribute on `@ParameterizedTest` to close `AutoCloseable`
+* New `autoCloseArguments` attribute in `@ParameterizedTest` to close `AutoCloseable`
   arguments at the end of the test. This attribute defaults to true.
 
 

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -76,6 +76,8 @@ on GitHub.
   directory and any contained directories instead of failing to delete them.
 * New `assertThrowsExactly` method which is a more strict version of `assertThrows`
   that allows you to assert that the thrown exception has the exact specified class.
+* New `autoCloseArguments` attribute on `@ParameterizedTest` to close `AutoCloseable`
+  arguments at the end of the test. This attribute defaults to true.
 
 
 [[release-notes-5.8.0-M2-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1404,6 +1404,7 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsSource_examp
 include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsProvider_example]
 ----
 
+
 [[writing-tests-parameterized-tests-argument-conversion]]
 ==== Argument Conversion
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1105,6 +1105,10 @@ parameterized method at the same index in the method's formal parameter list. An
 _aggregator_ is any parameter of type `ArgumentsAccessor` or any parameter annotated with
 `@AggregateWith`.
 
+NOTE: Arguments of type `AutoCloseable` will be closed once `@AfterEach` methods and
+`AfterEachCallback` implementations have been called. To prevent this from happening, set
+the `autoCloseArguments` attribute in `@ParameterizedTest` to `false`.
+
 [[writing-tests-parameterized-tests-sources]]
 ==== Sources of Arguments
 
@@ -1399,11 +1403,6 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsSource_examp
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsProvider_example]
 ----
-
-NOTE: Arguments of type `AutoCloseable` will be closed once `@AfterEach` methods and
-`AfterEachCallback` implementations have been called. To prevent this from happening, set
-the `autoCloseArguments` attribute in `@ParameterizedTest` to `false`.
-
 
 [[writing-tests-parameterized-tests-argument-conversion]]
 ==== Argument Conversion

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1402,7 +1402,7 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsProvider_exa
 
 NOTE: Arguments of type `AutoCloseable` will be closed once `@AfterEach` methods and
 `AfterEachCallback` implementations have been called. To prevent this from happening, set
-attribute `autoCloseArguments` of `ParameterizedTest` to false.
+the `autoCloseArguments` attribute in `@ParameterizedTest` to `false`.
 
 
 [[writing-tests-parameterized-tests-argument-conversion]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1400,6 +1400,10 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsSource_examp
 include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsProvider_example]
 ----
 
+NOTE: Arguments of type `AutoCloseable` will be closed once `@AfterEach` methods and
+`AfterEachCallback` implementations have been called. To prevent this from happening, set
+attribute `autoCloseArguments` of `ParameterizedTest` to false.
+
 
 [[writing-tests-parameterized-tests-argument-conversion]]
 ==== Argument Conversion

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.params;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -216,6 +217,7 @@ public @interface ParameterizedTest {
 	 * @see java.lang.AutoCloseable
 	 * @see ParameterizedTestParameterResolver
 	 */
+	@API(status = EXPERIMENTAL, since = "5.8")
 	boolean autoCloseArguments() default true;
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -207,4 +207,15 @@ public @interface ParameterizedTest {
 	 */
 	String name() default "{default_display_name}";
 
+	/**
+	 * If true, all arguments of the parameterized test implementing {@link AutoCloseable}
+	 * will be closed after {@code @AfterEach} methods and {@code AfterEachCallbacks}
+	 * have been called.
+	 *
+	 * @since 5.8
+	 * @see java.lang.AutoCloseable
+	 * @see ParameterizedTestParameterResolver
+	 */
+	boolean autoCloseArguments() default true;
+
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
@@ -13,8 +13,7 @@ package org.junit.jupiter.params;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -84,16 +83,14 @@ class ParameterizedTestParameterResolver implements ParameterResolver, AfterTest
 			return;
 		}
 
-		List<CloseableArgument> closeableArguments = Arrays.stream(arguments) //
+		Store store = context.getStore(NAMESPACE);
+		AtomicInteger argumentIndex = new AtomicInteger();
+
+		Arrays.stream(arguments) //
 				.filter(AutoCloseable.class::isInstance) //
 				.map(AutoCloseable.class::cast) //
 				.map(CloseableArgument::new) //
-				.collect(Collectors.toList());
-
-		Store store = context.getStore(NAMESPACE);
-		for (int i = 0; i < closeableArguments.size(); i++) {
-			store.put("closeableArgument" + i, closeableArguments.get(i));
-		}
+				.forEach(closeable -> store.put("closeableArgument" + argumentIndex.getAndIncrement(), closeable));
 	}
 
 	private static class CloseableArgument implements Store.CloseableResource {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
@@ -85,8 +85,9 @@ class ParameterizedTestParameterResolver implements ParameterResolver, AfterTest
 		}
 
 		List<CloseableArgument> closeableArguments = Arrays.stream(arguments) //
-				.filter(argument -> argument instanceof AutoCloseable) //
-				.map(autoCloseable -> new CloseableArgument((AutoCloseable) autoCloseable)) //
+				.filter(AutoCloseable.class::isInstance) //
+				.map(AutoCloseable.class::cast) //
+				.map(CloseableArgument::new) //
 				.collect(Collectors.toList());
 
 		Store store = context.getStore(NAMESPACE);


### PR DESCRIPTION
## Overview

Closes #2597.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
