### PR TITLE
Enable Predictive Test Selection for local and PR builds

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -19,7 +19,7 @@ runs:
       with:
         arguments: |
           -Porg.gradle.java.installations.auto-download=false
-          -Dplatform.tooling.support.tests.enabled=true
+          -PenablePredictiveTestSelection=${{ github.event_name == 'pull_request' }}
           "-Dscan.value.GitHub job=${{ github.job }}"
           javaToolchains
           ${{ inputs.arguments }}

--- a/buildSrc/src/main/kotlin/testing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/testing-conventions.gradle.kts
@@ -34,6 +34,9 @@ tasks.withType<Test>().configureEach {
 			}
 		}
 	}
+	predictiveSelection {
+		enabled.set(providers.gradleProperty("enablePredictiveTestSelection").map(String::toBoolean).orElse(true))
+	}
 	systemProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager")
 	// Required until ASM officially supports the JDK 14
 	systemProperty("net.bytebuddy.experimental", true)

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -66,21 +66,14 @@ val unzipMavenDistribution by tasks.registering(Copy::class) {
 }
 
 tasks.test {
-	// Opt-in via system property: '-Dplatform.tooling.support.tests.enabled=true'
-	enabled = System.getProperty("platform.tooling.support.tests.enabled")?.toBoolean() ?: false
 
-	// The following if-block is necessary since Gradle will otherwise
-	// always publish all mavenizedProjects even if this "test" task
-	// is not executed.
-	if (enabled) {
-		// All maven-aware projects must be installed, i.e. published to the local repository
-		val mavenizedProjects: List<Project> by rootProject
-		val tempRepoName: String by rootProject
+	// All maven-aware projects must be installed, i.e. published to the local repository
+	val mavenizedProjects: List<Project> by rootProject
+	val tempRepoName: String by rootProject
 
-		(mavenizedProjects + projects.junitBom.dependencyProject)
-				.map { project -> project.tasks.named("publishAllPublicationsTo${tempRepoName.capitalize()}Repository") }
-				.forEach { dependsOn(it) }
-	}
+	(mavenizedProjects + projects.junitBom.dependencyProject)
+			.map { project -> project.tasks.named("publishAllPublicationsTo${tempRepoName.capitalize()}Repository") }
+			.forEach { dependsOn(it) }
 
 	val tempRepoDir: File by rootProject
 	jvmArgumentProviders += MavenRepo(tempRepoDir)


### PR DESCRIPTION
## Overview

This PR enables [Gradle Enterprise Predictive Test Selection](https://gradle.com/gradle-enterprise-solutions/predictive-test-selection/) ([user manual](https://docs.grdev.net/enterprise/predictive-test-selection/)) for local and PR builds. CI builds on `main` and `release/*` will continue to always execute all tests.