### PR TITLE
Fix unintended exceptions in assertLinesMatch

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -202,7 +202,8 @@ class AssertLinesMatch {
 	}
 
 	static int parseFastForwardLimit(String fastForwardLine) {
-		String text = fastForwardLine.trim().substring(2, fastForwardLine.length() - 2).trim();
+		fastForwardLine = fastForwardLine.trim();
+		String text = fastForwardLine.substring(2, fastForwardLine.length() - 2).trim();
 		try {
 			int limit = Integer.parseInt(text);
 			condition(limit > 0, () -> format("fast-forward(%d) limit must be greater than zero", limit));

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -136,10 +136,10 @@ class AssertLinesMatch {
 				// fast-forward marker found in expected line: fast-forward actual line...
 				if (isFastForwardLine(expectedLine)) {
 					int fastForwardLimit = parseFastForwardLimit(expectedLine);
+					int actualRemaining = actualDeque.size();
 
 					// trivial case: fast-forward marker was in last expected line
 					if (expectedDeque.isEmpty()) {
-						int actualRemaining = actualDeque.size();
 						// no limit given or perfect match? we're done.
 						if (fastForwardLimit == Integer.MAX_VALUE || fastForwardLimit == actualRemaining) {
 							return;
@@ -150,6 +150,10 @@ class AssertLinesMatch {
 
 					// fast-forward limit was given: use it
 					if (fastForwardLimit != Integer.MAX_VALUE) {
+						if (actualRemaining < fastForwardLimit) {
+							fail("fast-forward(%d) error: not enough actual lines remaining (%s)", fastForwardLimit,
+								actualRemaining);
+						}
 						// fast-forward now: actualDeque.pop(fastForwardLimit)
 						for (int i = 0; i < fastForwardLimit; i++) {
 							actualDeque.pop();

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
@@ -165,6 +165,19 @@ class AssertLinesMatchAssertionsTests {
 	}
 
 	@Test
+	void assertLinesMatchUsingFastForwardMarkerWithTooHighLimitAndFollowingLineFails() {
+		/*
+		 * It is important here that the line counts are expected <= actual, that the
+		 * fast-forward exceeds the available actual lines and that it is not a
+		 * terminal fast-forward.
+		 */
+		var expected = List.of("first line", ">> 3 >>", "not present");
+		var actual = List.of("first line", "first skipped", "second skipped");
+		var error = assertThrows(AssertionFailedError.class, () -> assertLinesMatch(expected, actual));
+		assertError(error, "fast-forward(3) error: not enough actual lines remaining (2)", expected, actual);
+	}
+
+	@Test
 	void assertLinesMatchUsingFastForwardMarkerWithoutMatchingNextLineFails() {
 		var expected = List.of("first line", ">> fails, because next line is >>", "not present");
 		var actual = List.of("first line", "skipped", "last line");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertLinesMatchAssertionsTests.java
@@ -187,7 +187,8 @@ class AssertLinesMatchAssertionsTests {
 			() -> assertTrue(isFastForwardLine(">> stacktrace >>")),
 			() -> assertTrue(isFastForwardLine(">> single line, non Integer.parse()-able comment >>")),
 			() -> assertTrue(isFastForwardLine(">>9>>")), () -> assertTrue(isFastForwardLine(">> 9 >>")),
-			() -> assertTrue(isFastForwardLine(">> -9 >>")));
+			() -> assertTrue(isFastForwardLine(">> -9 >>")), () -> assertTrue(isFastForwardLine(" >> 9 >> ")),
+			() -> assertTrue(isFastForwardLine("  >> 9 >>  ")));
 	}
 
 	@Test
@@ -198,7 +199,9 @@ class AssertLinesMatchAssertionsTests {
 			() -> assertEquals(Integer.MAX_VALUE, parseFastForwardLimit(">> stacktrace >>")),
 			() -> assertEquals(Integer.MAX_VALUE, parseFastForwardLimit(">> non Integer.parse()-able comment >>")),
 			() -> assertEquals(9, parseFastForwardLimit(">>9>>")),
-			() -> assertEquals(9, parseFastForwardLimit(">> 9 >>")));
+			() -> assertEquals(9, parseFastForwardLimit(">> 9 >>")),
+			() -> assertEquals(9, parseFastForwardLimit(" >> 9 >> ")),
+			() -> assertEquals(9, parseFastForwardLimit("  >> 9 >>  ")));
 		Throwable error = assertThrows(PreconditionViolationException.class, () -> parseFastForwardLimit(">>0>>"));
 		assertMessageEquals(error, "fast-forward(0) limit must be greater than zero");
 		error = assertThrows(PreconditionViolationException.class, () -> parseFastForwardLimit(">>-1>>"));


### PR DESCRIPTION
## Overview

This pull request fixes two bugs in the `assertLinesMatch` implementation. The two bugs cause unintended exceptions to be thrown:
1. Fast-forward lines are not trimmed consistently, causing an `IndexOutOfBoundsException` when `"  >> 2 >>  "` is used, for example. This also caused `" >> 2 >> "` to be interpreted as unlimited fast-forward.
   
   This PR adds the missing `String.trim()` and adds test cases that fail without the fix.
2. A limited fast-forward that is not terminal (followed by at least one more expected line) causes a `NoSuchElementException` if it exceeds the number of remaining actual lines.
   
   This PR adds an `if` that will cause the assertion to fail with a detailed message and adds a test case that fail without the fix.

*This is my first pull request here, I welcome any feedback from maintainers how to improve. In particular, I am not sure what the best failure message for the `fail` in the second bug fix is.*

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
