### PR TITLE
Add EnumSource.MATCH_NONE mode

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
@@ -42,8 +42,9 @@ on GitHub.
 
 * Add support for `IterationSelector` to select a subset of the invocations of
   parameterized or dynamic tests.
-* Add support for `MATCH_NONE` mode in `EnumSource` which selects only those enum constants
-  whose names don't match any of the pattern supplied.
+* Add support for `MATCH_NONE` mode in `EnumSource` that selects only those enum constants
+  whose names match none of the supplied patterns.
+
 
 [[release-notes-5.9.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
@@ -42,7 +42,8 @@ on GitHub.
 
 * Add support for `IterationSelector` to select a subset of the invocations of
   parameterized or dynamic tests.
-
+* Add support for `MATCH_NONE` mode in `EnumSource` which selects only those enum constants
+  whose names don't match any of the pattern supplied.
 
 [[release-notes-5.9.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -126,7 +126,7 @@ public @interface EnumSource {
 		MATCH_ANY(Mode::validatePatterns, (name, patterns) -> patterns.stream().anyMatch(name::matches)),
 
 		/**
-		 * Select only those enum constants whose names don't match any pattern supplied
+		 * Select only those enum constants whose names match none of the patterns supplied
 		 * via the {@link EnumSource#names} attribute.
 		 *
 		 * @since 5.9

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -43,7 +43,7 @@ import org.junit.platform.commons.util.Preconditions;
  * {@link #mode} attributes.
  *
  * @since 5.0
- * @see ArgumentsSource
+ * @see org.junit.jupiter.params.provider.ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedTest
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
@@ -87,6 +87,7 @@ public @interface EnumSource {
 	 * @see Mode#EXCLUDE
 	 * @see Mode#MATCH_ALL
 	 * @see Mode#MATCH_ANY
+	 * @see Mode#MATCH_NONE
 	 * @see #names
 	 */
 	Mode mode() default Mode.INCLUDE;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.params.provider;
 
 import static java.util.stream.Collectors.toSet;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -42,7 +43,7 @@ import org.junit.platform.commons.util.Preconditions;
  * {@link #mode} attributes.
  *
  * @since 5.0
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedTest
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
@@ -121,7 +122,17 @@ public @interface EnumSource {
 		 *
 		 * @see java.util.stream.Stream#anyMatch(java.util.function.Predicate)
 		 */
-		MATCH_ANY(Mode::validatePatterns, (name, patterns) -> patterns.stream().anyMatch(name::matches));
+		MATCH_ANY(Mode::validatePatterns, (name, patterns) -> patterns.stream().anyMatch(name::matches)),
+
+		/**
+		 * Select only those enum constants whose names don't match any pattern supplied
+		 * via the {@link EnumSource#names} attribute.
+		 *
+		 * @since 5.9
+		 * @see java.util.stream.Stream#noneMatch(java.util.function.Predicate)
+		 */
+		@API(status = EXPERIMENTAL, since = "5.9")
+		MATCH_NONE(Mode::validatePatterns, (name, patterns) -> patterns.stream().noneMatch(name::matches));
 
 		private final Validator validator;
 		private final BiPredicate<String, Set<String>> selector;

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/EnumSourceTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/EnumSourceTests.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.MATCH_ALL;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.MATCH_ANY;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.MATCH_NONE;
 import static org.junit.jupiter.params.provider.EnumSourceTests.EnumWithThreeConstants.BAR;
 import static org.junit.jupiter.params.provider.EnumSourceTests.EnumWithThreeConstants.BAZ;
 import static org.junit.jupiter.params.provider.EnumSourceTests.EnumWithThreeConstants.FOO;
@@ -89,6 +90,20 @@ class EnumSourceTests {
 			() -> assertTrue(MATCH_ANY.select(FOO, Set.of("B..", "^F.*"))),
 			() -> assertTrue(MATCH_ANY.select(BAR, Set.of("B", "B.", "B.."))),
 			() -> assertTrue(MATCH_ANY.select(BAZ, Set.of("^.+[zZ]$"))));
+	}
+
+	@Test
+	void matchesNone() {
+		assertAll("matches none fails if any match", //
+			() -> assertFalse(MATCH_NONE.select(FOO, Set.of("F.."))),
+			() -> assertFalse(MATCH_NONE.select(FOO, Set.of("B..", "F.."))),
+			() -> assertFalse(MATCH_NONE.select(BAZ, Set.of("B.", "F.", "^.+[zZ]$"))));
+
+		assertAll("matches none", //
+			() -> assertTrue(MATCH_NONE.select(FOO, Set.of())), //
+			() -> assertTrue(MATCH_NONE.select(FOO, Set.of("F."))),
+			() -> assertTrue(MATCH_NONE.select(FOO, Set.of("B.."))),
+			() -> assertTrue(MATCH_NONE.select(BAZ, Set.of(".", "B.", "F."))));
 	}
 
 	enum EnumWithThreeConstants {


### PR DESCRIPTION
## Overview

Addresses issue #2761 
Introduced MATCH_NONE mode in `EnumSource` which only selects the enum constant if none of the regex matches. Added tests in `EnumSourceTest`

Questions:
 - Should I add usage in documentation? Current documentation `ParameterizedTestDemo` only contains `MATCH_ALL ` example. There is scope to add `MATCH_ANY` and `MATCH_NONE`

Todo:

- [x] Squash the commits once the changes are approved (will be done by Marc before merging)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
