### PR TITLE
Introduce support for text blocks in `@CsvSource`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.8.1.adoc
@@ -41,6 +41,10 @@ GitHub.
 ==== New Features and Improvements
 
 * `JAVA_18` has been added to the `JRE` enum for use with JRE-based execution conditions.
+* CSV content in `@CsvSource` can now be supplied as a _text block_ instead of an array of
+  strings. See the
+  <<../user-guide/index.adoc#writing-tests-parameterized-tests-sources-CsvSource, User
+  Guide>> for details and an example.
 * The `ExecutionMode` for the current test or container is now accessible via the
   `ExtensionContext`.
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1330,12 +1330,32 @@ include::{testDir}/example/ExternalMethodSourceDemo.java[tags=external_MethodSou
 [[writing-tests-parameterized-tests-sources-CsvSource]]
 ===== @CsvSource
 
-`@CsvSource` allows you to express argument lists as comma-separated values (i.e.,
-`String` literals).
+`@CsvSource` allows you to express argument lists as comma-separated values (i.e., CSV
+`String` literals). Each string provided via the `value` attribute in `@CsvSource`
+represents a CSV line and results in one invocation of the parameterized test.
 
 [source,java,indent=0]
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=CsvSource_example]
+----
+
+If the programming language you are using supports _text blocks_ -- for example, Java SE
+15 or higher -- you can alternatively use the `textBlock` attribute of `@CsvSource`. Each
+line within a text block represents a CSV line and results in one invocation of the
+parameterized test. Using a text block, the previous example can be implemented as follows.
+
+[source,java,indent=0]
+----
+@ParameterizedTest
+@CsvSource(textBlock = """
+	apple,         1
+	banana,        2
+	'lemon, lime', 0xF1
+	strawberry,    700_000
+""")
+void testWithCsvSource(String fruit, int rank) {
+	// ...
+}
 ----
 
 The default delimiter is a comma (`,`), but you can use another character by setting the
@@ -1354,8 +1374,8 @@ reference is a primitive type.
 NOTE: An _unquoted_ empty value will always be converted to a `null` reference regardless
 of any custom values configured via the `nullValues` attribute.
 
-Unless it starts with a quote character, leading and trailing whitespaces of a
-CSV column are trimmed by default. This behavior can be changed by setting the
+Unless it starts with a quote character, leading and trailing whitespace in a CSV column
+is trimmed by default. This behavior can be changed by setting the
 `ignoreLeadingAndTrailingWhitespace` attribute to `true`.
 
 [cols="50,50"]
@@ -1373,8 +1393,9 @@ CSV column are trimmed by default. This behavior can be changed by setting the
 [[writing-tests-parameterized-tests-sources-CsvFileSource]]
 ===== @CsvFileSource
 
-`@CsvFileSource` lets you use CSV files from the classpath or the local file system. Each
-line from a CSV file results in one invocation of the parameterized test.
+`@CsvFileSource` lets you use comma-separated value (CSV) files from the classpath or the
+local file system. Each line from a CSV file results in one invocation of the
+parameterized test.
 
 The default delimiter is a comma (`,`), but you can use another character by setting the
 `delimiter` attribute. Alternatively, the `delimiterString` attribute allows you to use a
@@ -1407,8 +1428,8 @@ reference is a primitive type.
 NOTE: An _unquoted_ empty value will always be converted to a `null` reference regardless
 of any custom values configured via the `nullValues` attribute.
 
-Unless it starts with a quote character, leading and trailing whitespaces of a
-CSV column are trimmed by default. This behavior can be changed by setting the
+Unless it starts with a quote character, leading and trailing whitespace in a CSV column
+is trimmed by default. This behavior can be changed by setting the
 `ignoreLeadingAndTrailingWhitespace` attribute to `true`.
 
 [[writing-tests-parameterized-tests-sources-ArgumentsSource]]

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -22,9 +22,9 @@ import java.lang.annotation.Target;
 import org.apiguardian.api.API;
 
 /**
- * {@code @CsvSource} is an {@link ArgumentsSource} which reads
- * comma-separated values (CSV) from one or more supplied
- * {@linkplain #value CSV lines}.
+ * {@code @CsvSource} is an {@link ArgumentsSource} which reads comma-separated
+ * values (CSV) from one or more CSV lines supplied via the {@link #value}
+ * attribute or {@link #textBlock} attribute.
  *
  * <p>The column delimiter (defaults to comma) can be customized with either
  * {@link #delimiter()} or {@link #delimiterString()}.
@@ -51,8 +51,65 @@ public @interface CsvSource {
 	 * the specified {@link #delimiter} or {@link #delimiterString}. Any line
 	 * beginning with a {@code #} symbol will be interpreted as a comment and will
 	 * be ignored.
+	 *
+	 * <p>Defaults to an empty array. You therefore must supply CSV content
+	 * via this attribute or the {@link #textBlock} attribute.
+	 *
+	 * <p>If <em>text block</em> syntax is supported by your programming language,
+	 * you may find it more convenient to declare your CSV content via the
+	 * {@link #textBlock} attribute.
+	 *
+	 * <h4>Example</h4>
+	 * <pre class="code">
+	 * {@literal @}ParameterizedTest
+	 * {@literal @}CsvSource({
+	 *     "apple,         1",
+	 *     "banana,        2",
+	 *     "'lemon, lime', 0xF1",
+	 *     "strawberry,    700_000",
+	 * })
+	 * void test(String fruit, int rank) {
+	 *     // ...
+	 * }</pre>
+	 *
+	 * @see #textBlock
 	 */
