### PR TITLE
the change to fix the issue #2748

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModuleSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ModuleSelector.java
@@ -12,35 +12,180 @@ package org.junit.platform.engine.discovery;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.lang.reflect.Method;
 import java.util.Objects;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.commons.util.ClassUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.commons.util.ToStringBuilder;
 import org.junit.platform.engine.DiscoverySelector;
 
 /**
- * A {@link DiscoverySelector} that selects a module name so that
- * {@link org.junit.platform.engine.TestEngine TestEngines} can discover
- * tests or containers based on modules.
+ * A {@link DiscoverySelector} that selects a {@link Method} or a combination of
+ * class name, method name, and parameter types so that
+ * {@link org.junit.platform.engine.TestEngine TestEngines} can discover tests
+ * or containers based on methods.
  *
- * @since 1.1
- * @see DiscoverySelectors#selectModule(String)
- * @see DiscoverySelectors#selectModules(java.util.Set)
+ * <p>If a Java {@link Method} is provided, the selector will return that
+ * {@linkplain #getJavaMethod() method} and its method name, class name, and
+ * parameter types accordingly. If a {@link Class} and method name, a class name
+ * and method name, or a <em>fully qualified method name</em> is provided,
+ * this selector will only attempt to lazily load the {@link Class} and
+ * {@link Method} if {@link #getJavaClass()} or {@link #getJavaMethod()} is
+ * invoked.
+ *
+ * <p>In this context, a Java {@code Method} means anything that can be referenced
+ * as a {@link Method} on the JVM &mdash; for example, methods from Java classes
+ * or methods from other JVM languages such Groovy, Scala, etc.
+ *
+ * @since 1.0
+ * @see DiscoverySelectors#selectMethod(String)
+ * @see DiscoverySelectors#selectMethod(String, String)
+ * @see DiscoverySelectors#selectMethod(String, String, String)
+ * @see DiscoverySelectors#selectMethod(Class, String)
+ * @see DiscoverySelectors#selectMethod(Class, String, String)
+ * @see DiscoverySelectors#selectMethod(Class, Method)
+ * @see org.junit.platform.engine.support.descriptor.MethodSource
  */
