### PR TITLE
User Guide: The definition of `Container` in JUnit5

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -363,6 +363,11 @@ traceability, etc.
 [[writing-tests-conditional-execution]]
 === Conditional Test Execution
 
+TIP: Before going further, let's define the concept of `Container` in the context of JUnit5.
+First of all, a `Container`, in Java, is an object created to hold other object named _children_ that are accessible with the class methods of this object.
+In the context of JUnit, it's the same thing but more focused on `TestClasses` and specifically test classes and nested test classes that have _children_. -- for example, you can have classes and nested classes as containers and test methods as tests. If there is a test method, which creates a lot of tests, then it's considered as a container.
+But, if a container have children that are not themselves tests, it will be pruned and not run.
+
 The <<extensions-conditions, `ExecutionCondition`>> extension API in JUnit Jupiter allows
 developers to either _enable_ or _disable_ a container or test based on certain
 conditions _programmatically_. The simplest example of such a condition is the built-in


### PR DESCRIPTION
## Overview

Add a definition of `Container` in the User Guide.
Issue #2205

--- 

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
