### PR TITLE
Provide access to the current ExecutionMode in ExtensionContext

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.1.adoc
@@ -39,7 +39,7 @@ GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* The current test or container's `ExecutionMode` is now accessible from `ExtensionContext`.
 
 
 [[release-notes-5.8.1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -390,9 +390,9 @@ public interface ExtensionContext {
 	 * @return the {@code ExecutionMode} of the test; never {@code null}
 	 *
 	 * @see org.junit.jupiter.api.parallel.ExecutionMode {@code @ExecutionMode}
-	 * @since 5.8
+	 * @since 5.8.1
 	 */
-	@API(status = STABLE, since = "5.8")
+	@API(status = STABLE, since = "5.8.1")
 	ExecutionMode getExecutionMode();
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.commons.util.Preconditions;
@@ -382,6 +383,17 @@ public interface ExtensionContext {
 	 * @see Namespace#GLOBAL
 	 */
 	Store getStore(Namespace namespace);
+
+	/**
+	 * Get the {@link ExecutionMode} associated with the current test or container.
+	 *
+	 * @return the {@code ExecutionMode} of the test; never {@code null}
+	 *
+	 * @see org.junit.jupiter.api.parallel.ExecutionMode {@code @ExecutionMode}
+	 * @since 5.8
+	 */
+	@API(status = STABLE, since = "5.8")
+	ExecutionMode getExecutionMode();
 
 	/**
 	 * {@code Store} provides methods for extensions to save and retrieve data.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -21,14 +21,17 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.ExtensionValuesStore;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.reporting.ReportEntry;
+import org.junit.platform.engine.support.hierarchical.Node;
 
 /**
  * @since 5.0
@@ -126,5 +129,22 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 	@Override
 	public <V> Optional<V> getConfigurationParameter(String key, Function<String, V> transformer) {
 		return this.configuration.getRawConfigurationParameter(key, transformer);
+	}
+
+	@Override
+	public ExecutionMode getExecutionMode() {
+		return toJupiterExecutionMode(getPlatformExecutionMode());
+	}
+
+	protected abstract Node.ExecutionMode getPlatformExecutionMode();
+
+	private ExecutionMode toJupiterExecutionMode(Node.ExecutionMode mode) {
+		switch (mode) {
+			case CONCURRENT:
+				return ExecutionMode.CONCURRENT;
+			case SAME_THREAD:
+				return ExecutionMode.SAME_THREAD;
+		}
+		throw new JUnitException("Unknown ExecutionMode: " + mode);
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassExtensionContext.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.support.hierarchical.Node;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
@@ -91,6 +92,11 @@ final class ClassExtensionContext extends AbstractExtensionContext<ClassBasedTes
 	@Override
 	public Optional<Throwable> getExecutionException() {
 		return Optional.ofNullable(this.throwableCollector.getThrowable());
+	}
+
+	@Override
+	protected Node.ExecutionMode getPlatformExecutionMode() {
+		return getTestDescriptor().getExecutionMode();
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicExtensionContext.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.support.hierarchical.Node;
 
 class DynamicExtensionContext extends AbstractExtensionContext<DynamicNodeTestDescriptor> {
 
@@ -61,4 +62,10 @@ class DynamicExtensionContext extends AbstractExtensionContext<DynamicNodeTestDe
 	public Optional<Throwable> getExecutionException() {
 		return Optional.empty();
 	}
+
+	@Override
+	protected Node.ExecutionMode getPlatformExecutionMode() {
+		return getTestDescriptor().getExecutionMode();
+	}
+
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineExtensionContext.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.support.hierarchical.Node;
 
 /**
  * @since 5.0
@@ -63,6 +64,11 @@ final class JupiterEngineExtensionContext extends AbstractExtensionContext<Jupit
 	@Override
 	public Optional<Throwable> getExecutionException() {
 		return Optional.empty();
+	}
+
+	@Override
+	protected Node.ExecutionMode getPlatformExecutionMode() {
+		return getTestDescriptor().getExecutionMode();
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodExtensionContext.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.support.hierarchical.Node;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
@@ -78,4 +79,8 @@ final class MethodExtensionContext extends AbstractExtensionContext<TestMethodTe
 		return Optional.ofNullable(this.throwableCollector.getThrowable());
 	}
 
+	@Override
+	protected Node.ExecutionMode getPlatformExecutionMode() {
+		return getTestDescriptor().getExecutionMode();
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateExtensionContext.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.support.hierarchical.Node;
 
 /**
  * @since 5.0
@@ -68,6 +69,11 @@ final class TestTemplateExtensionContext extends AbstractExtensionContext<TestTe
 	@Override
 	public Optional<Throwable> getExecutionException() {
 		return Optional.empty();
+	}
+
+	@Override
+	protected Node.ExecutionMode getPlatformExecutionMode() {
+		return getTestDescriptor().getExecutionMode();
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
@@ -64,6 +64,7 @@ public class ExtensionContextTests {
 	void setUp() {
 		when(configuration.getDefaultDisplayNameGenerator()).thenReturn(new DisplayNameGenerator.Standard());
 		when(configuration.getDefaultExecutionMode()).thenReturn(ExecutionMode.SAME_THREAD);
+		when(configuration.getDefaultClassesExecutionMode()).thenReturn(ExecutionMode.SAME_THREAD);
 	}
 
 	@Test
@@ -85,7 +86,8 @@ public class ExtensionContextTests {
 			() -> assertThrows(PreconditionViolationException.class, () -> engineContext.getRequiredTestMethod()),
 			() -> assertThat(engineContext.getDisplayName()).isEqualTo(engineTestDescriptor.getDisplayName()),
 			() -> assertThat(engineContext.getParent()).isEmpty(),
-			() -> assertThat(engineContext.getRoot()).isSameAs(engineContext)
+			() -> assertThat(engineContext.getRoot()).isSameAs(engineContext),
+			() -> assertThat(engineContext.getExecutionMode()).isEqualTo(ExecutionMode.SAME_THREAD)
 		);
 		// @formatter:on
 	}
@@ -109,7 +111,8 @@ public class ExtensionContextTests {
 			() -> assertThrows(PreconditionViolationException.class, () -> outerExtensionContext.getRequiredTestInstance()),
 			() -> assertThrows(PreconditionViolationException.class, () -> outerExtensionContext.getRequiredTestMethod()),
 			() -> assertThat(outerExtensionContext.getDisplayName()).isEqualTo(outerClassDescriptor.getDisplayName()),
-			() -> assertThat(outerExtensionContext.getParent()).isEmpty()
+			() -> assertThat(outerExtensionContext.getParent()).isEmpty(),
+			() -> assertThat(outerExtensionContext.getExecutionMode()).isEqualTo(ExecutionMode.SAME_THREAD)
 		);
 		// @formatter:on
 
@@ -175,7 +178,8 @@ public class ExtensionContextTests {
 			() -> assertThat(methodExtensionContext.getRequiredTestMethod()).isEqualTo(testMethod),
 			() -> assertThat(methodExtensionContext.getDisplayName()).isEqualTo(methodTestDescriptor.getDisplayName()),
 			() -> assertThat(methodExtensionContext.getParent()).contains(classExtensionContext),
-			() -> assertThat(methodExtensionContext.getRoot()).isSameAs(engineExtensionContext)
+			() -> assertThat(methodExtensionContext.getRoot()).isSameAs(engineExtensionContext),
+			() -> assertThat(methodExtensionContext.getExecutionMode()).isEqualTo(ExecutionMode.SAME_THREAD)
 		);
 		// @formatter:on
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.engine.execution.ExtensionValuesStore;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
 import org.junit.jupiter.params.provider.Arguments;
@@ -265,6 +266,11 @@ class ParameterizedTestExtensionTests {
 			@Override
 			public Store getStore(Namespace namespace) {
 				return new NamespaceAwareStore(store, namespace);
+			}
+
+			@Override
+			public ExecutionMode getExecutionMode() {
+				return ExecutionMode.SAME_THREAD;
 			}
 		};
 	}


### PR DESCRIPTION
## Overview

Resolves #2396.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
