### PR TITLE
Set merge strategy to `union` for release note files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *.key binary
 *.jar binary
 *.ttf binary
+release-notes-* merge=union


### PR DESCRIPTION
This would avoid merge conflicts on release note files.