### PR TITLE
Support declarative extension registration on fields and parameters

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.0-M2.adoc
@@ -56,6 +56,9 @@ on GitHub.
 * Generating Java Flight Recorder events via module `org.junit.platform.jfr` is now also
   supported on Java 8 Update 262 or higher, in addition to Java 11 or later. See
   <<../user-guide/index.adoc#running-tests, Flight Recorder Support>> for details.
+* Suites executed by the `junit-platform-suite` module will now inherit the configuration
+  parameters from the parent discovery request. This behavior can be disabled via the
+  `@DisableParentConfigurationParameters` annotation.
 
 
 [[release-notes-5.8.0-M2-junit-jupiter]]
@@ -82,6 +85,9 @@ on GitHub.
 
 ==== New Features and Improvements
 
+* New `assertThrowsExactly()` method in `Assertions` which is a more strict version of
+  `assertThrows()` that allows you to assert that the exception thrown is of the exact
+  type specified.
 * `@TempDir` can now be used to create multiple temporary directories. Instead of creating
   a single temporary directory per context (i.e. test class or method) every declaration
   of the `@TempDir` annotation on a field or method parameter now results in a separate
@@ -90,13 +96,15 @@ on GitHub.
   you can set the `junit.jupiter.tempdir.scope` configuration parameter to `per_context`.
 * `@TempDir` cleanup resets readable and executable permissions of the root temporary
   directory and any contained directories instead of failing to delete them.
-* `@TempDir` fields may now be private.
+* `@TempDir` fields may now be `private`.
+* `@ExtendWith` may now be used to register extensions declaratively via fields or
+  parameters in test class constructors, test methods, and lifecycle methods. See
+  <<../user-guide/index.adoc#extensions-registration-declarative, Declarative Extension
+  Registration>> for details.
 * New `named()` static factory method in the `Named` interface that serves as an _alias_
   for `Named.of()`. `named()` is intended to be used via `import static`.
 * New `class` URI scheme for dynamic test sources. This allows tests to be located using
   the information available in a `StackTraceElement`.
-* New `assertThrowsExactly` method which is a more strict version of `assertThrows`
-  that allows you to assert that the thrown exception has the exact specified class.
 * New `autoCloseArguments` attribute in `@ParameterizedTest` to close `AutoCloseable`
   arguments at the end of the test. This attribute defaults to true.
 
@@ -114,6 +122,4 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* Suites executed by the `junit-platform-suite` module will now inherit the
-  configuration parameters from the parent discovery request. This behaviour can
-  be disabled via the `@DisableParentConfigurationParameters` annotation.
+* ❓

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -21,8 +21,10 @@ Java's <<extensions-registration-automatic,`ServiceLoader`>> mechanism.
 
 Developers can register one or more extensions _declaratively_ by annotating a test
 interface, test class, test method, or custom _<<writing-tests-meta-annotations,composed
-annotation>>_ with `@ExtendWith(...)` and supplying class references for the extensions
-to register.
+annotation>>_ with `@ExtendWith(...)` and supplying class references for the extensions to
+register. As of JUnit Jupiter 5.8, `@ExtendWith` may also be declared on fields and on
+parameters in test class constructors, in test methods, and in `@BeforeAll`, `@AfterAll`,
+`@BeforeEach`, and `@AfterEach` lifecycle methods.
 
 For example, to register a custom `RandomParametersExtension` for a particular test
 method, you would annotate the test method as follows.

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -125,8 +125,8 @@ registered last and _after_ callback extensions to be registered first, relative
 programmatically registered extensions.
 ====
 
-NOTE: `@RegisterExtension` fields must not be `private` or `null` (at evaluation time) but
-may be either `static` or non-static.
+NOTE: `@RegisterExtension` fields must not be `null` (at evaluation time) but may be
+either `static` or non-static.
 
 [[extensions-registration-programmatic-static-fields]]
 ===== Static Fields
@@ -159,9 +159,9 @@ include::{testDir}/example/registration/WebServerDemo.java[tags=user_guide]
 
 The Kotlin programming language does not have the concept of a `static` field. However,
 the compiler can be instructed to generate static fields using annotations. Since, as
-stated earlier, `@RegisterExtension` fields must not be `private` nor `null`, one
-**cannot** use the `@JvmStatic` annotation in Kotlin as it generates `private` fields.
-Rather, the `@JvmField` annotation must be used.
+stated earlier, `@RegisterExtension` fields must not be `null`, one **cannot** use the
+`@JvmStatic` annotation in Kotlin as it generates `private` fields. Rather, the
+`@JvmField` annotation must be used.
 
 The following example is a version of the `WebServerDemo` from the previous section that
 has been ported to Kotlin.

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -22,28 +22,31 @@ Java's <<extensions-registration-automatic,`ServiceLoader`>> mechanism.
 Developers can register one or more extensions _declaratively_ by annotating a test
 interface, test class, test method, or custom _<<writing-tests-meta-annotations,composed
 annotation>>_ with `@ExtendWith(...)` and supplying class references for the extensions to
-register. As of JUnit Jupiter 5.8, `@ExtendWith` may also be declared on fields and on
+register. As of JUnit Jupiter 5.8, `@ExtendWith` may also be declared on fields or on
 parameters in test class constructors, in test methods, and in `@BeforeAll`, `@AfterAll`,
 `@BeforeEach`, and `@AfterEach` lifecycle methods.
 
-For example, to register a custom `RandomParametersExtension` for a particular test
-method, you would annotate the test method as follows.
+For example, to register a `WebServerExtension` for a particular test method, you would
+annotate the test method as follows. We assume the `WebServerExtension` starts a local web
+server and injects the server's URL into parameters annotated with `@WebServerUrl`.
 
 [source,java,indent=0]
 ----
-@ExtendWith(RandomParametersExtension.class)
 @Test
