### PR TITLE
Add feature that allow @RepeatedTest to stop upon failure junit-team#2119

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
@@ -153,6 +153,12 @@ public @interface RepeatedTest {
 	String name() default SHORT_DISPLAY_NAME;
 
 	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	/**
+	 * The flag determining whether the repeated tests will stop after first
+	 * fail occurring.
+	 *
+	 * @return The flag stopFirstFail
+	 */
 	boolean stopFirstFail() default false;
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
@@ -152,4 +152,7 @@ public @interface RepeatedTest {
 	 */
 	String name() default SHORT_DISPLAY_NAME;
 
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	boolean stopFirstFail() default false;
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepetitionInfo.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepetitionInfo.java
@@ -50,4 +50,6 @@ public interface RepetitionInfo {
 	 */
 	int getTotalRepetitions();
 
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	boolean getStopFlag();
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepetitionInfo.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepetitionInfo.java
@@ -50,6 +50,13 @@ public interface RepetitionInfo {
 	 */
 	int getTotalRepetitions();
 
+	/**
+	 * Get The flag determining whether the repeated tests will stop after first
+	 * fail occurring of the corresponding
+	 * {@link RepeatedTest @RepeatedTest} method.
+	 *
+	 * @see RepeatedTest#stopFirstFail
+	 */
 	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
 	boolean getStopFlag();
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -110,11 +110,12 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
             RepeatedTest repeatedTest = AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).get();
             temp = repeatedTest.stopFirstFail();
         }
+		final boolean StopFlag = temp;
 		List<TestTemplateInvocationContextProvider> providers = validateProviders(extensionContext,
 			context.getExtensionRegistry());
 		AtomicInteger invocationIndex = new AtomicInteger();
 		// @formatter:off
-		final boolean StopFlag = temp;
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
 		providers.stream()
 				.flatMap(provider -> provider.provideTestTemplateInvocationContexts(extensionContext))
 				.map(invocationContext -> createInvocationTestDescriptor(invocationContext, invocationIndex.incrementAndGet()))

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
@@ -31,6 +32,7 @@ import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
+import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
@@ -98,6 +100,10 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 			DynamicTestExecutor dynamicTestExecutor) throws Exception {
 
 		ExtensionContext extensionContext = context.getExtensionContext();
+//		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+//		Method testMethod = extensionContext.getRequiredTestMethod();
+//		RepeatedTest repeatedTest = AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).get();
+//		boolean stopFirstFail = repeatedTest.stopFirstFail();
 		List<TestTemplateInvocationContextProvider> providers = validateProviders(extensionContext,
 			context.getExtensionRegistry());
 		AtomicInteger invocationIndex = new AtomicInteger();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
@@ -43,11 +43,13 @@ class RepeatedTestExtension implements TestTemplateInvocationContextProvider {
 		RepeatedTest repeatedTest = AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).get();
 		int totalRepetitions = totalRepetitions(repeatedTest, testMethod);
 		RepeatedTestDisplayNameFormatter formatter = displayNameFormatter(repeatedTest, testMethod, displayName);
-
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		boolean stopFlag = repeatedTest.stopFirstFail();
 		// @formatter:off
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
 		return IntStream
 				.rangeClosed(1, totalRepetitions)
-				.mapToObj(repetition -> new RepeatedTestInvocationContext(repetition, totalRepetitions, formatter));
+				.mapToObj(repetition -> new RepeatedTestInvocationContext(repetition, totalRepetitions, stopFlag, formatter));
 		// @formatter:on
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestInvocationContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestInvocationContext.java
@@ -26,6 +26,8 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 
 	private final int currentRepetition;
 	private final int totalRepetitions;
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	private final boolean stopFlag;
 	private final RepeatedTestDisplayNameFormatter formatter;
 
 	public RepeatedTestInvocationContext(int currentRepetition, int totalRepetitions,
@@ -34,7 +36,19 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 		this.currentRepetition = currentRepetition;
 		this.totalRepetitions = totalRepetitions;
 		this.formatter = formatter;
+		this.stopFlag = false;
 	}
+
+	public RepeatedTestInvocationContext(int currentRepetition, int totalRepetitions, boolean stopFlag,
+										 RepeatedTestDisplayNameFormatter formatter) {
+
+		this.currentRepetition = currentRepetition;
+		this.totalRepetitions = totalRepetitions;
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		this.stopFlag = stopFlag;
+		this.formatter = formatter;
+	}
+
 
 	@Override
 	public String getDisplayName(int invocationIndex) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestInvocationContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestInvocationContext.java
@@ -36,15 +36,16 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 		this.currentRepetition = currentRepetition;
 		this.totalRepetitions = totalRepetitions;
 		this.formatter = formatter;
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
 		this.stopFlag = false;
 	}
 
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
 	public RepeatedTestInvocationContext(int currentRepetition, int totalRepetitions, boolean stopFlag,
 										 RepeatedTestDisplayNameFormatter formatter) {
 
 		this.currentRepetition = currentRepetition;
 		this.totalRepetitions = totalRepetitions;
-		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
 		this.stopFlag = stopFlag;
 		this.formatter = formatter;
 	}
@@ -57,7 +58,8 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 
 	@Override
 	public List<Extension> getAdditionalExtensions() {
-		return singletonList(new RepetitionInfoParameterResolver(this.currentRepetition, this.totalRepetitions));
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		return singletonList(new RepetitionInfoParameterResolver(this.currentRepetition, this.totalRepetitions, this.stopFlag));
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java
@@ -50,7 +50,8 @@ class RepetitionInfoParameterResolver implements ParameterResolver {
 
 	@Override
 	public RepetitionInfo resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		return new DefaultRepetitionInfo(this.currentRepetition, this.totalRepetitions);
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		return new DefaultRepetitionInfo(this.currentRepetition, this.totalRepetitions, this.stopFlag);
 	}
 
 	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java
@@ -26,10 +26,21 @@ class RepetitionInfoParameterResolver implements ParameterResolver {
 
 	private final int currentRepetition;
 	private final int totalRepetitions;
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	private final boolean stopFlag;
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	public RepetitionInfoParameterResolver(int currentRepetition, int totalRepetitions, boolean stopFlag) {
+		this.currentRepetition = currentRepetition;
+		this.totalRepetitions = totalRepetitions;
+		this.stopFlag = stopFlag;
+	}
 
 	public RepetitionInfoParameterResolver(int currentRepetition, int totalRepetitions) {
 		this.currentRepetition = currentRepetition;
 		this.totalRepetitions = totalRepetitions;
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		this.stopFlag = false;
 	}
 
 	@Override
@@ -42,14 +53,30 @@ class RepetitionInfoParameterResolver implements ParameterResolver {
 		return new DefaultRepetitionInfo(this.currentRepetition, this.totalRepetitions);
 	}
 
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	public boolean getStopFlag() {
+		return this.stopFlag;
+	}
+
 	private static class DefaultRepetitionInfo implements RepetitionInfo {
 
 		private final int currentRepetition;
 		private final int totalRepetitions;
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		private final boolean stopFlag;
 
 		DefaultRepetitionInfo(int currentRepetition, int totalRepetitions) {
 			this.currentRepetition = currentRepetition;
 			this.totalRepetitions = totalRepetitions;
+			// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+			this.stopFlag = false;
+		}
+
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		DefaultRepetitionInfo(int currentRepetition, int totalRepetitions, boolean stopFlag) {
+			this.currentRepetition = currentRepetition;
+			this.totalRepetitions = totalRepetitions;
+			this.stopFlag = stopFlag;
 		}
 
 		@Override
@@ -60,6 +87,12 @@ class RepetitionInfoParameterResolver implements ParameterResolver {
 		@Override
 		public int getTotalRepetitions() {
 			return this.totalRepetitions;
+		}
+
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		@Override
+		public boolean getStopFlag() {
+			return this.stopFlag;
 		}
 
 		@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -41,6 +41,22 @@ public interface TestDescriptor {
 	UniqueId getUniqueId();
 
 	/**
+	 * Get the test execution result for this descriptor.
+	 *
+	 * @return the {@code TestExecutionResult} for this descriptor; never
+	 * {@code null}
+	 */
+	TestExecutionResult getTestExecutionResult();
+
+	/**
+	 * Set the test execution result for this descriptor.
+	 *
+	 * @param result the {@code TestExecutionResult} of the current testDescriptor; never
+	 * {@code null}
+	 */
+	void setTestExecutionResult(TestExecutionResult result);
+
+	/**
 	 * Get the display name for this descriptor.
 	 *
 	 * <p>A <em>display name</em> is a human-readable name for a test or

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -20,10 +20,7 @@ import java.util.Set;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.TestSource;
-import org.junit.platform.engine.TestTag;
-import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.*;
 
 /**
  * Abstract base implementation of {@link TestDescriptor} that may be used by
@@ -40,6 +37,9 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	private final UniqueId uniqueId;
 
 	private final String displayName;
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	private TestExecutionResult result;
 
 	private final TestSource source;
 
@@ -98,6 +98,18 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	@Override
 	public final String getDisplayName() {
 		return this.displayName;
+	}
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	@Override
+	public final TestExecutionResult getTestExecutionResult() {
+		return result;
+	}
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+	@Override
+	public final void setTestExecutionResult(TestExecutionResult result) {
+		this.result = result;
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -193,6 +193,8 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 				() -> String.format("Failed to invoke nodeFinished() on Node %s", testDescriptor.getUniqueId()));
 		}
 		taskContext.getListener().executionFinished(testDescriptor, throwableCollector.toTestExecutionResult());
+//		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+//		testDescriptor.setTestExecutionResult(throwableCollector.toTestExecutionResult());
 		throwableCollector = null;
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -193,8 +193,8 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 				() -> String.format("Failed to invoke nodeFinished() on Node %s", testDescriptor.getUniqueId()));
 		}
 		taskContext.getListener().executionFinished(testDescriptor, throwableCollector.toTestExecutionResult());
-//		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
-//		testDescriptor.setTestExecutionResult(throwableCollector.toTestExecutionResult());
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2119
+		testDescriptor.setTestExecutionResult(throwableCollector.toTestExecutionResult());
 		throwableCollector = null;
 	}
 


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---
Add a new field stopFirstFail to **allow @RepeatedTest to stop upon failure**, but the implement is to skip the renaining tests when it encounters a failure, rather than stop them.

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
