### PR TITLE
Remove BOM dependencies from artifacts defined in the BOM to enable participation in Gradle source dependencies

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
@@ -74,7 +74,8 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* JUnit Jupiter can now participate in builds using a Gradle
+[source dependency](https://blog.gradle.org/introducing-source-dependencies).
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 description = "JUnit Jupiter API"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(libs.opentest4j)
 	api(projects.junitPlatformCommons)
 

--- a/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
+++ b/junit-jupiter-engine/junit-jupiter-engine.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 description = "JUnit Jupiter Engine"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformEngine)
 	api(projects.junitJupiterApi)
 

--- a/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
+++ b/junit-jupiter-migrationsupport/junit-jupiter-migrationsupport.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 description = "JUnit Jupiter Migration Support"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(libs.junit4)
 	api(projects.junitJupiterApi)
 

--- a/junit-jupiter-params/junit-jupiter-params.gradle.kts
+++ b/junit-jupiter-params/junit-jupiter-params.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 description = "JUnit Jupiter Params"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitJupiterApi)
 
 	compileOnlyApi(libs.apiguardian)

--- a/junit-jupiter/junit-jupiter.gradle.kts
+++ b/junit-jupiter/junit-jupiter.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 description = "JUnit Jupiter (Aggregator)"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitJupiterApi)
 	api(projects.junitJupiterParams)
 

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -8,8 +8,6 @@ plugins {
 description = "JUnit Platform Commons"
 
 dependencies {
-	api(platform(projects.junitBom))
-
 	compileOnlyApi(libs.apiguardian)
 }
 

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 description = "JUnit Platform Console"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformReporting)
 
 	compileOnlyApi(libs.apiguardian)

--- a/junit-platform-engine/junit-platform-engine.gradle.kts
+++ b/junit-platform-engine/junit-platform-engine.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 description = "JUnit Platform Engine API"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(libs.opentest4j)
 	api(projects.junitPlatformCommons)
 

--- a/junit-platform-jfr/junit-platform-jfr.gradle.kts
+++ b/junit-platform-jfr/junit-platform-jfr.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 description = "JUnit Platform Flight Recorder Support"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformLauncher)
 
 	compileOnlyApi(libs.apiguardian)

--- a/junit-platform-launcher/junit-platform-launcher.gradle.kts
+++ b/junit-platform-launcher/junit-platform-launcher.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 description = "JUnit Platform Launcher"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformEngine)
 
 	compileOnlyApi(libs.apiguardian)

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 description = "JUnit Platform Reporting"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformLauncher)
 
 	compileOnlyApi(libs.apiguardian)

--- a/junit-platform-runner/junit-platform-runner.gradle.kts
+++ b/junit-platform-runner/junit-platform-runner.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 description = "JUnit Platform Runner"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(libs.junit4)
 	api(projects.junitPlatformLauncher)
 	api(projects.junitPlatformSuiteApi)

--- a/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
+++ b/junit-platform-suite-api/junit-platform-suite-api.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 description = "JUnit Platform Suite API"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformCommons)
 
 	compileOnlyApi(libs.apiguardian)

--- a/junit-platform-suite-commons/junit-platform-suite-commons.gradle.kts
+++ b/junit-platform-suite-commons/junit-platform-suite-commons.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 description = "JUnit Platform Suite Commons"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformLauncher)
 
 	compileOnlyApi(libs.apiguardian)

--- a/junit-platform-suite-engine/junit-platform-suite-engine.gradle.kts
+++ b/junit-platform-suite-engine/junit-platform-suite-engine.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 description = "JUnit Platform Suite Engine"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformEngine)
 	api(projects.junitPlatformSuiteApi)
 

--- a/junit-platform-suite/junit-platform-suite.gradle.kts
+++ b/junit-platform-suite/junit-platform-suite.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 description = "JUnit Platform Suite (Aggregator)"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformSuiteApi)
 	implementation(projects.junitPlatformSuiteEngine)
 

--- a/junit-platform-testkit/junit-platform-testkit.gradle.kts
+++ b/junit-platform-testkit/junit-platform-testkit.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 description = "JUnit Platform Test Kit"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(libs.assertj)
 	api(libs.opentest4j)
 	api(projects.junitPlatformLauncher)

--- a/junit-vintage-engine/junit-vintage-engine.gradle.kts
+++ b/junit-vintage-engine/junit-vintage-engine.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 description = "JUnit Vintage Engine"
 
 dependencies {
-	api(platform(projects.junitBom))
 	api(projects.junitPlatformEngine)
 	api(libs.junit4)
 


### PR DESCRIPTION
## Overview

While investigating solutions to https://github.com/junit-team/junit5/issues/2883 I attempted to use a Gradle [source dependency](https://blog.gradle.org/introducing-source-dependencies) to depend on the latest version of this project since I couldn't find a published snapshot.

The build with a source dependency failed due to what looks like a circular dependency: most artifacts have a dependency on a BOM that declares them (and hence depends on them).

```
Could not determine the dependencies of task ':compileTestKotlin'.
> Could not resolve all task dependencies for configuration ':testCompileClasspath'.
   > Could not find any version that matches org.junit.jupiter:junit-jupiter:5.9.0-SNAPSHOT.
     Searched in the following locations:
       - Git repository at https://github.com/junit-team/junit5.git
     Required by:
         project : > project :junit5:junit-jupiter > project :junit5:junit-bom
```

When I remove the circular dependency with this change the source dependency build succeeds.

Open questions:
- Is there a reason the BOM is used in this way?
- Should I try to add a test to cover this? Could be tricky.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
