### PR TITLE
Use registered ParameterResolver(s) when invoking @MethodSource factory methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
@@ -71,6 +71,8 @@ on GitHub.
 * A subset of the invocations of parameterized or dynamic tests can now be selected via
   the new `IterationSelector` discovery selector when launching the JUnit Platform.
 * `JAVA_19` has been added to the `JRE` enum for use with JRE-based execution conditions.
+* `@MethodSource` factory methods can now accept arguments resolved by registered
+  `ParameterResolver`.
 
 
 [[release-notes-5.9.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1273,7 +1273,7 @@ or external classes.
 
 Factory methods within the test class must be `static` unless the test class is annotated
 with `@TestInstance(Lifecycle.PER_CLASS)`; whereas, factory methods in external classes
-must always be `static`. In addition, such factory methods must not accept any arguments.
+must always be `static`.
 
 Each factory method must generate a _stream_ of _arguments_, and each set of arguments
 within the stream will be provided as the physical arguments for individual invocations
@@ -1332,6 +1332,18 @@ package example;
 
 include::{testDir}/example/ExternalMethodSourceDemo.java[tags=external_MethodSource_example]
 ----
+
+Factory methods can declare parameters, which will be provided by registered implementations
+of `ParameterResolver`. In the following example, the factory method is referenced by its
+name since there's only one such method in the test class. If there are several methods with
+the same name, the factory method needs to be referenced by its fully qualified method name
+(e.g., `@MethodSource("example.MyTests#factoryMethodWithArguments(java.lang.String)")`).
+
+[source,java,indent=0]
+----
+include::{testDir}/example/MethodSourceParameterResolutionTestDemo.java[tags=parameter_resolution_MethodSource_example]
+----
+
 
 [[writing-tests-parameterized-tests-sources-CsvSource]]
 ===== @CsvSource

--- a/documentation/src/test/java/example/MethodSourceParameterResolutionTestDemo.java
+++ b/documentation/src/test/java/example/MethodSourceParameterResolutionTestDemo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MethodSourceParameterResolutionTestDemo {
+
+	// @formatter:off
+	// tag::parameter_resolution_MethodSource_example[]
+	@RegisterExtension
+	static final IntegerResolver integerResolver = new IntegerResolver();
+
+	@ParameterizedTest
+	@MethodSource("factoryMethodWithArguments")
+	void testWithArgumentsProviderUsingParameterResolvers(String argument) {
+		assertTrue(argument.startsWith("2"));
+	}
+
+	static Stream<Arguments> factoryMethodWithArguments(int quantity) {
+		return Stream.of(
+				arguments(quantity + " apple"),
+				arguments(quantity + " lemon")
+		);
+	}
+
+	static class IntegerResolver implements ParameterResolver {
+
+		@Override
+		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			return parameterContext.getParameter().getType() == int.class;
+		}
+
+		@Override
+		public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			return 2;
+		}
+
+	}
+	// end::parameter_resolution_MethodSource_example[]
+	// @formatter:on
+
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -68,7 +68,8 @@ class MethodArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<M
 		String methodParameters = methodParts[2];
 
 		return ReflectionUtils.findMethod(loadRequiredClass(className), methodName, methodParameters).orElseThrow(
-			() -> new JUnitException(format("Could not find method [%s] in class [%s]", methodName, className)));
+			() -> new JUnitException(
+				format("Could not find method [%s(%s)] in class [%s]", methodName, methodParameters, className)));
 	}
 
 	private Method getMethodByShortName(Class<?> testClass, String methodName) {
@@ -76,7 +77,7 @@ class MethodArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<M
 		Preconditions.condition(methods.size() > 0,
 			() -> format("Could not find method [%s] in class [%s]", methodName, testClass.getName()));
 		Preconditions.condition(methods.size() <= 1,
-			() -> format("Several factory method named [%s] were found in class [%s]", methodName,
+			() -> format("Several factory methods named [%s] were found in class [%s]", methodName,
 				testClass.getName()));
 		return methods.get(0);
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -87,8 +87,10 @@ import org.junit.jupiter.params.ParameterizedTest;
  * <p>Factory methods within the test class must be {@code static} unless the
  * {@link org.junit.jupiter.api.TestInstance.Lifecycle#PER_CLASS PER_CLASS}
  * test instance lifecycle mode is used; whereas, factory methods in external
- * classes must always be {@code static}. In any case, factory methods must not
- * declare any parameters.
+ * classes must always be {@code static}.
+ *
+ * <p>Factory methods can declare parameters,which will be provided by registered
+ * implementations of {@link org.junit.jupiter.api.extension.ParameterResolver}.
  *
  * @since 5.0
  * @see Arguments

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -89,7 +89,7 @@ import org.junit.jupiter.params.ParameterizedTest;
  * test instance lifecycle mode is used; whereas, factory methods in external
  * classes must always be {@code static}.
  *
- * <p>Factory methods can declare parameters,which will be provided by registered
+ * <p>Factory methods can declare parameters, which will be provided by registered
  * implementations of {@link org.junit.jupiter.api.extension.ParameterResolver}.
  *
  * @since 5.0

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -257,7 +257,7 @@ class MethodArgumentsProviderTests {
 			() -> provideArguments(ExternalFactoryMethods.class.getName() + "#nonExistentMethod").toArray());
 
 		assertThat(exception.getMessage()).isEqualTo(
-			"Could not find method [nonExistentMethod] in class [" + ExternalFactoryMethods.class.getName() + "]");
+			"Could not find method [nonExistentMethod()] in class [" + ExternalFactoryMethods.class.getName() + "]");
 	}
 
 	@Test
@@ -389,7 +389,7 @@ class MethodArgumentsProviderTests {
 				() -> provideArguments("stringStreamProviderWithOrWithoutParameter").toArray());
 
 			assertThat(exception.getMessage()).isEqualTo(
-				"Several factory method named [stringStreamProviderWithOrWithoutParameter] were found in class [org.junit.jupiter.params.provider.MethodArgumentsProviderTests$TestCase]");
+				"Several factory methods named [stringStreamProviderWithOrWithoutParameter] were found in class [org.junit.jupiter.params.provider.MethodArgumentsProviderTests$TestCase]");
 		}
 
 		@Test


### PR DESCRIPTION
## Overview

This PR adds the possibility to provide arguments to a `@MethodSource` factory method.
They will be resolved by any registered `ParameterResolver` supporting this type of parameter.

Closes #2191

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