-void test(@Random int i) {
-	// ...
+@ExtendWith(WebServerExtension.class)
+void getProductList(@WebServerUrl String serverUrl) {
+	WebClient webClient = new WebClient();
+	// Use WebClient to connect to web server using serverUrl and verify response
+	assertEquals(200, webClient.get(serverUrl + "/products").getResponseStatus());
 }
 ----
 
-To register a custom `RandomParametersExtension` for all tests in a particular class and
-its subclasses, you would annotate the test class as follows.
+To register the `WebServerExtension` for all tests in a particular class and its
+subclasses, you would annotate the test class as follows.
 
 [source,java,indent=0]
 ----
-@ExtendWith(RandomParametersExtension.class)
+@ExtendWith(WebServerExtension.class)
 class MyTests {
 	// ...
 }
@@ -73,15 +76,16 @@ class MySecondTests {
 [TIP]
 .Extension Registration Order
 ====
-Extensions registered declaratively via `@ExtendWith` will be executed in the order in
-which they are declared in the source code. For example, the execution of tests in both
-`MyFirstTests` and `MySecondTests` will be extended by the `DatabaseExtension` and
-`WebServerExtension`, **in exactly that order**.
+Extensions registered declaratively via `@ExtendWith` at the class level, method level, or
+parameter level will be executed in the order in which they are declared in the source
+code. For example, the execution of tests in both `MyFirstTests` and `MySecondTests` will
+be extended by the `DatabaseExtension` and `WebServerExtension`, **in exactly that order**.
 ====
 
 If you wish to combine multiple extensions in a reusable way, you can define a custom
 _<<writing-tests-meta-annotations,composed annotation>>_ and use `@ExtendWith` as a
-_meta-annotation_:
+_meta-annotation_ as in the following code listing. Then `@DatabaseAndWebServerExtension`
+can be used in place of `@ExtendWith({ DatabaseExtension.class, WebServerExtension.class })`.
 
 [source,java,indent=0]
 ----
@@ -91,6 +95,64 @@ _meta-annotation_:
 public @interface DatabaseAndWebServerExtension {
 }
 ----
+
+The above examples demonstrate how `@ExtendWith` can be applied at the class level or at
+the method level; however, for certain use cases it makes sense for an extension to be
+registered declaratively at the field or parameter level. Consider a
+`RandomNumberExtension` that generates random numbers that can be injected into a field or
+via a parameter in a constructor, test method, or lifecycle method. If the extension
+provides a `@Random` annotation that is meta-annotated with
+`@ExtendWith(RandomNumberExtension.class)` (see listing below), the extension can be used
+transparently as in the following `RandomNumberTests` example.
+
+[source,java,indent=0]
+----
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(RandomNumberExtension.class)
+public @interface Random {
+}
+----
+
+[source,java,indent=0]
+----
+class RandomNumberTests {
+
+	// use random number field in test methods and @BeforeEach
+	// or @AfterEach lifecycle methods
+	@Random
+	private int randomNumber1;
+
+	RandomNumberTests(@Random int randomNumber2) {
+		// use random number in constructor
+	}
+
+	@BeforeEach
+	void beforeEach(@Random int randomNumber3) {
+		// use random number in @BeforeEach method
+	}
+
+	@Test
+	void test(@Random int randomNumber4) {
+		// use random number in test method
+	}
+}
+----
+
+[TIP]
+.Extension Registration Order for `@ExtendWith` on Fields
+====
+Extensions registered declaratively via `@ExtendWith` on fields will be ordered relative
+to `@RegisterExtension` fields and other `@ExtendWith` fields using an algorithm that is
+deterministic but intentionally nonobvious. However, `@ExtendWith` fields can be ordered
+using the `@Order` annotation. See the <<extensions-registration-programmatic-order,
+Extension Registration Order>> tip for `@RegisterExtension` fields for details.
+====
+
+NOTE: `@ExtendWith` fields may be either `static` or non-static. The documentation on
+<<extensions-registration-programmatic-static-fields, Static Fields>> and
+<<extensions-registration-programmatic-instance-fields, Instance Fields>> for
+`@RegisterExtension` fields also applies to `@ExtendWith` fields.
 
 [[extensions-registration-programmatic]]
 ==== Programmatic Extension Registration
@@ -108,23 +170,23 @@ extension's constructor, a static factory method, or a builder API.
 [TIP]
 .Extension Registration Order
 ====
-By default, extensions registered programmatically via `@RegisterExtension` will be
-ordered using an algorithm that is deterministic but intentionally nonobvious. This
-ensures that subsequent runs of a test suite execute extensions in the same order, thereby
-allowing for repeatable builds. However, there are times when extensions need to be
-registered in an explicit order. To achieve that, annotate `@RegisterExtension` fields
-with `{Order}`.
+By default, extensions registered programmatically via `@RegisterExtension` or
+declaratively via `@ExtendWith` on fields will be ordered using an algorithm that is
+deterministic but intentionally nonobvious. This ensures that subsequent runs of a test
+suite execute extensions in the same order, thereby allowing for repeatable builds.
+However, there are times when extensions need to be registered in an explicit order. To
+achieve that, annotate `@RegisterExtension` fields or `@ExtendWith` fields with `{Order}`.
 
-Any `@RegisterExtension` field not annotated with `@Order` will be ordered using the
-_default_ order which has a value of `Integer.MAX_VALUE / 2`. This allows `@Order`
-annotated extension fields to be explicitly ordered before or after non-annotated
-extension fields. Extensions with an explicit order value less than the default order
-value will be registered before non-annotated extensions. Similarly, extensions with an
-explicit order value greater than the default order value will be registered after
-non-annotated extensions. For example, assigning an extension an explicit order value that
-is greater than the default order value allows _before_ callback extensions to be
-registered last and _after_ callback extensions to be registered first, relative to other
-programmatically registered extensions.
+Any `@RegisterExtension` field or `@ExtendWith` field not annotated with `@Order` will be
+ordered using the _default_ order which has a value of `Integer.MAX_VALUE / 2`. This
+allows `@Order` annotated extension fields to be explicitly ordered before or after
+non-annotated extension fields. Extensions with an explicit order value less than the
+default order value will be registered before non-annotated extensions. Similarly,
+extensions with an explicit order value greater than the default order value will be
+registered after non-annotated extensions. For example, assigning an extension an explicit
+order value that is greater than the default order value allows _before_ callback
+extensions to be registered last and _after_ callback extensions to be registered first,
+relative to other programmatically registered extensions.
 ====
 
 NOTE: `@RegisterExtension` fields must not be `null` (at evaluation time) but may be
@@ -151,19 +213,18 @@ lifecycle methods annotated with `@BeforeAll` or `@AfterAll` as well as `@Before
 `server` field if necessary.
 
 [source,java,indent=0]
-.An extension registered via a static field
+.Registering an extension via a static field in Java
 ----
 include::{testDir}/example/registration/WebServerDemo.java[tags=user_guide]
 ----
 
 [[extensions-registration-programmatic-static-fields-kotlin]]
-===== Static Fields in Kotlin
+====== Static Fields in Kotlin
 
 The Kotlin programming language does not have the concept of a `static` field. However,
-the compiler can be instructed to generate static fields using annotations. Since, as
-stated earlier, `@RegisterExtension` fields must not be `null`, one **cannot** use the
-`@JvmStatic` annotation in Kotlin as it generates `private` fields. Rather, the
-`@JvmField` annotation must be used.
+the compiler can be instructed to generate a `private static` field using the `@JvmStatic`
+annotation in Kotlin. If you want the Kotlin compiler to generate a `public static` field,
+you can use the `@JvmField` annotation instead.
 
 The following example is a version of the `WebServerDemo` from the previous section that
 has been ported to Kotlin.

--- a/documentation/src/test/kotlin/example/registration/KotlinWebServerDemo.kt
+++ b/documentation/src/test/kotlin/example/registration/KotlinWebServerDemo.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 class KotlinWebServerDemo {
 
     companion object {
-        @JvmField
+        @JvmStatic
         @RegisterExtension
         val server = WebServerExtension.builder()
                 .enableSecurity(false)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
@@ -24,8 +24,12 @@ import org.apiguardian.api.API;
 
 /**
  * {@code @ExtendWith} is a {@linkplain Repeatable repeatable} annotation
- * that is used to register {@linkplain Extension extensions} for the
- * annotated test class or test method.
+ * that is used to register {@linkplain Extension extensions} for the annotated
+ * test class, test interface, test method, field, or parameter.
+ *
+ * <p>Annotated parameters are supported in test class constructors, in test
+ * methods, and in {@code @BeforeAll}, {@code @AfterAll}, {@code @BeforeEach},
+ * and {@code @AfterEach} lifecycle methods.
  *
  * <h3>Supported Extension APIs</h3>
  * <ul>
@@ -49,7 +53,7 @@ import org.apiguardian.api.API;
  * @see RegisterExtension
  * @see Extension
  */
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtendWith.java
@@ -25,13 +25,46 @@ import org.apiguardian.api.API;
 /**
  * {@code @ExtendWith} is a {@linkplain Repeatable repeatable} annotation
  * that is used to register {@linkplain Extension extensions} for the annotated
- * test class, test interface, test method, field, or parameter.
+ * test class, test interface, test method, parameter, or field.
  *
  * <p>Annotated parameters are supported in test class constructors, in test
  * methods, and in {@code @BeforeAll}, {@code @AfterAll}, {@code @BeforeEach},
  * and {@code @AfterEach} lifecycle methods.
  *
+ * <p>{@code @ExtendWith} fields may be either {@code static} or non-static.
+ *
+ * <h3>Inheritance</h3>
+ *
+ * <p>{@code @ExtendWith} fields are inherited from superclasses as long as they
+ * are not <em>hidden</em> or <em>overridden</em>. Furthermore, {@code @ExtendWith}
+ * fields from superclasses will be registered before {@code @ExtendWith} fields
+ * in subclasses.
+ *
+ * <h3>Registration Order</h3>
+ *
+ * <p>When {@code @ExtendWith} is present on a test class, test interface, or
+ * test method or on a parameter in a test method or lifecycle method, the
+ * corresponding extensions will be registered in the order in which the
+ * {@code @ExtendWith} annotations are discovered. For example, if a test class
+ * is annotated with {@code @ExtendWith(A.class)} and then with
+ * {@code @ExtendWith(B.class)}, extension {@code A} will be registered before
+ * extension {@code B}.
+ *
+ * <p>By default, if multiple extensions are registered on fields via
+ * {@code @ExtendWith}, they will be ordered using an algorithm that is
+ * deterministic but intentionally nonobvious. This ensures that subsequent runs
+ * of a test suite execute extensions in the same order, thereby allowing for
+ * repeatable builds. However, there are times when extensions need to be
+ * registered in an explicit order. To achieve that, you can annotate
+ * {@code @ExtendWith} fields with {@link org.junit.jupiter.api.Order @Order}.
+ * Any {@code @ExtendWith} field not annotated with {@code @Order} will be
+ * ordered using the {@link org.junit.jupiter.api.Order#DEFAULT default} order
+ * value. Note that {@code @RegisterExtension} fields can also be ordered with
+ * {@code @Order}, relative to {@code @ExtendWith} fields and other
+ * {@code @RegisterExtension} fields.
+ *
  * <h3>Supported Extension APIs</h3>
+ *
  * <ul>
  * <li>{@link ExecutionCondition}</li>
  * <li>{@link InvocationInterceptor}</li>

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/RegisterExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/RegisterExtension.java
@@ -81,7 +81,9 @@ import org.apiguardian.api.API;
  * {@code @RegisterExtension} fields with {@link org.junit.jupiter.api.Order @Order}.
  * Any {@code @RegisterExtension} field not annotated with {@code @Order} will be
  * ordered using the {@link org.junit.jupiter.api.Order#DEFAULT default} order
- * value.
+ * value. Note that {@code @ExtendWith} fields can also be ordered with
+ * {@code @Order}, relative to {@code @RegisterExtension} fields and other
+ * {@code @ExtendWith} fields.
  *
  * <h3>Example Usage</h3>
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/RegisterExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/RegisterExtension.java
@@ -30,8 +30,8 @@ import org.apiguardian.api.API;
  * to pass arguments to the extension's constructor, {@code static} factory
  * method, or builder API.
  *
- * <p>{@code @RegisterExtension} fields must not be {@code private} or
- * {@code null} (when evaluated) but may be either {@code static} or non-static.
+ * <p>{@code @RegisterExtension} fields must not be {@code null} (when evaluated)
+ * but may be either {@code static} or non-static.
  *
  * <h3>Static Fields</h3>
  *

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -162,10 +162,14 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 		this.afterAllMethods = findAfterAllMethods(this.testClass, this.lifecycle == Lifecycle.PER_METHOD);
 
 		this.beforeAllMethods.forEach(method -> registerExtensionsFromExecutableParameters(registry, method));
-		this.afterAllMethods.forEach(method -> registerExtensionsFromExecutableParameters(registry, method));
-
+		// Since registerBeforeEachMethodAdapters() and registerAfterEachMethodAdapters() also
+		// invoke registerExtensionsFromExecutableParameters(), we invoke those methods before
+		// invoking registerExtensionsFromExecutableParameters() for @BeforeAll methods,
+		// thereby ensuring proper registration order for extensions registered via @ExtendWith
+		// on parameters in lifecycle methods.
 		registerBeforeEachMethodAdapters(registry);
 		registerAfterEachMethodAdapters(registry);
+		this.afterAllMethods.forEach(method -> registerExtensionsFromExecutableParameters(registry, method));
 
 		ThrowableCollector throwableCollector = createThrowableCollector();
 		ClassExtensionContext extensionContext = new ClassExtensionContext(context.getExtensionContext(),

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -13,6 +13,8 @@ package org.junit.jupiter.engine.descriptor;
 import static java.util.stream.Collectors.joining;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.ExtensionUtils.populateNewExtensionRegistryFromExtendWithAnnotation;
+import static org.junit.jupiter.engine.descriptor.ExtensionUtils.registerExtensionsFromConstructorParameters;
+import static org.junit.jupiter.engine.descriptor.ExtensionUtils.registerExtensionsFromExecutableParameters;
 import static org.junit.jupiter.engine.descriptor.ExtensionUtils.registerExtensionsFromFields;
 import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findAfterAllMethods;
 import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findAfterEachMethods;
@@ -152,15 +154,22 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 		// one factory registered per class).
 		this.testInstanceFactory = resolveTestInstanceFactory(registry);
 
+		if (this.testInstanceFactory == null) {
+			registerExtensionsFromConstructorParameters(registry, this.testClass);
+		}
+
+		this.beforeAllMethods = findBeforeAllMethods(this.testClass, this.lifecycle == Lifecycle.PER_METHOD);
+		this.afterAllMethods = findAfterAllMethods(this.testClass, this.lifecycle == Lifecycle.PER_METHOD);
+
+		this.beforeAllMethods.forEach(method -> registerExtensionsFromExecutableParameters(registry, method));
+		this.afterAllMethods.forEach(method -> registerExtensionsFromExecutableParameters(registry, method));
+
 		registerBeforeEachMethodAdapters(registry);
 		registerAfterEachMethodAdapters(registry);
 
 		ThrowableCollector throwableCollector = createThrowableCollector();
 		ClassExtensionContext extensionContext = new ClassExtensionContext(context.getExtensionContext(),
 			context.getExecutionListener(), this, this.lifecycle, context.getConfiguration(), throwableCollector);
-
-		this.beforeAllMethods = findBeforeAllMethods(this.testClass, this.lifecycle == Lifecycle.PER_METHOD);
-		this.afterAllMethods = findAfterAllMethods(this.testClass, this.lifecycle == Lifecycle.PER_METHOD);
 
 		// @formatter:off
 		return context.extend()
@@ -468,7 +477,10 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 	private void registerMethodsAsExtensions(List<Method> methods, ExtensionRegistrar registrar,
 			Function<Method, Extension> extensionSynthesizer) {
 
-		methods.forEach(method -> registrar.registerSyntheticExtension(extensionSynthesizer.apply(method), method));
+		methods.forEach(method -> {
+			registerExtensionsFromExecutableParameters(registrar, method);
+			registrar.registerSyntheticExtension(extensionSynthesizer.apply(method), method);
+		});
 	}
 
 	private BeforeEachMethodAdapter synthesizeBeforeEachMethodAdapter(Method method) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -164,7 +164,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 		this.beforeAllMethods.forEach(method -> registerExtensionsFromExecutableParameters(registry, method));
 		// Since registerBeforeEachMethodAdapters() and registerAfterEachMethodAdapters() also
 		// invoke registerExtensionsFromExecutableParameters(), we invoke those methods before
-		// invoking registerExtensionsFromExecutableParameters() for @BeforeAll methods,
+		// invoking registerExtensionsFromExecutableParameters() for @AfterAll methods,
 		// thereby ensuring proper registration order for extensions registered via @ExtendWith
 		// on parameters in lifecycle methods.
 		registerBeforeEachMethodAdapters(registry);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -148,7 +148,8 @@ final class ExtensionUtils {
 	/**
 	 * Register extensions using the supplied registrar from parameters in the
 	 * supplied {@link Executable} (i.e., a {@link java.lang.reflect.Constructor}
-	 * or {@link java.lang.reflect.Method}) that are annotated with{@link ExtendWith @ExtendWith}.
+	 * or {@link java.lang.reflect.Method}) that are meta-annotated with
+	 * {@link ExtendWith @ExtendWith}.
 	 *
 	 * @param registrar the registrar with which to register the extensions; never {@code null}
 	 * @param executable the constructor or method whose parameters should be searched; never {@code null}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -76,8 +76,8 @@ final class ExtensionUtils {
 
 	/**
 	 * Register extensions using the supplied registrar from fields in the supplied
-	 * class that are meta-annotated with {@link ExtendWith @ExtendWith} or
-	 * annotated with {@link RegisterExtension @RegisterExtension}.
+	 * class that are annotated with {@link ExtendWith @ExtendWith} or
+	 * {@link RegisterExtension @RegisterExtension}.
 	 *
 	 * <p>The extensions will be sorted according to {@link Order @Order} semantics
 	 * prior to registration.
@@ -141,7 +141,7 @@ final class ExtensionUtils {
 	/**
 	 * Register extensions using the supplied registrar from parameters in the
 	 * supplied {@link Executable} (i.e., a {@link java.lang.reflect.Constructor}
-	 * or {@link java.lang.reflect.Method}) that are meta-annotated with
+	 * or {@link java.lang.reflect.Method}) that are annotated with
 	 * {@link ExtendWith @ExtendWith}.
 	 *
 	 * @param registrar the registrar with which to register the extensions; never {@code null}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -16,7 +16,6 @@ import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
 import static org.junit.platform.commons.util.ReflectionUtils.findFields;
 import static org.junit.platform.commons.util.ReflectionUtils.getDeclaredConstructor;
-import static org.junit.platform.commons.util.ReflectionUtils.isNotPrivate;
 import static org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue;
 
 import java.lang.reflect.AnnotatedElement;
@@ -108,9 +107,6 @@ final class ExtensionUtils {
 		fields.stream()
 			.filter(field -> isAnnotated(field, RegisterExtension.class))
 			.forEach(field -> {
-				Preconditions.condition(isNotPrivate(field), () -> String.format(
-					"Failed to register extension via @RegisterExtension field [%s]: field must not be private.",
-					field));
 				tryToReadFieldValue(field, instance).ifSuccess(value -> {
 					Preconditions.condition(value instanceof Extension, () -> String.format(
 						"Failed to register extension via @RegisterExtension field [%s]: field value's type [%s] must implement an [%s] API.",

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -85,7 +85,8 @@ final class ExtensionUtils {
 
 	/**
 	 * Register extensions using the supplied registrar from fields in the supplied
-	 * class that are annotated with {@link RegisterExtension @RegisterExtension}.
+	 * class that are meta-annotated with {@link ExtendWith @ExtendWith} or
+	 * annotated with {@link RegisterExtension @RegisterExtension}.
 	 *
 	 * <p>The extensions will be sorted according to {@link Order @Order} semantics
 	 * prior to registration.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.descriptor;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.ExtensionUtils.populateNewExtensionRegistryFromExtendWithAnnotation;
+import static org.junit.jupiter.engine.descriptor.ExtensionUtils.registerExtensionsFromExecutableParameters;
 import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.createThrowableCollector;
 
 import java.lang.reflect.Method;
@@ -113,7 +114,10 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 	}
 
 	protected MutableExtensionRegistry populateNewExtensionRegistry(JupiterEngineExecutionContext context) {
-		return populateNewExtensionRegistryFromExtendWithAnnotation(context.getExtensionRegistry(), getTestMethod());
+		MutableExtensionRegistry registry = populateNewExtensionRegistryFromExtendWithAnnotation(
+			context.getExtensionRegistry(), getTestMethod());
+		registerExtensionsFromExecutableParameters(registry, getTestMethod());
+		return registry;
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultParameterContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultParameterContext.java
@@ -10,12 +10,7 @@
 
 package org.junit.jupiter.engine.execution;
 
-import static org.junit.platform.commons.util.ReflectionUtils.isInnerClass;
-
 import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.util.List;
 import java.util.Optional;
@@ -58,62 +53,17 @@ class DefaultParameterContext implements ParameterContext {
 
 	@Override
 	public boolean isAnnotated(Class<? extends Annotation> annotationType) {
-		return AnnotationUtils.isAnnotated(getEffectiveAnnotatedParameter(), annotationType);
+		return AnnotationUtils.isAnnotated(this.parameter, this.index, annotationType);
 	}
 
 	@Override
 	public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
-		return AnnotationUtils.findAnnotation(getEffectiveAnnotatedParameter(), annotationType);
+		return AnnotationUtils.findAnnotation(this.parameter, this.index, annotationType);
 	}
 
 	@Override
 	public <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
-		return AnnotationUtils.findRepeatableAnnotations(getEffectiveAnnotatedParameter(), annotationType);
-	}
-
-	/**
-	 * Due to a bug in {@code javac} on JDK versions prior to JDK 9, looking up
-	 * annotations directly on a {@link Parameter} will fail for inner class
-	 * constructors.
-	 *
-	 * <h4>Bug in {@code javac} on JDK versions prior to JDK 9</h4>
-	 *
-	 * <p>The parameter annotations array in the compiled byte code for the user's
-	 * test class excludes an entry for the implicit <em>enclosing instance</em>
-	 * parameter for an inner class constructor.
-	 *
-	 * <h4>Workaround</h4>
-	 *
-	 * <p>JUnit provides a workaround for this off-by-one error by helping extension
-	 * authors to access annotations on the preceding {@link Parameter} object (i.e.,
-	 * {@code index - 1}). The {@linkplain #getIndex() current index} must never be
-	 * zero in such situations since JUnit Jupiter should never ask a
-	 * {@code ParameterResolver} to resolve a parameter for the implicit <em>enclosing
-	 * instance</em> parameter.
-	 *
-	 * <h4>WARNING</h4>
-	 *
-	 * <p>The {@code AnnotatedElement} returned by this method should never be cast and
-	 * treated as a {@code Parameter} since the metadata (e.g., {@link Parameter#getName()},
-	 * {@link Parameter#getType()}, etc.) will not match those for the declared parameter
-	 * at the given index in an inner class constructor.
-	 *
-	 * @return the actual {@code Parameter} for this context, or the <em>effective</em>
-	 * {@code Parameter} if the aforementioned bug is detected
-	 */
-	private AnnotatedElement getEffectiveAnnotatedParameter() {
-		Executable executable = getDeclaringExecutable();
-
-		if (executable instanceof Constructor && isInnerClass(executable.getDeclaringClass())
-				&& executable.getParameterAnnotations().length == executable.getParameterCount() - 1) {
-
-			Preconditions.condition(this.index != 0,
-				"A ParameterContext should never be created for parameter index 0 in an inner class constructor");
-
-			return executable.getParameters()[this.index - 1];
-		}
-
-		return this.parameter;
+		return AnnotationUtils.findRepeatableAnnotations(this.parameter, this.index, annotationType);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistrar.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistrar.java
@@ -24,6 +24,18 @@ import org.junit.jupiter.api.extension.Extension;
 public interface ExtensionRegistrar {
 
 	/**
+	 * Instantiate an extension of the given type using its default constructor
+	 * and register it in the registry.
+	 *
+	 * <p>A new {@link Extension} should not be registered if an extension of the
+	 * given type already exists in the registry or a parent registry.
+	 *
+	 * @param extensionType the type of extension to register
+	 * @since 5.8
+	 */
+	void registerExtension(Class<? extends Extension> extensionType);
+
+	/**
 	 * Register the supplied {@link Extension}, without checking if an extension
 	 * of that type has already been registered.
 	 *

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -139,16 +139,8 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		// @formatter:on
 	}
 
-	/**
-	 * Instantiate an extension of the given type using its default constructor
-	 * and register it in this registry.
-	 *
-	 * <p>A new {@link Extension} will not be registered if an extension of the
-	 * given type already exists in this registry or a parent registry.
-	 *
-	 * @param extensionType the type of extension to register
-	 */
-	void registerExtension(Class<? extends Extension> extensionType) {
+	@Override
+	public void registerExtension(Class<? extends Extension> extensionType) {
 		if (!isAlreadyRegistered(extensionType)) {
 			registerLocalExtension(ReflectionUtils.newInstance(extensionType));
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -95,7 +95,7 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 	 * @return a new {@code ExtensionRegistry}; never {@code null}
 	 */
 	public static MutableExtensionRegistry createRegistryFrom(MutableExtensionRegistry parentRegistry,
-			List<Class<? extends Extension>> extensionTypes) {
+			Stream<Class<? extends Extension>> extensionTypes) {
 
 		Preconditions.notNull(parentRegistry, "parentRegistry must not be null");
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.engine.execution.injection.sample.LongParameterResolver;
+
+/**
+ * Integration tests that verify support for extension registration via
+ * {@link ExtendWith @ExtendWith} on annotations on parameters and fields.
+ *
+ * @since 5.8
+ */
+class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void constructorParameter() {
+		assertOneTestSucceeded(ConstructorParameterTestCase.class);
+	}
+
+	@Test
+	void constructorParameterForNestedTestClass() {
+		assertOneTestSucceeded(NestedConstructorParameterTestCase.class);
+	}
+
+	@Test
+	void beforeAllMethodParameter() {
+		assertOneTestSucceeded(BeforeAllParameterTestCase.class);
+	}
+
+	@Test
+	void afterAllMethodParameter() {
+		assertOneTestSucceeded(AfterAllParameterTestCase.class);
+	}
+
+	@Test
+	void beforeEachMethodParameter() {
+		assertOneTestSucceeded(BeforeEachParameterTestCase.class);
+	}
+
+	@Test
+	void afterEachMethodParameter() {
+		assertOneTestSucceeded(AfterEachParameterTestCase.class);
+	}
+
+	@Test
+	void testMethodParameter() {
+		assertOneTestSucceeded(TestMethodParameterTestCase.class);
+	}
+
+	@Test
+	void testFactoryMethodParameter() {
+		assertTestsSucceeded(TestFactoryMethodParameterTestCase.class, 2);
+	}
+
+	@Test
+	void testTemplateMethodParameter() {
+		assertTestsSucceeded(TestTemplateMethodParameterTestCase.class, 2);
+	}
+
+	private void assertOneTestSucceeded(Class<?> testClass) {
+		assertTestsSucceeded(testClass, 1);
+	}
+
+	private void assertTestsSucceeded(Class<?> testClass, int expected) {
+		executeTestsForClass(testClass).testEvents().assertStatistics(
+			stats -> stats.started(expected).succeeded(expected).skipped(0).aborted(0).failed(0));
+	}
+
+	// -------------------------------------------------------------------
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the constructor
+	 * and then used for lifecycle and test methods.
+	 */
+	@ExtendWith(LongParameterResolver.class)
+	static class ConstructorParameterTestCase {
+
+		ConstructorParameterTestCase(@MagicParameter("constructor") String text) {
+			assertThat(text).isEqualTo("ConstructorParameterTestCase-0-constructor");
+		}
+
+		@BeforeEach
+		void beforeEach(String text, TestInfo testInfo) {
+			assertThat(text).isEqualTo("beforeEach-0-enigma");
+			assertThat(testInfo).isNotNull();
+		}
+
+		@Test
+		void test(TestInfo testInfo, String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("test-1-enigma");
+		}
+
+		/**
+		 * Redeclaring {@code @MagicParameter} should not result in a
+		 * {@link ParameterResolutionException}.
+		 */
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-method");
+		}
+
+	}
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the constructor
+	 * and then used for lifecycle and test methods.
+	 */
+	@Nested
+	@ExtendWith(LongParameterResolver.class)
+	class NestedConstructorParameterTestCase {
+
+		NestedConstructorParameterTestCase(@MagicParameter("constructor") String text) {
+			// Index is 1 instead of 0, since constructors for non-static nested classes
+			// receive a reference to the enclosing instance as the first argument: this$0
+			assertThat(text).isEqualTo("NestedConstructorParameterTestCase-1-constructor");
+		}
+
+		@BeforeEach
+		void beforeEach(String text, TestInfo testInfo) {
+			assertThat(text).isEqualTo("beforeEach-0-enigma");
+			assertThat(testInfo).isNotNull();
+		}
+
+		@Test
+		void test(TestInfo testInfo, String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("test-1-enigma");
+		}
+
+		/**
+		 * Redeclaring {@code @MagicParameter} should not result in a
+		 * {@link ParameterResolutionException}.
+		 */
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-method");
+		}
+
+	}
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @BeforeAll}
+	 * method and then used for other lifecycle methods and test methods.
+	 */
+	@ExtendWith(LongParameterResolver.class)
+	static class BeforeAllParameterTestCase {
+
+		@BeforeAll
+		static void beforeAll(@MagicParameter("method") String text, TestInfo testInfo) {
+			assertThat(text).isEqualTo("beforeAll-0-method");
+			assertThat(testInfo).isNotNull();
+		}
+
+		@BeforeEach
+		void beforeEach(String text, TestInfo testInfo) {
+			assertThat(text).isEqualTo("beforeEach-0-enigma");
+			assertThat(testInfo).isNotNull();
+		}
+
+		@Test
+		void test(TestInfo testInfo, String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("test-1-enigma");
+		}
+
+		/**
+		 * Redeclaring {@code @MagicParameter} should not result in a
+		 * {@link ParameterResolutionException}.
+		 */
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-method");
+		}
+
+		@AfterAll
+		static void afterAll(String text, TestInfo testInfo) {
+			assertThat(text).isEqualTo("afterAll-0-enigma");
+			assertThat(testInfo).isNotNull();
+		}
+
+	}
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @AfterAll} method.
+	 */
+	@ExtendWith(LongParameterResolver.class)
+	static class AfterAllParameterTestCase {
+
+		@Test
+		void test(TestInfo testInfo, String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("test-1-enigma");
+		}
+
+		@AfterAll
+		static void afterAll(Long number, TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterAll-2-method");
+		}
+
+	}
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @BeforeEach}
+	 * method and then used for other lifecycle methods and test methods.
+	 */
+	@ExtendWith(LongParameterResolver.class)
+	static class BeforeEachParameterTestCase {
+
+		@BeforeEach
+		void beforeEach(@MagicParameter("method") String text, TestInfo testInfo) {
+			assertThat(text).isEqualTo("beforeEach-0-method");
+			assertThat(testInfo).isNotNull();
+		}
+
+		@Test
+		void test(TestInfo testInfo, String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("test-1-enigma");
+		}
+
+		/**
+		 * Redeclaring {@code @MagicParameter} should not result in a
+		 * {@link ParameterResolutionException}.
+		 */
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-method");
+		}
+
+	}
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @AfterEach} method.
+	 */
+	@ExtendWith(LongParameterResolver.class)
+	static class AfterEachParameterTestCase {
+
+		@Test
+		void test() {
+		}
+
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-method");
+		}
+
+	}
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @Test}
+	 * method and then used for after-each lifecycle methods.
+	 */
+	@ExtendWith(LongParameterResolver.class)
+	static class TestMethodParameterTestCase {
+
+		@Test
+		void test(TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("test-1-method");
+		}
+
+		/**
+		 * Redeclaring {@code @MagicParameter} should not result in a
+		 * {@link ParameterResolutionException}.
+		 */
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-enigma");
+		}
+
+	}
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @TestFactory}
+	 * method and then used for after-each lifecycle methods.
+	 */
+	@ExtendWith(LongParameterResolver.class)
+	static class TestFactoryMethodParameterTestCase {
+
+		@TestFactory
+		Stream<DynamicTest> testFactory(TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("testFactory-1-method");
+
+			return IntStream.of(2, 4).mapToObj(num -> dynamicTest("" + num, () -> assertTrue(num % 2 == 0)));
+		}
+
+		/**
+		 * Redeclaring {@code @MagicParameter} should not result in a
+		 * {@link ParameterResolutionException}.
+		 */
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-enigma");
+		}
+
+	}
+
+	/**
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @TestTemplate}
+	 * method and then used for after-each lifecycle methods.
+	 */
+	@ExtendWith(LongParameterResolver.class)
+	static class TestTemplateMethodParameterTestCase {
+
+		@TestTemplate
+		@ExtendWith(TwoInvocationsContextProvider.class)
+		void testTemplate(TestInfo testInfo, @MagicParameter("method") String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("testTemplate-1-method");
+		}
+
+		/**
+		 * Redeclaring {@code @MagicParameter} should not result in a
+		 * {@link ParameterResolutionException}.
+		 */
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-enigma");
+		}
+
+	}
+
+	private static class TwoInvocationsContextProvider implements TestTemplateInvocationContextProvider {
+
+		@Override
+		public boolean supportsTestTemplate(ExtensionContext context) {
+			return true;
+		}
+
+		@Override
+		public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+			return Stream.of(emptyTestTemplateInvocationContext(), emptyTestTemplateInvocationContext());
+		}
+
+		private static TestTemplateInvocationContext emptyTestTemplateInvocationContext() {
+			return new TestTemplateInvocationContext() {
+			};
+		}
+	}
+
+}
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(MagicParameter.Extension.class)
+@interface MagicParameter {
+
+	String value();
+
+	class Extension implements ParameterResolver {
+
+		@Override
+		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+			return parameterContext.getParameter().getType() == String.class;
+		}
+
+		@Override
+		public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+			String text = parameterContext.findAnnotation(MagicParameter.class)//
+					.map(MagicParameter::value)//
+					.orElse("enigma");
+			Executable declaringExecutable = parameterContext.getDeclaringExecutable();
+			String name = declaringExecutable instanceof Constructor
+					? declaringExecutable.getDeclaringClass().getSimpleName()
+					: declaringExecutable.getName();
+			return String.format("%s-%d-%s", name, parameterContext.getIndex(), text);
+		}
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -139,7 +139,8 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 		assertOneTestSucceeded(AllInOneWithTestInstancePerMethodTestCase.class);
 		assertThat(getRegisteredLocalExtensions(listener))//
 				.containsExactly(//
-					"StaticField", // @ExtendWith on static field
+					"StaticField1", // @ExtendWith on static field
+					"StaticField2", // @ExtendWith on static field
 					"ClassLevelExtension1", // @RegisterExtension on static field
 					"ClassLevelExtension2", // @RegisterExtension on static field
 					"ConstructorParameter", // @ExtendWith on parameter in constructor
@@ -148,7 +149,8 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 					"AfterEachParameter", // @ExtendWith on parameter in @AfterEach method
 					"AfterAllParameter", // @ExtendWith on parameter in static @AfterAll method
 					"TestParameter", // @ExtendWith on parameter in @Test method
-					"InstanceField", // @ExtendWith on instance field
+					"InstanceField1", // @ExtendWith on instance field
+					"InstanceField2", // @ExtendWith on instance field
 					"InstanceLevelExtension1", // @RegisterExtension on instance field
 					"InstanceLevelExtension2"// @RegisterExtension on instance field
 				);
@@ -157,7 +159,8 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 		assertOneTestSucceeded(AllInOneWithTestInstancePerClassTestCase.class);
 		assertThat(getRegisteredLocalExtensions(listener))//
 				.containsExactly(//
-					"StaticField", // @ExtendWith on static field
+					"StaticField1", // @ExtendWith on static field
+					"StaticField2", // @ExtendWith on static field
 					"ClassLevelExtension1", // @RegisterExtension on static field
 					"ClassLevelExtension2", // @RegisterExtension on static field
 					"ConstructorParameter", // @ExtendWith on parameter in constructor
@@ -165,7 +168,8 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 					"BeforeEachParameter", // @ExtendWith on parameter in @BeforeEach method
 					"AfterEachParameter", // @ExtendWith on parameter in @AfterEach method
 					"AfterAllParameter", // @ExtendWith on parameter in static @AfterAll method
-					"InstanceField", // @ExtendWith on instance field
+					"InstanceField1", // @ExtendWith on instance field
+					"InstanceField2", // @ExtendWith on instance field
 					"InstanceLevelExtension1", // @RegisterExtension on instance field
 					"InstanceLevelExtension2", // @RegisterExtension on instance field
 					"TestParameter" // @ExtendWith on parameter in @Test method
@@ -598,11 +602,19 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 	@TestInstance(Lifecycle.PER_METHOD)
 	static class AllInOneWithTestInstancePerMethodTestCase {
 
-		@StaticField
-		static String staticField;
+		@StaticField1
+		static String staticField1;
 
-		@InstanceField
-		String instanceField;
+		@StaticField2
+		@ExtendWith(StaticField2.Extension.class)
+		static String staticField2;
+
+		@InstanceField1
+		String instanceField1;
+
+		@InstanceField2
+		@ExtendWith(InstanceField2.Extension.class)
+		String instanceField2;
 
 		@RegisterExtension
 		@Order(1)
@@ -625,36 +637,44 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 		}
 
 		@BeforeAll
-		static void beforeAll(@BeforeAllParameter String text) {
+		static void beforeAll(@ExtendWith(BeforeAllParameter.Extension.class) @BeforeAllParameter String text) {
 			assertThat(text).isEqualTo("enigma");
-			assertThat(staticField).isEqualTo("beforeAll - staticField");
+			assertThat(staticField1).isEqualTo("beforeAll - staticField1");
+			assertThat(staticField2).isEqualTo("beforeAll - staticField2");
 		}
 
 		@BeforeEach
 		void beforeEach(@BeforeEachParameter String text) {
 			assertThat(text).isEqualTo("enigma");
-			assertThat(staticField).isEqualTo("beforeAll - staticField");
-			assertThat(instanceField).isEqualTo("beforeEach - instanceField");
+			assertThat(staticField1).isEqualTo("beforeAll - staticField1");
+			assertThat(staticField2).isEqualTo("beforeAll - staticField2");
+			assertThat(instanceField1).isEqualTo("beforeEach - instanceField1");
+			assertThat(instanceField2).isEqualTo("beforeEach - instanceField2");
 		}
 
 		@Test
 		void test(@TestParameter String text) {
 			assertThat(text).isEqualTo("enigma");
-			assertThat(staticField).isEqualTo("beforeAll - staticField");
-			assertThat(instanceField).isEqualTo("beforeEach - instanceField");
+			assertThat(staticField1).isEqualTo("beforeAll - staticField1");
+			assertThat(staticField2).isEqualTo("beforeAll - staticField2");
+			assertThat(instanceField1).isEqualTo("beforeEach - instanceField1");
+			assertThat(instanceField2).isEqualTo("beforeEach - instanceField2");
 		}
 
 		@AfterEach
 		void afterEach(@AfterEachParameter String text) {
 			assertThat(text).isEqualTo("enigma");
-			assertThat(staticField).isEqualTo("beforeAll - staticField");
-			assertThat(instanceField).isEqualTo("beforeEach - instanceField");
+			assertThat(staticField1).isEqualTo("beforeAll - staticField1");
+			assertThat(staticField2).isEqualTo("beforeAll - staticField2");
+			assertThat(instanceField1).isEqualTo("beforeEach - instanceField1");
+			assertThat(instanceField2).isEqualTo("beforeEach - instanceField2");
 		}
 
 		@AfterAll
 		static void afterAll(@AfterAllParameter String text) {
 			assertThat(text).isEqualTo("enigma");
-			assertThat(staticField).isEqualTo("beforeAll - staticField");
+			assertThat(staticField1).isEqualTo("beforeAll - staticField1");
+			assertThat(staticField2).isEqualTo("beforeAll - staticField2");
 		}
 
 	}
@@ -730,7 +750,8 @@ class BaseParameterExtension<T extends Annotation> implements ParameterResolver 
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(BeforeAllParameter.Extension.class)
+// Intentionally NOT annotated as follows
+// @ExtendWith(BeforeAllParameter.Extension.class)
 @interface BeforeAllParameter {
 	class Extension extends BaseParameterExtension<BeforeAllParameter> {
 	}
@@ -811,17 +832,35 @@ class BaseFieldExtension<T extends Annotation> implements BeforeAllCallback, Bef
 
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(InstanceField.Extension.class)
-@interface InstanceField {
-	class Extension extends BaseFieldExtension<InstanceField> {
+@ExtendWith(InstanceField1.Extension.class)
+@interface InstanceField1 {
+	class Extension extends BaseFieldExtension<InstanceField1> {
 	}
 }
 
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(StaticField.Extension.class)
-@interface StaticField {
-	class Extension extends BaseFieldExtension<StaticField> {
+// Intentionally NOT annotated as follows
+// @ExtendWith(InstanceField2.Extension.class)
+@interface InstanceField2 {
+	class Extension extends BaseFieldExtension<InstanceField2> {
+	}
+}
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(StaticField1.Extension.class)
+@interface StaticField1 {
+	class Extension extends BaseFieldExtension<StaticField1> {
+	}
+}
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+// Intentionally NOT annotated as follows
+// @ExtendWith(StaticField2.Extension.class)
+@interface StaticField2 {
+	class Extension extends BaseFieldExtension<StaticField2> {
 	}
 }
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -354,7 +354,10 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 	}
 
 	/**
-	 * The {@link MagicParameter.Extension} is first registered for the {@code @AfterAll} method.
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @AfterAll}
+	 * method, but that registration occurs before the test method is invoked, which
+	 * allows the string parameters in the after-each and test methods to be resolved
+	 * by the {@link MagicParameter.Extension} as well.
 	 */
 	@ExtendWith(LongParameterResolver.class)
 	static class AfterAllParameterTestCase {
@@ -363,6 +366,13 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 		void test(TestInfo testInfo, String text) {
 			assertThat(testInfo).isNotNull();
 			assertThat(text).isEqualTo("test-1-enigma");
+		}
+
+		@AfterEach
+		void afterEach(Long number, TestInfo testInfo, String text) {
+			assertThat(number).isEqualTo(42L);
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("afterEach-2-enigma");
 		}
 
 		@AfterAll
@@ -407,13 +417,18 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 	}
 
 	/**
-	 * The {@link MagicParameter.Extension} is first registered for the {@code @AfterEach} method.
+	 * The {@link MagicParameter.Extension} is first registered for the {@code @AfterEach}
+	 * method, but that registration occurs before the test method is invoked, which
+	 * allows the test method's parameter to be resolved by the {@link MagicParameter.Extension}
+	 * as well.
 	 */
 	@ExtendWith(LongParameterResolver.class)
 	static class AfterEachParameterTestCase {
 
 		@Test
-		void test() {
+		void test(TestInfo testInfo, String text) {
+			assertThat(testInfo).isNotNull();
+			assertThat(text).isEqualTo("test-1-enigma");
 		}
 
 		@AfterEach
@@ -438,10 +453,6 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 			assertThat(text).isEqualTo("test-1-method");
 		}
 
-		/**
-		 * Redeclaring {@code @MagicParameter} should not result in a
-		 * {@link ParameterResolutionException}.
-		 */
 		@AfterEach
 		void afterEach(Long number, TestInfo testInfo, String text) {
 			assertThat(number).isEqualTo(42L);
@@ -466,10 +477,6 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 			return IntStream.of(2, 4).mapToObj(num -> dynamicTest("" + num, () -> assertTrue(num % 2 == 0)));
 		}
 
-		/**
-		 * Redeclaring {@code @MagicParameter} should not result in a
-		 * {@link ParameterResolutionException}.
-		 */
 		@AfterEach
 		void afterEach(Long number, TestInfo testInfo, String text) {
 			assertThat(number).isEqualTo(42L);
@@ -493,10 +500,6 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 			assertThat(text).isEqualTo("testTemplate-1-method");
 		}
 
-		/**
-		 * Redeclaring {@code @MagicParameter} should not result in a
-		 * {@link ParameterResolutionException}.
-		 */
 		@AfterEach
 		void afterEach(Long number, TestInfo testInfo, String text) {
 			assertThat(number).isEqualTo(42L);

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -139,39 +139,39 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 		assertOneTestSucceeded(AllInOneWithTestInstancePerMethodTestCase.class);
 		assertThat(getRegisteredLocalExtensions(listener))//
 				.containsExactly(//
-					"StaticField1", // @ExtendWith on static field
+					"ClassLevelExtension2", // @RegisterExtension on static field
 					"StaticField2", // @ExtendWith on static field
 					"ClassLevelExtension1", // @RegisterExtension on static field
-					"ClassLevelExtension2", // @RegisterExtension on static field
+					"StaticField1", // @ExtendWith on static field
 					"ConstructorParameter", // @ExtendWith on parameter in constructor
 					"BeforeAllParameter", // @ExtendWith on parameter in static @BeforeAll method
 					"BeforeEachParameter", // @ExtendWith on parameter in @BeforeEach method
 					"AfterEachParameter", // @ExtendWith on parameter in @AfterEach method
 					"AfterAllParameter", // @ExtendWith on parameter in static @AfterAll method
 					"TestParameter", // @ExtendWith on parameter in @Test method
-					"InstanceField1", // @ExtendWith on instance field
-					"InstanceField2", // @ExtendWith on instance field
 					"InstanceLevelExtension1", // @RegisterExtension on instance field
-					"InstanceLevelExtension2"// @RegisterExtension on instance field
+					"InstanceField1", // @ExtendWith on instance field
+					"InstanceLevelExtension2", // @RegisterExtension on instance field
+					"InstanceField2" // @ExtendWith on instance field
 				);
 
 		listener.clear();
 		assertOneTestSucceeded(AllInOneWithTestInstancePerClassTestCase.class);
 		assertThat(getRegisteredLocalExtensions(listener))//
 				.containsExactly(//
-					"StaticField1", // @ExtendWith on static field
+					"ClassLevelExtension2", // @RegisterExtension on static field
 					"StaticField2", // @ExtendWith on static field
 					"ClassLevelExtension1", // @RegisterExtension on static field
-					"ClassLevelExtension2", // @RegisterExtension on static field
+					"StaticField1", // @ExtendWith on static field
 					"ConstructorParameter", // @ExtendWith on parameter in constructor
 					"BeforeAllParameter", // @ExtendWith on parameter in static @BeforeAll method
 					"BeforeEachParameter", // @ExtendWith on parameter in @BeforeEach method
 					"AfterEachParameter", // @ExtendWith on parameter in @AfterEach method
 					"AfterAllParameter", // @ExtendWith on parameter in static @AfterAll method
-					"InstanceField1", // @ExtendWith on instance field
-					"InstanceField2", // @ExtendWith on instance field
 					"InstanceLevelExtension1", // @RegisterExtension on instance field
+					"InstanceField1", // @ExtendWith on instance field
 					"InstanceLevelExtension2", // @RegisterExtension on instance field
+					"InstanceField2", // @ExtendWith on instance field
 					"TestParameter" // @ExtendWith on parameter in @Test method
 				);
 	}
@@ -603,13 +603,23 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 	static class AllInOneWithTestInstancePerMethodTestCase {
 
 		@StaticField1
+		@Order(Integer.MAX_VALUE)
 		static String staticField1;
 
 		@StaticField2
 		@ExtendWith(StaticField2.Extension.class)
+		@Order(3)
 		static String staticField2;
 
+		@RegisterExtension
+		private static Extension classLevelExtension1 = new ClassLevelExtension1();
+
+		@RegisterExtension
+		@Order(1)
+		static Extension classLevelExtension2 = new ClassLevelExtension2();
+
 		@InstanceField1
+		@Order(2)
 		String instanceField1;
 
 		@InstanceField2
@@ -618,18 +628,10 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 
 		@RegisterExtension
 		@Order(1)
-		private static Extension classLevelExtension1 = new ClassLevelExtension1();
-
-		@RegisterExtension
-		@Order(2)
-		static Extension classLevelExtension2 = new ClassLevelExtension2();
-
-		@RegisterExtension
-		@Order(1)
 		private Extension instanceLevelExtension1 = new InstanceLevelExtension1();
 
 		@RegisterExtension
-		@Order(2)
+		@Order(3)
 		Extension instanceLevelExtension2 = new InstanceLevelExtension2();
 
 		AllInOneWithTestInstancePerMethodTestCase(@ConstructorParameter String text) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -77,7 +77,7 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 
 	@Test
 	void constructorParameterForNestedTestClass() {
-		assertOneTestSucceeded(NestedConstructorParameterTestCase.class);
+		assertTestsSucceeded(NestedConstructorParameterTestCase.class, 2);
 	}
 
 	@Test
@@ -210,10 +210,11 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 	@ExtendWith(LongParameterResolver.class)
 	class NestedConstructorParameterTestCase {
 
-		NestedConstructorParameterTestCase(@MagicParameter("constructor") String text) {
-			// Index is 1 instead of 0, since constructors for non-static nested classes
+		NestedConstructorParameterTestCase(TestInfo testInfo, @MagicParameter("constructor") String text) {
+			assertThat(testInfo).isNotNull();
+			// Index is 2 instead of 1, since constructors for non-static nested classes
 			// receive a reference to the enclosing instance as the first argument: this$0
-			assertThat(text).isEqualTo("NestedConstructorParameterTestCase-1-constructor");
+			assertThat(text).isEqualTo("NestedConstructorParameterTestCase-2-constructor");
 		}
 
 		@BeforeEach
@@ -237,6 +238,40 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 			assertThat(number).isEqualTo(42L);
 			assertThat(testInfo).isNotNull();
 			assertThat(text).isEqualTo("afterEach-2-method");
+		}
+
+		@Nested
+		class DoublyNestedConstructorParameterTestCase {
+
+			DoublyNestedConstructorParameterTestCase(TestInfo testInfo, String text) {
+				assertThat(testInfo).isNotNull();
+				// Index is 2 instead of 1, since constructors for non-static nested classes
+				// receive a reference to the enclosing instance as the first argument: this$0
+				assertThat(text).isEqualTo("DoublyNestedConstructorParameterTestCase-2-enigma");
+			}
+
+			@BeforeEach
+			void beforeEach(String text, TestInfo testInfo) {
+				assertThat(text).isEqualTo("beforeEach-0-enigma");
+				assertThat(testInfo).isNotNull();
+			}
+
+			@Test
+			void test(TestInfo testInfo, String text) {
+				assertThat(testInfo).isNotNull();
+				assertThat(text).isEqualTo("test-1-enigma");
+			}
+
+			/**
+			 * Redeclaring {@code @MagicParameter} should not result in a
+			 * {@link ParameterResolutionException}.
+			 */
+			@AfterEach
+			void afterEach(Long number, TestInfo testInfo, @MagicParameter("method") String text) {
+				assertThat(number).isEqualTo(42L);
+				assertThat(testInfo).isNotNull();
+				assertThat(text).isEqualTo("afterEach-2-method");
+			}
 		}
 
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -533,7 +533,7 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 	static class StaticFieldTestCase {
 
 		@MagicField
-		static String staticField1;
+		private static String staticField1;
 
 		@MagicField
 		static String staticField2;
@@ -560,7 +560,7 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 		String instanceField1;
 
 		@MagicField
-		String instanceField2;
+		private String instanceField2;
 
 		@Test
 		void test() {
@@ -606,7 +606,7 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 
 		@RegisterExtension
 		@Order(1)
-		static Extension classLevelExtension1 = new ClassLevelExtension1();
+		private static Extension classLevelExtension1 = new ClassLevelExtension1();
 
 		@RegisterExtension
 		@Order(2)
@@ -614,7 +614,7 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 
 		@RegisterExtension
 		@Order(1)
-		Extension instanceLevelExtension1 = new InstanceLevelExtension1();
+		private Extension instanceLevelExtension1 = new InstanceLevelExtension1();
 
 		@RegisterExtension
 		@Order(2)

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -10,9 +10,12 @@
 
 package org.junit.jupiter.engine.extension;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;
+import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
@@ -21,10 +24,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -37,7 +43,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -45,8 +55,12 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.jupiter.engine.execution.injection.sample.LongParameterResolver;
+import org.junit.platform.commons.logging.LogRecordListener;
+import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
  * Integration tests that verify support for extension registration via
@@ -55,8 +69,6 @@ import org.junit.jupiter.engine.execution.injection.sample.LongParameterResolver
  * @since 5.8
  */
 class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTestEngineTests {
-
-	static final List<String> instantiationSequence = new ArrayList<>();
 
 	@Test
 	void constructorParameter() {
@@ -104,12 +116,43 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 	}
 
 	@Test
-	void registrationOrder() {
-		instantiationSequence.clear();
+	void staticField() {
+		assertOneTestSucceeded(StaticFieldTestCase.class);
+	}
 
-		assertOneTestSucceeded(AllInOneTestCase.class);
-		assertThat(instantiationSequence).containsExactly("ConstructorParameter", "BeforeAllParameter",
-			"AfterAllParameter", "BeforeEachParameter", "AfterEachParameter", "TestParameter");
+	@Test
+	void instanceField() {
+		assertOneTestSucceeded(InstanceFieldTestCase.class);
+	}
+
+	@Test
+	void fieldsWithTestInstancePerClass() {
+		assertOneTestSucceeded(TestInstancePerClassFieldTestCase.class);
+	}
+
+	@Test
+	@TrackLogRecords
+	void registrationOrder(LogRecordListener listener) {
+		assertOneTestSucceeded(AllInOneWithTestInstancePerMethodTestCase.class);
+		assertThat(getRegisteredLocalExtensions(listener))//
+				.containsExactly("StaticField", "ConstructorParameter", "BeforeAllParameter", "BeforeEachParameter",
+					"AfterEachParameter", "AfterAllParameter", "TestParameter", "InstanceField");
+
+		listener.clear();
+		assertOneTestSucceeded(AllInOneWithTestInstancePerClassTestCase.class);
+		assertThat(getRegisteredLocalExtensions(listener))//
+				.containsExactly("StaticField", "ConstructorParameter", "BeforeAllParameter", "BeforeEachParameter",
+					"AfterEachParameter", "AfterAllParameter", "InstanceField", "TestParameter");
+	}
+
+	private List<String> getRegisteredLocalExtensions(LogRecordListener listener) {
+		// @formatter:off
+		return listener.stream(MutableExtensionRegistry.class, Level.FINER)
+			.map(LogRecord::getMessage)
+			.filter(message -> message.contains("local extension"))
+			.map(message -> message.substring(message.lastIndexOf('.') + 1, message.indexOf("$")))
+			.collect(toList());
+		// @formatter:on
 	}
 
 	private void assertOneTestSucceeded(Class<?> testClass) {
@@ -413,37 +456,128 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 		}
 	}
 
-	static class AllInOneTestCase {
+	/**
+	 * The {@link MagicField.Extension} is registered via a static field.
+	 */
+	static class StaticFieldTestCase {
 
-		AllInOneTestCase(@ConstructorParameter String text) {
-			assertThat(text).isNotNull();
+		@MagicField
+		static String staticField1;
+
+		@MagicField
+		static String staticField2;
+
+		@BeforeAll
+		static void beforeAll() {
+			assertThat(staticField1).isEqualTo("beforeAll - staticField1");
+			assertThat(staticField2).isEqualTo("beforeAll - staticField2");
+		}
+
+		@Test
+		void test() {
+			assertThat(staticField1).isEqualTo("beforeAll - staticField1");
+			assertThat(staticField2).isEqualTo("beforeAll - staticField2");
+		}
+	}
+
+	/**
+	 * The {@link MagicField.Extension} is registered via an instance field.
+	 */
+	static class InstanceFieldTestCase {
+
+		@MagicField
+		String instanceField1;
+
+		@MagicField
+		String instanceField2;
+
+		@Test
+		void test() {
+			assertThat(instanceField1).isEqualTo("beforeEach - instanceField1");
+			assertThat(instanceField2).isEqualTo("beforeEach - instanceField2");
+		}
+	}
+
+	/**
+	 * The {@link MagicField.Extension} is registered via a static field and
+	 * an instance field.
+	 */
+	@TestInstance(Lifecycle.PER_CLASS)
+	static class TestInstancePerClassFieldTestCase {
+
+		@MagicField
+		static String staticField;
+
+		@MagicField
+		String instanceField;
+
+		@BeforeAll
+		void beforeAll() {
+			assertThat(staticField).isEqualTo("beforeAll - staticField");
+			assertThat(instanceField).isNull();
+		}
+
+		@Test
+		void test() {
+			assertThat(staticField).isEqualTo("beforeAll - staticField");
+			assertThat(instanceField).isEqualTo("beforeEach - instanceField");
+		}
+	}
+
+	@TestInstance(Lifecycle.PER_METHOD)
+	static class AllInOneWithTestInstancePerMethodTestCase {
+
+		@StaticField
+		static String staticField;
+
+		@InstanceField
+		String instanceField;
+
+		AllInOneWithTestInstancePerMethodTestCase(@ConstructorParameter String text) {
+			assertThat(text).isEqualTo("enigma");
 		}
 
 		@BeforeAll
 		static void beforeAll(@BeforeAllParameter String text) {
-			assertThat(text).isNotNull();
+			assertThat(text).isEqualTo("enigma");
+			assertThat(staticField).isEqualTo("beforeAll - staticField");
 		}
 
 		@BeforeEach
 		void beforeEach(@BeforeEachParameter String text) {
-			assertThat(text).isNotNull();
+			assertThat(text).isEqualTo("enigma");
+			assertThat(staticField).isEqualTo("beforeAll - staticField");
+			assertThat(instanceField).isEqualTo("beforeEach - instanceField");
 		}
 
 		@Test
 		void test(@TestParameter String text) {
-			assertThat(text).isNotNull();
+			assertThat(text).isEqualTo("enigma");
+			assertThat(staticField).isEqualTo("beforeAll - staticField");
+			assertThat(instanceField).isEqualTo("beforeEach - instanceField");
 		}
 
 		@AfterEach
 		void afterEach(@AfterEachParameter String text) {
-			assertThat(text).isNotNull();
+			assertThat(text).isEqualTo("enigma");
+			assertThat(staticField).isEqualTo("beforeAll - staticField");
+			assertThat(instanceField).isEqualTo("beforeEach - instanceField");
 		}
 
 		@AfterAll
 		static void afterAll(@AfterAllParameter String text) {
-			assertThat(text).isNotNull();
+			assertThat(text).isEqualTo("enigma");
+			assertThat(staticField).isEqualTo("beforeAll - staticField");
 		}
 
+	}
+
+	@TestInstance(Lifecycle.PER_CLASS)
+	static class AllInOneWithTestInstancePerClassTestCase extends AllInOneWithTestInstancePerMethodTestCase {
+
+		AllInOneWithTestInstancePerClassTestCase(@ConstructorParameter String text) {
+			super(text);
+		}
 	}
 
 }
@@ -477,17 +611,14 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 }
 
 @SuppressWarnings("unused")
-class BaseExtension<T extends Annotation> implements ParameterResolver {
+class BaseParameterExtension<T extends Annotation> implements ParameterResolver {
 
 	private final Class<T> annotationType;
 
 	@SuppressWarnings("unchecked")
-	BaseExtension() {
+	BaseParameterExtension() {
 		Type genericSuperclass = getClass().getGenericSuperclass();
 		this.annotationType = (Class<T>) ((ParameterizedType) genericSuperclass).getActualTypeArguments()[0];
-
-		ExtensionRegistrationViaParametersAndFieldsTests.instantiationSequence//
-				.add(getClass().getEnclosingClass().getSimpleName());
 	}
 
 	@Override
@@ -506,7 +637,7 @@ class BaseExtension<T extends Annotation> implements ParameterResolver {
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(ConstructorParameter.Extension.class)
 @interface ConstructorParameter {
-	class Extension extends BaseExtension<ConstructorParameter> {
+	class Extension extends BaseParameterExtension<ConstructorParameter> {
 	}
 }
 
@@ -514,7 +645,7 @@ class BaseExtension<T extends Annotation> implements ParameterResolver {
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(BeforeAllParameter.Extension.class)
 @interface BeforeAllParameter {
-	class Extension extends BaseExtension<BeforeAllParameter> {
+	class Extension extends BaseParameterExtension<BeforeAllParameter> {
 	}
 }
 
@@ -522,7 +653,7 @@ class BaseExtension<T extends Annotation> implements ParameterResolver {
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(AfterAllParameter.Extension.class)
 @interface AfterAllParameter {
-	class Extension extends BaseExtension<AfterAllParameter> {
+	class Extension extends BaseParameterExtension<AfterAllParameter> {
 	}
 }
 
@@ -530,7 +661,7 @@ class BaseExtension<T extends Annotation> implements ParameterResolver {
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(BeforeEachParameter.Extension.class)
 @interface BeforeEachParameter {
-	class Extension extends BaseExtension<BeforeEachParameter> {
+	class Extension extends BaseParameterExtension<BeforeEachParameter> {
 	}
 }
 
@@ -538,7 +669,7 @@ class BaseExtension<T extends Annotation> implements ParameterResolver {
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(AfterEachParameter.Extension.class)
 @interface AfterEachParameter {
-	class Extension extends BaseExtension<AfterEachParameter> {
+	class Extension extends BaseParameterExtension<AfterEachParameter> {
 	}
 }
 
@@ -546,6 +677,63 @@ class BaseExtension<T extends Annotation> implements ParameterResolver {
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(TestParameter.Extension.class)
 @interface TestParameter {
-	class Extension extends BaseExtension<TestParameter> {
+	class Extension extends BaseParameterExtension<TestParameter> {
+	}
+}
+
+class BaseFieldExtension<T extends Annotation> implements BeforeAllCallback, BeforeEachCallback {
+
+	private final Class<T> annotationType;
+
+	@SuppressWarnings("unchecked")
+	BaseFieldExtension() {
+		Type genericSuperclass = getClass().getGenericSuperclass();
+		this.annotationType = (Class<T>) ((ParameterizedType) genericSuperclass).getActualTypeArguments()[0];
+	}
+
+	@Override
+	public final void beforeAll(ExtensionContext context) throws Exception {
+		injectFields("beforeAll", context.getRequiredTestClass(), null, ReflectionUtils::isStatic);
+	}
+
+	@Override
+	public final void beforeEach(ExtensionContext context) throws Exception {
+		injectFields("beforeEach", context.getRequiredTestClass(), context.getRequiredTestInstance(),
+			ReflectionUtils::isNotStatic);
+	}
+
+	private void injectFields(String trigger, Class<?> testClass, Object instance, Predicate<Field> predicate) {
+		findAnnotatedFields(testClass, this.annotationType, predicate).forEach(field -> {
+			try {
+				makeAccessible(field).set(instance, trigger + " - " + field.getName());
+			}
+			catch (Throwable t) {
+				ExceptionUtils.throwAsUncheckedException(t);
+			}
+		});
+	}
+}
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(MagicField.Extension.class)
+@interface MagicField {
+	class Extension extends BaseFieldExtension<MagicField> {
+	}
+}
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(InstanceField.Extension.class)
+@interface InstanceField {
+	class Extension extends BaseFieldExtension<InstanceField> {
+	}
+}
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(StaticField.Extension.class)
+@interface StaticField {
+	class Extension extends BaseFieldExtension<StaticField> {
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistryTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistryTests.java
@@ -10,9 +10,6 @@
 
 package org.junit.jupiter.engine.extension;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -104,12 +102,12 @@ class ExtensionRegistryTests {
 		MutableExtensionRegistry parent = registry;
 		parent.registerExtension(MyExtension.class);
 
-		MutableExtensionRegistry child = createRegistryFrom(parent, singletonList(YourExtension.class));
+		MutableExtensionRegistry child = createRegistryFrom(parent, Stream.of(YourExtension.class));
 		assertExtensionRegistered(child, MyExtension.class);
 		assertExtensionRegistered(child, YourExtension.class);
 		assertEquals(2, countExtensions(child, MyExtensionApi.class));
 
-		ExtensionRegistry grandChild = createRegistryFrom(child, emptyList());
+		ExtensionRegistry grandChild = createRegistryFrom(child, Stream.empty());
 		assertExtensionRegistered(grandChild, MyExtension.class);
 		assertExtensionRegistered(grandChild, YourExtension.class);
 		assertEquals(2, countExtensions(grandChild, MyExtensionApi.class));
@@ -121,12 +119,12 @@ class ExtensionRegistryTests {
 		parent.registerExtension(MyExtension.class);
 		assertEquals(1, countExtensions(parent, MyExtensionApi.class));
 
-		MutableExtensionRegistry child = createRegistryFrom(parent, asList(MyExtension.class, YourExtension.class));
+		MutableExtensionRegistry child = createRegistryFrom(parent, Stream.of(MyExtension.class, YourExtension.class));
 		assertExtensionRegistered(child, MyExtension.class);
 		assertExtensionRegistered(child, YourExtension.class);
 		assertEquals(2, countExtensions(child, MyExtensionApi.class));
 
-		ExtensionRegistry grandChild = createRegistryFrom(child, asList(MyExtension.class, YourExtension.class));
+		ExtensionRegistry grandChild = createRegistryFrom(child, Stream.of(MyExtension.class, YourExtension.class));
 		assertExtensionRegistered(grandChild, MyExtension.class);
 		assertExtensionRegistered(grandChild, YourExtension.class);
 		assertEquals(2, countExtensions(grandChild, MyExtensionApi.class));

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ProgrammaticExtensionRegistrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ProgrammaticExtensionRegistrationTests.java
@@ -167,8 +167,7 @@ class ProgrammaticExtensionRegistrationTests extends AbstractJupiterTestEngineTe
 	@Test
 	void instanceLevelWithPrivateField() {
 		Class<?> testClass = InstanceLevelExtensionRegistrationWithPrivateFieldTestCase.class;
-		executeTestsForClass(testClass).testEvents().assertThatEvents().haveExactly(1, finishedWithFailure(
-			instanceOf(PreconditionViolationException.class), message(expectedNotPrivateMessage(testClass))));
+		executeTestsForClass(testClass).testEvents().assertStatistics(stats -> stats.succeeded(1));
 	}
 
 	/**
@@ -177,8 +176,7 @@ class ProgrammaticExtensionRegistrationTests extends AbstractJupiterTestEngineTe
 	@Test
 	void classLevelWithPrivateField() {
 		Class<?> testClass = ClassLevelExtensionRegistrationWithPrivateFieldTestCase.class;
-		executeTestsForClass(testClass).containerEvents().assertThatEvents().haveExactly(1, finishedWithFailure(
-			instanceOf(PreconditionViolationException.class), message(expectedNotPrivateMessage(testClass))));
+		executeTestsForClass(testClass).testEvents().assertStatistics(stats -> stats.succeeded(1));
 	}
 
 	@Test
@@ -217,11 +215,6 @@ class ProgrammaticExtensionRegistrationTests extends AbstractJupiterTestEngineTe
 
 		executeTestsForClass(testClass).containerEvents().assertThatEvents().haveExactly(1, finishedWithFailure(
 			instanceOf(PreconditionViolationException.class), message(expectedMessage(testClass, String.class))));
-	}
-
-	private String expectedNotPrivateMessage(Class<?> testClass) {
-		return "Failed to register extension via @RegisterExtension field [" + field(testClass)
-				+ "]: field must not be private.";
 	}
 
 	private String expectedMessage(Class<?> testClass, Class<?> valueType) {
@@ -602,14 +595,16 @@ class ProgrammaticExtensionRegistrationTests extends AbstractJupiterTestEngineTe
 	static class InstanceLevelExtensionRegistrationWithPrivateFieldTestCase extends AbstractTestCase {
 
 		@RegisterExtension
-		private Extension extension;
+		private Extension extension = new Extension() {
+		};
 
 	}
 
 	static class ClassLevelExtensionRegistrationWithPrivateFieldTestCase extends AbstractTestCase {
 
 		@RegisterExtension
-		private static Extension extension;
+		private static Extension extension = new Extension() {
+		};
 
 	}
 


### PR DESCRIPTION
## Overview

This is a PR for #864.

The implementation is essentially feature complete and tested (following the 80/20 rule); however, there are some points that should be discussed before merging this PR into the `main` branch.

## Topics for Discussion

When discussing any of these topics, I recommend that you review the current behavior by analyzing the tests in `ExtensionRegistrationViaParametersAndFieldsTests` before spending time studying the actual implementation details.

1. **Registration Order**: I have done my best to register extensions in the order in which the fields or parameters are used in the lifecycle of a test class and test method. This can be inspected in the `registrationOrder()` test method. Implementation details can be found in `ClassBasedTestDescriptor` and `TestMethodTestDescriptor`.
2. **`@Order` Support**: `ExtensionUtils.registerExtensionsFromFields()` already supported `@Order` for extensions registered via `@RegisterExtension`, and `@Order` is now also applied to extensions registered via fields using `@ExtendWith`. But... `@ExtendWith` extensions are registered _before_ `@RegisterExtension` extensions.
3. **`@ExtendWith` target**: `@ExtendWith` can currently be declared on a `TYPE` or `METHOD`. It cannot be declared directly on a `PARAMETER` or `FIELD`.
4. **Private fields**: `@RegisterExtension` fields are not allowed to be `private`, but in this PR fields meta-annotated with `@ExtendWith` are allowed to be `private`.

I will share my thoughts on these topics as comments and invite feedback.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