-	String[] value();
+	String[] value() default {};
+
+	/**
+	 * The CSV lines to use as the source of arguments, supplied as a single
+	 * <em>text block</em>; must not be empty.
+	 *
+	 * <p>Each line in the text block corresponds to a line in a CSV file and will
+	 * be split using the specified {@link #delimiter} or {@link #delimiterString}.
+	 * Any line beginning with a {@code #} symbol will be interpreted as a comment
+	 * and will be ignored.
+	 *
+	 * <p>Defaults to an empty string. You therefore must supply CSV content
+	 * via this attribute or the {@link #value} attribute.
+	 *
+	 * <p>Text block syntax is supported by various languages on the JVM
+	 * including Java SE 15 or higher. If text blocks are not supported, you
+	 * should declare your CSV content via the {@link #value} attribute.
+	 *
+	 * <h4>Example</h4>
+	 * <pre class="code">
+	 * {@literal @}ParameterizedTest
+	 * {@literal @}CsvSource(textBlock = """
+	 *     apple,         1
+	 *     banana,        2
+	 *     'lemon, lime', 0xF1
+	 *     strawberry,    700_000
+	 * """)
+	 * void test(String fruit, int rank) {
+	 *     // ...
+	 * }</pre>
+	 *
+	 * @since 5.8.1
+	 * @see #value
+	 */
+	@API(status = EXPERIMENTAL, since = "5.8.1")
+	String textBlock() default "";
 
 	/**
 	 * The column delimiter character to use when reading the {@linkplain #value lines}.
@@ -128,4 +185,5 @@ public @interface CsvSource {
 	 */
 	@API(status = EXPERIMENTAL, since = "5.8")
 	boolean ignoreLeadingAndTrailingWhitespace() default true;
+
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -90,6 +90,32 @@ import org.opentest4j.TestAbortedException;
  */
 class ParameterizedTestIntegrationTests {
 
+	@ParameterizedTest
+	@CsvSource(textBlock = """
+				apple,         1
+				banana,        2
+				'lemon, lime', 0xF1
+				strawberry,    700_000
+			""")
+	void executesLinesFromTextBlock(String fruit, int rank) {
+		switch (fruit) {
+			case "apple":
+				assertThat(rank).isEqualTo(1);
+				break;
+			case "banana":
+				assertThat(rank).isEqualTo(2);
+				break;
+			case "lemon, lime":
+				assertThat(rank).isEqualTo(241);
+				break;
+			case "strawberry":
+				assertThat(rank).isEqualTo(700_000);
+				break;
+			default:
+				fail("Unexpected fruit : " + fruit);
+		}
+	}
+
 	@Test
 	void executesWithSingleArgumentsProviderWithMultipleInvocations() {
 		var results = execute("testWithTwoSingleStringArgumentsProvider", String.class);

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MockCsvAnnotationBuilder.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MockCsvAnnotationBuilder.java
@@ -83,6 +83,7 @@ abstract class MockCsvAnnotationBuilder<A extends Annotation, B extends MockCsvA
 	static class MockCsvSourceBuilder extends MockCsvAnnotationBuilder<CsvSource, MockCsvSourceBuilder> {
 
 		private String[] lines = new String[0];
+		private String textBlock = "";
 
 		@Override
 		protected MockCsvSourceBuilder getSelf() {
@@ -91,6 +92,11 @@ abstract class MockCsvAnnotationBuilder<A extends Annotation, B extends MockCsvA
 
 		MockCsvSourceBuilder lines(String... lines) {
 			this.lines = lines;
+			return this;
+		}
+
+		MockCsvSourceBuilder textBlock(String textBlock) {
+			this.textBlock = textBlock;
 			return this;
 		}
 
@@ -108,6 +114,7 @@ abstract class MockCsvAnnotationBuilder<A extends Annotation, B extends MockCsvA
 
 			// @CsvSource
 			when(annotation.value()).thenReturn(this.lines);
+			when(annotation.textBlock()).thenReturn(this.textBlock);
 
 			return annotation;
 		}


### PR DESCRIPTION
## Overview

With the introduction of support for _text blocks_ as a first-class language feature in recent JDKs (preview feature in Java SE 15), we can improve the user experience with `@CsvSource` by allowing the user to provide a text block instead of an array of strings.

## Example

Given the following parameterized test using a text block...

```java
@ParameterizedTest
@CsvSource(textBlock = """
    apple,         1
    banana,        2
    'lemon, lime', 0xF1
    strawberry,    700_000
""")
void csvSourceWithTextBlock(String fruit, int rank) {
	System.out.println(fruit + " : " + rank);
}
```
... the output is:

```
apple : 1
banana : 2
lemon, lime : 241
strawberry : 700000
```

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
