### PR TITLE
Document how to run the ConsoleLauncher with classpath wildcards

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -563,9 +563,8 @@ Test run finished after 64 ms
 [         0 tests failed          ]
 ----
 
-You can also run the
-standalone `ConsoleLauncher` as shown below
-(for example, to include all jars in a directory):
+You can also run the standalone `ConsoleLauncher` as shown below (for example, to include
+all jars in a directory):
 
 [source,console,subs=attributes+]
 ----
@@ -573,8 +572,6 @@ $ java -cp classes:testlib/* org.junit.platform.console.ConsoleLauncher <OPTIONS
 ----
 
 .Exit Code
-
-
 NOTE: The `{ConsoleLauncher}` exits with a status code of `1` if any containers or tests
 failed. If no tests are discovered and the `--fail-if-no-tests` command-line option is
 supplied, the `ConsoleLauncher` exits with a status code of `2`. Otherwise the exit code

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -563,8 +563,6 @@ Test run finished after 64 ms
 [         0 tests failed          ]
 ----
 
-.Exit Code
-
 You can also https://docs.oracle.com/javase/tutorial/deployment/jar/run.html[run] the
 standalone `ConsoleLauncher` as shown below
 (for example, to include all jars in directory):

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -565,7 +565,7 @@ Test run finished after 64 ms
 
 You can also https://docs.oracle.com/javase/tutorial/deployment/jar/run.html[run] the
 standalone `ConsoleLauncher` as shown below
-(for example, to include all jars in directory):
+(for example, to include all jars in a directory):
 
 [source,console,subs=attributes+]
 ----

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -563,7 +563,7 @@ Test run finished after 64 ms
 [         0 tests failed          ]
 ----
 
-You can also https://docs.oracle.com/javase/tutorial/deployment/jar/run.html[run] the
+You can also run the
 standalone `ConsoleLauncher` as shown below
 (for example, to include all jars in a directory):
 

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -564,6 +564,19 @@ Test run finished after 64 ms
 ----
 
 .Exit Code
+
+You can also https://docs.oracle.com/javase/tutorial/deployment/jar/run.html[run] the
+standalone `ConsoleLauncher` as shown below
+(for example, to include all jars in directory):
+
+[source,console,subs=attributes+]
+----
+$ java -cp classes:testlib/* org.junit.platform.console.ConsoleLauncher <OPTIONS>
+----
+
+.Exit Code
+
+
 NOTE: The `{ConsoleLauncher}` exits with a status code of `1` if any containers or tests
 failed. If no tests are discovered and the `--fail-if-no-tests` command-line option is
 supplied, the `ConsoleLauncher` exits with a status code of `2`. Otherwise the exit code


### PR DESCRIPTION
## Overview

This enables you to use the compact "jar star" pattern in your classpath.
Partially addresses https://github.com/junit-team/junit5/issues/2788

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
