### PR TITLE
Prune suite discovery result before use

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M1.adoc
@@ -15,7 +15,7 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Fix handling of global post-discovery filters that apply to `@Suite` classes.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -121,15 +121,24 @@ public class TestPlan {
 	public void addInternal(TestIdentifier testIdentifier) {
 		Preconditions.notNull(testIdentifier, "testIdentifier must not be null");
 		allIdentifiers.put(testIdentifier.getUniqueIdObject(), testIdentifier);
-		if (testIdentifier.getParentIdObject().isPresent()) {
-			UniqueId parentId = testIdentifier.getParentIdObject().get();
-			Set<TestIdentifier> directChildren = children.computeIfAbsent(parentId,
-				key -> synchronizedSet(new LinkedHashSet<>(16)));
-			directChildren.add(testIdentifier);
-		}
-		else {
+
+		// Root identifiers. Typically, a test engine.
+		if (!testIdentifier.getParentIdObject().isPresent()) {
 			roots.add(testIdentifier);
+			return;
 		}
+
+		// Identifiers without a parent in this test plan. Could be a test
+		// engine that is used in a suite.
+		UniqueId parentId = testIdentifier.getParentIdObject().get();
+		if (!allIdentifiers.containsKey(parentId)) {
+			roots.add(testIdentifier);
+			return;
+		}
+
+		Set<TestIdentifier> directChildren = children.computeIfAbsent(parentId,
+			key -> synchronizedSet(new LinkedHashSet<>(16)));
+		directChildren.add(testIdentifier);
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -96,7 +96,7 @@ public class EngineDiscoveryOrchestrator {
 	public LauncherDiscoveryResult discover(LauncherDiscoveryRequest request, Phase phase, UniqueId parentId) {
 		Map<TestEngine, TestDescriptor> testEngines = discover(request, phase, parentId::appendEngine);
 		LauncherDiscoveryResult result = new LauncherDiscoveryResult(testEngines, request.getConfigurationParameters());
-		return result.withPrunedEngines();
+		return result.withRetainedEngines(TestDescriptor::containsTests);
 	}
 
 	private Map<TestEngine, TestDescriptor> discover(LauncherDiscoveryRequest request, Phase phase,

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -11,7 +11,6 @@
 package org.junit.platform.launcher.core;
 
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toMap;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.engine.Filter.composeFilters;
 
@@ -21,7 +20,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -96,8 +94,9 @@ public class EngineDiscoveryOrchestrator {
 	 * will not emit start or emit events for engines without tests.
 	 */
 	public LauncherDiscoveryResult discover(LauncherDiscoveryRequest request, Phase phase, UniqueId parentId) {
-		Map<TestEngine, TestDescriptor> result = discover(request, phase, parentId::appendEngine);
-		return new LauncherDiscoveryResult(pruneEngines(result), request.getConfigurationParameters());
+		Map<TestEngine, TestDescriptor> testEngines = discover(request, phase, parentId::appendEngine);
+		LauncherDiscoveryResult result = new LauncherDiscoveryResult(testEngines, request.getConfigurationParameters());
+		return result.withPrunedEngines();
 	}
 
 	private Map<TestEngine, TestDescriptor> discover(LauncherDiscoveryRequest request, Phase phase,
@@ -200,15 +199,6 @@ public class EngineDiscoveryOrchestrator {
 			logger.debug(
 				() -> String.format("The following containers and tests were %s: %s", exclusionReason, displayNames));
 		});
-	}
-
-	private Map<TestEngine, TestDescriptor> pruneEngines(Map<TestEngine, TestDescriptor> result) {
-		// @formatter:off
-		return result.entrySet()
-				.stream()
-				.filter(entry -> TestDescriptor.containsTests(entry.getValue()))
-				.collect(toMap(Entry::getKey, Entry::getValue));
-		// @formatter:on
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -69,10 +69,7 @@ public class EngineExecutionOrchestrator {
 		Preconditions.notNull(engineExecutionListener, "engineExecutionListener must not be null");
 		Preconditions.notNull(testExecutionListener, "testExecutionListener must not be null");
 
-		// #2838: The discovery result from a suite may have been filtered by
-		// post discovery filters from the launcher. The discovery result should
-		// be pruned accordingly
-		InternalTestPlan internalTestPlan = InternalTestPlan.from(discoveryResult.withPrunedEngines());
+		InternalTestPlan internalTestPlan = InternalTestPlan.from(discoveryResult);
 		execute(internalTestPlan, engineExecutionListener, testExecutionListener);
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -10,12 +10,9 @@
 
 package org.junit.platform.launcher.core;
 
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.launcher.core.ListenerRegistry.forEngineExecutionListeners;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -75,17 +72,8 @@ public class EngineExecutionOrchestrator {
 		// #2838: The discovery result from a suite may have been filtered by
 		// post discovery filters from the launcher. The discovery result should
 		// be pruned accordingly
-		InternalTestPlan internalTestPlan = InternalTestPlan.from(pruneEngines(discoveryResult));
+		InternalTestPlan internalTestPlan = InternalTestPlan.from(discoveryResult.withPrunedEngines());
 		execute(internalTestPlan, engineExecutionListener, testExecutionListener);
-	}
-
-	private LauncherDiscoveryResult pruneEngines(LauncherDiscoveryResult discoveryResult) {
-		// @formatter:off
-		Map<TestEngine, TestDescriptor> testEngineDescriptors = discoveryResult.getTestEngines().stream()
-				.filter(engine -> TestDescriptor.containsTests(discoveryResult.getEngineTestDescriptor(engine)))
-				.collect(toMap(identity(), discoveryResult::getEngineTestDescriptor));
-		// @formatter:on
-		return new LauncherDiscoveryResult(testEngineDescriptors, discoveryResult.getConfigurationParameters());
 	}
 
 	private void execute(InternalTestPlan internalTestPlan, EngineExecutionListener parentEngineExecutionListener,

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryResult.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryResult.java
@@ -17,6 +17,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.junit.platform.engine.ConfigurationParameters;
@@ -57,19 +58,19 @@ public class LauncherDiscoveryResult {
 		return this.testEngineDescriptors.values();
 	}
 
-	public LauncherDiscoveryResult withPrunedEngines() {
-		Map<TestEngine, TestDescriptor> prunedTestEngineDescriptors = pruneEngines();
+	public LauncherDiscoveryResult withRetainedEngines(Predicate<? super TestDescriptor> predicate) {
+		Map<TestEngine, TestDescriptor> prunedTestEngineDescriptors = retainEngines(predicate);
 		if (prunedTestEngineDescriptors.size() < testEngineDescriptors.size()) {
 			return new LauncherDiscoveryResult(prunedTestEngineDescriptors, configurationParameters);
 		}
 		return this;
 	}
 
-	private Map<TestEngine, TestDescriptor> pruneEngines() {
+	private Map<TestEngine, TestDescriptor> retainEngines(Predicate<? super TestDescriptor> predicate) {
 		// @formatter:off
 		return testEngineDescriptors.entrySet()
 				.stream()
-				.filter(entry -> TestDescriptor.containsTests(entry.getValue()))
+				.filter(entry -> predicate.test(entry.getValue()))
 				.collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
 		// @formatter:on
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryResult.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryResult.java
@@ -11,6 +11,7 @@
 package org.junit.platform.launcher.core;
 
 import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toMap;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Collection;
@@ -54,6 +55,23 @@ public class LauncherDiscoveryResult {
 
 	Collection<TestDescriptor> getEngineTestDescriptors() {
 		return this.testEngineDescriptors.values();
+	}
+
+	public LauncherDiscoveryResult withPrunedEngines() {
+		Map<TestEngine, TestDescriptor> prunedTestEngineDescriptors = pruneEngines();
+		if (prunedTestEngineDescriptors.size() < testEngineDescriptors.size()) {
+			return new LauncherDiscoveryResult(prunedTestEngineDescriptors, configurationParameters);
+		}
+		return this;
+	}
+
+	private Map<TestEngine, TestDescriptor> pruneEngines() {
+		// @formatter:off
+		return testEngineDescriptors.entrySet()
+				.stream()
+				.filter(entry -> TestDescriptor.containsTests(entry.getValue()))
+				.collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+		// @formatter:on
 	}
 
 }

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
@@ -142,7 +142,11 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 
 	void execute(EngineExecutionListener parentEngineExecutionListener) {
 		parentEngineExecutionListener.executionStarted(this);
-		LauncherDiscoveryResult discoveryResult = this.launcherDiscoveryResult;
+		// #2838: The discovery result from a suite may have been filtered by
+		// post discovery filters from the launcher. The discovery result should
+		// be pruned accordingly
+		LauncherDiscoveryResult discoveryResult = this.launcherDiscoveryResult.withRetainedEngines(
+			getChildren()::contains);
 		TestExecutionSummary summary = launcher.execute(discoveryResult, parentEngineExecutionListener);
 		parentEngineExecutionListener.executionFinished(this, computeTestExecutionResult(summary));
 	}

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -343,7 +343,6 @@ class SuiteEngineTests {
 				.filters(excludeTags("excluded"))
 				.execute()
 				.allEvents()
-				.debug()
 				.assertThatEvents()
 				.haveExactly(1, event(test(JUnit4TestsTestCase.class.getName()), finishedSuccessfully()))
 				.doNotHave(test(TaggedTestTestCase.class.getName()))

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -10,9 +10,9 @@
 
 package org.junit.platform.suite.engine;
 
-import static org.junit.platform.engine.FilterResult.includedIf;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
+import static org.junit.platform.launcher.TagFilter.excludeTags;
 import static org.junit.platform.suite.engine.SuiteEngineDescriptor.ENGINE_ID;
 import static org.junit.platform.testkit.engine.EventConditions.container;
 import static org.junit.platform.testkit.engine.EventConditions.displayName;
@@ -28,7 +28,6 @@ import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.platform.engine.FilterResult;
-import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.PostDiscoveryFilter;
@@ -341,7 +340,7 @@ class SuiteEngineTests {
 		// @formatter:off
 		EngineTestKit.engine(ENGINE_ID)
 				.selectors(selectClass(MultiEngineSuite.class))
-				.filters((PostDiscoveryFilter) object -> includedIf(!object.getTags().contains(TestTag.create("excluded"))))
+				.filters(excludeTags("excluded"))
 				.execute()
 				.allEvents()
 				.debug()

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -347,7 +347,8 @@ class SuiteEngineTests {
 				.debug()
 				.assertThatEvents()
 				.haveExactly(1, event(test(JUnit4TestsTestCase.class.getName()), finishedSuccessfully()))
-				.doNotHave(event(test(TaggedTestTestCase.class.getName())));
+				.doNotHave(test(TaggedTestTestCase.class.getName()))
+				.doNotHave(container("junit-jupiter"));
 		// @formatter:on
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteTestDescriptorTests.java
@@ -59,7 +59,7 @@ class SuiteTestDescriptorTests {
 	}
 
 	@Test
-	void suitDiscoversTestsFromClass() {
+	void suiteDiscoversTestsFromClass() {
 		suite.addDiscoveryRequestFrom(SelectClassesSuite.class);
 		suite.discover();
 		assertEquals(Set.of(jupiterEngineId, testClassId, methodId),

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testcases/JUnit4TestsTestCase.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testcases/JUnit4TestsTestCase.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.engine.testcases;
+
+import org.junit.Test;
+
+public class JUnit4TestsTestCase {
+	@Test
+	public void aTest() {
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testcases/TaggedTestTestCase.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testcases/TaggedTestTestCase.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.engine.testcases;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+public class TaggedTestTestCase {
+	@Test
+	@Tag("excluded")
+	public void test() {
+	}
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/MultiEngineSuite.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/MultiEngineSuite.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.suite.engine.testsuites;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.engine.testcases.JUnit4TestsTestCase;
+import org.junit.platform.suite.engine.testcases.TaggedTestTestCase;
+
+@Suite
+@SelectClasses({ JUnit4TestsTestCase.class, TaggedTestTestCase.class })
+public class MultiEngineSuite {
+
+}


### PR DESCRIPTION
## Overview

Fixes: #2838.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
