### PR TITLE
Support FreeBSD and OpenBSD in `@EnabledOnOs` and `@DisabledOnOs`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
@@ -29,6 +29,7 @@ on GitHub.
 * JUnit OSGi bundles now contain `engine` and `launcher` requirements ensuring that at
   resolution time a fully running set of dependencies are calculated avoiding the need
   for these to be manually specified.
+* New support for FreeBSD and OpenBSD operating systems in `@EnabledOnOs` and `@DisabledOnOs`.
 
 
 [[release-notes-5.9.0-M1-junit-jupiter]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/OS.java
@@ -30,8 +30,10 @@ import org.junit.platform.commons.util.StringUtils;
  *
  * @since 5.1
  * @see #AIX
+ * @see #FREEBSD
  * @see #LINUX
  * @see #MAC
+ * @see #OPENBSD
  * @see #SOLARIS
  * @see #WINDOWS
  * @see #OTHER
@@ -50,6 +52,14 @@ public enum OS {
 	AIX,
 
 	/**
+	 * FreeBSD operating system.
+	 *
+	 * @since 5.9
+	 */
+	@API(status = STABLE, since = "5.9")
+	FREEBSD,
+
+	/**
 	 * Linux-based operating system.
 	 */
 	LINUX,
@@ -58,6 +68,14 @@ public enum OS {
 	 * Apple Macintosh operating system (e.g., macOS).
 	 */
 	MAC,
+
+	/**
+	 * OpenBSD operating system.
+	 *
+	 * @since 5.9
+	 */
+	@API(status = STABLE, since = "5.9")
+	OPENBSD,
 
 	/**
 	 * Oracle Solaris operating system.
@@ -70,8 +88,8 @@ public enum OS {
 	WINDOWS,
 
 	/**
-	 * An operating system other than {@link #AIX}, {@link #LINUX}, {@link #MAC},
-	 * {@link #SOLARIS}, or {@link #WINDOWS}.
+	 * An operating system other than {@link #AIX}, {@link #FREEBSD}, {@link #LINUX},
+	 * {@link #MAC}, {@link #OPENBSD}, {@link #SOLARIS}, or {@link #WINDOWS}.
 	 */
 	OTHER;
 
@@ -107,11 +125,17 @@ public enum OS {
 		if (osName.contains("aix")) {
 			return AIX;
 		}
+		if (osName.contains("freebsd")) {
+			return FREEBSD;
+		}
 		if (osName.contains("linux")) {
 			return LINUX;
 		}
 		if (osName.contains("mac")) {
 			return MAC;
+		}
+		if (osName.contains("openbsd")) {
+			return OPENBSD;
 		}
 		if (osName.contains("sunos") || osName.contains("solaris")) {
 			return SOLARIS;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
@@ -12,8 +12,11 @@ package org.junit.jupiter.api.condition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onAix;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onOpenbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
 
@@ -73,6 +76,24 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
+	 * @see DisabledOnOsIntegrationTests#aix()
+	 */
+	@Test
+	void aix() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onAix());
+	}
+
+	/**
+	 * @see DisabledOnOsIntegrationTests#freebsd()
+	 */
+	@Test
+	void freebsd() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onFreebsd());
+	}
+
+	/**
 	 * @see DisabledOnOsIntegrationTests#linux()
 	 */
 	@Test
@@ -100,6 +121,15 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
+	 * @see DisabledOnOsIntegrationTests#openbsd()
+	 */
+	@Test
+	void openbsd() {
+		evaluateCondition();
+		assertDisabledOnCurrentOsIf(onOpenbsd());
+	}
+
+	/**
 	 * @see DisabledOnOsIntegrationTests#windows()
 	 */
 	@Test
@@ -123,7 +153,8 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertDisabledOnCurrentOsIf(!(onLinux() || onMac() || onSolaris() || onWindows()));
+		assertDisabledOnCurrentOsIf(
+			!(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd() || onSolaris() || onWindows()));
 	}
 
 	private void assertDisabledOnCurrentOsIf(boolean condition) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsIntegrationTests.java
