### PR TITLE
Upgrade Gradle enterprise plugin dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
     implementation("gradle.plugin.net.nemerosa:versioning:2.15.1")
 	implementation("org.gradle:test-retry-gradle-plugin:1.3.1")
-	compileOnly("com.gradle.enterprise:test-distribution-gradle-plugin:2.2.1") // keep in sync with root settings.gradle.kts
+	compileOnly("com.gradle.enterprise:test-distribution-gradle-plugin:2.2.2") // keep in sync with root settings.gradle.kts
 }
 
 tasks {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,8 +5,8 @@ pluginManagement {
 		gradlePluginPortal()
 	}
 	plugins {
-		id("com.gradle.enterprise") version "3.8"
-		id("com.gradle.enterprise.test-distribution") version "2.2.1" // keep in sync with buildSrc/build.gradle.kts
+		id("com.gradle.enterprise") version "3.8.1"
+		id("com.gradle.enterprise.test-distribution") version "2.2.2" // keep in sync with buildSrc/build.gradle.kts
 		id("com.gradle.common-custom-user-data-gradle-plugin") version "1.6.2"
 		id("org.ajoberstar.git-publish") version "3.0.0"
 		kotlin("jvm") version "1.5.31"


### PR DESCRIPTION
## Overview

Bump up Gradle plugin dependencies

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
