### PR TITLE
Added before and after all classes callback

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AfterAllClassesCallback.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AfterAllClassesCallback.java
@@ -1,0 +1,18 @@
+package org.junit.jupiter.engine.descriptor;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+@FunctionalInterface
+@API(
+    status = Status.STABLE,
+    since = "5.0"
+)
+public interface AfterAllClassesCallback extends Extension {
+    default Integer getAfterCallbackExecutionOrder() {
+        return 0;
+    };
+    void afterAllClasses(ExtensionContext var1) throws Exception;
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AllClassesCallbackActions.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AllClassesCallbackActions.java
@@ -1,0 +1,52 @@
+package org.junit.jupiter.engine.descriptor;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class AllClassesCallbackActions {
+    public static synchronized void invokeBeforeAllClassesCallbacks(JupiterEngineExecutionContext context) {
+        ExtensionRegistry registry = context.getExtensionRegistry();
+        ExtensionContext extensionContext = context.getExtensionContext();
+
+        List<BeforeAllClassesCallback> callbacks = registry.getExtensions(BeforeAllClassesCallback.class);
+        callbacks.stream().filter(
+            (callback) ->
+                !AllClassesContext.getBeforeAllClassesCallbacksExecutedMap().containsKey(callback.getClass().getCanonicalName()) ||
+                !AllClassesContext.getBeforeAllClassesCallbacksExecutedMap().get(callback.getClass().getCanonicalName())
+        ).sorted(Comparator.comparing(BeforeAllClassesCallback::getBeforeCallbackExecutionOrder)).forEach(
+            (callback) -> {
+                try {
+                    callback.beforeAllClasses(extensionContext);
+                    AllClassesContext.addNewBeforeAllClassesCallbacksExecutedToMap(callback.getClass().getCanonicalName(), true);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        );
+    }
+
+    public static synchronized void invokeAfterAllClassesCallbacks(JupiterEngineExecutionContext context) {
+        ExtensionRegistry registry = context.getExtensionRegistry();
+        ExtensionContext extensionContext = context.getExtensionContext();
+
+        List<AfterAllClassesCallback> callbacks = registry.getExtensions(AfterAllClassesCallback.class);
+        callbacks.stream().filter(
+            (callback) ->
+                !AllClassesContext.getAfterAllClassesCallbacksExecutedMap().containsKey(callback.getClass().getCanonicalName()) ||
+                    !AllClassesContext.getAfterAllClassesCallbacksExecutedMap().get(callback.getClass().getCanonicalName())
+        ).sorted(Comparator.comparing(AfterAllClassesCallback::getAfterCallbackExecutionOrder)).forEach(
+            (callback) -> {
+                try {
+                    callback.afterAllClasses(extensionContext);
+                    AllClassesContext.addNewAfterAllClassesCallbacksExecutedToMap(callback.getClass().getCanonicalName(), true);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        );
+    }
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AllClassesContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AllClassesContext.java
@@ -1,0 +1,24 @@
+package org.junit.jupiter.engine.descriptor;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class AllClassesContext {
+    private static ConcurrentHashMap<String, Boolean> beforeAllClassesCallbacksExecutedMap = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<String, Boolean> afterAllClassesCallbacksExecutedMap = new ConcurrentHashMap<>();
+
+    public static synchronized ConcurrentHashMap<String, Boolean> getBeforeAllClassesCallbacksExecutedMap() {
+        return beforeAllClassesCallbacksExecutedMap;
+    }
+
+    public static synchronized void addNewBeforeAllClassesCallbacksExecutedToMap(String name, Boolean value) {
+        beforeAllClassesCallbacksExecutedMap.put(name, value);
+    }
+
+    public static synchronized ConcurrentHashMap<String, Boolean> getAfterAllClassesCallbacksExecutedMap() {
+        return afterAllClassesCallbacksExecutedMap;
+    }
+
+    public static synchronized void addNewAfterAllClassesCallbacksExecutedToMap(String name, Boolean value) {
+        afterAllClassesCallbacksExecutedMap.put(name, value);
+    }
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/BeforeAllClassesCallback.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/BeforeAllClassesCallback.java
@@ -1,0 +1,18 @@
+package org.junit.jupiter.engine.descriptor;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+@FunctionalInterface
+@API(
+    status = Status.STABLE,
+    since = "5.0"
+)
+public interface BeforeAllClassesCallback extends Extension {
+    default Integer getBeforeCallbackExecutionOrder() {
+        return 0;
+    };
+    void beforeAllClasses(ExtensionContext var1) throws Exception;
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -491,4 +491,13 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 			ReflectiveInterceptorCall.ofVoidMethod(interceptorCall));
 	}
 
+	@Override
+	public void beforeAllClasses(JupiterEngineExecutionContext context) {
+		AllClassesCallbackActions.invokeBeforeAllClassesCallbacks(context);
+	}
+
+	@Override
+	public void afterAllClasses(JupiterEngineExecutionContext context) {
+		AllClassesCallbackActions.invokeAfterAllClassesCallbacks(context);
+	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/Node.java
@@ -359,4 +359,10 @@ public interface Node<C extends EngineExecutionContext> {
 		 */
 		void invoke(C context) throws Exception;
 	}
+
+	default void beforeAllClasses(C context) throws Exception {
+	}
+
+	default void afterAllClasses(C context) throws Exception {
+	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -137,6 +137,9 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 
 		throwableCollector.execute(() -> {
 			node.around(context, ctx -> {
+				if(!testDescriptor.getParent().isPresent()) {
+					node.beforeAllClasses(context);
+				}
 				context = ctx;
 				throwableCollector.execute(() -> {
 					// @formatter:off
@@ -159,6 +162,9 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 				});
 
 				throwableCollector.execute(() -> node.after(context));
+				if(!testDescriptor.getParent().isPresent()) {
+					node.afterAllClasses(context);
+				}
 			});
 		});
 	}


### PR DESCRIPTION
## Overview

Now we can add extensions for executing before all test classes and after all test classes

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
