### PR TITLE
Log a warning when no engines are available

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderTestEngineRegistry.java
@@ -41,7 +41,13 @@ public final class ServiceLoaderTestEngineRegistry {
 	public Iterable<TestEngine> loadTestEngines() {
 		Iterable<TestEngine> testEngines = ServiceLoader.load(TestEngine.class,
 			ClassLoaderUtils.getDefaultClassLoader());
-		logger.config(() -> createDiscoveredTestEnginesMessage(testEngines));
+
+		if (testEngines.iterator().hasNext()) {
+			logger.config(() -> createDiscoveredTestEnginesMessage(testEngines));
+		}
+		else {
+			logger.warn(() -> "No TestEngine implementation discovered.");
+		}
 		return testEngines;
 	}
 
@@ -51,10 +57,8 @@ public final class ServiceLoaderTestEngineRegistry {
 		List<String> details = ((Stream<TestEngine>) CollectionUtils.toStream(testEngines))
 				.map(engine -> String.format("%s (%s)", engine.getId(), join(", ", computeAttributes(engine))))
 				.collect(toList());
-		return details.isEmpty()
-				? "No TestEngine implementation discovered."
-				: "Discovered TestEngines with IDs: [" + join(", ", details) + "]";
 		// @formatter:on
+		return "Discovered TestEngines with IDs: [" + join(", ", details) + "]";
 	}
 
 	private List<String> computeAttributes(TestEngine engine) {


### PR DESCRIPTION
## Overview

Logs a warning when no engines are available, either due to not being present on the class path or excluded through a filter.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
