### PR TITLE
Declare a compile-only dependence on module `org.apiguardian.api`

### DIFF
--- a/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java
+++ b/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java
@@ -12,7 +12,7 @@
  * Defines JUnit Jupiter API for writing tests.
  */
 module org.junit.jupiter.api {
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires transitive org.junit.platform.commons;
 	requires transitive org.opentest4j;
 

--- a/junit-jupiter-engine/src/module/org.junit.jupiter.engine/module-info.java
+++ b/junit-jupiter-engine/src/module/org.junit.jupiter.engine/module-info.java
@@ -17,7 +17,7 @@
  * @provides org.junit.platform.engine.TestEngine
  */
 module org.junit.jupiter.engine {
-	requires org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires org.junit.jupiter.api;
 	requires org.junit.platform.commons;
 	requires org.junit.platform.engine;

--- a/junit-jupiter-migrationsupport/src/module/org.junit.jupiter.migrationsupport/module-info.java
+++ b/junit-jupiter-migrationsupport/src/module/org.junit.jupiter.migrationsupport/module-info.java
@@ -15,7 +15,7 @@
  */
 module org.junit.jupiter.migrationsupport {
 	requires transitive junit; // 4
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires transitive org.junit.jupiter.api;
 	requires org.junit.platform.commons;
 

--- a/junit-jupiter-params/src/module/org.junit.jupiter.params/module-info.java
+++ b/junit-jupiter-params/src/module/org.junit.jupiter.params/module-info.java
@@ -14,7 +14,7 @@
  * @since 5.0
  */
 module org.junit.jupiter.params {
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires transitive org.junit.jupiter.api;
 	requires transitive org.junit.platform.commons;
 

--- a/junit-platform-commons/src/module/org.junit.platform.commons/module-info.java
+++ b/junit-platform-commons/src/module/org.junit.platform.commons/module-info.java
@@ -16,7 +16,7 @@
 module org.junit.platform.commons {
 	requires java.logging;
 	requires java.management; // needed by RuntimeUtils to determine input arguments
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 
 	exports org.junit.platform.commons;
 	exports org.junit.platform.commons.annotation;

--- a/junit-platform-console/src/module/org.junit.platform.console/module-info.java
+++ b/junit-platform-console/src/module/org.junit.platform.console/module-info.java
@@ -15,7 +15,7 @@
  * @provides java.util.spi.ToolProvider
  */
 module org.junit.platform.console {
-	requires org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires org.junit.platform.commons;
 	requires org.junit.platform.engine;
 	requires org.junit.platform.launcher;

--- a/junit-platform-engine/src/module/org.junit.platform.engine/module-info.java
+++ b/junit-platform-engine/src/module/org.junit.platform.engine/module-info.java
@@ -17,7 +17,7 @@
  * @since 1.0
  */
 module org.junit.platform.engine {
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires transitive org.junit.platform.commons;
 	requires transitive org.opentest4j;
 

--- a/junit-platform-jfr/src/module/org.junit.platform.jfr/module-info.java
+++ b/junit-platform-jfr/src/module/org.junit.platform.jfr/module-info.java
@@ -21,7 +21,7 @@
  */
 module org.junit.platform.jfr {
 	requires jdk.jfr;
-	requires org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires org.junit.platform.engine;
 	requires org.junit.platform.launcher;
 

--- a/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
+++ b/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
@@ -21,7 +21,7 @@
  */
 module org.junit.platform.launcher {
 	requires transitive java.logging;
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires transitive org.junit.platform.commons;
 	requires transitive org.junit.platform.engine;
 

--- a/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
+++ b/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
@@ -15,7 +15,7 @@
  */
 module org.junit.platform.reporting {
 	requires java.xml;
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires org.junit.platform.commons;
 	requires transitive org.junit.platform.engine;
 	requires transitive org.junit.platform.launcher;

--- a/junit-platform-runner/src/module/org.junit.platform.runner/module-info.java
+++ b/junit-platform-runner/src/module/org.junit.platform.runner/module-info.java
@@ -16,7 +16,7 @@
  */
 module org.junit.platform.runner {
 	requires transitive junit; // 4
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires transitive org.junit.platform.launcher;
 	requires transitive org.junit.platform.suite.api;
 	requires org.junit.platform.suite.commons;

--- a/junit-platform-suite-api/src/module/org.junit.platform.suite.api/module-info.java
+++ b/junit-platform-suite-api/src/module/org.junit.platform.suite.api/module-info.java
@@ -14,7 +14,7 @@
  * @since 1.0
  */
 module org.junit.platform.suite.api {
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires transitive org.junit.platform.commons;
 
 	exports org.junit.platform.suite.api;

--- a/junit-platform-suite-commons/src/module/org.junit.platform.suite.commons/module-info.java
+++ b/junit-platform-suite-commons/src/module/org.junit.platform.suite.commons/module-info.java
@@ -14,7 +14,7 @@
  * @since 1.8
  */
 module org.junit.platform.suite.commons {
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires org.junit.platform.suite.api;
 	requires org.junit.platform.commons;
 	requires org.junit.platform.engine;

--- a/junit-platform-suite-engine/src/module/org.junit.platform.suite.engine/module-info.java
+++ b/junit-platform-suite-engine/src/module/org.junit.platform.suite.engine/module-info.java
@@ -16,7 +16,7 @@
  * @provides org.junit.platform.engine.TestEngine
  */
 module org.junit.platform.suite.engine {
-	requires org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires org.junit.platform.suite.api;
 	requires org.junit.platform.suite.commons;
 	requires org.junit.platform.commons;

--- a/junit-platform-testkit/src/module/org.junit.platform.testkit/module-info.java
+++ b/junit-platform-testkit/src/module/org.junit.platform.testkit/module-info.java
@@ -15,7 +15,7 @@
  * @uses org.junit.platform.engine.TestEngine
  */
 module org.junit.platform.testkit {
-	requires transitive org.apiguardian.api;
+	requires static transitive org.apiguardian.api;
 	requires transitive org.assertj.core;
 	requires org.junit.platform.commons;
 	requires transitive org.junit.platform.engine;

--- a/junit-vintage-engine/src/module/org.junit.vintage.engine/module-info.java
+++ b/junit-vintage-engine/src/module/org.junit.vintage.engine/module-info.java
@@ -17,7 +17,7 @@
  */
 module org.junit.vintage.engine {
 	requires junit; // 4
-	requires org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires org.junit.platform.engine;
 
 	provides org.junit.platform.engine.TestEngine

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-api.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-api.expected.txt
@@ -6,7 +6,7 @@ exports org.junit.jupiter.api.function
 exports org.junit.jupiter.api.io
 exports org.junit.jupiter.api.parallel
 requires java.base mandated
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.platform.commons transitive
 requires org.opentest4j transitive
 qualified opens org.junit.jupiter.api.condition to org.junit.platform.commons

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-engine.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-engine.expected.txt
@@ -1,6 +1,6 @@
 org.junit.jupiter.engine@${jupiterVersion} jar:file:.+/junit-jupiter-engine-\d.+\.jar..module-info\.class
 requires java.base mandated
-requires org.apiguardian.api
+requires org.apiguardian.api static
 requires org.junit.jupiter.api
 requires org.junit.platform.commons
 requires org.junit.platform.engine

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-migrationsupport.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-migrationsupport.expected.txt
@@ -6,6 +6,6 @@ exports org.junit.jupiter.migrationsupport.rules.adapter
 exports org.junit.jupiter.migrationsupport.rules.member
 requires java.base mandated
 requires junit transitive
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.jupiter.api transitive
 requires org.junit.platform.commons

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-params.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-jupiter-params.expected.txt
@@ -5,7 +5,7 @@ exports org.junit.jupiter.params.converter
 exports org.junit.jupiter.params.provider
 exports org.junit.jupiter.params.support
 requires java.base mandated
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.jupiter.api transitive
 requires org.junit.platform.commons transitive
 qualified opens org.junit.jupiter.params to org.junit.platform.commons

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
@@ -6,6 +6,6 @@ exports org.junit.platform.commons.support
 requires java.base mandated
 requires java.logging
 requires java.management
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 qualified exports org.junit.platform.commons.logging to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.runner org.junit.platform.suite.api org.junit.platform.suite.engine org.junit.platform.testkit org.junit.vintage.engine
 qualified exports org.junit.platform.commons.util to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.runner org.junit.platform.suite.api org.junit.platform.suite.commons org.junit.platform.suite.engine org.junit.platform.testkit org.junit.vintage.engine

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-console.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-console.expected.txt
@@ -1,6 +1,6 @@
 org.junit.platform.console@${platformVersion} jar:file:.+/junit-platform-console-\d.+\.jar..module-info\.class
 requires java.base mandated
-requires org.apiguardian.api
+requires org.apiguardian.api static
 requires org.junit.platform.commons
 requires org.junit.platform.engine
 requires org.junit.platform.launcher

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-engine.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-engine.expected.txt
@@ -8,6 +8,6 @@ exports org.junit.platform.engine.support.discovery
 exports org.junit.platform.engine.support.filter
 exports org.junit.platform.engine.support.hierarchical
 requires java.base mandated
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.platform.commons transitive
 requires org.opentest4j transitive

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-jfr.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-jfr.expected.txt
@@ -1,7 +1,7 @@
 org.junit.platform.jfr@${platformVersion} jar:file:.+/junit-platform-jfr-\d.+\.jar..module-info\.class
 requires java.base mandated
 requires jdk.jfr
-requires org.apiguardian.api
+requires org.apiguardian.api static
 requires org.junit.platform.engine
 requires org.junit.platform.launcher
 provides org.junit.platform.launcher.LauncherDiscoveryListener with org.junit.platform.jfr.FlightRecordingDiscoveryListener

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-launcher.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-launcher.expected.txt
@@ -5,7 +5,7 @@ exports org.junit.platform.launcher.listeners
 exports org.junit.platform.launcher.listeners.discovery
 requires java.base mandated
 requires java.logging transitive
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.platform.commons transitive
 requires org.junit.platform.engine transitive
 uses org.junit.platform.engine.TestEngine

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-reporting.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-reporting.expected.txt
@@ -3,7 +3,7 @@ exports org.junit.platform.reporting.legacy
 exports org.junit.platform.reporting.legacy.xml
 requires java.base mandated
 requires java.xml
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.platform.commons
 requires org.junit.platform.engine transitive
 requires org.junit.platform.launcher transitive

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-runner.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-runner.expected.txt
@@ -2,7 +2,7 @@ org.junit.platform.runner@${platformVersion} jar:file:.+/junit-platform-runner-\
 exports org.junit.platform.runner
 requires java.base mandated
 requires junit transitive
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.platform.launcher transitive
 requires org.junit.platform.suite.api transitive
 requires org.junit.platform.suite.commons

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-suite-api.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-suite-api.expected.txt
@@ -1,5 +1,5 @@
 org.junit.platform.suite.api@${platformVersion} jar:file:.+/junit-platform-suite-api-\d.+\.jar..module-info\.class
 exports org.junit.platform.suite.api
 requires java.base mandated
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.platform.commons transitive

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-suite-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-suite-commons.expected.txt
@@ -1,6 +1,6 @@
 org.junit.platform.suite.commons@${platformVersion} jar:file:.+/junit-platform-suite-commons-\d.+\.jar..module-info\.class
 requires java.base mandated
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.junit.platform.commons
 requires org.junit.platform.engine
 requires org.junit.platform.launcher transitive

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-suite-engine.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-suite-engine.expected.txt
@@ -1,6 +1,6 @@
 org.junit.platform.suite.engine@${platformVersion} jar:file:.+/junit-platform-suite-engine-\d.+\.jar..module-info\.class
 requires java.base mandated
-requires org.apiguardian.api
+requires org.apiguardian.api static
 requires org.junit.platform.commons
 requires org.junit.platform.engine
 requires org.junit.platform.launcher

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-testkit.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-testkit.expected.txt
@@ -1,7 +1,7 @@
 org.junit.platform.testkit@${platformVersion} jar:file:.+/junit-platform-testkit-\d.+\.jar..module-info\.class
 exports org.junit.platform.testkit.engine
 requires java.base mandated
-requires org.apiguardian.api transitive
+requires org.apiguardian.api static transitive
 requires org.assertj.core transitive
 requires org.junit.platform.commons
 requires org.junit.platform.engine transitive

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-vintage-engine.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-vintage-engine.expected.txt
@@ -1,7 +1,7 @@
 org.junit.vintage.engine@${vintageVersion} jar:file:.+/junit-vintage-engine-\d.+\.jar..module-info\.class
 requires java.base mandated
 requires junit
-requires org.apiguardian.api
+requires org.apiguardian.api static
 requires org.junit.platform.engine
 provides org.junit.platform.engine.TestEngine with org.junit.vintage.engine.VintageTestEngine
 contains org.junit.vintage.engine


### PR DESCRIPTION
## Overview

Prevent

```
java.lang.module.FindException: Module org.apiguardian.api not found, required by org.junit.platform.commons
```

errors at runtime.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
