### PR TITLE
Reduce info logging noise

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -183,7 +183,7 @@ public interface ClassOrderer {
 
 		static {
 			DEFAULT_SEED = System.nanoTime();
-			logger.info(() -> "ClassOrderer.Random default seed: " + DEFAULT_SEED);
+			logger.config(() -> "ClassOrderer.Random default seed: " + DEFAULT_SEED);
 		}
 
 		/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -253,7 +253,7 @@ public interface MethodOrderer {
 
 		static {
 			DEFAULT_SEED = System.nanoTime();
-			logger.info(() -> "MethodOrderer.Random default seed: " + DEFAULT_SEED);
+			logger.config(() -> "MethodOrderer.Random default seed: " + DEFAULT_SEED);
 		}
 
 		/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/EnumConfigurationParameterConverter.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/EnumConfigurationParameterConverter.java
@@ -53,7 +53,7 @@ public class EnumConfigurationParameterConverter<E extends Enum<E>> {
 			try {
 				constantName = value.get().trim().toUpperCase(Locale.ROOT);
 				E result = Enum.valueOf(enumType, constantName);
-				logger.info(() -> String.format("Using %s '%s' set via the '%s' configuration parameter.",
+				logger.config(() -> String.format("Using %s '%s' set via the '%s' configuration parameter.",
 					enumDisplayName, result, key));
 				return result;
 			}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/InstantiatingConfigurationParameterConverter.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/InstantiatingConfigurationParameterConverter.java
@@ -60,7 +60,7 @@ class InstantiatingConfigurationParameterConverter<T> {
 	}
 
 	private void logSuccessMessage(String className, String key) {
-		logger.info(() -> String.format("Using default %s '%s' set via the '%s' configuration parameter.", name,
+		logger.config(() -> String.format("Using default %s '%s' set via the '%s' configuration parameter.", name,
 			className, key));
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/config/InstantiatingConfigurationParameterConverterTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/config/InstantiatingConfigurationParameterConverterTests.java
@@ -46,7 +46,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		DisplayNameGenerator displayNameGenerator = converter.get(configurationParameters, KEY).orElseThrow();
 
 		assertThat(displayNameGenerator).isInstanceOf(CustomDisplayNameGenerator.class);
-		assertExpectedLogMessage(listener, Level.INFO,
+		assertExpectedLogMessage(listener, Level.CONFIG,
 			"Using default display name generator "
 					+ "'org.junit.jupiter.engine.descriptor.CustomDisplayNameGenerator' set via the "
 					+ "'junit.jupiter.displayname.generator.default' configuration parameter.");
@@ -87,7 +87,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		DisplayNameGenerator displayNameGenerator = converter.get(configurationParameters, KEY).orElseThrow();
 
 		assertThat(displayNameGenerator).isInstanceOf(CustomDisplayNameGenerator.class);
-		assertExpectedLogMessage(listener, Level.INFO,
+		assertExpectedLogMessage(listener, Level.CONFIG,
 			"Using default display name generator "
 					+ "'org.junit.jupiter.engine.descriptor.CustomDisplayNameGenerator' set via the "
 					+ "'junit.jupiter.displayname.generator.default' configuration parameter.");

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -195,7 +195,7 @@ public class EngineDiscoveryOrchestrator {
 			String displayNames = testDescriptors.stream().map(TestDescriptor::getDisplayName).collect(joining(", "));
 			long containerCount = testDescriptors.stream().filter(TestDescriptor::isContainer).count();
 			long methodCount = testDescriptors.stream().filter(TestDescriptor::isTest).count();
-			logger.info(() -> String.format("%d containers and %d tests were %s", containerCount, methodCount,
+			logger.config(() -> String.format("%d containers and %d tests were %s", containerCount, methodCount,
 				exclusionReason));
 			logger.debug(
 				() -> String.format("The following containers and tests were %s: %s", exclusionReason, displayNames));

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -236,7 +236,7 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 				}
 
 				URL configFileUrl = resources.iterator().next(); // same as List#get(0)
-				logger.info(() -> String.format(
+				logger.config(() -> String.format(
 					"Loading JUnit Platform configuration parameters from classpath resource [%s].", configFileUrl));
 				URLConnection urlConnection = configFileUrl.openConnection();
 				urlConnection.setUseCaches(false);


### PR DESCRIPTION
## Overview

Prior to this commit code in JUnit logged messages via its internal Logging Facade at information level. When a user, a framework, or a tool running JUnit-based tests doesn't explicitly configure logging, the default Java Util Logging frameworks is used, which in turn emits message via `System.err`. Since those messages then appear on some environments red color, they are confusing and somewhat distracting.

This commit replaces all calls of `Logger.info()` to their `config()` variants.

Closes #2664

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
