### PR TITLE
Document new failure message argument position in JUnit 4 migration tips

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -63,6 +63,8 @@ tests to JUnit Jupiter.
 * `@Rule` and `@ClassRule` no longer exist; superseded by `@ExtendWith` and
   `@RegisterExtension`
   - See also <<migrating-from-junit4-rule-support>>.
+* Many assertions and assumptions now accept the message as their last parameter instead of the first one
+  - See also <<migrating-from-junit4-message-parameter, New message parameter position>>.
 
 
 [[migrating-from-junit4-rule-support]]
@@ -113,6 +115,31 @@ automatically registers the `IgnoreCondition` along with
 <<migrating-from-junit4-rule-support>>). The `IgnoreCondition` is an
 `{ExecutionCondition}` that disables test classes or test methods that are annotated with
 `@Ignore`.
+
+
+[[migrating-from-junit4-message-parameter]]
+=== New message parameter position
+
+The introduction of the classes `Assumptions` and `Assertions` brought a new parameters' order for existing methods. While on JUnit 4 assertion and assumption methods would accept the message parameter as their first one, JUnit 5 implements them with the message as the last parameter.
+
+For instance, the method `assertEquals` in JUnit 4 is `assertEquals(String message, Object expected, Object actual)` and in JUnit 5 `assertEquals(Object expected, Object actual, String message)`.
+
+The methods affected by this change are the following:
+
+- Assertions
+  * `assertTrue`
+  * `assertFalse`
+  * `assertNull`
+  * `assertNotNull`
+  * `assertEquals`
+  * `assertNotEquals`
+  * `assertArrayEquals`
+  * `assertSame`
+  * `assertNotSame`
+  * `assertThrows`
+- Assumptions
+  * `assumeTrue`
+  * `assumeFalse`
 
 [source,java,indent=0]
 ----

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -116,6 +116,11 @@ automatically registers the `IgnoreCondition` along with
 `{ExecutionCondition}` that disables test classes or test methods that are annotated with
 `@Ignore`.
 
+[source,java,indent=0]
+----
+include::{testDir}/example/IgnoredTestsDemo.java[tags=user_guide]
+----
+
 
 [[migrating-from-junit4-message-parameter]]
 === New message parameter position
@@ -140,8 +145,3 @@ The methods affected by this change are the following:
 - Assumptions
   * `assumeTrue`
   * `assumeFalse`
-
-[source,java,indent=0]
-----
-include::{testDir}/example/IgnoredTestsDemo.java[tags=user_guide]
-----

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -63,8 +63,8 @@ tests to JUnit Jupiter.
 * `@Rule` and `@ClassRule` no longer exist; superseded by `@ExtendWith` and
   `@RegisterExtension`
   - See also <<migrating-from-junit4-rule-support>>.
-* Many assertions and assumptions now accept the message as their last parameter instead of the first one
-  - See also <<migrating-from-junit4-message-parameter, New message parameter position>>.
+* Assertions and assumptions in JUnit Jupiter accept the failure message as their last argument instead of the first one.
+  - See <<migrating-from-junit4-failure-message-arguments>> for details.
 
 
 [[migrating-from-junit4-rule-support]]
@@ -122,12 +122,13 @@ include::{testDir}/example/IgnoredTestsDemo.java[tags=user_guide]
 ----
 
 
-[[migrating-from-junit4-message-parameter]]
-=== New message parameter position
+[[migrating-from-junit4-failure-message-arguments]]
+=== Failure Message Arguments
 
-The introduction of the classes `Assumptions` and `Assertions` brought a new parameters' order for existing methods. While on JUnit 4 assertion and assumption methods would accept the message parameter as their first one, JUnit 5 implements them with the message as the last parameter.
+The `Assumptions` and `Assertions` classes in JUnit Jupiter declare arguments in a different order than in JUnit 4. In JUnit 4 assertion and assumption methods accept the failure message as the first argument; whereas, in JUnit Jupiter assertion and assumption methods accept the failure message as the last argument.
 
-For instance, the method `assertEquals` in JUnit 4 is `assertEquals(String message, Object expected, Object actual)` and in JUnit 5 `assertEquals(Object expected, Object actual, String message)`.
+For instance, the method `assertEquals` in JUnit 4 is declared as `assertEquals(String message, Object expected, Object actual)`, but in JUnit Jupiter it is declared as `assertEquals(Object expected, Object actual, String message)`.
+The rationale for this is that a failure message is _optional_, and optional arguments should be declared after required arguments in a method signature.
 
 The methods affected by this change are the following:
 

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -63,7 +63,8 @@ tests to JUnit Jupiter.
 * `@Rule` and `@ClassRule` no longer exist; superseded by `@ExtendWith` and
   `@RegisterExtension`
   - See also <<migrating-from-junit4-rule-support>>.
-* Assertions and assumptions in JUnit Jupiter accept the failure message as their last argument instead of the first one.
+* Assertions and assumptions in JUnit Jupiter accept the failure message as their last
+  argument instead of the first one.
   - See <<migrating-from-junit4-failure-message-arguments>> for details.
 
 
@@ -125,10 +126,16 @@ include::{testDir}/example/IgnoredTestsDemo.java[tags=user_guide]
 [[migrating-from-junit4-failure-message-arguments]]
 === Failure Message Arguments
 
-The `Assumptions` and `Assertions` classes in JUnit Jupiter declare arguments in a different order than in JUnit 4. In JUnit 4 assertion and assumption methods accept the failure message as the first argument; whereas, in JUnit Jupiter assertion and assumption methods accept the failure message as the last argument.
+The `Assumptions` and `Assertions` classes in JUnit Jupiter declare arguments in a
+different order than in JUnit 4. In JUnit 4 assertion and assumption methods accept
+the failure message as the first argument; whereas, in JUnit Jupiter assertion and
+assumption methods accept the failure message as the last argument.
 
-For instance, the method `assertEquals` in JUnit 4 is declared as `assertEquals(String message, Object expected, Object actual)`, but in JUnit Jupiter it is declared as `assertEquals(Object expected, Object actual, String message)`.
-The rationale for this is that a failure message is _optional_, and optional arguments should be declared after required arguments in a method signature.
+For instance, the method `assertEquals` in JUnit 4 is declared as
+`assertEquals(String message, Object expected, Object actual)`, but in JUnit Jupiter it
+is declared as `assertEquals(Object expected, Object actual, String message)`.
+The rationale for this is that a failure message is _optional_, and optional arguments
+should be declared after required arguments in a method signature.
 
 The methods affected by this change are the following:
 


### PR DESCRIPTION
See #2809.

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