-@API(status = STABLE, since = "1.1")
-public class ModuleSelector implements DiscoverySelector {
+@API(status = STABLE, since = "1.0")
+public class MethodSelector implements DiscoverySelector {
 
-	private final String moduleName;
+	private final String className;
+	private final String methodName;
+	private final String methodParameterTypes;
 
-	ModuleSelector(String moduleName) {
-		this.moduleName = moduleName;
+	private Class<?> javaClass;
+	private Method javaMethod;
+
+	MethodSelector(String className, String methodName) {
+		this(className, methodName, "");
+	}
+
+	MethodSelector(String className, String methodName, String methodParameterTypes) {
+		this.className = className;
+		this.methodName = methodName;
+		this.methodParameterTypes = methodParameterTypes;
+	}
+
+	MethodSelector(Class<?> javaClass, String methodName) {
+		this(javaClass, methodName, "");
+	}
+
+	MethodSelector(Class<?> javaClass, String methodName, String methodParameterTypes) {
+		this.javaClass = javaClass;
+		this.className = javaClass.getName();
+		this.methodName = methodName;
+		this.methodParameterTypes = methodParameterTypes;
+	}
+
+	MethodSelector(Class<?> javaClass, Method method) {
+		this.javaClass = javaClass;
+		this.className = javaClass.getName();
+		this.javaMethod = method;
+		this.methodName = method.getName();
+		this.methodParameterTypes = ClassUtils.nullSafeToString(method.getParameterTypes());
 	}
 
 	/**
-	 * Get the selected module name.
+	 * Get the selected class name.
 	 */
-	public String getModuleName() {
-		return this.moduleName;
+	public String getClassName() {
+		return this.className;
+	}
+
+	/**
+	 * Get the selected method name.
+	 */
+	public String getMethodName() {
+		return this.methodName;
+	}
+
+	/**
+	 * Get the parameter types for the selected method as a {@link String},
+	 * typically a comma-separated list of primitive types, fully qualified
+	 * class names, or array types.
+	 *
+	 * <p>Note: the parameter types are provided as a single string instead of
+	 * a collection in order to allow this selector to be used in a generic
+	 * fashion by various test engines. It is therefore the responsibility of
+	 * the caller of this method to determine how to parse the returned string.
+	 *
+	 * @return the parameter types supplied to this {@code MethodSelector} via
+	 * a constructor or deduced from a {@code Method} supplied via a constructor;
+	 * never {@code null}
+	 */
+	public String getMethodParameterTypes() {
+		return this.methodParameterTypes;
+	}
+
+	/**
+	 * Get the {@link Class} in which the selected {@linkplain #getJavaMethod
+	 * method} is declared, or a subclass thereof.
+	 *
+	 * <p>If the {@link Class} was not provided, but only the name, this method
+	 * attempts to lazily load the {@code Class} based on its name and throws a
+	 * {@link PreconditionViolationException} if the class cannot be loaded.
+	 *
+	 * @see #getJavaMethod()
+	 */
+	public Class<?> getJavaClass() {
+		lazyLoadJavaClass();
+		return this.javaClass;
+	}
+
+	/**
+	 * Get the selected {@link Method}.
+	 *
+	 * <p>If the {@link Method} was not provided, but only the name, this method
+	 * attempts to lazily load the {@code Method} based on its name and throws a
+	 * {@link PreconditionViolationException} if the method cannot be loaded.
+	 *
+	 * @see #getJavaClass()
+	 */
+	public Method getJavaMethod() {
+		lazyLoadJavaMethod();
+		return this.javaMethod;
+	}
+
+	private void lazyLoadJavaClass() {
+		if (this.javaClass == null) {
+			// @formatter:off
+			this.javaClass = ReflectionUtils.tryToLoadClass(this.className).getOrThrow(
+					cause -> new PreconditionViolationException("Could not load class with name: " + this.className, cause));
+			// @formatter:on
+		}
+	}
+
+	private void lazyLoadJavaMethod() {
+		lazyLoadJavaClass();
+
+		if (this.javaMethod == null) {
+			if (StringUtils.isNotBlank(this.methodParameterTypes)) {
+				this.javaMethod = ReflectionUtils.findMethod(this.javaClass, this.methodName,
+						this.methodParameterTypes).orElseThrow(
+						() -> new PreconditionViolationException(String.format(
+								"Could not find method with name [%s] and parameter types [%s] in class [%s].",
+								this.methodName, this.methodParameterTypes, this.javaClass.getName())));
+			}
+			else {
+				this.javaMethod = ReflectionUtils.findMethod(this.javaClass, this.methodName).orElseThrow(
+						() -> new PreconditionViolationException(
+								String.format("Could not find method with name [%s] in class [%s].", this.methodName,
+										this.javaClass.getName())));
+			}
+		}
+	}
+
+	/**
+	 * the method to convert the internal kotlin name to java byte code
+	 * @return the java byte code after converting
+	 */
+	public String kotlinInternalByteCode(){
+		String originalname = this.getMethodName();
+		return originalname.concat("$kotlin");
 	}
 
 	/**
@@ -55,8 +200,10 @@ public class ModuleSelector implements DiscoverySelector {
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-		ModuleSelector that = (ModuleSelector) o;
-		return Objects.equals(this.moduleName, that.moduleName);
+		MethodSelector that = (MethodSelector) o;
+		return Objects.equals(this.className, that.className)//
+				&& Objects.equals(this.methodName, that.methodName)//
+				&& Objects.equals(this.methodParameterTypes, that.methodParameterTypes);
 	}
 
 	/**
@@ -65,12 +212,18 @@ public class ModuleSelector implements DiscoverySelector {
 	@API(status = STABLE, since = "1.3")
 	@Override
 	public int hashCode() {
-		return this.moduleName.hashCode();
+		return Objects.hash(this.className, this.methodName, this.methodParameterTypes);
 	}
 
 	@Override
 	public String toString() {
-		return new ToStringBuilder(this).append("moduleName", this.moduleName).toString();
+		// @formatter:off
+		return new ToStringBuilder(this)
+				.append("className", this.className)
+				.append("methodName", this.methodName)
+				.append("methodParameterTypes", this.methodParameterTypes)
+				.toString();
+		// @formatter:on
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
@@ -13,7 +13,9 @@ package org.junit.platform.engine.support.descriptor;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.util.ClassUtils.nullSafeToString;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Objects;
 
 import org.apiguardian.api.API;
@@ -196,7 +198,7 @@ public class MethodSource implements TestSource {
 		if (this.javaClass == null) {
 			// @formatter:off
 			this.javaClass = ReflectionUtils.tryToLoadClass(this.className).getOrThrow(
-				cause -> new PreconditionViolationException("Could not load class with name: " + this.className, cause));
+					cause -> new PreconditionViolationException("Could not load class with name: " + this.className, cause));
 			// @formatter:on
 		}
 	}
@@ -207,18 +209,74 @@ public class MethodSource implements TestSource {
 		if (this.javaMethod == null) {
 			if (StringUtils.isNotBlank(this.methodParameterTypes)) {
 				this.javaMethod = ReflectionUtils.findMethod(this.javaClass, this.methodName,
-					this.methodParameterTypes).orElseThrow(
+						this.methodParameterTypes).orElseThrow(
 						() -> new PreconditionViolationException(String.format(
-							"Could not find method with name [%s] and parameter types [%s] in class [%s].",
-							this.methodName, this.methodParameterTypes, this.javaClass.getName())));
+								"Could not find method with name [%s] and parameter types [%s] in class [%s].",
+								this.methodName, this.methodParameterTypes, this.javaClass.getName())));
 			}
 			else {
 				this.javaMethod = ReflectionUtils.findMethod(this.javaClass, this.methodName).orElseThrow(
-					() -> new PreconditionViolationException(
-						String.format("Could not find method with name [%s] in class [%s].", this.methodName,
-							this.javaClass.getName())));
+						() -> new PreconditionViolationException(
+								String.format("Could not find method with name [%s] in class [%s].", this.methodName,
+										this.javaClass.getName())));
 			}
 		}
+	}
+
+	/**
+	 * the fuction to get the kotlin function name from the java method
+	 * @param forceConvert the boolean for forcing the method to convert without type check
+	 * @return the result of the kotlin function name
+	 */
+
+	public String getKotlinFunctionName(boolean forceConvert) {
+		Method method = this.javaMethod;
+		String name = method.getName();
+		if (isKotlinClass(method.getDeclaringClass())||forceConvert) {
+			if (isKotlinInternal(method)||(forceConvert&&method.getName().contains("$"))) {
+				name = nameWithoutInternalPart(name);
+			}
+			if (isKotlinSpecial(method)||(forceConvert&&method.getName().contains("-"))) {
+				name = nameWithoutSpecialPart(name);
+			}
+		}
+		return name;
+	}
+
+	public String getKotlinFunctionName() {
+		return getKotlinFunctionName(false);
+	}
+
+	private static boolean isKotlinInternal(Method method) {
+		if ((method.getModifiers() & Modifier.PUBLIC) == 0) {
+			return false;
+		}
+		return method.getName().endsWith("$kotlin");
+	}
+
+	private static boolean isKotlinSpecial(Method method) {
+		String name = isKotlinInternal(method) ? nameWithoutInternalPart(method.getName()): method.getName();
+		int lastIndexOfHyphen = name.lastIndexOf('-');
+		return lastIndexOfHyphen >= 0 && lastIndexOfHyphen == (name.length() - 8);
+	}
+
+	private static boolean isKotlinClass(Class<?> aClass) {
+		for (Annotation annotation : aClass.getDeclaredAnnotations()) {
+			if (annotation.annotationType().getTypeName().equals("kotlin.Metadata")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static String nameWithoutInternalPart(String name) {
+		int lastDollarPosition = name.lastIndexOf('$');
+		return name.substring(0, lastDollarPosition);
+	}
+
+	private static String nameWithoutSpecialPart(String name) {
+		int lastDollarPosition = name.lastIndexOf('-');
+		return name.substring(0, lastDollarPosition);
 	}
 
 	@Override

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/MethodSelectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/MethodSelectorTests.java
@@ -11,6 +11,8 @@
 package org.junit.platform.engine.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -45,7 +47,16 @@ class MethodSelectorTests extends AbstractEqualsAndHashCodeTests {
 		var e = assertThrows(PreconditionViolationException.class, selector::getJavaClass);
 
 		assertThat(e).hasMessage("Could not load class with name: TestClass").hasCauseInstanceOf(
-			ClassNotFoundException.class);
+				ClassNotFoundException.class);
+	}
+
+	@Test
+	void testGetKotlinInternalByteCode(){
+		var selector1 = new MethodSelector("TestClass", "method", "int, boolean");
+		assertAll(()->assertEquals("method$kotlin", selector1.kotlinInternalByteCode()));
+
+		var selector2 = new MethodSelector("TestClass", "method");
+		assertAll(()->assertEquals("method$kotlin", selector2.kotlinInternalByteCode()));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/MethodSourceTests.java
@@ -32,8 +32,8 @@ class MethodSourceTests extends AbstractTestSourceTests {
 	@Override
 	Stream<Serializable> createSerializableInstances() throws Exception {
 		return Stream.of( //
-			MethodSource.from(getMethod("method1")), //
-			MethodSource.from(getMethod("method2")) //
+				MethodSource.from(getMethod("method1")), //
+				MethodSource.from(getMethod("method2")) //
 		);
 	}
 
@@ -82,14 +82,14 @@ class MethodSourceTests extends AbstractTestSourceTests {
 	@Test
 	void instantiationWithNullClassOrMethodShouldThrowPreconditionViolationException() {
 		assertThrows(PreconditionViolationException.class,
-			() -> MethodSource.from(null, String.class.getDeclaredMethod("getBytes")));
+				() -> MethodSource.from(null, String.class.getDeclaredMethod("getBytes")));
 		assertThrows(PreconditionViolationException.class, () -> MethodSource.from(String.class, null));
 	}
 
 	@Test
 	void instantiationWithClassAndMethodShouldResultInACorrectObject() throws Exception {
 		var source = MethodSource.from(String.class,
-			String.class.getDeclaredMethod("lastIndexOf", String.class, int.class));
+				String.class.getDeclaredMethod("lastIndexOf", String.class, int.class));
 		assertEquals(String.class.getName(), source.getClassName());
 		assertEquals("lastIndexOf", source.getMethodName());
 		assertEquals("java.lang.String, int", source.getMethodParameterTypes());
@@ -121,37 +121,37 @@ class MethodSourceTests extends AbstractTestSourceTests {
 	@Test
 	void twoEqualMethodSourceObjectsShouldHaveEqualHashCodes() {
 		assertEquals(MethodSource.from("TestClass1", "testMethod1").hashCode(),
-			MethodSource.from("TestClass1", "testMethod1").hashCode());
+				MethodSource.from("TestClass1", "testMethod1").hashCode());
 	}
 
 	@Test
 	void twoEqualMethodsWithEqualParametersShouldHaveEqualMethodSourceObjects() {
 		assertEquals(MethodSource.from("TestClass1", "testMethod1", "int, String"),
-			MethodSource.from("TestClass1", "testMethod1", "int, String"));
+				MethodSource.from("TestClass1", "testMethod1", "int, String"));
 	}
 
 	@Test
 	void twoUnequalMethodsWithEqualParametersShouldHaveUnequalMethodSourceObjects() {
 		assertNotEquals(MethodSource.from("TestClass1", "testMethod1", "int, String"),
-			MethodSource.from("TestClass1", "testMethod2", "int, String"));
+				MethodSource.from("TestClass1", "testMethod2", "int, String"));
 	}
 
 	@Test
 	void twoEqualMethodsWithUnequalParametersShouldHaveUnequalMethodSourceObjects() {
 		assertNotEquals(MethodSource.from("TestClass1", "testMethod1", "int, String"),
-			MethodSource.from("TestClass1", "testMethod1", "float, int, String"));
+				MethodSource.from("TestClass1", "testMethod1", "float, int, String"));
 	}
 
 	@Test
 	void twoEqualMethodsWithEqualParametersShouldHaveEqualMethodSourceHashCodes() {
 		assertEquals(MethodSource.from("TestClass1", "testMethod1", "int, String").hashCode(),
-			MethodSource.from("TestClass1", "testMethod1", "int, String").hashCode());
+				MethodSource.from("TestClass1", "testMethod1", "int, String").hashCode());
 	}
 
 	@Test
 	void twoEqualMethodsWithUnequalParametersShouldHaveUnequalMethodSourceHashCodes() {
 		assertNotEquals(MethodSource.from("TestClass1", "testMethod1", "int, String").hashCode(),
-			MethodSource.from("TestClass1", "testMethod1", "float, int, String").hashCode());
+				MethodSource.from("TestClass1", "testMethod1", "float, int, String").hashCode());
 	}
 
 	@Test
@@ -255,7 +255,6 @@ class MethodSourceTests extends AbstractTestSourceTests {
 	@Test
 	void getJavaMethodFromStringShouldThrowExceptionIfParameterTypesDoNotMatch() {
 		var source = MethodSource.from(getClass().getName(), "method3", Double.TYPE);
-
 		assertThrows(PreconditionViolationException.class, source::getJavaMethod);
 	}
 
@@ -264,6 +263,18 @@ class MethodSourceTests extends AbstractTestSourceTests {
 		var source = MethodSource.from(getClass().getName(), "methodX");
 
 		assertThrows(PreconditionViolationException.class, source::getJavaMethod);
+	}
+
+	@Test
+	void ConvertToKotlinFunctionName() throws NoSuchMethodException {
+		var normalMethod = getClass().getDeclaredMethod("normalMethod", Integer.TYPE);
+		var internalMethod = getClass().getDeclaredMethod("internalMethod$kotlin", Integer.TYPE);
+
+		var  normal= MethodSource.from(normalMethod);
+		var internal= MethodSource.from(internalMethod);
+
+		assertEquals("normalMethod",normal.getKotlinFunctionName());
+		assertEquals("internalMethod",internal.getKotlinFunctionName(true));
 	}
 
 	private Method getMethod(String name) throws Exception {
@@ -290,4 +301,9 @@ class MethodSourceTests extends AbstractTestSourceTests {
 	void methodVoid() {
 	}
 
+	void normalMethod(int number) {
+	}
+
+	void internalMethod$kotlin(int number) {
+	}
 }


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---it is for fixing the issue #2748. To be honestly, it just finish the internal part. For special type, the 7 characters rule is true. I found it in [the document](https://github.com/Kotlin/KEEP/blob/master/proposals/inline-classes.md#mangling-rules) and [the souce code](https://github.com/JetBrains/kotlin/blob/92d200e093c693b3c06e53a39e0b0973b84c7ec5/compiler/backend/src/org/jetbrains/kotlin/codegen/state/inlineClassManglingUtils.kt). But its hash fuction is difficult, I still didn't get it. Maybe I will continue to fix it when I am available。
It's my first time to try to do this. If there is something wrong, please give me the comment to introduce.

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
