### PR TITLE
Provide a MethodOrderer which enforces unique order(junit-team#2757)

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -244,6 +244,45 @@ public interface MethodOrderer {
 	}
 
 	/**
+	 * {@code MethodOrderer} that sorts methods based on the {@link Order @Order}
+	 * annotation and check whether there is duplicate order
+	 *
+	 * <p>If there are duplicate orders, then throw an {@link Exception}
+	 *
+	 */
+	class EnforcingOrderAnnotation implements MethodOrderer{
+		public EnforcingOrderAnnotation() {
+		}
+		/**
+		 * Sort the methods encapsulated in the supplied
+		 * {@link MethodOrdererContext} based on the {@link Order}
+		 * annotation.
+		 *
+		 * If {@code enforced} and methods have duplicate {@link Order}
+		 * throws an {@link DuplicateOrderException}
+		 */
+		public void orderMethods(MethodOrdererContext context) {
+			try {
+				long methodCnt = context.getMethodDescriptors().size();
+				long distinctOrderCnt = context.getMethodDescriptors()
+						.stream()
+						.mapToInt(OrderAnnotation::getOrder)
+						.distinct()
+						.count();
+				if (methodCnt != distinctOrderCnt)
+					throw new Exception("duplicate order" + "expected: " + methodCnt + " but was: <" + distinctOrderCnt + ">");
+			}catch (Exception e){
+				e.printStackTrace();
+			}
+		}
+
+		@Override
+		public Optional<ExecutionMode> getDefaultExecutionMode() {
+			return MethodOrderer.super.getDefaultExecutionMode();
+		}
+	}
+
+	/**
 	 * {@code MethodOrderer} that orders methods pseudo-randomly.
 	 *
 	 * <h4>Custom Seed</h4>

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.extension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 import static org.junit.jupiter.api.MethodOrderer.Random.RANDOM_SEED_PROPERTY_NAME;
 import static org.junit.jupiter.api.Order.DEFAULT;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.MethodDescriptor;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.MethodOrderer.EnforcingOrderAnnotation;
 import org.junit.jupiter.api.MethodOrderer.Random;
 import org.junit.jupiter.api.MethodOrdererContext;
 import org.junit.jupiter.api.Nested;
@@ -176,6 +178,26 @@ class OrderedMethodTests {
 
 		assertThat(callSequence).containsExactly("test1()", "test2()", "test3()");
 		assertThat(threadNames).hasSize(1);
+	}
+
+	@Test
+	void duplicateOrderer() {
+		var tests = executeTestsInParallel(WithoutTestDuplicateMethodOrderTestCase.class, OrderAnnotation.class);
+
+		tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
+
+		assertThat(callSequence).containsExactly("test1()", "test2()", "test3()","test4()");
+		assertThat(threadNames).hasSize(1);
+	}
+
+	@Test
+	void duplicateOrdererException() {
+		try {
+			var tests = executeTestsInParallel(WithoutTestDuplicateMethodOrderExceptionTestCase.class, EnforcingOrderAnnotation.class);
+		}catch (Exception e){
+			fail("duplicate order");
+			e.printStackTrace();
+		}
 	}
 
 	@Test
@@ -728,6 +750,66 @@ class OrderedMethodTests {
 		@Test
 		@Order(2)
 		void test2() {
+		}
+
+		@Test
+		@Order(3)
+		void test3() {
+		}
+
+		@Test
+		@Order(1)
+		void test1() {
+		}
+
+	}
+
+	static class WithoutTestDuplicateMethodOrderExceptionTestCase {
+
+		@BeforeEach
+		void trackInvocations(TestInfo testInfo) {
+			callSequence.add(testInfo.getDisplayName());
+			threadNames.add(Thread.currentThread().getName());
+		}
+
+		@Test
+		@Order(2)
+		void test2() {
+		}
+
+		@Test
+		@Order(2)
+		void test4() {
+		}
+
+		@Test
+		@Order(3)
+		void test3() {
+		}
+
+		@Test
+		@Order(1)
+		void test1() {
+		}
+
+	}
+
+	static class WithoutTestDuplicateMethodOrderTestCase {
+
+		@BeforeEach
+		void trackInvocations(TestInfo testInfo) {
+			callSequence.add(testInfo.getDisplayName());
+			threadNames.add(Thread.currentThread().getName());
+		}
+
+		@Test
+		@Order(2)
+		void test2() {
+		}
+
+		@Test
+		@Order(4)
+		void test4() {
 		}
 
 		@Test


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
