### PR TITLE
Use value references in Javadoc to eliminate duplication

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.api;
 
 import static java.util.Comparator.comparingInt;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -61,6 +62,20 @@ import org.junit.platform.commons.logging.LoggerFactory;
 @API(status = EXPERIMENTAL, since = "5.8")
 public interface ClassOrderer {
 
+	/**
+	 * Property name used to set the default class orderer class name: {@value}
+	 *
+	 * <h4>Supported Values</h4>
+	 *
+	 * <p>Supported values include fully qualified class names for types that
+	 * implement {@link org.junit.jupiter.api.ClassOrderer}.
+	 *
+	 * <p>If not specified, test classes are not ordered unless test classes are
+	 * annotated with {@link TestClassOrder @TestClassOrder}.
+	 *
+	 * @since 5.8
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_ORDER_PROPERTY_NAME = "junit.jupiter.testclass.order.default";
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -35,7 +35,7 @@ import org.junit.platform.commons.logging.LoggerFactory;
  * class}.
  *
  * <p>A {@link ClassOrderer} can be configured <em>globally</em> for the entire
- * test suite via the {@code junit.jupiter.testclass.order.default} configuration
+ * test suite via the {@value #DEFAULT_ORDER_PROPERTY_NAME} configuration
  * parameter (see the User Guide for details) or <em>locally</em> for
  * {@link Nested @Nested} test classes via the {@link TestClassOrder @TestClassOrder}
  * annotation.
@@ -60,6 +60,8 @@ import org.junit.platform.commons.logging.LoggerFactory;
  */
 @API(status = EXPERIMENTAL, since = "5.8")
 public interface ClassOrderer {
+
+	String DEFAULT_ORDER_PROPERTY_NAME = "junit.jupiter.testclass.order.default";
 
 	/**
 	 * Order the classes encapsulated in the supplied {@link ClassOrdererContext}.
@@ -173,12 +175,11 @@ public interface ClassOrderer {
 	 * of this class. In order to support repeatable builds, the value of the
 	 * default random seed is logged at {@code CONFIG} level. In addition, a
 	 * custom seed (potentially the default seed from the previous test plan
-	 * execution) may be specified via the {@link Random#RANDOM_SEED_PROPERTY_NAME
-	 * junit.jupiter.execution.order.random.seed} <em>configuration parameter</em>
-	 * which can be supplied via the {@code Launcher} API, build tools (e.g.,
-	 * Gradle and Maven), a JVM system property, or the JUnit Platform configuration
-	 * file (i.e., a file named {@code junit-platform.properties} in the root of
-	 * the class path). Consult the User Guide for further information.
+	 * execution) may be specified via the {@value Random#RANDOM_SEED_PROPERTY_NAME}
+	 * <em>configuration parameter</em> which can be supplied via the {@code Launcher}
+	 * API, build tools (e.g., Gradle and Maven), a JVM system property, or the JUnit
+	 * Platform configuration file (i.e., a file named {@code junit-platform.properties}
+	 * in the root of the class path). Consult the User Guide for further information.
 	 *
 	 * @see Random#RANDOM_SEED_PROPERTY_NAME
 	 * @see java.util.Random

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGeneration.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGeneration.java
@@ -29,6 +29,12 @@ import org.apiguardian.api.API;
  * interfaces. It is also inherited from {@linkplain Class#getEnclosingClass()
  * enclosing classes} for {@link Nested @Nested} test classes.
  *
+ * <p>As an alternative to {@code @DisplayNameGeneration}, a global
+ * {@link DisplayNameGenerator} can be configured for the entire test suite via
+ * the {@value DisplayNameGenerator#DEFAULT_GENERATOR_PROPERTY_NAME} configuration parameter. See
+ * the User Guide for details. Note, however, that a {@code @DisplayNameGeneration}
+ * declaration always overrides a global {@code DisplayNameGenerator}.
+ *
  * @since 5.4
  * @see DisplayName
  * @see DisplayNameGenerator

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -33,6 +33,12 @@ import org.junit.platform.commons.util.ReflectionUtils;
  *
  * <p>Concrete implementations must have a <em>default constructor</em>.
  *
+ * <p>A {@link DisplayNameGenerator} can be configured <em>globally</em> for the
+ * entire test suite via the {@value #DEFAULT_GENERATOR_PROPERTY_NAME}
+ * configuration parameter (see the User Guide for details) or <em>locally</em>
+ * for a test class via the {@link TestClassOrder @DisplayNameGeneration}
+ * annotation.
+ *
  * <h4>Built-in Implementations</h4>
  * <ul>
  * <li>{@link Standard}</li>
@@ -47,6 +53,8 @@ import org.junit.platform.commons.util.ReflectionUtils;
  */
 @API(status = STABLE, since = "5.7")
 public interface DisplayNameGenerator {
+
+	String DEFAULT_GENERATOR_PROPERTY_NAME = "junit.jupiter.displayname.generator.default";
 
 	/**
 	 * Generate a display name for the given top-level or {@code static} nested test class.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -54,6 +54,21 @@ import org.junit.platform.commons.util.ReflectionUtils;
 @API(status = STABLE, since = "5.7")
 public interface DisplayNameGenerator {
 
+	/**
+	 * Property name used to set the default display name generator class name:
+	 * {@value}
+	 *
+	 * <h4>Supported Values</h4>
+	 *
+	 * <p>Supported values include fully qualified class names for types that
+	 * implement {@link DisplayNameGenerator}.
+	 *
+	 * <p>If not specified, the default is
+	 * {@link DisplayNameGenerator.Standard}.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_GENERATOR_PROPERTY_NAME = "junit.jupiter.displayname.generator.default";
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -34,6 +34,11 @@ import org.junit.platform.commons.util.ClassUtils;
  * {@code @Test}, {@code @RepeatedTest}, {@code @ParameterizedTest},
  * {@code @TestFactory}, or {@code @TestTemplate}.
  *
+ * <p>A {@link MethodOrderer} can be configured <em>globally</em> for the entire
+ * test suite via the {@value #DEFAULT_ORDER_PROPERTY_NAME} configuration
+ * parameter (see the User Guide for details) or <em>locally</em> for a test
+ * class via the {@link TestClassOrder @TestMethodOrder} annotation.
+ *
  * <h4>Built-in Implementations</h4>
  *
  * <p>JUnit Jupiter provides the following built-in {@code MethodOrderer}
@@ -53,6 +58,8 @@ import org.junit.platform.commons.util.ClassUtils;
  */
 @API(status = STABLE, since = "5.7")
 public interface MethodOrderer {
+
+	String DEFAULT_ORDER_PROPERTY_NAME = "junit.jupiter.testmethod.order.default";
 
 	/**
 	 * Order the methods encapsulated in the supplied {@link MethodOrdererContext}.
@@ -232,12 +239,11 @@ public interface MethodOrderer {
 	 * of this class. In order to support repeatable builds, the value of the
 	 * default random seed is logged at {@code CONFIG} level. In addition, a
 	 * custom seed (potentially the default seed from the previous test plan
-	 * execution) may be specified via the {@link Random#RANDOM_SEED_PROPERTY_NAME
-	 * junit.jupiter.execution.order.random.seed} <em>configuration parameter</em>
-	 * which can be supplied via the {@code Launcher} API, build tools (e.g.,
-	 * Gradle and Maven), a JVM system property, or the JUnit Platform configuration
-	 * file (i.e., a file named {@code junit-platform.properties} in the root of
-	 * the class path). Consult the User Guide for further information.
+	 * execution) may be specified via the {@value ClassOrderer.Random#RANDOM_SEED_PROPERTY_NAME}
+	 * <em>configuration parameter</em> which can be supplied via the {@code Launcher}
+	 * API, build tools (e.g., Gradle and Maven), a JVM system property, or the JUnit
+	 * Platform configuration file (i.e., a file named {@code junit-platform.properties}
+	 * in the root of the class path). Consult the User Guide for further information.
 	 *
 	 * @see Random#RANDOM_SEED_PROPERTY_NAME
 	 * @see java.util.Random

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -37,7 +37,7 @@ import org.junit.platform.commons.util.ClassUtils;
  * <p>A {@link MethodOrderer} can be configured <em>globally</em> for the entire
  * test suite via the {@value #DEFAULT_ORDER_PROPERTY_NAME} configuration
  * parameter (see the User Guide for details) or <em>locally</em> for a test
- * class via the {@link TestClassOrder @TestMethodOrder} annotation.
+ * class via the {@link TestMethodOrder @TestMethodOrder} annotation.
  *
  * <h4>Built-in Implementations</h4>
  *
@@ -59,6 +59,20 @@ import org.junit.platform.commons.util.ClassUtils;
 @API(status = STABLE, since = "5.7")
 public interface MethodOrderer {
 
+	/**
+	 * Property name used to set the default method orderer class name: {@value}
+	 *
+	 * <h4>Supported Values</h4>
+	 *
+	 * <p>Supported values include fully qualified class names for types that
+	 * implement {@link org.junit.jupiter.api.MethodOrderer}.
+	 *
+	 * <p>If not specified, test methods will be ordered using an algorithm that
+	 * is deterministic but intentionally non-obvious.
+	 *
+	 * @since 5.7
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_ORDER_PROPERTY_NAME = "junit.jupiter.testmethod.order.default";
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestClassOrder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestClassOrder.java
@@ -33,7 +33,7 @@ import org.apiguardian.api.API;
  *
  * <p>As an alternative to {@code @TestClassOrder}, a global {@link ClassOrderer}
  * can be configured for the entire test suite via the
- * {@code junit.jupiter.testclass.order.default} configuration parameter. See
+ * {@value ClassOrderer#DEFAULT_ORDER_PROPERTY_NAME} configuration parameter. See
  * the User Guide for details. Note, however, that a {@code @TestClassOrder}
  * declaration always overrides a global {@code ClassOrderer}.
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
@@ -31,7 +31,7 @@ import org.apiguardian.api.API;
  * implicitly default to {@link Lifecycle#PER_METHOD PER_METHOD}. Note, however,
  * that an explicit lifecycle mode is <em>inherited</em> within a test class
  * hierarchy. In addition, the <em>default</em> lifecycle mode may be overridden
- * via the {@code junit.jupiter.testinstance.lifecycle.default} <em>configuration
+ * via the {@value Lifecycle#DEFAULT_LIFECYCLE_PROPERTY_NAME} <em>configuration
  * parameter</em> which can be supplied via the {@code Launcher} API, build tools
  * (e.g., Gradle and Maven), a JVM system property, or the JUnit Platform
  * configuration file (i.e., a file named {@code junit-platform.properties} in
@@ -91,6 +91,8 @@ public @interface TestInstance {
 		 * @see #PER_CLASS
 		 */
 		PER_METHOD;
+
+		public static final String DEFAULT_LIFECYCLE_PROPERTY_NAME = "junit.jupiter.testinstance.lifecycle.default";
 
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
@@ -76,22 +76,40 @@ public @interface TestInstance {
 	enum Lifecycle {
 
 		/**
-		 * When using this mode, a new test instance will be created once per test class.
+		 * When using this mode, a new test instance will be created once per
+		 * test class.
 		 *
 		 * @see #PER_METHOD
 		 */
 		PER_CLASS,
 
 		/**
-		 * When using this mode, a new test instance will be created for each test method,
-		 * test factory method, or test template method.
+		 * When using this mode, a new test instance will be created for each
+		 * test method, test factory method, or test template method.
 		 *
-		 * <p>This mode is analogous to the behavior found in JUnit versions 1 through 4.
+		 * <p>This mode is analogous to the behavior found in JUnit versions 1
+		 * through 4.
 		 *
 		 * @see #PER_CLASS
 		 */
 		PER_METHOD;
 
+		/**
+		 * Property name used to set the default test instance lifecycle mode:
+		 * {@value}
+		 *
+		 * <h4>Supported Values</h4>
+		 *
+		 * <p>Supported values include names of enum constants defined in
+		 * {@link org.junit.jupiter.api.TestInstance.Lifecycle}, ignoring case.
+		 *
+		 * <p>If not specified, the default is "per_method" which corresponds to
+		 * {@code @TestInstance(Lifecycle.PER_METHOD)}.
+		 *
+		 * @since 5.0
+		 * @see org.junit.jupiter.api.TestInstance
+		 */
+		@API(status = STABLE, since = "5.9")
 		public static final String DEFAULT_LIFECYCLE_PROPERTY_NAME = "junit.jupiter.testinstance.lifecycle.default";
 
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestMethodOrder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestMethodOrder.java
@@ -35,6 +35,12 @@ import org.apiguardian.api.API;
  * a test class, test methods will be ordered using a default algorithm that is
  * deterministic but intentionally nonobvious.
  *
+ * <p>As an alternative to {@code @TestMethodOrder}, a global {@link MethodOrderer}
+ * can be configured for the entire test suite via the
+ * {@value MethodOrderer#DEFAULT_ORDER_PROPERTY_NAME} configuration parameter. See
+ * the User Guide for details. Note, however, that a {@code @TestClassOrder}
+ * declaration always overrides a global {@code ClassOrderer}.
+ *
  * <h4>Example Usage</h4>
  *
  * <p>The following demonstrates how to guarantee that test methods are executed

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
@@ -68,7 +68,9 @@ import org.apiguardian.api.API;
  * overrides {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME}
  * which overrides {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}.
  *
- * <p>Values must be in the following, case-insensitive format:
+ * <h3 id="supported-values">Supported Values</h3>
+ *
+ * <p>Values for timeouts must be in the following, case-insensitive format:
  * {@code <number> [ns|μs|ms|s|m|h|d]}. The space between the number and the
  * unit may be omitted. Specifying no unit is equivalent to using seconds.
  *
@@ -105,16 +107,212 @@ import org.apiguardian.api.API;
 @API(status = STABLE, since = "5.7")
 public @interface Timeout {
 
+	/**
+	 * Property name used to set the default timeout for all testable and
+	 * lifecycle methods: {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a more
+	 * specific property or a {@link Timeout @Timeout}
+	 * annotation present on the method or on an enclosing test class (for
+	 * testable methods).
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.default";
+
+	/**
+	 * Property name used to set the default timeout for all testable methods:
+	 * {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a more
+	 * specific property or a {@link Timeout @Timeout}
+	 * annotation present on the testable method or on an enclosing test class.
+	 *
+	 * <p>This property overrides the {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}
+	 * property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testable.method.default";
+
+	/**
+	 * Property name used to set the default timeout for all {@link Test @Test}
+	 * methods: {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a
+	 * {@link Timeout @Timeout} annotation present on the {@link Test @Test}
+	 * method or on an enclosing test class.
+	 *
+	 * <p>This property overrides the
+	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.test.method.default";
+
+	/**
+	 * Property name used to set the default timeout for all
+	 * {@link TestTemplate @TestTemplate} methods: {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a
+	 * {@link Timeout @Timeout} annotation present on the
+	 * {@link TestTemplate @TestTemplate} method or on an enclosing test class.
+	 *
+	 * <p>This property overrides the
+	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testtemplate.method.default";
+
+	/**
+	 * Property name used to set the default timeout for all
+	 * {@link TestFactory @TestFactory} methods: {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a
+	 * {@link Timeout @Timeout} annotation present on the
+	 * {@link TestFactory @TestFactory} method or on an enclosing test class.
+	 *
+	 * <p>This property overrides the
+	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testfactory.method.default";
+
+	/**
+	 * Property name used to set the default timeout for all lifecycle methods:
+	 * {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a more
+	 * specific property or a {@link Timeout @Timeout} annotation present on the
+	 * lifecycle method.
+	 *
+	 * <p>This property overrides the {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}
+	 * property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.lifecycle.method.default";
+
+	/**
+	 * Property name used to set the default timeout for all
+	 * {@link BeforeAll @BeforeAll} methods: {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a
+	 * {@link Timeout @Timeout} annotation present on the
+	 * {@link BeforeAll @BeforeAll} method.
+	 *
+	 * <p>This property overrides the
+	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.beforeall.method.default";
+
+	/**
+	 * Property name used to set the default timeout for all
+	 * {@link BeforeEach @BeforeEach} methods: {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a
+	 * {@link Timeout @Timeout} annotation present on the
+	 * {@link BeforeEach @BeforeEach} method.
+	 *
+	 * <p>This property overrides the
+	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.beforeeach.method.default";
+
+	/**
+	 * Property name used to set the default timeout for all
+	 * {@link AfterEach @AfterEach} methods: {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a
+	 * {@link Timeout @Timeout} annotation present on the
+	 * {@link AfterEach @AfterEach} method.
+	 *
+	 * <p>This property overrides the
+	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.aftereach.method.default";
+
+	/**
+	 * Property name used to set the default timeout for all
+	 * {@link AfterAll @AfterAll} methods: {@value}.
+	 *
+	 * <p>The value of this property will be used unless overridden by a
+	 * {@link Timeout @Timeout} annotation present on the
+	 * {@link AfterAll @AfterAll} method.
+	 *
+	 * <p>This property overrides the
+	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
+	 *
+	 * <p>Please refer to the <a href="#supported-values">class
+	 * description</a> for the definition of supported values.
+	 *
+	 * @since 5.5
+	 */
+	@API(status = STABLE, since = "5.9")
 	String DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.afterall.method.default";
+
+	/**
+	 * Property used to determine if timeouts are applied to tests: {@value}.
+	 *
+	 * <p>The value of this property will be used to toggle whether
+	 * {@link Timeout @Timeout} is applied to tests.</p>
+	 *
+	 * <h4>Supported timeout mode values:</h4>
+	 * <ul>
+	 * <li>{@code enabled}: enables timeouts
+	 * <li>{@code disabled}: disables timeouts
+	 * <li>{@code disabled_on_debug}: disables timeouts while debugging
+	 * </ul>
+	 *
+	 * <p>If not specified, the default is {@code enabled}.
+	 *
+	 * @since 5.6
+	 */
+	@API(status = STABLE, since = "5.9")
 	String TIMEOUT_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.mode";
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
@@ -41,32 +41,32 @@ import org.apiguardian.api.API;
  * default timeout is defined via one of the following configuration parameters:
  *
  * <dl>
- *     <dt>{@code junit.jupiter.execution.timeout.default}</dt>
+ *     <dt>{@value #DEFAULT_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for all testable and lifecycle methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.testable.method.default}</dt>
+ *     <dt>{@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for all testable methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.test.method.default}</dt>
+ *     <dt>{@value #DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for {@link Test @Test} methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.testtemplate.method.default}</dt>
+ *     <dt>{@value #DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for {@link TestTemplate @TestTemplate} methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.testfactory.method.default}</dt>
+ *     <dt>{@value DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for {@link TestFactory @TestFactory} methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.lifecycle.method.default}</dt>
+ *     <dt>{@value DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for all lifecycle methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.beforeall.method.default}</dt>
+ *     <dt>{@value #DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for {@link BeforeAll @BeforeAll} methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.beforeeach.method.default}</dt>
+ *     <dt>{@value #DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for {@link BeforeEach @BeforeEach} methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.aftereach.method.default}</dt>
+ *     <dt>{@value #DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for {@link AfterEach @AfterEach} methods</dd>
- *     <dt>{@code junit.jupiter.execution.timeout.afterall.method.default}</dt>
+ *     <dt>{@value #DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
  *     <dd>Default timeout for {@link AfterAll @AfterAll} methods</dd>
  * </dl>
  *
  * <p>More specific configuration parameters override less specific ones. For
- * example, {@code junit.jupiter.execution.timeout.test.method.default}
- * overrides {@code junit.jupiter.execution.timeout.testable.method.default}
- * which overrides {@code junit.jupiter.execution.timeout.default}.
+ * example, {@value #DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME}
+ * overrides {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME}
+ * which overrides {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}.
  *
  * <p>Values must be in the following, case-insensitive format:
  * {@code <number> [ns|μs|ms|s|m|h|d]}. The space between the number and the
@@ -84,6 +84,18 @@ import org.apiguardian.api.API;
  * <tr><td> {@code 42 d}  </td><td> {@code @Timeout(value = 42, unit = DAYS)}         </td></tr>
  * </table>
  *
+ * <h3>Disabling Timeouts</h3>
+ *
+ * <p>You may use the {@value #TIMEOUT_MODE_PROPERTY_NAME} configuration
+ * parameter to explicitly enable or disable timeouts.
+ *
+ * <p>Supported values:
+ * <ul>
+ * <li>{@code enabled}: enables timeouts
+ * <li>{@code disabled}: disables timeouts
+ * <li>{@code disabled_on_debug}: disables timeouts while debugging
+ * </ul>
+ *
  * @since 5.5
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
@@ -92,6 +104,18 @@ import org.apiguardian.api.API;
 @Inherited
 @API(status = STABLE, since = "5.7")
 public @interface Timeout {
+
+	String DEFAULT_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.default";
+	String DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testable.method.default";
+	String DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.test.method.default";
+	String DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testtemplate.method.default";
+	String DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testfactory.method.default";
+	String DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.lifecycle.method.default";
+	String DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.beforeall.method.default";
+	String DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.beforeeach.method.default";
+	String DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.aftereach.method.default";
+	String DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.afterall.method.default";
+	String TIMEOUT_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.mode";
 
 	/**
 	 * The duration of this timeout.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  * <h4>Old behavior</h4>
  *
  * <p>You can revert to the old behavior of using a single temporary directory
- * by setting the {@code junit.jupiter.tempdir.scope} configuration parameter to
+ * by setting the {@value #SCOPE_PROPERTY_NAME} configuration parameter to
  * {@code per_context}. In that case, the scope of the temporary directory
  * depends on where the first {@code @TempDir} annotation is encountered when
  * executing a test class. The temporary directory will be shared by all tests
@@ -93,6 +93,9 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 @Documented
 @API(status = EXPERIMENTAL, since = "5.4")
 public @interface TempDir {
+
+	String SCOPE_PROPERTY_NAME = "junit.jupiter.tempdir.scope";
+
 
 	/**
 	 * The name of the configuration parameter that is used to configure the

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.io;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.io.File;
@@ -94,8 +95,26 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 @API(status = EXPERIMENTAL, since = "5.4")
 public @interface TempDir {
 
+	/**
+	 * Property name used to set the scope of temporary directories created via
+	 * {@link org.junit.jupiter.api.io.TempDir @TempDir} annotation: {@value}
+	 *
+	 * <h4>Supported Values</h4>
+	 * <ul>
+	 * <li>{@code per_context}: creates a single temporary directory for the
+	 * entire test class or method, depending on where it's first declared
+	 * <li>{@code per_declaration}: creates separate temporary directories for
+	 * each declaration site of the {@code @TempDir} annotation.
+	 * </ul>
+	 *
+	 * <p>If not specified, the default is {@code per_declaration}.
+	 *
+	 * @since 5.8
+	 */
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@Deprecated
+	@API(status = DEPRECATED, since = "5.9")
 	String SCOPE_PROPERTY_NAME = "junit.jupiter.tempdir.scope";
-
 
 	/**
 	 * The name of the configuration parameter that is used to configure the

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Execution.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Execution.java
@@ -27,6 +27,23 @@ import org.apiguardian.api.API;
  * <p>Since JUnit Jupiter 5.4, this annotation is {@linkplain Inherited inherited}
  * within class hierarchies.
  *
+ * <h3>Default Execution Mode</h3>
+ *
+ * <p>If this annotation is not present, {@link ExecutionMode#SAME_THREAD} is
+ * used unless a default execution mode is defined via one of the following
+ * configuration parameters:
+ *
+ * <dl>
+ *     <dt>{@value #DEFAULT_EXECUTION_MODE_PROPERTY_NAME}</dt>
+ *     <dd>Default execution mode for all classes and tests</dd>
+ *     <dt>{@value #DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME}</dt>
+ *     <dd>Default execution mode for top-level classes</dd>
+ * </dl>
+ *
+ * <p>{@value #DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME}
+ * overrides {@value #DEFAULT_EXECUTION_MODE_PROPERTY_NAME} for top-level
+ * classes
+ *
  * @see Isolated
  * @see ResourceLock
  * @since 5.3
@@ -36,6 +53,43 @@ import org.apiguardian.api.API;
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Inherited
 public @interface Execution {
+
+	/**
+	 * Property name used to set the default test execution mode: {@value}
+	 *
+	 * <p>This setting is only effective if parallel execution is enabled.
+	 *
+	 * <h4>Supported Values</h4>
+	 *
+	 * <p>Supported values include names of enum constants defined in
+	 * {@link ExecutionMode}, ignoring case.
+	 *
+	 * <p>If not specified, the default is "same_thread" which corresponds to
+	 * {@code @Execution(ExecutionMode.SAME_THREAD)}.
+	 *
+	 * @since 5.4
+	 */
+	@API(status = EXPERIMENTAL, since = "5.9")
+	String DEFAULT_EXECUTION_MODE_PROPERTY_NAME = "junit.jupiter.execution.parallel.mode.default";
+
+	/**
+	 * Property name used to set the default test execution mode for top-level
+	 * classes: {@value}
+	 *
+	 * <p>This setting is only effective if parallel execution is enabled.
+	 *
+	 * <h4>Supported Values</h4>
+	 *
+	 * <p>Supported values include names of enum constants defined in
+	 * {@link ExecutionMode}, ignoring case.
+	 *
+	 * <p>If not specified, it will be resolved into the same value as
+	 * {@link #DEFAULT_EXECUTION_MODE_PROPERTY_NAME}.
+	 *
+	 * @since 5.4
+	 */
+	@API(status = EXPERIMENTAL, since = "5.9")
+	String DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME = "junit.jupiter.execution.parallel.mode.classes.default";
 
 	/**
 	 * The required/preferred execution mode.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -19,7 +19,10 @@ import static org.junit.platform.engine.support.hierarchical.DefaultParallelExec
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_STRATEGY_PROPERTY_NAME;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.platform.commons.util.ClassNamePatternFilterUtils;
 import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfigurationStrategy;
 
 /**
@@ -91,7 +94,7 @@ public final class Constants {
 	 * @see #DEACTIVATE_CONDITIONS_PATTERN_PROPERTY_NAME
 	 * @see org.junit.jupiter.api.extension.ExecutionCondition
 	 */
-	public static final String DEACTIVATE_ALL_CONDITIONS_PATTERN = JupiterConfiguration.DEACTIVATE_ALL_CONDITIONS_PATTERN;
+	public static final String DEACTIVATE_ALL_CONDITIONS_PATTERN = ClassNamePatternFilterUtils.DEACTIVATE_ALL_PATTERN;
 
 	/**
 	 * Property name used to set the default display name generator class name: {@value}
@@ -247,7 +250,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all testable methods.
@@ -266,7 +269,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
@@ -287,7 +290,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
@@ -308,7 +311,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
@@ -329,7 +332,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all lifecycle methods.
@@ -348,7 +351,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
@@ -368,7 +371,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
@@ -388,7 +391,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
@@ -408,7 +411,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
@@ -428,7 +431,7 @@ public final class Constants {
 	 * @see org.junit.jupiter.api.Timeout
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME = JupiterConfiguration.DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
+	public static final String DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property used to determine if timeouts are applied to tests: {@value}.
@@ -448,7 +451,7 @@ public final class Constants {
 	 * @since 5.6
 	 */
 	@API(status = EXPERIMENTAL, since = "5.6")
-	public static final String TIMEOUT_MODE_PROPERTY_NAME = JupiterConfiguration.TIMEOUT_MODE_PROPERTY_NAME;
+	public static final String TIMEOUT_MODE_PROPERTY_NAME = Timeout.TIMEOUT_MODE_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default method orderer class name: {@value}
@@ -492,7 +495,7 @@ public final class Constants {
 	@SuppressWarnings("DeprecatedIsStillUsed")
 	@Deprecated
 	@API(status = DEPRECATED, since = "5.8")
-	public static final String TEMP_DIR_SCOPE_PROPERTY_NAME = JupiterConfiguration.TEMP_DIR_SCOPE_PROPERTY_NAME;
+	public static final String TEMP_DIR_SCOPE_PROPERTY_NAME = TempDir.SCOPE_PROPERTY_NAME;
 
 	private Constants() {
 		/* no-op */

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -19,32 +19,26 @@ import static org.junit.platform.engine.support.hierarchical.DefaultParallelExec
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_STRATEGY_PROPERTY_NAME;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.commons.util.ClassNamePatternFilterUtils;
 import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfigurationStrategy;
 
 /**
  * Collection of constants related to the {@link JupiterTestEngine}.
- *
- * <h3 id="supported-values-timeouts">Supported Values for Timeouts</h3>
- *
- * <p>Values for timeouts must be in the following, case-insensitive format:
- * {@code <number> [ns|μs|ms|s|m|h|d]}. The space between the number and the
- * unit may be omitted. Specifying no unit is equivalent to using seconds.
- *
- * <table class="plain">
- * <tr><th> Value         </th><th> Equivalent annotation                             </th></tr>
- * <tr><td> {@code 42}    </td><td> {@code @Timeout(42)}                              </td></tr>
- * <tr><td> {@code 42 ns} </td><td> {@code @Timeout(value = 42, unit = NANOSECONDS)}  </td></tr>
- * <tr><td> {@code 42 μs} </td><td> {@code @Timeout(value = 42, unit = MICROSECONDS)} </td></tr>
- * <tr><td> {@code 42 ms} </td><td> {@code @Timeout(value = 42, unit = MILLISECONDS)} </td></tr>
- * <tr><td> {@code 42 s}  </td><td> {@code @Timeout(value = 42, unit = SECONDS)}      </td></tr>
- * <tr><td> {@code 42 m}  </td><td> {@code @Timeout(value = 42, unit = MINUTES)}      </td></tr>
- * <tr><td> {@code 42 h}  </td><td> {@code @Timeout(value = 42, unit = HOURS)}        </td></tr>
- * <tr><td> {@code 42 d}  </td><td> {@code @Timeout(value = 42, unit = DAYS)}         </td></tr>
- * </table>
  *
  * @since 5.0
  * @see org.junit.platform.engine.ConfigurationParameters
@@ -99,15 +93,9 @@ public final class Constants {
 	/**
 	 * Property name used to set the default display name generator class name: {@value}
 	 *
-	 * <h4>Supported Values</h4>
-	 *
-	 * <p>Supported values include fully qualified class names for types that implement
-	 * {@link org.junit.jupiter.api.DisplayNameGenerator}.
-	 *
-	 * <p>If not specified, the default is
-	 * {@link org.junit.jupiter.api.DisplayNameGenerator.Standard}.
+	 * @see DisplayNameGenerator#DEFAULT_GENERATOR_PROPERTY_NAME
 	 */
-	public static final String DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME = JupiterConfiguration.DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME;
+	public static final String DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME = DisplayNameGenerator.DEFAULT_GENERATOR_PROPERTY_NAME;
 
 	/**
 	 * Property name used to enable auto-detection and registration of extensions via
@@ -120,17 +108,9 @@ public final class Constants {
 	/**
 	 * Property name used to set the default test instance lifecycle mode: {@value}
 	 *
-	 * <h4>Supported Values</h4>
-	 *
-	 * <p>Supported values include names of enum constants defined in
-	 * {@link org.junit.jupiter.api.TestInstance.Lifecycle}, ignoring case.
-	 *
-	 * <p>If not specified, the default is "per_method" which corresponds to
-	 * {@code @TestInstance(Lifecycle.PER_METHOD)}.
-	 *
-	 * @see org.junit.jupiter.api.TestInstance
+	 * @see TestInstance.Lifecycle#DEFAULT_LIFECYCLE_PROPERTY_NAME
 	 */
-	public static final String DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME;
+	public static final String DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME = TestInstance.Lifecycle.DEFAULT_LIFECYCLE_PROPERTY_NAME;
 
 	/**
 	 * Property name used to enable parallel test execution: {@value}
@@ -145,43 +125,19 @@ public final class Constants {
 	/**
 	 * Property name used to set the default test execution mode: {@value}
 	 *
-	 * <p>This setting is only effective if parallel execution is enabled.
-	 *
-	 * <h4>Supported Values</h4>
-	 *
-	 * <p>Supported values include names of enum constants defined in
-	 * {@link org.junit.jupiter.api.parallel.ExecutionMode}, ignoring case.
-	 *
-	 * <p>If not specified, the default is "same_thread" which corresponds to
-	 * {@code @Execution(ExecutionMode.SAME_THREAD)}.
-	 *
-	 * @since 5.4
-	 * @see org.junit.jupiter.api.parallel.Execution
-	 * @see org.junit.jupiter.api.parallel.ExecutionMode
+	 * @see Execution#DEFAULT_EXECUTION_MODE_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.4")
-	public static final String DEFAULT_PARALLEL_EXECUTION_MODE = JupiterConfiguration.DEFAULT_EXECUTION_MODE_PROPERTY_NAME;
+	public static final String DEFAULT_PARALLEL_EXECUTION_MODE = Execution.DEFAULT_EXECUTION_MODE_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default test execution mode for top-level
 	 * classes: {@value}
 	 *
-	 * <p>This setting is only effective if parallel execution is enabled.
-	 *
-	 * <h4>Supported Values</h4>
-	 *
-	 * <p>Supported values include names of enum constants defined in
-	 * {@link org.junit.jupiter.api.parallel.ExecutionMode}, ignoring case.
-	 *
-	 * <p>If not specified, it will be resolved into the same value as
-	 * {@link #DEFAULT_PARALLEL_EXECUTION_MODE}.
-	 *
-	 * @since 5.4
-	 * @see org.junit.jupiter.api.parallel.Execution
-	 * @see org.junit.jupiter.api.parallel.ExecutionMode
+	 * @see Execution#DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
-	public static final String DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME = JupiterConfiguration.DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME;
+	public static final String DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME = Execution.DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME;
 
 	static final String PARALLEL_CONFIG_PREFIX = "junit.jupiter.execution.parallel.config.";
 
@@ -236,199 +192,88 @@ public final class Constants {
 
 	/**
 	 * Property name used to set the default timeout for all testable and
-	 * lifecycle methods.
+	 * lifecycle methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a more
-	 * specific property or a {@link org.junit.jupiter.api.Timeout @Timeout}
-	 * annotation present on the method or on an enclosing test class (for testable
-	 * methods).
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TIMEOUT_PROPERTY_NAME;
 
 	/**
-	 * Property name used to set the default timeout for all testable methods.
+	 * Property name used to set the default timeout for all testable methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a more
-	 * specific property or a {@link org.junit.jupiter.api.Timeout @Timeout}
-	 * annotation present on the testable method or on an enclosing test class.
-	 *
-	 * <p>This property overrides the {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}
-	 * property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
-	 * {@link org.junit.jupiter.api.Test @Test} methods.
+	 * {@link Test @Test} methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link org.junit.jupiter.api.Timeout @Timeout} annotation present on the
-	 * {@link org.junit.jupiter.api.Test @Test} method or on an enclosing test
-	 * class.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
-	 * {@link org.junit.jupiter.api.TestTemplate @TestTemplate} methods.
+	 * {@link TestTemplate @TestTemplate} methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link org.junit.jupiter.api.Timeout @Timeout} annotation present on the
-	 * {@link org.junit.jupiter.api.TestTemplate @TestTemplate} method or on an
-	 * enclosing test class.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
-	 * {@link org.junit.jupiter.api.TestFactory @TestFactory} methods.
+	 * {@link TestFactory @TestFactory} methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link org.junit.jupiter.api.Timeout @Timeout} annotation present on the
-	 * {@link org.junit.jupiter.api.TestFactory @TestFactory} method or on an
-	 * enclosing test class.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
-	 * Property name used to set the default timeout for all lifecycle methods.
+	 * Property name used to set the default timeout for all lifecycle methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a more
-	 * specific property or a {@link org.junit.jupiter.api.Timeout @Timeout}
-	 * annotation present on the lifecycle method.
-	 *
-	 * <p>This property overrides the {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}
-	 * property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
-	 * {@link org.junit.jupiter.api.BeforeAll @BeforeAll} methods.
+	 * {@link BeforeAll @BeforeAll} methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link org.junit.jupiter.api.Timeout @Timeout} annotation present on the
-	 * {@link org.junit.jupiter.api.BeforeAll @BeforeAll} method.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
-	 * {@link org.junit.jupiter.api.BeforeEach @BeforeEach} methods.
+	 * {@link BeforeEach @BeforeEach} methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link org.junit.jupiter.api.Timeout @Timeout} annotation present on the
-	 * {@link org.junit.jupiter.api.BeforeEach @BeforeEach} method.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
-	 * {@link org.junit.jupiter.api.AfterEach @AfterEach} methods.
+	 * {@link AfterEach @AfterEach} methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link org.junit.jupiter.api.Timeout @Timeout} annotation present on the
-	 * {@link org.junit.jupiter.api.AfterEach @AfterEach} method.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default timeout for all
-	 * {@link org.junit.jupiter.api.AfterAll @AfterAll} methods.
+	 * {@link AfterAll @AfterAll} methods: {@value}.
 	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link org.junit.jupiter.api.Timeout @Timeout} annotation present on the
-	 * {@link org.junit.jupiter.api.AfterAll @AfterAll} method.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values-timeouts">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 * @see org.junit.jupiter.api.Timeout
+	 * @see Timeout#DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.5")
 	public static final String DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME = Timeout.DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
@@ -436,19 +281,7 @@ public final class Constants {
 	/**
 	 * Property used to determine if timeouts are applied to tests: {@value}.
 	 *
-	 * <p>The value of this property will be used to toggle whether
-	 * {@link org.junit.jupiter.api.Timeout @Timeout} is applied to tests.</p>
-	 *
-	 * <h4>Supported timeout mode values:</h4>
-	 * <ul>
-	 * <li>{@code enabled}: enables timeouts
-	 * <li>{@code disabled}: disables timeouts
-	 * <li>{@code disabled_on_debug}: disables timeouts while debugging
-	 * </ul>
-	 *
-	 * <p>If not specified, the default is {@code enabled}.
-	 *
-	 * @since 5.6
+	 * @see Timeout#TIMEOUT_MODE_PROPERTY_NAME
 	 */
 	@API(status = EXPERIMENTAL, since = "5.6")
 	public static final String TIMEOUT_MODE_PROPERTY_NAME = Timeout.TIMEOUT_MODE_PROPERTY_NAME;
@@ -456,43 +289,25 @@ public final class Constants {
 	/**
 	 * Property name used to set the default method orderer class name: {@value}
 	 *
-	 * <h4>Supported Values</h4>
-	 *
-	 * <p>Supported values include fully qualified class names for types that
-	 * implement {@link org.junit.jupiter.api.MethodOrderer}.
-	 *
-	 * <p>If not specified, test methods will be ordered using an algorithm that
-	 * is deterministic but intentionally non-obvious.
+	 * @see MethodOrderer#DEFAULT_ORDER_PROPERTY_NAME
 	 */
-	@API(status = EXPERIMENTAL, since = "5.7")
-	public static final String DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME;
+	@API(status = STABLE, since = "5.9")
+	public static final String DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME = MethodOrderer.DEFAULT_ORDER_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the default class orderer class name: {@value}
 	 *
-	 * <h4>Supported Values</h4>
-	 *
-	 * <p>Supported values include fully qualified class names for types that
-	 * implement {@link org.junit.jupiter.api.ClassOrderer}.
+	 * @see ClassOrderer#DEFAULT_ORDER_PROPERTY_NAME
 	 */
-	@API(status = EXPERIMENTAL, since = "5.8")
-	public static final String DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME = JupiterConfiguration.DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME;
+	@API(status = STABLE, since = "5.9")
+	public static final String DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME = ClassOrderer.DEFAULT_ORDER_PROPERTY_NAME;
 
 	/**
 	 * Property name used to set the scope of temporary directories created via
-	 * {@link org.junit.jupiter.api.io.TempDir @TempDir} annotation: {@value}
+	 * {@link TempDir @TempDir} annotation: {@value}
 	 *
-	 * <h4>Supported Values</h4>
-	 * <ul>
-	 * <li>{@code per_context}: creates a single temporary directory for the
-	 * entire test class or method, depending on where it's first declared
-	 * <li>{@code per_declaration}: creates separate temporary directories for
-	 * each declaration site of the {@code @TempDir} annotation.
-	 * </ul>
-	 *
-	 * <p>If not specified, the default is {@code per_declaration}.
+	 * @see TempDir#SCOPE_PROPERTY_NAME
 	 */
-	@SuppressWarnings("DeprecatedIsStillUsed")
 	@Deprecated
 	@API(status = DEPRECATED, since = "5.8")
 	public static final String TEMP_DIR_SCOPE_PROPERTY_NAME = TempDir.SCOPE_PROPERTY_NAME;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
@@ -33,8 +34,8 @@ public interface JupiterConfiguration {
 
 	String DEACTIVATE_CONDITIONS_PATTERN_PROPERTY_NAME = "junit.jupiter.conditions.deactivate";
 	String PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME = "junit.jupiter.execution.parallel.enabled";
-	String DEFAULT_EXECUTION_MODE_PROPERTY_NAME = "junit.jupiter.execution.parallel.mode.default";
-	String DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME = "junit.jupiter.execution.parallel.mode.classes.default";
+	String DEFAULT_EXECUTION_MODE_PROPERTY_NAME = Execution.DEFAULT_EXECUTION_MODE_PROPERTY_NAME;
+	String DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME = Execution.DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME;
 	String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = "junit.jupiter.extensions.autodetection.enabled";
 	String DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME = TestInstance.Lifecycle.DEFAULT_LIFECYCLE_PROPERTY_NAME;
 	String DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME = DisplayNameGenerator.DEFAULT_GENERATOR_PROPERTY_NAME;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.platform.commons.util.ClassNamePatternFilterUtils;
 
 /**
  * @since 5.4
@@ -37,23 +36,10 @@ public interface JupiterConfiguration {
 	String DEFAULT_EXECUTION_MODE_PROPERTY_NAME = "junit.jupiter.execution.parallel.mode.default";
 	String DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME = "junit.jupiter.execution.parallel.mode.classes.default";
 	String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = "junit.jupiter.extensions.autodetection.enabled";
-	String DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME = "junit.jupiter.testinstance.lifecycle.default";
-	String DEACTIVATE_ALL_CONDITIONS_PATTERN = ClassNamePatternFilterUtils.DEACTIVATE_ALL_PATTERN;
-	String DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME = "junit.jupiter.displayname.generator.default";
-	String DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME = "junit.jupiter.testmethod.order.default";
-	String DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME = "junit.jupiter.testclass.order.default";
-	String TEMP_DIR_SCOPE_PROPERTY_NAME = "junit.jupiter.tempdir.scope";
-	String DEFAULT_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.default";
-	String DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testable.method.default";
-	String DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.test.method.default";
-	String DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testtemplate.method.default";
-	String DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testfactory.method.default";
-	String DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.lifecycle.method.default";
-	String DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.beforeall.method.default";
-	String DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.beforeeach.method.default";
-	String DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.aftereach.method.default";
-	String DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.afterall.method.default";
-	String TIMEOUT_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.mode";
+	String DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME = TestInstance.Lifecycle.DEFAULT_LIFECYCLE_PROPERTY_NAME;
+	String DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME = DisplayNameGenerator.DEFAULT_GENERATOR_PROPERTY_NAME;
+	String DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME = MethodOrderer.DEFAULT_ORDER_PROPERTY_NAME;
+	String DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME = ClassOrderer.DEFAULT_ORDER_PROPERTY_NAME;
 
 	Optional<String> getRawConfigurationParameter(String key);
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -15,7 +15,6 @@ import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.io.CleanupMode.DEFAULT;
 import static org.junit.jupiter.api.io.CleanupMode.NEVER;
 import static org.junit.jupiter.api.io.CleanupMode.ON_SUCCESS;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.TEMP_DIR_SCOPE_PROPERTY_NAME;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedFields;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
@@ -197,7 +196,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		return context.getRoot().getStore(NAMESPACE).getOrComputeIfAbsent( //
 			Scope.class, //
 			__ -> new EnumConfigurationParameterConverter<>(Scope.class, "@TempDir scope") //
-					.get(TEMP_DIR_SCOPE_PROPERTY_NAME, context::getConfigurationParameter, Scope.PER_DECLARATION), //
+					.get(TempDir.SCOPE_PROPERTY_NAME, context::getConfigurationParameter, Scope.PER_DECLARATION), //
 			Scope.class //
 		);
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -192,6 +192,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		return (type == Path.class) ? path : path.toFile();
 	}
 
+	@SuppressWarnings("deprecation")
 	private Scope getScope(ExtensionContext context) {
 		return context.getRoot().getStore(NAMESPACE).getOrComputeIfAbsent( //
 			Scope.class, //

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutConfiguration.java
@@ -10,16 +10,16 @@
 
 package org.junit.jupiter.engine.extension;
 
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME;
-import static org.junit.jupiter.engine.config.JupiterConfiguration.DEFAULT_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.DEFAULT_TIMEOUT_PROPERTY_NAME;
 
 import java.util.Map;
 import java.util.Optional;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.engine.extension;
 
-import static org.junit.jupiter.engine.config.JupiterConfiguration.TIMEOUT_MODE_PROPERTY_NAME;
+import static org.junit.jupiter.api.Timeout.TIMEOUT_MODE_PROPERTY_NAME;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerContextTests.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
-import org.junit.jupiter.engine.Constants;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 
 /**
@@ -71,8 +70,7 @@ class TempDirectoryPerContextTests extends AbstractJupiterTestEngineTests {
 	protected EngineExecutionResults executeTestsForClass(Class<?> testClass) {
 		return executeTests(request() //
 				.selectors(selectClass(testClass)) //
-				.configurationParameter(Constants.TEMP_DIR_SCOPE_PROPERTY_NAME,
-					TempDirectory.Scope.PER_CONTEXT.toString()) //
+				.configurationParameter(TempDir.SCOPE_PROPERTY_NAME, TempDirectory.Scope.PER_CONTEXT.toString()) //
 				.build());
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -193,7 +193,7 @@ public @interface ParameterizedTest {
 	 * <p>If the default display name flag (<code>{default_display_name}</code>)
 	 * is not overridden, JUnit will:
 	 * <ul>
-	 * <li>Look up the {@code junit.jupiter.params.displayname.default}
+	 * <li>Look up the {@value ParameterizedTestExtension#DISPLAY_NAME_PATTERN_KEY}
 	 * <em>configuration parameter</em> and use it if available. The configuration
 	 * parameter can be supplied via the {@code Launcher} API, build tools (e.g.,
 	 * Gradle and Maven), a JVM system property, or the JUnit Platform configuration


### PR DESCRIPTION
Triggered by discussion in fd93eeca94479b71ce0d06d61df874a167a3fbf7.