@@ -13,12 +13,18 @@ package org.junit.jupiter.api.condition;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onAix;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onOpenbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
+import static org.junit.jupiter.api.condition.OS.AIX;
+import static org.junit.jupiter.api.condition.OS.FREEBSD;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.OPENBSD;
 import static org.junit.jupiter.api.condition.OS.OTHER;
 import static org.junit.jupiter.api.condition.OS.SOLARIS;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
@@ -50,9 +56,22 @@ class DisabledOnOsIntegrationTests {
 	}
 
 	@Test
-	@DisabledOnOs(value = { LINUX, MAC, WINDOWS, SOLARIS, OTHER }, disabledReason = "Disabled on every OS")
+	@DisabledOnOs(value = { AIX, FREEBSD, LINUX, MAC, OPENBSD, WINDOWS, SOLARIS,
+			OTHER }, disabledReason = "Disabled on every OS")
 	void disabledOnEveryOs() {
 		fail("should be disabled");
+	}
+
+	@Test
+	@DisabledOnOs(AIX)
+	void aix() {
+		assertFalse(onAix());
+	}
+
+	@Test
+	@DisabledOnOs(FREEBSD)
+	void freebsd() {
+		assertFalse(onFreebsd());
 	}
 
 	@Test
@@ -74,6 +93,12 @@ class DisabledOnOsIntegrationTests {
 	}
 
 	@Test
