### PR TITLE
Use @JvmField instead of @JvmStatic in Kotlin / @RegisterExtension

### DIFF
--- a/documentation/src/test/kotlin/example/registration/KotlinWebServerDemo.kt
+++ b/documentation/src/test/kotlin/example/registration/KotlinWebServerDemo.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 class KotlinWebServerDemo {
 
     companion object {
-        @JvmStatic
+        @JvmField
         @RegisterExtension
         val server = WebServerExtension.builder()
                 .enableSecurity(false)


### PR DESCRIPTION
The documentation says:

>The Kotlin programming language does not have the concept of a static field. However, the compiler can be instructed to generate a private static field using the @JvmStatic annotation in Kotlin. If you want the Kotlin compiler to generate a public static field, you can use the @JvmField annotation instead.

But the example shows the use of `@JvmStatic`, which is not working with, e.g. WireMock:

```kotlin
companion object {
    @RegisterExtension
    @JvmStatic
    val wireMock = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build()
}
```

Gives

```
org.junit.platform.commons.PreconditionViolationException: Failed to register extension via @RegisterExtension field [private static final com.github.tomakehurst.wiremock.junit5.WireMockExtension a.b.c.ClientTest.wireMock]: field must not be private.
```

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
