### PR TITLE
Fix integration tests by avoiding downloads from archive.apache.org

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ junit4 = { module = "junit:junit", version = { require = "[4.12,)", prefer = "4.
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.4.3" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 log4j-jul = { module = "org.apache.logging.log4j:log4j-jul", version.ref = "log4j" }
+maven = { module = "org.apache.maven:apache-maven", version = "3.8.5" }
 mockito = { module = "org.mockito:mockito-junit-jupiter", version = "4.1.0" }
 opentest4j = { module = "org.opentest4j:opentest4j", version.ref = "opentest4j" }
 picocli = { module = "info.picocli:picocli", version = "4.6.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+ant = "1.10.12"
 apiguardian = "1.1.2"
 asciidoctor-pdf = "1.5.3"
 assertj = "3.21.0"
@@ -14,6 +15,9 @@ opentest4j = "1.2.0"
 surefire = "2.22.2"
 
 [libraries]
+ant = { module = "org.apache.ant:ant", version.ref = "ant" }
+ant-junit = { module = "org.apache.ant:ant-junit", version.ref = "ant" }
+ant-junitlauncher = { module = "org.apache.ant:ant-junitlauncher", version.ref = "ant" }
 apiguardian = { module = "org.apiguardian:apiguardian-api", version.ref = "apiguardian" }
 archunit = { module = "com.tngtech.archunit:archunit-junit5", version = "0.23.0" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
@@ -40,4 +44,5 @@ spock1 = { module = "org.spockframework:spock-core", version = "1.3-groovy-2.5" 
 univocity-parsers = { module = "com.univocity:univocity-parsers", version = "2.9.1" }
 
 [bundles]
+ant = ["ant", "ant-junit", "ant-junitlauncher"]
 log4j = ["log4j-core", "log4j-jul"]

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -11,6 +11,7 @@ javaLibrary {
 }
 
 val thirdPartyJars by configurations.creating
+val antJars by configurations.creating
 
 dependencies {
 	implementation(libs.bartholdy) {
@@ -35,12 +36,19 @@ dependencies {
 	testRuntimeOnly(libs.slf4j.julBinding) {
 		because("provide appropriate SLF4J binding")
 	}
+	testImplementation(libs.ant) {
+		because("we reference Ant's main class")
+	}
 
 	thirdPartyJars(libs.junit4)
 	thirdPartyJars(libs.assertj)
 	thirdPartyJars(libs.apiguardian)
 	thirdPartyJars(libs.hamcrest)
 	thirdPartyJars(libs.opentest4j)
+
+	antJars(platform(projects.junitBom))
+	antJars(libs.bundles.ant)
+	antJars(projects.junitPlatformConsoleStandalone)
 }
 
 tasks.test {
@@ -62,7 +70,8 @@ tasks.test {
 
 	val tempRepoDir: File by rootProject
 	jvmArgumentProviders += MavenRepo(tempRepoDir)
-	jvmArgumentProviders += ThirdPartyJars(thirdPartyJars)
+	jvmArgumentProviders += JarPath(thirdPartyJars)
+	jvmArgumentProviders += JarPath(antJars)
 
 	(options as JUnitPlatformOptions).apply {
 		includeEngines("archunit")
@@ -117,6 +126,6 @@ class JavaHomeDir(project: Project, @Input val version: Int) : CommandLineArgume
 	}
 }
 
-class ThirdPartyJars(@Classpath val configuration: Configuration) : CommandLineArgumentProvider {
-	override fun asArguments() = listOf("-DthirdPartyJars=${configuration.asPath}")
+class JarPath(@Classpath val configuration: Configuration, @Input val key: String = configuration.name) : CommandLineArgumentProvider {
+	override fun asArguments() = listOf("-D${key}=${configuration.asPath}")
 }

--- a/platform-tooling-support-tests/projects/ant-starter/build.xml
+++ b/platform-tooling-support-tests/projects/ant-starter/build.xml
@@ -14,7 +14,6 @@
     <path id="test.classpath">
         <pathelement path="build/test"/>
         <pathelement path="build/main"/>
-        <fileset dir="${ant.home}/lib" includes="*.jar" />
     </path>
 
     <target name="build" description="clean build" depends="clean, test" />

--- a/platform-tooling-support-tests/src/main/java/platform/tooling/support/Request.java
+++ b/platform-tooling-support-tests/src/main/java/platform/tooling/support/Request.java
@@ -37,14 +37,12 @@ public class Request {
 	private static final Path TOOLS = Paths.get("build", "test-tools");
 	public static final Path WORKSPACE = Paths.get("build", "test-workspace");
 
-	private static final String MAVEN_VERSION = "3.6.1";
-
 	public static Builder builder() {
 		return new Builder();
 	}
 
 	public static Maven maven() {
-		return Maven.install(MAVEN_VERSION, TOOLS);
+		return new Maven(Path.of(System.getProperty("mavenDistribution")));
 	}
 
 	private Tool tool;

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
@@ -10,21 +10,19 @@
 
 package platform.tooling.support.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 
-import de.sormuras.bartholdy.tool.Ant;
+import de.sormuras.bartholdy.Tool;
+import de.sormuras.bartholdy.tool.AbstractTool;
+import de.sormuras.bartholdy.tool.Java;
 
+import org.apache.tools.ant.Main;
 import org.junit.jupiter.api.Test;
-import org.opentest4j.TestAbortedException;
-
-import platform.tooling.support.Helper;
-import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
 
 /**
@@ -33,13 +31,11 @@ import platform.tooling.support.Request;
 class AntStarterTests {
 
 	@Test
-	void ant_1_10_6() {
-		var standalone = MavenRepo.jar("junit-platform-console-standalone").getParent();
+	void ant_starter() {
 		var result = Request.builder() //
-				.setTool(Ant.install("1.10.6", Paths.get("build", "test-tools"))) //
+				.setTool(ant()) //
 				.setProject("ant-starter") //
-				.addArguments("-verbose", "-lib", standalone.toAbsolutePath()) //
-				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
+				.addArguments("-verbose") //
 				.build() //
 				.run();
 
@@ -47,14 +43,10 @@ class AntStarterTests {
 
 		assertEquals(0, result.getExitCode());
 		assertEquals("", result.getOutput("err"), "error log isn't empty");
-		assertThat(result.getOutput("out")).contains("Using Java version: 1.8");
 		assertLinesMatch(List.of(">> HEAD >>", //
 			"test.junit.launcher:", //
 			">>>>", //
-			"\\[junitlauncher\\] Test run finished after [\\d]+ ms", //
-			">>>>", //
-			"\\[junitlauncher\\] \\[         5 tests successful      \\]", //
-			"\\[junitlauncher\\] \\[         0 tests failed          \\]", //
+			"\\[junitlauncher\\] Tests run: 5, Failures: 0, Aborted: 0, Skipped: 0, Time elapsed: .+ sec", //
 			">>>>", //
 			"test.console.launcher:", //
 			">>>>", //
@@ -64,6 +56,36 @@ class AntStarterTests {
 			"     \\[java\\] \\[         0 tests failed          \\]", //
 			">> TAIL >>"), //
 			result.getOutputLines("out"));
+	}
+
+	private static Tool ant() {
+		Java java = new Java();
+		return new AbstractTool() {
+			@Override
+			public Path getHome() {
+				return java.getHome();
+			}
+
+			@Override
+			public String getProgram() {
+				return java.getProgram();
+			}
+
+			@Override
+			protected List<String> getToolArguments() {
+				return List.of("-cp", System.getProperty("antJars"), Main.class.getName());
+			}
+
+			@Override
+			public String getName() {
+				return "embedded-ant";
+			}
+
+			@Override
+			public String getVersion() {
+				return Main.getAntVersion();
+			}
+		};
 	}
 
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
@@ -14,11 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
-import java.nio.file.Path;
 import java.util.List;
 
-import de.sormuras.bartholdy.Tool;
-import de.sormuras.bartholdy.tool.AbstractTool;
 import de.sormuras.bartholdy.tool.Java;
 
 import org.apache.tools.ant.Main;
@@ -33,8 +30,9 @@ class AntStarterTests {
 	@Test
 	void ant_starter() {
 		var result = Request.builder() //
-				.setTool(ant()) //
+				.setTool(new Java()) //
 				.setProject("ant-starter") //
+				.addArguments("-cp", System.getProperty("antJars"), Main.class.getName()) //
 				.addArguments("-verbose") //
 				.build() //
 				.run();
@@ -57,35 +55,4 @@ class AntStarterTests {
 			">> TAIL >>"), //
 			result.getOutputLines("out"));
 	}
-
-	private static Tool ant() {
-		Java java = new Java();
-		return new AbstractTool() {
-			@Override
-			public Path getHome() {
-				return java.getHome();
-			}
-
-			@Override
-			public String getProgram() {
-				return java.getProgram();
-			}
-
-			@Override
-			protected List<String> getToolArguments() {
-				return List.of("-cp", System.getProperty("antJars"), Main.class.getName());
-			}
-
-			@Override
-			public String getName() {
-				return "embedded-ant";
-			}
-
-			@Override
-			public String getVersion() {
-				return Main.getAntVersion();
-			}
-		};
-	}
-
 }


### PR DESCRIPTION
## Overview

- Resolve Ant from Maven Central via Gradle
- Resolve Maven from Maven Central via Gradle

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
