### PR TITLE
Issue: #2582 Do not swallow Exceptions in tests if something is throw…

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -145,7 +145,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 		if (isPerMethodLifecycle(context) && context.getExtensionContext().getTestInstance().isPresent()) {
 			invokeTestInstancePreDestroyCallbacks(context);
 		}
-		super.cleanUp(context);
+		context.getThrowableCollector().execute(() -> super.cleanUp(context));
 		context.getThrowableCollector().assertEmpty();
 	}
 


### PR DESCRIPTION


## Overview

Implemented fix as suggest in #2582 by @marcphilipp  -> wrapping the `super.cleanUp()` invocation in `TestMethodTestDescriptor.cleanUp()`

if a dedicated test is needed, please give some advice where to put it.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
