### PR TITLE
Provide module-source-path compiler arg through CommandLineArgumentProvider

### DIFF
--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -154,7 +154,6 @@ val compileModule by tasks.registering(JavaCompile::class) {
 			"-Xlint:all,-requires-automatic,-requires-transitive-automatic",
 			"-Werror", // Terminates compilation when warnings occur.
 			"--module-version", "${project.version}",
-			"--module-source-path", files(modularProjects.map { "${it.projectDir}/src/module" }).asPath
 	))
 	options.compilerArgumentProviders.add(ModulePathArgumentProvider())
 	options.compilerArgumentProviders.addAll(modularProjects.map { PatchModuleArgumentProvider(it) })
@@ -218,7 +217,12 @@ tasks.compileTestJava {
 inner class ModulePathArgumentProvider : CommandLineArgumentProvider, Named {
 	@get:CompileClasspath
 	val modulePath: Provider<Configuration> = configurations.compileClasspath
-	override fun asArguments() = listOf("--module-path", modulePath.get().asPath)
+	override fun asArguments() = listOf(
+                                    "--module-path",
+                                    modulePath.get().asPath,
+                                    "--module-source-path",
+                                    files(modularProjects.map { "${it.projectDir}/src/module" }).asPath
+                                  )
 	@Internal
 	override fun getName() = "module-path"
 }


### PR DESCRIPTION
## Overview

`module-source-path` _compiler argument_ contains absolute paths which break Gradle build cache relocatability.
The already existing ModulePathArgumentProvider can be used to overcome this.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
