### PR TITLE
Add implicit conversion from integral types to byte array

### DIFF
--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -231,6 +231,18 @@ class DefaultArgumentConverterTests {
 
 	// -------------------------------------------------------------------------
 
+	/**
+	 * @since FIXME
+	 */
+	@Test
+	void convertsIntegralTypesToByteArray() {
+		assertConverts((byte) 0x7F, byte[].class, new byte[] { 0x7F });
+		assertConverts((short) 0x7E7F, byte[].class, new byte[] { 0x7E, 0x7F });
+		assertConverts(0x7C7D7E7F, byte[].class, new byte[] { 0x7C, 0x7D, 0x7E, 0x7F });
+		assertConverts(0x78797A7B7C7D7E7FL, byte[].class,
+			new byte[] { 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F });
+	}
+
 	private void assertConverts(Object input, Class<?> targetClass, Object expectedOutput) {
 		var result = DefaultArgumentConverter.INSTANCE.convert(input, targetClass);
 


### PR DESCRIPTION
## Overview

This adds implicit type conversion from integral types to byte array. 

| Source Type       | Target Type | Example                                                                            |
|-------------------|-------------|------------------------------------------------------------------------------------|
| `byte` / `Byte`   | `byte[]`    | `0xF` &#8594; `ByteBuffer.allocate(Byte.BYTES).put((byte) 0xF).array()`                     |
| `short` / `Short` | `byte[]`    | `0xFFF` &#8594; `ByteBuffer.allocate(Short.BYTES).putShort((short) 0xFFF).array()`           |
| `int` / `Integer` | `byte[]`    | `0xFFFFFFF` &#8594; `ByteBuffer.allocate(Integer.BYTES).putInt(0xFFFFFFF).array()`       |
| `long` / `Long`   | `byte[]`    | `0xFFFFFFFFL` &#8594; `ByteBuffer.allocate(Long.BYTES).putLong(0xFFFFFFFFL).array()` |

Fixes #2702.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
