### PR TITLE
Use correct HTML heading levels in Javadoc

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3122,7 +3122,7 @@ public class Assertions {
 	 * <em>Assert</em> that execution of the supplied {@code executable} does
 	 * <em>not</em> throw any kind of {@linkplain Throwable exception}.
 	 *
-	 * <h3>Usage Note</h3>
+	 * <h4>Usage Note</h4>
 	 * <p>Although any exception thrown from a test method will cause the test
 	 * to <em>fail</em>, there are certain use cases where it can be beneficial
 	 * to explicitly assert that an exception is not thrown for a given code
@@ -3139,7 +3139,7 @@ public class Assertions {
 	 * <em>Assert</em> that execution of the supplied {@code executable} does
 	 * <em>not</em> throw any kind of {@linkplain Throwable exception}.
 	 *
-	 * <h3>Usage Note</h3>
+	 * <h4>Usage Note</h4>
 	 * <p>Although any exception thrown from a test method will cause the test
 	 * to <em>fail</em>, there are certain use cases where it can be beneficial
 	 * to explicitly assert that an exception is not thrown for a given code
@@ -3158,7 +3158,7 @@ public class Assertions {
 	 * <em>Assert</em> that execution of the supplied {@code executable} does
 	 * <em>not</em> throw any kind of {@linkplain Throwable exception}.
 	 *
-	 * <h3>Usage Note</h3>
+	 * <h4>Usage Note</h4>
 	 * <p>Although any exception thrown from a test method will cause the test
 	 * to <em>fail</em>, there are certain use cases where it can be beneficial
 	 * to explicitly assert that an exception is not thrown for a given code
@@ -3182,7 +3182,7 @@ public class Assertions {
 	 *
 	 * <p>If the assertion passes, the {@code supplier}'s result will be returned.
 	 *
-	 * <h3>Usage Note</h3>
+	 * <h4>Usage Note</h4>
 	 * <p>Although any exception thrown from a test method will cause the test
 	 * to <em>fail</em>, there are certain use cases where it can be beneficial
 	 * to explicitly assert that an exception is not thrown for a given code
@@ -3203,7 +3203,7 @@ public class Assertions {
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
 	 *
-	 * <h3>Usage Note</h3>
+	 * <h4>Usage Note</h4>
 	 * <p>Although any exception thrown from a test method will cause the test
 	 * to <em>fail</em>, there are certain use cases where it can be beneficial
 	 * to explicitly assert that an exception is not thrown for a given code
@@ -3225,7 +3225,7 @@ public class Assertions {
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
 	 *
-	 * <h3>Usage Note</h3>
+	 * <h4>Usage Note</h4>
 	 * <p>Although any exception thrown from a test method will cause the test
 	 * to <em>fail</em>, there are certain use cases where it can be beneficial
 	 * to explicitly assert that an exception is not thrown for a given code

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -205,7 +205,7 @@ public interface ClassOrderer {
 		 * <p>The same property is used by {@link MethodOrderer.Random} for
 		 * consistency between the two random orderers.
 		 *
-		 * <h3>Supported Values</h3>
+		 * <h4>Supported Values</h4>
 		 *
 		 * <p>Supported values include any string that can be converted to a
 		 * {@link Long} via {@link Long#valueOf(String)}.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -264,7 +264,7 @@ public interface MethodOrderer {
 		 * <p>The same property is used by {@link ClassOrderer.Random} for
 		 * consistency between the two random orderers.
 		 *
-		 * <h3>Supported Values</h3>
+		 * <h4>Supported Values</h4>
 		 *
 		 * <p>Supported values include any string that can be converted to a
 		 * {@link Long} via {@link Long#valueOf(String)}.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInfo.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInfo.java
@@ -48,7 +48,7 @@ public interface TestInfo {
 	 * <p>The display name is either a default name or a custom name configured
 	 * via {@link DisplayName @DisplayName}.
 	 *
-	 * <h3>Default Display Names</h3>
+	 * <h4>Default Display Names</h4>
 	 *
 	 * <p>If the context in which {@code TestInfo} is used is at the container
 	 * level, the default display name is generated based on the name of the

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -41,7 +41,7 @@ public interface ParameterContext {
 	/**
 	 * Get the {@link Parameter} for this context.
 	 *
-	 * <h3>WARNING</h3>
+	 * <h4>WARNING</h4>
 	 * <p>When searching for annotations on the parameter in this context,
 	 * favor {@link #isAnnotated(Class)}, {@link #findAnnotation(Class)}, and
 	 * {@link #findRepeatableAnnotations(Class)} over methods in the
@@ -93,7 +93,7 @@ public interface ParameterContext {
 	 * <em>present</em> or <em>meta-present</em> on the {@link Parameter} for
 	 * this context.
 	 *
-	 * <h3>WARNING</h3>
+	 * <h4>WARNING</h4>
 	 * <p>Favor the use of this method over directly invoking
 	 * {@link Parameter#isAnnotationPresent(Class)} due to a bug in {@code javac}
 	 * on JDK versions prior to JDK 9.
@@ -111,7 +111,7 @@ public interface ParameterContext {
 	 * <em>present</em> or <em>meta-present</em> on the {@link Parameter} for
 	 * this context.
 	 *
-	 * <h3>WARNING</h3>
+	 * <h4>WARNING</h4>
 	 * <p>Favor the use of this method over directly invoking annotation lookup
 	 * methods in the {@link Parameter} API due to a bug in {@code javac} on JDK
 	 * versions prior to JDK 9.
@@ -131,7 +131,7 @@ public interface ParameterContext {
 	 * {@code annotationType} that are either <em>present</em> or
 	 * <em>meta-present</em> on the {@link Parameter} for this context.
 	 *
-	 * <h3>WARNING</h3>
+	 * <h4>WARNING</h4>
 	 * <p>Favor the use of this method over directly invoking annotation lookup
 	 * methods in the {@link Parameter} API due to a bug in {@code javac} on JDK
 	 * versions prior to JDK 9.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -52,7 +52,7 @@ public final class Constants {
 	/**
 	 * Property name used to provide patterns for deactivating conditions: {@value}
 	 *
-	 * <h3>Pattern Matching Syntax</h3>
+	 * <h4>Pattern Matching Syntax</h4>
 	 *
 	 * <p>If the property value consists solely of an asterisk ({@code *}), all
 	 * conditions will be deactivated. Otherwise, the property value will be treated
@@ -63,7 +63,7 @@ public final class Constants {
 	 * against one or more characters in a FQCN. All other characters in a pattern
 	 * will be matched one-to-one against a FQCN.
 	 *
-	 * <h3>Examples</h3>
+	 * <h4>Examples</h4>
 	 *
 	 * <ul>
 	 * <li>{@code *}: deactivates all conditions.
@@ -96,7 +96,7 @@ public final class Constants {
 	/**
 	 * Property name used to set the default display name generator class name: {@value}
 	 *
-	 * <h3>Supported Values</h3>
+	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values include fully qualified class names for types that implement
 	 * {@link org.junit.jupiter.api.DisplayNameGenerator}.
@@ -117,7 +117,7 @@ public final class Constants {
 	/**
 	 * Property name used to set the default test instance lifecycle mode: {@value}
 	 *
-	 * <h3>Supported Values</h3>
+	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values include names of enum constants defined in
 	 * {@link org.junit.jupiter.api.TestInstance.Lifecycle}, ignoring case.
@@ -144,7 +144,7 @@ public final class Constants {
 	 *
 	 * <p>This setting is only effective if parallel execution is enabled.
 	 *
-	 * <h3>Supported Values</h3>
+	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values include names of enum constants defined in
 	 * {@link org.junit.jupiter.api.parallel.ExecutionMode}, ignoring case.
@@ -165,7 +165,7 @@ public final class Constants {
 	 *
 	 * <p>This setting is only effective if parallel execution is enabled.
 	 *
-	 * <h3>Supported Values</h3>
+	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values include names of enum constants defined in
 	 * {@link org.junit.jupiter.api.parallel.ExecutionMode}, ignoring case.
@@ -436,7 +436,7 @@ public final class Constants {
 	 * <p>The value of this property will be used to toggle whether
 	 * {@link org.junit.jupiter.api.Timeout @Timeout} is applied to tests.</p>
 	 *
-	 * <h3>Supported timeout mode values:</h3>
+	 * <h4>Supported timeout mode values:</h4>
 	 * <ul>
 	 * <li>{@code enabled}: enables timeouts
 	 * <li>{@code disabled}: disables timeouts
@@ -453,7 +453,7 @@ public final class Constants {
 	/**
 	 * Property name used to set the default method orderer class name: {@value}
 	 *
-	 * <h3>Supported Values</h3>
+	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values include fully qualified class names for types that
 	 * implement {@link org.junit.jupiter.api.MethodOrderer}.
@@ -467,7 +467,7 @@ public final class Constants {
 	/**
 	 * Property name used to set the default class orderer class name: {@value}
 	 *
-	 * <h3>Supported Values</h3>
+	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values include fully qualified class names for types that
 	 * implement {@link org.junit.jupiter.api.ClassOrderer}.
@@ -479,7 +479,7 @@ public final class Constants {
 	 * Property name used to set the scope of temporary directories created via
 	 * {@link org.junit.jupiter.api.io.TempDir @TempDir} annotation: {@value}
 	 *
-	 * <h3>Supported Values</h3>
+	 * <h4>Supported Values</h4>
 	 * <ul>
 	 * <li>{@code per_context}: creates a single temporary directory for the
 	 * entire test class or method, depending on where it's first declared

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
@@ -45,7 +45,7 @@ public final class ExceptionUtils {
 	 * the Java compiler into believing that the thrown exception is an
 	 * unchecked exception even if it is a checked exception.
 	 *
-	 * <h3>Warning</h3>
+	 * <h4>Warning</h4>
 	 *
 	 * <p>This method should be used sparingly.
 	 *

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestTag.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestTag.java
@@ -58,7 +58,7 @@ public final class TestTag implements Serializable {
 	 * Determine if the supplied tag name is valid with regard to the supported
 	 * syntax for tags.
 	 *
-	 * <h3>Syntax Rules for Tags</h3>
+	 * <h4>Syntax Rules for Tags</h4>
 	 * <ul>
 	 * <li>A tag must not be {@code null}.</li>
 	 * <li>A tag must not be blank.</li>

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -414,7 +414,7 @@ public final class DiscoverySelectors {
 	 * <em>source code syntax</em> (e.g., {@code int[][]}, {@code java.lang.String[]},
 	 * etc.).
 	 *
-	 * <h3>Examples</h3>
+	 * <h4>Examples</h4>
 	 *
 	 * <table class="plain">
 	 * <tr><th>Method</th><th>Fully Qualified Method Name</th></tr>

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -94,7 +94,7 @@ public class LauncherConstants {
 	 * Property name used to provide patterns for deactivating listeners registered
 	 * via the {@link java.util.ServiceLoader ServiceLoader} mechanism: {@value}
 	 *
-	 * <h3>Pattern Matching Syntax</h3>
+	 * <h4>Pattern Matching Syntax</h4>
 	 *
 	 * <p>If the property value consists solely of an asterisk ({@code *}), all
 	 * listeners will be deactivated. Otherwise, the property value will be treated
@@ -105,7 +105,7 @@ public class LauncherConstants {
 	 * against one or more characters in a FQCN. All other characters in a pattern
 	 * will be matched one-to-one against a FQCN.
 	 *
-	 * <h3>Examples</h3>
+	 * <h4>Examples</h4>
 	 *
 	 * <ul>
 	 * <li>{@code *}: deactivates all listeners.

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -88,7 +88,7 @@ public final class LauncherDiscoveryRequestBuilder {
 	/**
 	 * Property name used to set the default discovery listener that is added to all : {@value}
 	 *
-	 * <h3>Supported Values</h3>
+	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values are {@code "logging"} and {@code "abortOnFailure"}.
 	 *

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -73,7 +73,7 @@ public final class EngineTestKit {
 	 * mechanism, analogous to the manner in which test engines are loaded in
 	 * the JUnit Platform Launcher API.
 	 *
-	 * <h3>Example Usage</h3>
+	 * <h4>Example Usage</h4>
 	 *
 	 * <pre class="code">
 	 * EngineTestKit
@@ -102,7 +102,7 @@ public final class EngineTestKit {
 	/**
 	 * Create an execution {@link Builder} for the supplied {@link TestEngine}.
 	 *
-	 * <h3>Example Usage</h3>
+	 * <h4>Example Usage</h4>
 	 *
 	 * <pre class="code">
 	 * EngineTestKit


### PR DESCRIPTION
## Overview

HTML headers in the documentation of type members (except for nested types) should start at `<h4>`, see https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#html-content

Normally the javadoc tool warns about this, but it looks like this is not the case when executing the `javadoc` task for JUnit. Maybe the build scripts need to be adjusted?

The current usage of `<h3>` causes it to look rather strange because that is the same level as the member name itself.
Example:
![Header usage example screenshot](https://user-images.githubusercontent.com/11685886/147375792-aa672d5d-708d-4331-abe5-654b6f22f7dd.png)

([`org.junit.jupiter.api.TestInfo.getDisplayName()`](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/TestInfo.html#getDisplayName()))

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
