### PR TITLE
Resolve MethodSource parameters from Kotlin Companion Object

### DIFF
--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -37,11 +37,13 @@ dependencies {
 
 	testImplementation(projects.junitJupiter)
 	testImplementation(projects.junitJupiterMigrationsupport)
+	testImplementation(projects.junitJupiterParams)
 	testImplementation(projects.junitPlatformConsole)
 	testImplementation(projects.junitPlatformRunner)
 	testImplementation(projects.junitPlatformSuite)
 	testImplementation(projects.junitPlatformTestkit)
 	testImplementation(kotlin("stdlib"))
+	testImplementation(kotlin("reflect"))
 
 	testImplementation(projects.junitVintageEngine)
 	testRuntimeOnly(libs.bundles.log4j)

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1327,6 +1327,31 @@ package example;
 include::{testDir}/example/ExternalMethodSourceDemo.java[tags=external_MethodSource_example]
 ----
 
+When you write Parameterized tests in https://kotlinlang.org/[Kotlin] you have following options to create reference
+to the _factory_ method:
+
+* With `kotlin-reflection` library on classpath you can also use Companion object's method without any additional annotation.
+
+[source,kotlin,indent=0]
+----
+include::{kotlinTestDir}/example/KotlinParameterizedTests.kt[tags=companion]
+----
+
+* Use `@TestInstance(Lifecycle.PER_CLASS)` test class.
+
+[source,kotlin,indent=0]
+----
+include::{kotlinTestDir}/example/KotlinParameterizedTests.kt[tags=test_instance_per_class]
+----
+
+* Use `@JvmStatic` annotation on Companion object's method.
+
+[source,kotlin,indent=0]
+----
+include::{kotlinTestDir}/example/KotlinParameterizedTests.kt[tags=jvm_static]
+----
+
+
 [[writing-tests-parameterized-tests-sources-CsvSource]]
 ===== @CsvSource
 

--- a/documentation/src/test/kotlin/example/KotlinParameterizedTests.kt
+++ b/documentation/src/test/kotlin/example/KotlinParameterizedTests.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package example
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+// tag::test_instance_per_class[]
+@TestInstance(PER_CLASS)
+class TestInstancePerClassTest {
+    @ParameterizedTest
+    @MethodSource("fromInstanceMethodSource")
+    fun fromInstanceMethod(value: String) {
+        Assertions.assertEquals("instance", value)
+    }
+
+    fun fromInstanceMethodSource() = arrayOf(arrayOf("instance"))
+}
+// end::test_instance_per_class[]
+
+// tag::jvm_static[]
+class MethodSourceFromJvmStaticTest {
+    @ParameterizedTest
+    @MethodSource("jvmStaticSource")
+    fun fromJvmStatic(value: String) {
+        Assertions.assertEquals("jvm-static", value)
+    }
+
+    companion object {
+        @JvmStatic
+        fun jvmStaticSource() = arrayOf(arrayOf("jvm-static"))
+    }
+}
+// end::jvm_static[]
+
+// tag::companion[]
+class MethodSourceFromCompanionTest {
+    @ParameterizedTest
+    @MethodSource("companionSource")
+    fun fromCompanion(value: String) {
+        Assertions.assertEquals("companion", value)
+    }
+
+    companion object {
+        fun companionSource() = arrayOf(arrayOf("companion"))
+    }
+}
+// end::companion[]

--- a/junit-jupiter-params/junit-jupiter-params.gradle.kts
+++ b/junit-jupiter-params/junit-jupiter-params.gradle.kts
@@ -21,7 +21,9 @@ dependencies {
 	testImplementation(testFixtures(projects.junitJupiterEngine))
 
 	compileOnly(kotlin("stdlib"))
+	compileOnly(kotlin("reflect"))
 	testImplementation(kotlin("stdlib"))
+	testImplementation(kotlin("reflect"))
 
 	osgiVerification(projects.junitJupiterEngine)
 	osgiVerification(projects.junitPlatformLauncher)

--- a/junit-jupiter-params/src/main/kotlin/org/junit/jupiter/params/provider/MethodSourceKotlinCompanionResolver.kt
+++ b/junit-jupiter-params/src/main/kotlin/org/junit/jupiter/params/provider/MethodSourceKotlinCompanionResolver.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.provider
+
+import org.apiguardian.api.API
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.platform.commons.JUnitException
+import org.junit.platform.commons.function.Try
+import org.junit.platform.commons.support.AnnotationSupport
+import org.junit.platform.commons.support.ReflectionSupport
+import org.junit.platform.commons.util.Preconditions
+import org.junit.platform.commons.util.ReflectionUtils
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.companionObjectInstance
+import kotlin.reflect.full.functions
+
+@API(
+        status = API.Status.INTERNAL,
+        since = "5.9.0"
+)
+internal object MethodSourceKotlinCompanionResolver {
+    /**
+     * Check if it is possible to resolve provider method from Kotlin's Companion object.
+     *
+     * Companion object can be resolved if following conditions are met:
+     * - Kotlin is on class path
+     * - Class containing provider method is Kotlin class
+     */
+    fun canResolveArguments(context: ExtensionContext, factoryMethodName: String): Boolean =
+            kotlinIsOnClasspath() &&
+                    maybeKotlinCompanionFactoryMethodResolvable(context, factoryMethodName)
+
+    /**
+     * Resolves provider arguments from Companion object.
+     *
+     * Note that [canResolveArguments] have to be called before calling this method to
+     * do few pre checks if we can try to resolve parameters.
+     *
+     * This method checks if there is `kotlin-reflect.jar` library on class path to support
+     * working with Companion objects (and client is indicated by message to do so).
+     */
+    fun resolveArguments(context: ExtensionContext, factoryMethodName: String): Any? {
+        if (!kotlinIsOnClasspath()) {
+            throw JUnitException("Kotlin is not on classpath")
+        }
+
+        val (companionInstance, factoryFunction) = try {
+            resolveCompanionMethod(context, factoryMethodName)
+        } catch (e: Throwable) {
+            when (e) {
+                is KotlinReflectionNotSupportedError -> throw JUnitException("No kotlin-reflect.jar in the classpath", e)
+                else -> throw JUnitException("Class [${context.requiredTestClass.name}] or factory method [$factoryMethodName] are not compatible with Kotlin's companion object MethodSource", e)
+            }
+        }
+        return factoryFunction.call(companionInstance)
+    }
+
+    private fun resolveCompanionMethod(context: ExtensionContext, factoryMethodName: String): CompanionMethod {
+        return if (factoryMethodName.contains("#")) {
+            val fullyQualifiedMethod = FullyQualifiedMethod.fromFactoryMethodName(factoryMethodName)
+            val clazz = ReflectionUtils.tryToLoadClass(
+                    fullyQualifiedMethod.className.removeSuffix(".Companion")
+            ).get()!!
+            resolveCompanionProvider(clazz, fullyQualifiedMethod.methodName)
+        } else {
+            val clazz = context.requiredTestClass!!
+            val companionMethods = classHierarchy(clazz)
+                    .map { item ->
+                        Try.call { resolveCompanionProvider(item, factoryMethodName) }
+                    }
+            val companionMethod = companionMethods.filter { it.isSuccess }
+                    .map { it.get() }
+                    .firstOrNull()
+            when {
+                companionMethod != null -> companionMethod
+                else -> {
+                    val e = JUnitException("Unable to find Companion object with method [$factoryMethodName] in class hierarchy of [${clazz.name}]")
+                    companionMethods.filter { it.isFailure }
+                            .map { it.cause }
+                            .forEach {
+                                e.addSuppressed(it)
+                            }
+                    throw e
+                }
+            }
+        }.also {
+            Preconditions.condition(it.method.parameters.size == 1 &&
+                    it.method.parameters[0].kind == KParameter.Kind.INSTANCE) {
+                "factory method [$factoryMethodName] must not declare formal parameters"
+            }
+        }
+    }
+
+    private fun classHierarchy(clazz: Class<*>): List<Class<*>> {
+        val list = mutableListOf<Class<*>>()
+        var currentClass: Class<*>? = clazz
+        while (currentClass != null) {
+            list += currentClass
+            currentClass = currentClass.superclass
+        }
+        return list
+    }
+
+    private fun resolveCompanionProvider(clazz: Class<*>, factoryMethodName: String): CompanionMethod {
+        if (!isKotlinClass(clazz)) throw JUnitException("Class [${clazz.name}] is not a Kotlin class")
+
+        val companionObject = requiredCompanionInstance(clazz)
+        val kFunction = requiredFactoryFunction(companionObject, factoryMethodName, clazz)
+        return CompanionMethod(companionObject, kFunction)
+    }
+
+    private fun requiredFactoryFunction(companionObject: Any, methodName: String, clazz: Class<*>): KFunction<*> =
+            companionObject::class.functions.firstOrNull { it.name == methodName }
+                    ?: throw JUnitException("Could not find method [$methodName] in companion object of class [${clazz.name}]")
+
+    private fun requiredCompanionInstance(clazz: Class<*>): Any {
+        // KotlinReflectionNotSupportedError is thrown when no kotlin-reflect.jar is not on classpath
+        clazz.kotlin.isCompanion
+        // now we can try get for companion object instance
+        return clazz.kotlin.companionObjectInstance
+                ?: throw JUnitException("Companion object not found on [${clazz.name}]")
+    }
+
+    private fun maybeKotlinCompanionFactoryMethodResolvable(
+            context: ExtensionContext,
+            factoryMethodName: String
+    ): Boolean =
+            try {
+                resolveCompanionMethod(context, factoryMethodName)
+                true
+            } catch (e: Throwable) {
+                e is KotlinReflectionNotSupportedError
+            }
+
+    private fun kotlinIsOnClasspath(): Boolean = kotlinMetadataTry.isSuccess
+
+    private fun isKotlinClass(javaClass: Class<*>): Boolean =
+            AnnotationSupport.findAnnotation(javaClass, Metadata::class.java).isPresent
+
+    private val kotlinMetadataTry = ReflectionSupport.tryToLoadClass("kotlin.Metadata")!!
+
+    private data class FullyQualifiedMethod(
+            val className: String,
+            val methodName: String,
+            val methodParameters: String
+    ) {
+        companion object {
+            fun fromFactoryMethodName(factoryMethodName: String): FullyQualifiedMethod {
+                val methodParts = ReflectionUtils.parseFullyQualifiedMethodName(factoryMethodName)!!
+                return FullyQualifiedMethod(
+                        methodParts[0]!!,
+                        methodParts[1]!!,
+                        methodParts[2]!!
+                )
+            }
+        }
+    }
+
+    private data class CompanionMethod(val instance: Any, val method: KFunction<*>)
+}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -259,6 +259,33 @@ class MethodArgumentsProviderTests {
 			"Could not find method [nonExistentMethod] in class [" + ExternalFactoryMethods.class.getName() + "]");
 	}
 
+	@Test
+	void kotlinOwnCompanionObjectProvider() {
+		var arguments = provideArguments(WithCompanionTestCase.class, null, false, "stringsProvider");
+		assertThat(arguments).containsExactly(array("with-companion"));
+	}
+
+	@Test
+	void kotlinOtherCompanionObjectProvider() {
+		var arguments = provideArguments(WithCompanionTestCase.class.getName() + "#stringsProvider");
+		assertThat(arguments).containsExactly(array("with-companion"));
+	}
+
+	@Test
+	void kotlinWithoutCompanionObject() {
+		var exception = assertThrows(JUnitException.class,
+			() -> provideArguments(WithoutCompanionTestCase.class.getName() + "#doesNotMatter").toArray());
+
+		assertThat(exception.getMessage()).isEqualTo(
+			"Could not find method [doesNotMatter] in class [" + WithoutCompanionTestCase.class.getName() + "]");
+	}
+
+	@Test
+	void kotlinJvmStaticCompanionObject() {
+		var arguments = provideArguments(JvmStaticCompanionTestCase.class.getName() + "#stringsProvider");
+		assertThat(arguments).containsExactly(array("jvm-static"));
+	}
+
 	@Nested
 	class PrimitiveArrays {
 

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/KotlinTestCases.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/KotlinTestCases.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.provider
+
+class WithCompanionTestCase {
+    companion object {
+        fun stringsProvider(): Array<String> {
+            return arrayOf("with-companion")
+        }
+    }
+}
+
+class JvmStaticCompanionTestCase {
+    companion object {
+        @JvmStatic
+        fun stringsProvider(): Array<String> {
+            return arrayOf("jvm-static")
+        }
+    }
+}
+
+class WithoutCompanionTestCase
+
+class WithoutProviderMethodTestCase {
+    companion object
+}
+
+class CompanionMethodWithParametersTestCase {
+    companion object {
+        fun stringsProvider(value: Int): Array<String> {
+            return arrayOf("with-parameters-$value")
+        }
+    }
+}

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromCompanionTest.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromCompanionTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.provider
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+
+class MethodSourceFromCompanionTest {
+    @ParameterizedTest
+    @MethodSource("parameterizedTestSource")
+    fun parameterizedTest(value: String) {
+        assertEquals("foo", value)
+    }
+
+    companion object {
+        fun parameterizedTestSource() = arrayOf(arrayOf("foo"))
+    }
+}

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromInheritedCompanionTest.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromInheritedCompanionTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.provider
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+
+class MethodSourceFromInheritedCompanionTest : BaseTest() {
+    @ParameterizedTest
+    @MethodSource("childTestSource")
+    fun childTest(value: String) {
+        assertEquals("child", value)
+    }
+
+    @ParameterizedTest
+    @MethodSource("parentTestSource")
+    fun parentTest(value: String) {
+        assertEquals("parent", value)
+    }
+
+    @ParameterizedTest
+    @MethodSource("deepParentTestSource")
+    fun deepParentTest(value: String) {
+        assertEquals("deep", value)
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.junit.jupiter.params.provider.BaseTest.Companion#parentTestSource")
+    fun fullyQualifiedParentTest1(value: String) {
+        assertEquals("parent", value)
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.junit.jupiter.params.provider.BaseTest#parentTestSource")
+    fun fullyQualifiedParentTest2(value: String) {
+        assertEquals("parent", value)
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.junit.jupiter.params.provider.DeepBaseTest#parentTestSource")
+    fun fullyQualifiedParentTest3(value: String) {
+        assertEquals("ignored-by-implicit-lookup", value)
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.junit.jupiter.params.provider.DeepBaseTest#deepParentTestSource")
+    fun fullyQualifiedParentTest4(value: String) {
+        assertEquals("deep", value)
+    }
+
+    companion object {
+        fun childTestSource() = arrayOf(arrayOf("child"))
+    }
+}
+
+open class BaseTest : DeepBaseTest() {
+    companion object {
+        fun parentTestSource() = arrayOf(arrayOf("parent"))
+    }
+}
+
+open class DeepBaseTest {
+    companion object {
+        fun parentTestSource() = arrayOf(arrayOf("ignored-by-implicit-lookup"))
+
+        fun deepParentTestSource() = arrayOf(arrayOf("deep"))
+    }
+}

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromJvmStaticTest.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromJvmStaticTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.provider
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+
+class MethodSourceFromJvmStaticTest {
+    @ParameterizedTest
+    @MethodSource("parameterizedTestSource")
+    fun parameterizedTest(value: String) {
+        assertEquals("foo", value)
+    }
+
+    companion object {
+        @JvmStatic
+        fun parameterizedTestSource() = arrayOf(arrayOf("foo"))
+    }
+}

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromOtherCompanionTest.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromOtherCompanionTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.provider
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+
+class MethodSourceFromOtherCompanionTest {
+    @ParameterizedTest
+    @MethodSource("org.junit.jupiter.params.provider.OtherClass#parameterizedTestSource")
+    fun parameterizedTest(value: String) {
+        assertEquals("foo", value)
+    }
+}
+
+class OtherClass {
+    companion object {
+        fun parameterizedTestSource() = arrayOf(arrayOf("foo"))
+    }
+}

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromOtherJvmStaticCompanionTest.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceFromOtherJvmStaticCompanionTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.provider
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+
+class MethodSourceFromOtherJvmStaticCompanionTest {
+    @ParameterizedTest
+    @MethodSource("org.junit.jupiter.params.provider.OtherClassJvmStatic#parameterizedTestSource")
+    fun parameterizedTest(value: String) {
+        assertEquals("foo", value)
+    }
+}
+
+class OtherClassJvmStatic {
+    companion object {
+        @JvmStatic
+        fun parameterizedTestSource() = arrayOf(arrayOf("foo"))
+    }
+}

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceKotlinCompanionResolverTest.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/provider/MethodSourceKotlinCompanionResolverTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.provider
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.platform.commons.JUnitException
+import org.mockito.Mockito
+import java.util.*
+
+class MethodSourceKotlinCompanionResolverTest {
+    @Test
+    fun classWithoutCompanionObject() {
+        val clazz = WithoutCompanionTestCase::class.java
+        assertThatThrownBy {
+            val context = extensionContext(clazz)
+            MethodSourceKotlinCompanionResolver.resolveArguments(context, "doesNotMatter")
+        }.isInstanceOf(JUnitException::class.java)
+                .hasMessage("Class [${clazz.name}] or factory method [doesNotMatter] are not compatible with Kotlin's companion object MethodSource")
+                .getRootCause()
+                .hasMessage("Unable to find Companion object with method [doesNotMatter] in class hierarchy of [${clazz.name}]")
+                .hasSuppressedException(JUnitException("Companion object not found on [${clazz.name}]"))
+                .hasSuppressedException(JUnitException("Class [${Object::class.java.name}] is not a Kotlin class"))
+    }
+
+    @Test
+    fun classWithoutProviderMethod() {
+        val clazz = WithoutProviderMethodTestCase::class.java
+        assertThatThrownBy {
+            val context = extensionContext(clazz)
+            MethodSourceKotlinCompanionResolver.resolveArguments(context, "thisShouldNotBeFound")
+        }.isInstanceOf(JUnitException::class.java)
+                .hasMessage("Class [${clazz.name}] or factory method [thisShouldNotBeFound] are not compatible with Kotlin's companion object MethodSource")
+                .getRootCause()
+                .hasMessage("Unable to find Companion object with method [thisShouldNotBeFound] in class hierarchy of [${clazz.name}]")
+                .hasSuppressedException(JUnitException("Could not find method [thisShouldNotBeFound] in companion object of class [${clazz.name}]"))
+                .hasSuppressedException(JUnitException("Class [${Object::class.java.name}] is not a Kotlin class"))
+    }
+
+    @Test
+    fun notAKotlinClass() {
+        val clazz = MethodArgumentsProviderTests.TestCase::class.java
+        assertThatThrownBy {
+            val context = extensionContext(clazz)
+            MethodSourceKotlinCompanionResolver.resolveArguments(context, "doesNotMatter")
+        }.isInstanceOf(JUnitException::class.java)
+                .hasMessage("Class [${clazz.name}] or factory method [doesNotMatter] are not compatible with Kotlin's companion object MethodSource")
+                .getRootCause()
+                .hasMessage("Unable to find Companion object with method [doesNotMatter] in class hierarchy of [${clazz.name}]")
+                .hasSuppressedException(JUnitException("Class [${clazz.name}] is not a Kotlin class"))
+                .hasSuppressedException(JUnitException("Class [${Object::class.java.name}] is not a Kotlin class"))
+    }
+
+    @Test
+    fun notAKotlinClassFromDifferentCompanion() {
+        val clazz = WithCompanionTestCase::class.java
+        val clazzSecond = MethodArgumentsProviderTests.TestCase::class.java
+        assertThatThrownBy {
+            val context = extensionContext(clazz)
+            MethodSourceKotlinCompanionResolver.resolveArguments(context, "${clazzSecond.name}#doesNotMatter")
+        }.isInstanceOf(JUnitException::class.java)
+                .hasMessage("Class [${clazz.name}] or factory method [${clazzSecond.name}#doesNotMatter] are not compatible with Kotlin's companion object MethodSource")
+                .hasRootCauseInstanceOf(JUnitException::class.java)
+                .hasRootCauseMessage("Class [${clazzSecond.name}] is not a Kotlin class")
+    }
+
+    @Test
+    fun companionMethodWithParameters() {
+        assertThatThrownBy {
+            val context = extensionContext(CompanionMethodWithParametersTestCase::class.java)
+            MethodSourceKotlinCompanionResolver.resolveArguments(context, "stringsProvider")
+        }.isInstanceOf(JUnitException::class.java)
+                .hasMessage("Class [${CompanionMethodWithParametersTestCase::class.java.name}] or factory method [stringsProvider] are not compatible with Kotlin's companion object MethodSource")
+                .hasRootCauseInstanceOf(JUnitException::class.java)
+                .hasRootCauseMessage("factory method [stringsProvider] must not declare formal parameters")
+    }
+
+    @Test
+    fun methodWithParametersFromDifferentCompanion() {
+        assertThatThrownBy {
+            val context = extensionContext(MethodArgumentsProviderTests.TestCase::class.java)
+            MethodSourceKotlinCompanionResolver.resolveArguments(context, "${CompanionMethodWithParametersTestCase::class.java.name}#stringsProvider")
+        }.isInstanceOf(JUnitException::class.java)
+                .hasMessage("Class [${MethodArgumentsProviderTests.TestCase::class.java.name}] or factory method [${CompanionMethodWithParametersTestCase::class.java.name}#stringsProvider] are not compatible with Kotlin's companion object MethodSource")
+                .hasRootCauseInstanceOf(JUnitException::class.java)
+                .hasRootCauseMessage("factory method [${CompanionMethodWithParametersTestCase::class.java.name}#stringsProvider] must not declare formal parameters")
+    }
+
+    @Test
+    fun invalidClassNameFromDifferentCompanion() {
+        val clazz = WithCompanionTestCase::class.java
+        val companionMethod = "i.am.aclass.ThatDoesNotExists#doesNotMatter"
+        assertThatThrownBy {
+            val context = extensionContext(clazz)
+            MethodSourceKotlinCompanionResolver.resolveArguments(context, companionMethod)
+        }.isInstanceOf(ClassNotFoundException::class.java)
+                .hasMessage("i.am.aclass.ThatDoesNotExists")
+    }
+
+    companion object {
+        private fun extensionContext(testClass: Class<*>): ExtensionContext {
+            val extensionContext = Mockito.mock(ExtensionContext::class.java)
+
+            Mockito.`when`(extensionContext.testClass).thenReturn(Optional.ofNullable(testClass))
+            Mockito.`when`(extensionContext.testMethod).thenReturn(Optional.empty())
+
+            Mockito.doCallRealMethod().`when`(extensionContext).requiredTestMethod
+            Mockito.doCallRealMethod().`when`(extensionContext).requiredTestClass
+
+            Mockito.`when`(extensionContext.testInstance).thenReturn(Optional.empty())
+            return extensionContext
+        }
+    }
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/function/Try.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/function/Try.java
@@ -150,6 +150,15 @@ public abstract class Try<V> {
 	public abstract V get() throws Exception;
 
 	/**
+	 * If this {@code Try} is a failure, get the contained exception cause; if this
+	 * {@code Try} is a success, throw the exception.
+	 *
+	 * @return the contained exception cause, if available; never {@code null}
+	 * @throws UnsupportedOperationException if this {@code Try} is a success
+	 */
+	public abstract Exception getCause();
+
+	/**
 	 * If this {@code Try} is a success, get the contained value; if this
 	 * {@code Try} is a failure, call the supplied {@link Function} with the
 	 * contained exception and throw the resulting {@link Exception}.
@@ -180,6 +189,20 @@ public abstract class Try<V> {
 	 * @return the same {@code Try} for method chaining
 	 */
 	public abstract Try<V> ifFailure(Consumer<Exception> causeConsumer);
+
+	/**
+	 * Return {@code true} if this {@code Try} is failure.
+	 *
+	 * @return {@code true} when failure
+	 */
+	public abstract boolean isFailure();
+
+	/**
+	 * Return {@code true} if this {@code Try} is success.
+	 *
+	 * @return {@code true} when success
+	 */
+	public abstract boolean isSuccess();
 
 	/**
 	 * If this {@code Try} is a failure, return an empty {@link Optional}; if
@@ -247,6 +270,11 @@ public abstract class Try<V> {
 		}
 
 		@Override
+		public Exception getCause() {
+			throw new UnsupportedOperationException("getCause on Success");
+		}
+
+		@Override
 		public <E extends Exception> V getOrThrow(Function<? super Exception, E> exceptionTransformer) {
 			// don't call exceptionTransformer because this Try is a success
 			return this.value;
@@ -263,6 +291,16 @@ public abstract class Try<V> {
 		public Try<V> ifFailure(Consumer<Exception> causeConsumer) {
 			// don't call causeConsumer because this Try was a success
 			return this;
+		}
+
+		@Override
+		public boolean isSuccess() {
+			return true;
+		}
+
+		@Override
+		public boolean isFailure() {
+			return false;
 		}
 
 		@Override
@@ -330,6 +368,11 @@ public abstract class Try<V> {
 		}
 
 		@Override
+		public Exception getCause() {
+			return this.cause;
+		}
+
+		@Override
 		public <E extends Exception> V getOrThrow(Function<? super Exception, E> exceptionTransformer) throws E {
 			checkNotNull(exceptionTransformer, "exceptionTransformer");
 			throw exceptionTransformer.apply(this.cause);
@@ -346,6 +389,16 @@ public abstract class Try<V> {
 			checkNotNull(causeConsumer, "causeConsumer");
 			causeConsumer.accept(this.cause);
 			return this;
+		}
+
+		@Override
+		public boolean isSuccess() {
+			return false;
+		}
+
+		@Override
+		public boolean isFailure() {
+			return true;
 		}
 
 		@Override

--- a/platform-tests/src/test/java/org/junit/platform/commons/function/TryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/function/TryTests.java
@@ -79,6 +79,20 @@ public class TryTests {
 	}
 
 	@Test
+	void tryTypeIndicators() throws Exception {
+		assertThat(Try.success("foo").isSuccess()).isTrue();
+		assertThat(Try.success("foo").isFailure()).isFalse();
+		assertThat(Try.failure(new IllegalStateException()).isSuccess()).isFalse();
+		assertThat(Try.failure(new IllegalStateException()).isFailure()).isTrue();
+	}
+
+	@Test
+	void tryGetCause() throws Exception {
+		assertThrows(UnsupportedOperationException.class, () -> Try.success("foo").getCause());
+		assertThat(Try.failure(new IllegalStateException()).getCause()).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
 	void triesWithSameContentAreEqual() {
 		var cause = new Exception();
 		Callable<Object> failingCallable = () -> {

--- a/platform-tooling-support-tests/projects/params-kotlin-companion-no-reflectlib/pom.xml
+++ b/platform-tooling-support-tests/projects/params-kotlin-companion-no-reflectlib/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>params-kotlin-companion-no-reflectlib</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+        <junit.jupiter.version>${env.JUNIT_JUPITER_VERSION}</junit.jupiter.version>
+        <kotlin.version>1.4.10</kotlin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+<!--        Without kotlin-reflect Library on classpath-->
+<!--        <dependency>-->
+<!--            <groupId>org.jetbrains.kotlin</groupId>-->
+<!--            <artifactId>kotlin-reflect</artifactId>-->
+<!--            <version>${kotlin.version}</version>-->
+<!--        </dependency>-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+                                println("Using Java version: ${java.version}")
+                            </source>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>local-temp</id>
+            <url>file://${maven.repo}</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+</project>

--- a/platform-tooling-support-tests/projects/params-kotlin-companion-no-reflectlib/src/test/kotlin/com/example/project/MethodSourceFromCompanionTest.kt
+++ b/platform-tooling-support-tests/projects/params-kotlin-companion-no-reflectlib/src/test/kotlin/com/example/project/MethodSourceFromCompanionTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package com.example.project;
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class MethodSourceFromCompanionTest {
+	@ParameterizedTest
+	@MethodSource("fromCompanionSource")
+	fun fromCompanion(value: String) {
+		assertEquals("companion", value)
+	}
+
+	companion object {
+		fun fromCompanionSource() = arrayOf(arrayOf("companion"))
+	}
+}

--- a/platform-tooling-support-tests/projects/params-kotlin-companion-no-reflectlib/src/test/kotlin/com/example/project/MethodSourceFromJvmStaticTest.kt
+++ b/platform-tooling-support-tests/projects/params-kotlin-companion-no-reflectlib/src/test/kotlin/com/example/project/MethodSourceFromJvmStaticTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package com.example.project;
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class MethodSourceFromJvmStaticTest {
+	@ParameterizedTest
+	@MethodSource("jvmStaticSource")
+	fun parameterizedTest(value: String) {
+		assertEquals("jvm-static", value)
+	}
+
+	companion object {
+		@JvmStatic
+		fun jvmStaticSource() = arrayOf(arrayOf("jvm-static"))
+	}
+}

--- a/platform-tooling-support-tests/projects/params-kotlin-companion-no-reflectlib/src/test/kotlin/com/example/project/TestInstancePerClassTest.kt
+++ b/platform-tooling-support-tests/projects/params-kotlin-companion-no-reflectlib/src/test/kotlin/com/example/project/TestInstancePerClassTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package com.example.project;
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+@org.junit.jupiter.api.TestInstance(org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS)
+class TestInstancePerClassTest {
+	@ParameterizedTest
+	@MethodSource("perClassFromCompanionSource")
+	fun perClassFromCompanion(value: String) {
+		assertEquals("companion", value)
+	}
+
+	@ParameterizedTest
+	@MethodSource("perClassFromInstanceSource")
+	fun perClassFromInstance(value: String) {
+		assertEquals("instance", value)
+	}
+
+	fun perClassFromInstanceSource() = arrayOf(arrayOf("instance"))
+
+	companion object {
+		fun perClassFromCompanionSource() = arrayOf(arrayOf("companion"))
+	}
+}

--- a/platform-tooling-support-tests/projects/params-kotlin-companion-with-reflectlib/pom.xml
+++ b/platform-tooling-support-tests/projects/params-kotlin-companion-with-reflectlib/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>params-kotlin-companion-with-reflectlib</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+        <junit.jupiter.version>${env.JUNIT_JUPITER_VERSION}</junit.jupiter.version>
+        <kotlin.version>1.4.10</kotlin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+                                println("Using Java version: ${java.version}")
+                            </source>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>local-temp</id>
+            <url>file://${maven.repo}</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+</project>

--- a/platform-tooling-support-tests/projects/params-kotlin-companion-with-reflectlib/src/test/kotlin/com/example/project/MethodSourceFromCompanionTest.kt
+++ b/platform-tooling-support-tests/projects/params-kotlin-companion-with-reflectlib/src/test/kotlin/com/example/project/MethodSourceFromCompanionTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package com.example.project;
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class MethodSourceFromCompanionTest {
+	@ParameterizedTest
+	@MethodSource("parameterizedTestSource")
+	fun parameterizedTest(value: String) {
+		assertEquals("companion", value)
+	}
+
+	@ParameterizedTest
+	@MethodSource("com.example.project.Foo#parameterizedTestSource")
+	fun parameterizedTestFromOtherCompanion(value: String) {
+		assertEquals("other-companion", value)
+	}
+
+	@ParameterizedTest
+	@MethodSource("parameterizedTestSourceStatic")
+	fun parameterizedTestFromStatic(value: String) {
+		assertEquals("jvmstatic", value)
+	}
+
+	companion object {
+		fun parameterizedTestSource() = arrayOf(arrayOf("companion"))
+
+		@JvmStatic
+		fun parameterizedTestSourceStatic() = arrayOf(arrayOf("jvmstatic"))
+	}
+}
+
+
+class Foo {
+	companion object {
+		fun parameterizedTestSource() = arrayOf(arrayOf("other-companion"))
+	}
+}

--- a/platform-tooling-support-tests/projects/params-kotlin-companion-with-reflectlib/src/test/kotlin/com/example/project/MethodSourceFromJvmStaticTest.kt
+++ b/platform-tooling-support-tests/projects/params-kotlin-companion-with-reflectlib/src/test/kotlin/com/example/project/MethodSourceFromJvmStaticTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package com.example.project;
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class MethodSourceFromJvmStaticTest {
+	@ParameterizedTest
+	@MethodSource("parameterizedTestSource")
+	fun parameterizedTest(value: String) {
+		assertEquals("jvm-static", value)
+	}
+
+	companion object {
+		@JvmStatic
+		fun parameterizedTestSource() = arrayOf(arrayOf("jvm-static"))
+	}
+}

--- a/platform-tooling-support-tests/projects/params-kotlin-companion-with-reflectlib/src/test/kotlin/com/example/project/TestInstancePerClassTest.kt
+++ b/platform-tooling-support-tests/projects/params-kotlin-companion-with-reflectlib/src/test/kotlin/com/example/project/TestInstancePerClassTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package com.example.project;
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+@org.junit.jupiter.api.TestInstance(org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS)
+class TestInstancePerClassTest {
+	@ParameterizedTest
+	@MethodSource("parameterizedTestSourceCompanion")
+	fun parameterizedTest(value: String) {
+		assertEquals("companion", value)
+	}
+
+	@ParameterizedTest
+	@MethodSource("parameterizedTestSourceInstance")
+	fun parameterizedTestFromStatic(value: String) {
+		assertEquals("instance", value)
+	}
+
+	fun parameterizedTestSourceInstance() = arrayOf(arrayOf("instance"))
+
+	companion object {
+		fun parameterizedTestSourceCompanion() = arrayOf(arrayOf("companion"))
+	}
+}

--- a/platform-tooling-support-tests/projects/params-without-kotlin/pom.xml
+++ b/platform-tooling-support-tests/projects/params-without-kotlin/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>params-without-kotlin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+        <junit.jupiter.version>${env.JUNIT_JUPITER_VERSION}</junit.jupiter.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+                                println("Using Java version: ${java.version}")
+                            </source>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>local-temp</id>
+            <url>file://${maven.repo}</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+</project>

--- a/platform-tooling-support-tests/projects/params-without-kotlin/src/test/java/com/example/project/MethodSourceWithoutKotlinTest.java
+++ b/platform-tooling-support-tests/projects/params-without-kotlin/src/test/java/com/example/project/MethodSourceWithoutKotlinTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package com.example.project;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MethodSourceWithoutKotlinTest {
+	@ParameterizedTest
+	@MethodSource("parameterizedTestSource")
+	void parameterizedTest(String value) {
+		assertEquals("no-kotlin", value);
+	}
+
+	private static Object parameterizedTestSource() {
+		return new Object[] {new Object[] {"no-kotlin"}};
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ModularUserGuideTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ModularUserGuideTests.java
@@ -99,6 +99,8 @@ class ModularUserGuideTests {
 					// Don't include command-line tools that "require io.github.classgraph"
 					.filter(s -> !s.contains("tools")).forEach(args::add);
 		}
+		args.add("-encoding");
+		args.add("UTF-8");
 
 		var javac = ToolProvider.findFirst("javac").orElseThrow();
 		var code = javac.run(new PrintWriter(out), new PrintWriter(err), args.toArray(String[]::new));

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ParamsKotlinCompanionNoReflectLibTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ParamsKotlinCompanionNoReflectLibTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
+import platform.tooling.support.Request;
+
+/**
+ * @since 1.3
+ */
+class ParamsKotlinCompanionNoReflectLibTests {
+
+	@Test
+	void verifyParamsKotlinCompanionNoReflectLibProject() {
+		var result = Request.builder() //
+				.setTool(Request.maven()) //
+				.setProject("params-kotlin-companion-no-reflectlib") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
+				.addArguments("--debug", "verify") //
+				.setTimeout(Duration.ofMinutes(2)) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
+				.build() //
+				.run();
+
+		assumeFalse(result.isTimedOut(), () -> "tool timed out: " + result);
+
+		assertEquals(1, result.getExitCode());
+		assertEquals("", result.getOutput("err"));
+
+		assertTrue(result.getOutputLines("out").contains(
+			"org.junit.platform.commons.JUnitException: No kotlin-reflect.jar in the classpath"));
+		assertTrue(result.getOutputLines("out").contains(
+			"Caused by: kotlin.jvm.KotlinReflectionNotSupportedError: Kotlin reflection implementation is not found at runtime. Make sure you have kotlin-reflect.jar in the classpath"));
+
+		assertTrue(result.getOutputLines("out").stream().anyMatch(
+			it -> it.startsWith("[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: ")
+					&& it.endsWith(" s <<< FAILURE! - in com.example.project.MethodSourceFromCompanionTest")));
+		assertTrue(result.getOutputLines("out").stream().anyMatch(
+			it -> it.startsWith("[ERROR] fromCompanion{String}  Time elapsed: ") && it.endsWith(" s  <<< ERROR!")));
+
+		assertTrue(result.getOutputLines("out").stream().anyMatch(
+			it -> it.startsWith("[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: ")
+					&& it.endsWith(" s - in com.example.project.MethodSourceFromJvmStaticTest")));
+
+		assertTrue(result.getOutputLines("out").stream().anyMatch(
+			it -> it.startsWith("[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: ")
+					&& it.endsWith(" s <<< FAILURE! - in com.example.project.TestInstancePerClassTest")));
+		assertTrue(result.getOutputLines("out").stream().anyMatch(
+			it -> it.startsWith("[ERROR] perClassFromCompanion{String}  Time elapsed: ")
+					&& it.endsWith(" s  <<< ERROR!")));
+
+		assertTrue(result.getOutputLines("out").contains("[INFO] BUILD FAILURE"));
+		assertTrue(result.getOutputLines("out").contains("[ERROR] Tests run: 4, Failures: 0, Errors: 2, Skipped: 0"));
+		assertThat(result.getOutput("out")).contains("Using Java version: 1.8");
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ParamsKotlinCompanionWithReflectLibTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ParamsKotlinCompanionWithReflectLibTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
+import platform.tooling.support.Request;
+
+/**
+ * @since 1.3
+ */
+class ParamsKotlinCompanionWithReflectLibTests {
+
+	@Test
+	void verifyParamsKotlinCompanionWithReflectLibProject() {
+		var result = Request.builder() //
+				.setTool(Request.maven()) //
+				.setProject("params-kotlin-companion-with-reflectlib") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
+				.addArguments("--debug", "verify") //
+				.setTimeout(Duration.ofMinutes(2)) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
+				.build() //
+				.run();
+
+		assumeFalse(result.isTimedOut(), () -> "tool timed out: " + result);
+
+		assertEquals(0, result.getExitCode());
+		assertEquals("", result.getOutput("err"));
+		assertTrue(result.getOutputLines("out").contains("[INFO] BUILD SUCCESS"));
+		assertTrue(result.getOutputLines("out").contains("[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0"));
+		assertThat(result.getOutput("out")).contains("Using Java version: 1.8");
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ParamsKotlinWithoutKotlinTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ParamsKotlinWithoutKotlinTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
+import platform.tooling.support.Request;
+
+/**
+ * @since 1.3
+ */
+class ParamsKotlinWithoutKotlinTests {
+
+	@Test
+	void verifyParamsKotlinJvmStaticProject() {
+		var result = Request.builder() //
+				.setTool(Request.maven()) //
+				.setProject("params-without-kotlin") //
+				.addArguments("-Dmaven.repo=" + System.getProperty("maven.repo")) //
+				.addArguments("--debug", "verify") //
+				.setTimeout(Duration.ofMinutes(2)) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
+				.build() //
+				.run();
+
+		assumeFalse(result.isTimedOut(), () -> "tool timed out: " + result);
+
+		assertEquals(0, result.getExitCode());
+		assertEquals("", result.getOutput("err"));
+		assertTrue(result.getOutputLines("out").contains("[INFO] BUILD SUCCESS"));
+		assertTrue(result.getOutputLines("out").contains("[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0"));
+		assertThat(result.getOutput("out")).contains("Using Java version: 1.8");
+	}
+}


### PR DESCRIPTION
## Overview

Hi, this is update of my old PR https://github.com/junit-team/junit5/pull/2475 rebased to current main branch. It was closed by stale bot. 
What do you think about improvement? It allow to used method source on Kotlin's companion object without `@JvmStatic` or `PER_CLASS` lifecycle settings.
Thx
Ivos

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
