### PR TITLE
Use stable JfrUnit version via JitPack

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,6 @@ repositories {
 	mavenCentral()
 	gradlePluginPortal()
 	maven(url = "https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local/")
-	maven(url = "https://jitpack.io")
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,6 +8,7 @@ repositories {
 	mavenCentral()
 	gradlePluginPortal()
 	maven(url = "https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local/")
+	maven(url = "https://jitpack.io")
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ commons-io = { module = "commons-io:commons-io", version = "2.9.0" }
 groovy3 = { module = "org.codehaus.groovy:groovy", version = "3.0.8" }
 groovy2-bom = { module = "org.codehaus.groovy:groovy-bom", version = "2.5.14" }
 hamcrest = { module = "org.hamcrest:hamcrest", version = "2.2" }
-jfrunit = { module = "com.github.gunnarmorling:jfrunit", version = "main-SNAPSHOT" }
+jfrunit = { module = "com.github.gunnarmorling:jfrunit", version = "f3b30c0784" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
 jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
 joox = { module = "org.jooq:joox", version = "1.6.2" }


### PR DESCRIPTION
## Overview

As @gunnarmorling didn't release an early-access version of https://github.com/moditect/jfrunit yet, we want to refer to
a stable version of this library in our tests.

This is achieved by referring to a specific GIT tag and making use of JitPack's feature to build and server Maven-based artifacts.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
