### PR TITLE
Only retry deleting directories when cleaning up `TempDir` once

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
@@ -43,7 +43,7 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Only retry deleting directories when cleaning up `@TempDir` once.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -33,6 +33,8 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Predicate;
@@ -69,9 +71,12 @@ import org.junit.platform.commons.util.ReflectionUtils;
  */
 class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterResolver {
 
-	private static final Namespace NAMESPACE = Namespace.create(TempDirectory.class);
+	static final Namespace NAMESPACE = Namespace.create(TempDirectory.class);
 	private static final String KEY = "temp.dir";
 	private static final String TEMP_DIR_PREFIX = "junit";
+
+	// for testing purposes
+	static final String FILE_OPERATIONS_KEY = "file.operations";
 
 	private final JupiterConfiguration configuration;
 
@@ -238,18 +243,23 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				return;
 			}
 
-			SortedMap<Path, IOException> failures = deleteAllFilesAndDirectories();
+			FileOperations fileOperations = executionContext.getStore(NAMESPACE) //
+					.getOrDefault(FILE_OPERATIONS_KEY, FileOperations.class, FileOperations.DEFAULT);
+
+			SortedMap<Path, IOException> failures = deleteAllFilesAndDirectories(fileOperations);
 			if (!failures.isEmpty()) {
 				throw createIOExceptionWithAttachedFailures(failures);
 			}
 		}
 
-		private SortedMap<Path, IOException> deleteAllFilesAndDirectories() throws IOException {
+		private SortedMap<Path, IOException> deleteAllFilesAndDirectories(FileOperations fileOperations)
+				throws IOException {
 			if (Files.notExists(dir)) {
 				return Collections.emptySortedMap();
 			}
 
 			SortedMap<Path, IOException> failures = new TreeMap<>();
+			Set<Path> retriedPaths = new HashSet<>();
 			resetPermissions(dir);
 			Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
 
@@ -280,7 +290,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 				private FileVisitResult deleteAndContinue(Path path) {
 					try {
-						Files.delete(path);
+						fileOperations.delete(path);
 					}
 					catch (NoSuchFileException ignore) {
 						// ignore
@@ -296,17 +306,22 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				}
 
 				private void resetPermissionsAndTryToDeleteAgain(Path path, IOException exception) {
-					try {
-						resetPermissions(path);
-						if (Files.isDirectory(path)) {
-							Files.walkFileTree(path, this);
+					boolean notYetRetried = retriedPaths.add(path);
+					if (notYetRetried) {
+						try {
+							resetPermissions(path);
+							if (Files.isDirectory(path)) {
+								Files.walkFileTree(path, this);
+							}
+							else {
+								fileOperations.delete(path);
+							}
 						}
-						else {
-							Files.delete(path);
+						catch (Exception suppressed) {
+							exception.addSuppressed(suppressed);
 						}
 					}
-					catch (Exception suppressed) {
-						exception.addSuppressed(suppressed);
+					else {
 						failures.put(path, exception);
 					}
 				}
@@ -363,6 +378,14 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		PER_CONTEXT,
 
 		PER_DECLARATION
+
+	}
+
+	interface FileOperations {
+
+		FileOperations DEFAULT = Files::delete;
+
+		void delete(Path path) throws IOException;
 
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/CloseablePathCleanupTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/CloseablePathCleanupTests.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.io.CleanupMode.ALWAYS;
 import static org.junit.jupiter.api.io.CleanupMode.NEVER;
 import static org.junit.jupiter.api.io.CleanupMode.ON_SUCCESS;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,11 +23,15 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.engine.execution.ExtensionValuesStore;
+import org.junit.jupiter.engine.execution.NamespaceAwareStore;
 
 /**
  * Integration tests for cleanup of the {@link TempDirectory} when the {@link CleanupMode} is
@@ -42,6 +47,12 @@ class CloseablePathCleanupTests extends AbstractJupiterTestEngineTests {
 	private final ExtensionContext extensionContext = mock(ExtensionContext.class);
 
 	private TempDirectory.CloseablePath closeablePath;
+
+	@BeforeEach
+	void setUpExtensionContext() {
+		var store = new NamespaceAwareStore(new ExtensionValuesStore(null), Namespace.GLOBAL);
+		when(extensionContext.getStore(any())).thenReturn(store);
+	}
 
 	@AfterEach
 	void cleanupTempDirectory() throws IOException {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -24,6 +24,7 @@ import static org.junit.platform.testkit.engine.EventConditions.finishedWithFail
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.cause;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.suppressed;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,11 +53,15 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.jupiter.engine.Constants;
+import org.junit.jupiter.engine.extension.TempDirectory.FileOperations;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 
 /**
@@ -184,6 +189,17 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 	void canBeUsedViaStaticFieldInsideNestedTestClasses() {
 		executeTestsForClass(StaticTempDirUsageInsideNestedClassTestCase.class).testEvents()//
 				.assertStatistics(stats -> stats.started(2).succeeded(2));
+	}
+
+	@Test
+	void onlyAttemptsToDeleteUndeletableDirectoriesOnce() {
+		var results = executeTestsForClass(UndeletableDirectoryTestCase.class);
+
+		assertSingleFailedTest(results, //
+			instanceOf(IOException.class), //
+			message(it -> it.startsWith("Failed to delete temp directory")), //
+			suppressed(0, instanceOf(IOException.class), message("Simulated failure")), //
+			suppressed(1, instanceOf(IOException.class), message("Simulated failure")));
 	}
 
 	@Nested
@@ -987,6 +1003,21 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 
 		private static Map<String, Path> getTempDirs(TestInfo testInfo) {
 			return tempDirs.computeIfAbsent(testInfo.getDisplayName(), __ -> new LinkedHashMap<>());
+		}
+	}
+
+	static class UndeletableDirectoryTestCase {
+
+		@RegisterExtension
+		Extension injector = (BeforeEachCallback) context -> context //
+				.getStore(TempDirectory.NAMESPACE) //
+				.put(TempDirectory.FILE_OPERATIONS_KEY, (FileOperations) path -> {
+					throw new IOException("Simulated failure");
+				});
+
+		@Test
+		void test(@TempDir Path tempDir) throws Exception {
+			Files.createDirectory(tempDir.resolve("test-sub-dir"));
 		}
 	}
 }


### PR DESCRIPTION
## Overview

Fixes #2883.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