+	@DisabledOnOs(OPENBSD)
+	void openbsd() {
+		assertFalse(onOpenbsd());
+	}
+
+	@Test
 	@DisabledOnOs(WINDOWS)
 	void windows() {
 		assertFalse(onWindows());
@@ -88,7 +113,7 @@ class DisabledOnOsIntegrationTests {
 	@Test
 	@DisabledOnOs(OTHER)
 	void other() {
-		assertTrue(onLinux() || onMac() || onSolaris() || onWindows());
+		assertTrue(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd() || onSolaris() || onWindows());
 	}
 
 	// -------------------------------------------------------------------------

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
@@ -153,7 +153,7 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	void other() {
 		evaluateCondition();
 		assertEnabledOnCurrentOsIf(
-			!(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd || onSolaris() || onWindows()));
+			!(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd() || onSolaris() || onWindows()));
 		assertCustomDisabledReasonIs("Disabled on almost every OS");
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
@@ -12,8 +12,11 @@ package org.junit.jupiter.api.condition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onAix;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onFreebsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onLinux;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onMac;
+import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onOpenbsd;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onSolaris;
 import static org.junit.jupiter.api.condition.EnabledOnOsIntegrationTests.onWindows;
 
@@ -72,6 +75,24 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
+	 * @see EnabledOnOsIntegrationTests#aix()
+	 */
+	@Test
+	void aix() {
+		evaluateCondition();
+		assertEnabledOnCurrentOsIf(onAix());
+	}
+
+	/**
+	 * @see EnabledOnOsIntegrationTests#freebsd()
+	 */
+	@Test
+	void freebsd() {
+		evaluateCondition();
+		assertEnabledOnCurrentOsIf(onFreebsd());
+	}
+
+	/**
 	 * @see EnabledOnOsIntegrationTests#linux()
 	 */
 	@Test
@@ -99,6 +120,15 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
+	 * @see EnabledOnOsIntegrationTests#openbsd()
+	 */
+	@Test
+	void openbsd() {
+		evaluateCondition();
+		assertEnabledOnCurrentOsIf(onOpenbsd());
+	}
+
+	/**
 	 * @see EnabledOnOsIntegrationTests#windows()
 	 */
 	@Test
@@ -122,7 +152,8 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertEnabledOnCurrentOsIf(!(onLinux() || onMac() || onSolaris() || onWindows()));
+		assertEnabledOnCurrentOsIf(
+			!(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd || onSolaris() || onWindows()));
 		assertCustomDisabledReasonIs("Disabled on almost every OS");
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
@@ -12,8 +12,11 @@ package org.junit.jupiter.api.condition;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.condition.OS.AIX;
+import static org.junit.jupiter.api.condition.OS.FREEBSD;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.OPENBSD;
 import static org.junit.jupiter.api.condition.OS.OTHER;
 import static org.junit.jupiter.api.condition.OS.SOLARIS;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
@@ -48,8 +51,20 @@ class EnabledOnOsIntegrationTests {
 	}
 
 	@Test
-	@EnabledOnOs({ LINUX, MAC, WINDOWS, SOLARIS, OTHER })
+	@EnabledOnOs({ AIX, FREEBSD, LINUX, MAC, OPENBSD, WINDOWS, SOLARIS, OTHER })
 	void enabledOnEveryOs() {
+	}
+
+	@Test
+	@EnabledOnOs(AIX)
+	void aix() {
+		assertTrue(onAix());
+	}
+
+	@Test
+	@EnabledOnOs(FREEBSD)
+	void freebsd() {
+		assertTrue(onFreebsd());
 	}
 
 	@Test
@@ -71,6 +86,12 @@ class EnabledOnOsIntegrationTests {
 	}
 
 	@Test
+	@EnabledOnOs(OPENBSD)
+	void openbsd() {
+		assertTrue(onOpenbsd());
+	}
+
+	@Test
 	@EnabledOnOs(WINDOWS)
 	void windows() {
 		assertTrue(onWindows());
@@ -85,7 +106,15 @@ class EnabledOnOsIntegrationTests {
 	@Test
 	@EnabledOnOs(value = OTHER, disabledReason = "Disabled on almost every OS")
 	void other() {
-		assertFalse(onLinux() || onMac() || onSolaris() || onWindows());
+		assertFalse(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd || onSolaris() || onWindows());
+	}
+
+	static boolean onAix() {
+		return OS_NAME.contains("aix");
+	}
+
+	static boolean onFreebsd() {
+		return OS_NAME.contains("freebsd");
 	}
 
 	static boolean onLinux() {
@@ -94,6 +123,10 @@ class EnabledOnOsIntegrationTests {
 
 	static boolean onMac() {
 		return OS_NAME.contains("mac");
+	}
+
+	static boolean onOpenbsd() {
+		return OS_NAME.contains("openbsd");
 	}
 
 	static boolean onSolaris() {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsIntegrationTests.java
@@ -106,7 +106,7 @@ class EnabledOnOsIntegrationTests {
 	@Test
 	@EnabledOnOs(value = OTHER, disabledReason = "Disabled on almost every OS")
 	void other() {
-		assertFalse(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd || onSolaris() || onWindows());
+		assertFalse(onAix() || onFreebsd() || onLinux() || onMac() || onOpenbsd() || onSolaris() || onWindows());
 	}
 
 	static boolean onAix() {

--- a/platform-tests/src/test/java/org/junit/jupiter/api/condition/OSTests.java
+++ b/platform-tests/src/test/java/org/junit/jupiter/api/condition/OSTests.java
@@ -41,6 +41,12 @@ class OSTests {
 		}
 
 		@ParameterizedTest
+		@ValueSource(strings = { "FREEBSD", "FreeBSD" })
+		void freebsd(String name) {
+			assertEquals(OS.FREEBSD, OS.parse(name));
+		}
+
+		@ParameterizedTest
 		@ValueSource(strings = { "LINUX", "Linux" })
 		void linux(String name) {
 			assertEquals(OS.LINUX, OS.parse(name));
@@ -50,6 +56,12 @@ class OSTests {
 		@ValueSource(strings = { "MAC", "mac" })
 		void mac(String name) {
 			assertEquals(OS.MAC, OS.parse(name));
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "OPENBSD", "OpenBSD" })
+		void openbsd(String name) {
+			assertEquals(OS.OPENBSD, OS.parse(name));
 		}
 
 		@ParameterizedTest


### PR DESCRIPTION
## Overview

My cross-platform project supports FreeBSD and OpenBSD and I'd like to be able to use the annotations rather than conditionals.  I followed the same format used for AIX.

I see some additional tests in [org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java](https://github.com/junit-team/junit5/blob/e69243ae0f3c68f07d075ac3901c98c375d040f0/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java) and [junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java](https://github.com/junit-team/junit5/blob/e69243ae0f3c68f07d075ac3901c98c375d040f0/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java) that were not updated with the AIX addition so I did not (yet) add these OS's.  Let me know if you'd like me to update these with all three new additions.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
