### PR TITLE
Add an example of inner class fully qualified method name

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -109,7 +109,7 @@ public @interface MethodSource {
 	 *
 	 * <p>Factory methods in external classes must be referenced by <em>fully
 	 * qualified method name</em> &mdash; for example,
-	 * {@code com.example.StringsProviders#blankStrings}.
+	 * {@code com.example.StringsProviders#blankStrings} or {@code com.example.OuterClass$InnerClass#classMethod}.
 	 *
 	 * <p>If no factory method names are declared, a method within the test class
 	 * that has the same name as the test method will be used as the factory

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -109,7 +109,8 @@ public @interface MethodSource {
 	 *
 	 * <p>Factory methods in external classes must be referenced by <em>fully
 	 * qualified method name</em> &mdash; for example,
-	 * {@code com.example.StringsProviders#blankStrings} or {@code com.example.OuterClass$InnerClass#classMethod}.
+	 * {@code com.example.StringsProviders#blankStrings} or
+	 * {@code com.example.OuterClass$InnerClass#classMethod}.
 	 *
 	 * <p>If no factory method names are declared, a method within the test class
 	 * that has the same name as the test method will be used as the factory


### PR DESCRIPTION
## Overview

This took me a while to figure out the syntax, so I thought improving the documentation could be beneficial.
As an aside, there are also no tests for `MethodSource` with an inner class.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

Doco-only change, so DoD is not relevant.