### PR TITLE
Noinspection for !isPresent()

### DIFF
--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
@@ -463,6 +463,7 @@ public final class Events {
 				.findFirst();
 		// @formatter:on
 
+		//noinspection SimplifyOptionalCallChains
 		if (!matchedEvent.isPresent()) {
 			softly.fail("Condition did not match any event: " + condition);
 		}


### PR DESCRIPTION
Avoiding "Can be replaced with 'isEmpty()'" hint, which can't be use here since it's not part of Java 8. The method isEmpty() was added to Optional in Java 11: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Optional.html#isEmpty()

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
