### PR TITLE
Use `oracle-actions/setup-java` to install JDK

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -29,17 +29,12 @@ jobs:
           fetch-depth: 1
       - name: Set up Test JDK
         uses: ./.github/actions/setup-test-jdk
-      - name: 'Download JDK ${{ matrix.jdk }}'
-        id: download-jdk
-        uses: sormuras/download-jdk@v1
-        with:
-          feature: '${{ matrix.jdk }}'
       - name: 'Set up JDK ${{ matrix.jdk }}'
-        uses: actions/setup-java@v2
+        uses: oracle-actions/setup-java@v1
         with:
-          distribution: 'jdkfile'
-          java-version: '${{ steps.download-jdk.outputs.version }}'
-          jdkFile: '${{ steps.download-jdk.outputs.file }}'
+          website: jdk.java.net
+          release: ${{ matrix.jdk }}
+          version: latest
       - name: 'Prepare JDK${{ matrix.jdk }} env var'
         shell: bash
         run: echo "JDK${{ matrix.jdk }}=$JAVA_HOME" >> $GITHUB_ENV


### PR DESCRIPTION
## Overview

Use https://github.com/oracle-actions/setup-java to download and install an OpenJDK 18 build from https://jdk.java.net

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
