### PR TITLE
Add Assumptions.assumeDoesNotThrow

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -258,9 +258,8 @@ public class Assumptions {
 
 	private static void throwTestAbortedException(String message) {
 		throw new TestAbortedException(
-				StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
+			StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
 	}
-
 
 	// --- assumingDoesNotThrow --------------------------------------------------
 
@@ -308,7 +307,7 @@ public class Assumptions {
 	 * the {@code TestAbortedException} if the execution throws an exception
 	 * @throws TestAbortedException if the execution of the executable throws an exception
 	 */
-	public static void assumeDoesNotThrow(Executable executable, Object messageOrSupplier) throws TestAbortedException{
+	public static void assumeDoesNotThrow(Executable executable, Object messageOrSupplier) throws TestAbortedException {
 		try {
 			executable.execute();
 		}
@@ -366,7 +365,8 @@ public class Assumptions {
 	 * @return the supplier's result if the assumption passes
 	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 */
-	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier, Object messageOrSupplier) throws TestAbortedException{
+	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier, Object messageOrSupplier)
+			throws TestAbortedException {
 		try {
 			return supplier.get();
 		}
@@ -374,7 +374,8 @@ public class Assumptions {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(t);//?  might not need finally
 			//throwTestAbortedException(nullSafeGet(messageOrSupplier));
 			String message = nullSafeGet(messageOrSupplier);
-			throw new TestAbortedException(StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
+			throw new TestAbortedException(
+				StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
 		}
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -258,7 +258,7 @@ public class Assumptions {
 
 	private static void throwTestAbortedException(String message) {
 		throw new TestAbortedException(
-		    StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
+			StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
 	}
 
 	// --- assumingDoesNotThrow --------------------------------------------------

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -11,14 +11,17 @@
 package org.junit.jupiter.api;
 
 import static org.apiguardian.api.API.Status.STABLE;
+import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.opentest4j.TestAbortedException;
 
 /**
@@ -255,7 +258,123 @@ public class Assumptions {
 
 	private static void throwTestAbortedException(String message) {
 		throw new TestAbortedException(
-			StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
+				StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
 	}
 
+
+	// --- assumingDoesNotThrow --------------------------------------------------
+
+	// --- executable ---
+
+	/**
+	 * Validate that execution of the supplied executable does not throw any kind of exception.
+	 *
+	 * @param executable the executable which to check whether it throws an exception when executed
+	 * @throws TestAbortedException if the execution of the executable throws an exception
+	 */
+	public static void assumeDoesNotThrow(Executable executable) {
+		assumeDoesNotThrow(executable, (Object) null);
+	}
+
+	/**
+	 * Validate that execution of the supplied executable does not throw any kind of exception.
+	 *
+	 * @param executable the executable which to check whether it throws an exception when executed
+	 * @param message the message to be included in the {@code TestAbortedException}
+	 * if the execution throws an exception
+	 * @throws TestAbortedException if the execution of the executable throws an exception
+	 */
+	public static void assumeDoesNotThrow(Executable executable, String message) {
+		assumeDoesNotThrow(executable, (Object) message);
+	}
+
+	/**
+	 * Validate that execution of the supplied executable does not throw any kind of exception.
+	 *
+	 * @param executable the executable which to check whether it throws an exception when executed
+	 * @param messageSupplier the supplier of the message to be included in
+	 * the {@code TestAbortedException} if the execution throws an exception
+	 * @throws TestAbortedException if the execution of the executable throws an exception
+	 */
+	public static void assumeDoesNotThrow(Executable executable, Supplier<String> messageSupplier) {
+		assumeDoesNotThrow(executable, (Object) messageSupplier);
+	}
+
+	/**
+	 * Validate that execution of the supplied executable does not throw any kind of exception.
+	 *
+	 * @param executable the executable which to check whether it throws an exception when executed
+	 * @param messageOrSupplier the message itself or the supplier of the message to be included in
+	 * the {@code TestAbortedException} if the execution throws an exception
+	 * @throws TestAbortedException if the execution of the executable throws an exception
+	 */
+	public static void assumeDoesNotThrow(Executable executable, Object messageOrSupplier) throws TestAbortedException{
+		try {
+			executable.execute();
+		}
+		catch (Throwable t) {
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);//?  might not need finally
+			throwTestAbortedException(nullSafeGet(messageOrSupplier));
+		}
+	}
+
+	// --- supplier ---
+
+	/**
+	 * Validate that execution of the supplied supplier does not throw any kind of exception.
+	 *
+	 * @param supplier the supplied supplier which to check whether it throws an exception when executed
+	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
+	 * @return the supplier's result if the assumption passes
+	 */
+	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier) {
+		return assumeDoesNotThrow(supplier, (Object) null);
+	}
+
+	/**
+	 * Validate that execution of the supplied supplier does not throw any kind of exception.
+	 *
+	 * @param supplier the supplied supplier which to check whether it throws an exception when executed
+	 * @param message the message to be included in the {@code TestAbortedException}
+	 * if the execution throws an exception
+	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
+	 * @return the supplier's result if the assumption passes
+	 */
+	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier, String message) {
+		return assumeDoesNotThrow(supplier, (Object) message);
+	}
+
+	/**
+	 * Validate that execution of the supplied supplier does not throw any kind of exception.
+	 *
+	 * @param supplier the supplied supplier which to check whether it throws an exception when executed
+	 * @param messageSupplier the supplier of the message to be included in
+	 * the {@code TestAbortedException} if the execution throws an exception
+	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
+	 * @return the supplier's result if the assumption passes
+	 */
+	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier, Supplier<String> messageSupplier) {
+		return assumeDoesNotThrow(supplier, (Object) messageSupplier);
+	}
+
+	/**
+	 * Validate that execution of the supplied supplier does not throw any kind of exception.
+	 *
+	 * @param supplier the supplier which to check whether it throws an exception when executed
+	 * @param messageOrSupplier the message itself or the supplier of the message to be included in
+	 * the {@code TestAbortedException} if the execution throws an exception
+	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
+	 * @return the supplier's result if the assumption passes
+	 */
+	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier, Object messageOrSupplier) throws TestAbortedException{
+		try {
+			return supplier.get();
+		}
+		catch (Throwable t) {
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);//?  might not need finally
+			//throwTestAbortedException(nullSafeGet(messageOrSupplier));
+			String message = nullSafeGet(messageOrSupplier);
+			throw new TestAbortedException(StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
+		}
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -375,6 +375,7 @@ public class Assumptions {
 			String message = nullSafeGet(messageOrSupplier);
 			throw new TestAbortedException(
 				StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
+
 		}
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -324,8 +324,8 @@ public class Assumptions {
 	 * Validate that execution of the supplied supplier does not throw any kind of exception.
 	 *
 	 * @param supplier the supplied supplier which to check whether it throws an exception when executed
-	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 * @return the supplier's result if the assumption passes
+	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 */
 	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier) {
 		return assumeDoesNotThrow(supplier, (Object) null);
@@ -337,8 +337,8 @@ public class Assumptions {
 	 * @param supplier the supplied supplier which to check whether it throws an exception when executed
 	 * @param message the message to be included in the {@code TestAbortedException}
 	 * if the execution throws an exception
-	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 * @return the supplier's result if the assumption passes
+	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 */
 	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier, String message) {
 		return assumeDoesNotThrow(supplier, (Object) message);
@@ -350,8 +350,8 @@ public class Assumptions {
 	 * @param supplier the supplied supplier which to check whether it throws an exception when executed
 	 * @param messageSupplier the supplier of the message to be included in
 	 * the {@code TestAbortedException} if the execution throws an exception
-	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 * @return the supplier's result if the assumption passes
+	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 */
 	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier, Supplier<String> messageSupplier) {
 		return assumeDoesNotThrow(supplier, (Object) messageSupplier);
@@ -363,8 +363,8 @@ public class Assumptions {
 	 * @param supplier the supplier which to check whether it throws an exception when executed
 	 * @param messageOrSupplier the message itself or the supplier of the message to be included in
 	 * the {@code TestAbortedException} if the execution throws an exception
-	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 * @return the supplier's result if the assumption passes
+	 * @throws TestAbortedException if the execution of the supplied supplier throws an exception
 	 */
 	public static <T> T assumeDoesNotThrow(ThrowingSupplier<T> supplier, Object messageOrSupplier) throws TestAbortedException{
 		try {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -258,7 +258,7 @@ public class Assumptions {
 
 	private static void throwTestAbortedException(String message) {
 		throw new TestAbortedException(
-			StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
+		    StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
 	}
 
 	// --- assumingDoesNotThrow --------------------------------------------------
@@ -312,7 +312,7 @@ public class Assumptions {
 			executable.execute();
 		}
 		catch (Throwable t) {
-			UnrecoverableExceptions.rethrowIfUnrecoverable(t);//?  might not need finally
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			throwTestAbortedException(nullSafeGet(messageOrSupplier));
 		}
 	}
@@ -371,8 +371,7 @@ public class Assumptions {
 			return supplier.get();
 		}
 		catch (Throwable t) {
-			UnrecoverableExceptions.rethrowIfUnrecoverable(t);//?  might not need finally
-			//throwTestAbortedException(nullSafeGet(messageOrSupplier));
+			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			String message = nullSafeGet(messageOrSupplier);
 			throw new TestAbortedException(
 				StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
@@ -10,23 +10,23 @@
 
 package org.junit.jupiter.api;
 
-import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.api.function.ThrowingSupplier;
-import org.opentest4j.TestAbortedException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeDoesNotThrow;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumingThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.FutureTask;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeDoesNotThrow;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumingThat;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.opentest4j.TestAbortedException;
 
 /**
  * Unit tests for JUnit Jupiter {@link Assumptions}.

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
@@ -336,8 +336,7 @@ class AssumptionsTests {
 			expectTestAbortedException();
 		}
 		catch (TestAbortedException ex) {
-			assertMessageEquals(ex,
-					"Assumption failed: Custom message");
+			assertMessageEquals(ex, "Assumption failed: Custom message");
 		}
 	}
 
@@ -381,9 +380,6 @@ class AssumptionsTests {
 			assertMessageEquals(ex, "Assumption failed: Custom message");
 		}
 	}
-
-
-
 
 	// --- supplier ------------------------------------------------------------
 	@Test
@@ -476,7 +472,7 @@ class AssumptionsTests {
 		catch (Throwable ex) {
 			assertTrue(ex instanceof TestAbortedException);
 			assertMessageEquals((TestAbortedException) ex,
-					msg == null ? "Assumption failed" : "Assumption failed: " + msg);
+				msg == null ? "Assumption failed" : "Assumption failed: " + msg);
 		}
 	}
 
@@ -487,7 +483,7 @@ class AssumptionsTests {
 	private static void assertMessageEquals(TestAbortedException ex, String msg) throws AssertionError {
 		if (!msg.equals(ex.getMessage())) {
 			throw new AssertionError(
-					"Message in TestAbortedException should be [" + msg + "], but was [" + ex.getMessage() + "].");
+				"Message in TestAbortedException should be [" + msg + "], but was [" + ex.getMessage() + "].");
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
@@ -204,7 +204,7 @@ class AssumptionsTests {
 
 	// --- assummeDoesNotThrow --------------------------------------------------
 	@Test
-	void assumeDoesNotThrowWithMethodReferenceForNonVoidReturnType(){
+	void assumeDoesNotThrowWithMethodReferenceForNonVoidReturnType() {
 		FutureTask<String> future = new FutureTask<>(() -> {
 			return "foo";
 		});
@@ -227,7 +227,7 @@ class AssumptionsTests {
 	}
 
 	@Test
-	void assumeDoesNotThrowWithMethodReferenceForVoidReturnType(){
+	void assumeDoesNotThrowWithMethodReferenceForVoidReturnType() {
 		var foo = new Foo();
 
 		// Note: the following does not compile since the compiler cannot properly
@@ -326,7 +326,7 @@ class AssumptionsTests {
 			assertMessageEquals(ex, "Assumption failed");
 		}
 	}
-	///
+
 	@Test
 	void assumeDoesNotThrowWithExecutableThatThrowsAnExceptionWithMessageString() {
 		try {
@@ -351,8 +351,7 @@ class AssumptionsTests {
 			expectTestAbortedException();
 		}
 		catch (TestAbortedException ex) {
-			assertMessageEquals(ex,
-					"Assumption failed: Custom message");
+			assertMessageEquals(ex, "Assumption failed: Custom message");
 		}
 	}
 
@@ -365,8 +364,7 @@ class AssumptionsTests {
 			expectTestAbortedException();
 		}
 		catch (TestAbortedException ex) {
-			assertMessageEquals(ex,
-					"Assumption failed: Custom message");
+			assertMessageEquals(ex, "Assumption failed: Custom message");
 		}
 	}
 
@@ -380,8 +378,7 @@ class AssumptionsTests {
 			expectTestAbortedException();
 		}
 		catch (TestAbortedException ex) {
-			assertMessageEquals(ex,
-					"Assumption failed: Custom message");
+			assertMessageEquals(ex, "Assumption failed: Custom message");
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
@@ -10,21 +10,23 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
-import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assumptions.*;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.opentest4j.TestAbortedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.FutureTask;
 
-import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.api.function.ThrowingSupplier;
-import org.opentest4j.AssertionFailedError;
-import org.opentest4j.TestAbortedException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeDoesNotThrow;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumingThat;
 
 /**
  * Unit tests for JUnit Jupiter {@link Assumptions}.

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
@@ -10,18 +10,20 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.jupiter.api.Assumptions.assumingThat;
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
+import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assumptions.*;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.FutureTask;
 
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
 /**
@@ -30,6 +32,11 @@ import org.opentest4j.TestAbortedException;
  * @since 5.0
  */
 class AssumptionsTests {
+
+	private static final Executable nix = () -> {
+	};
+
+	private static final ThrowingSupplier<String> something = () -> "enigma";
 
 	// --- assumeTrue ----------------------------------------------------
 
@@ -195,6 +202,273 @@ class AssumptionsTests {
 		}));
 	}
 
+	// --- assummeDoesNotThrow --------------------------------------------------
+	@Test
+	void assumeDoesNotThrowWithMethodReferenceForNonVoidReturnType(){
+		FutureTask<String> future = new FutureTask<>(() -> {
+			return "foo";
+		});
+		future.run();
+
+		String result;
+
+		// Current compiler's type inference: does NOT compile since the compiler
+		// cannot figure out which overloaded variant of assumeDoesNotThrow() to
+		// invoke (i.e., Executable vs. ThrowingSupplier).
+		//
+		// result = assumeDoesNotThrow(future::get);
+
+		// Explicitly as an Executable
+		assumeDoesNotThrow((Executable) future::get);
+
+		// Explicitly as a ThrowingSupplier
+		result = assumeDoesNotThrow((ThrowingSupplier<String>) future::get);
+		assertEquals("foo", result);
+	}
+
+	@Test
+	void assumeDoesNotThrowWithMethodReferenceForVoidReturnType(){
+		var foo = new Foo();
+
+		// Note: the following does not compile since the compiler cannot properly
+		// perform type inference for a method reference for an overloaded method
+		// that has a void return type such as Foo.overloaded(...), IFF the
+		// compiler is simultaneously trying to pick which overloaded variant
+		// of assumeDoesNotThrow() to invoke.
+		//
+		// assumeDoesNotThrow(foo::overloaded);
+
+		// Current compiler's type inference
+		assumeDoesNotThrow(foo::normalMethod);
+		// Explicitly as an Executable
+		assumeDoesNotThrow((Executable) foo::normalMethod);
+		assumeDoesNotThrow((Executable) foo::overloaded);
+	}
+
+	// --- executable ----------------------------------------------------------
+
+	@Test
+	void assumeDoesNotThrowAnythingWithExecutable() {
+		assumeDoesNotThrow(nix);
+	}
+
+	@Test
+	void assumeDoesNotThrowAnythingWithExecutableAndMessage() {
+		assumeDoesNotThrow(nix, "message");
+	}
+
+	@Test
+	void assumeDoesNotThrowAnythingWithExecutableAndMessageSupplier() {
+		assumeDoesNotThrow(nix, () -> "message");
+	}
+
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsACheckedException() {
+		try {
+			assumeDoesNotThrow((Executable) () -> {
+				throw new IOException();
+			});
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsACheckedExceptionWithMessage() {
+		String message = "Checked exception message";
+		try {
+			assumeDoesNotThrow((Executable) () -> {
+				throw new IOException(message);
+			});
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsARuntimeException() {
+		try {
+			assumeDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException();
+			});
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsARuntimeExceptionWithMessage() {
+		String message = "Runtime exception message";
+		try {
+			assumeDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException(message);
+			});
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsAnError() {
+		try {
+			assumeDoesNotThrow((Executable) AssertionTestUtils::recurseIndefinitely);
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed");
+		}
+	}
+	///
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsAnExceptionWithMessageString() {
+		try {
+			assumeDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException();
+			}, "Custom message");
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex,
+					"Assumption failed: Custom message");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsAnExceptionWithMessageWithMessageString() {
+		String message = "Runtime exception message";
+		try {
+			assumeDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException(message);
+			}, "Custom message");
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex,
+					"Assumption failed: Custom message");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsAnExceptionWithMessageSupplier() {
+		try {
+			assumeDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException();
+			}, () -> "Custom message");
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex,
+					"Assumption failed: Custom message");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithExecutableThatThrowsAnExceptionWithMessageWithMessageSupplier() {
+		String message = "Runtime exception message";
+		try {
+			assumeDoesNotThrow((Executable) () -> {
+				throw new IllegalStateException(message);
+			}, () -> "Custom message");
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex,
+					"Assumption failed: Custom message");
+		}
+	}
+
+
+
+
+	// --- supplier ------------------------------------------------------------
+	@Test
+	void assumeDoesNotThrowAnythingWithSupplier() {
+		assertEquals("enigma", assumeDoesNotThrow(something));
+	}
+
+	@Test
+	void assumeDoesNotThrowAnythingWithSupplierAndMessage() {
+		assertEquals("enigma", assumeDoesNotThrow(something, "message"));
+	}
+
+	@Test
+	void assumeDoesNotThrowAnythingWithSupplierAndMessageSupplier() {
+		assertEquals("enigma", assumeDoesNotThrow(something, () -> "message"));
+	}
+
+	@Test
+	void assumeDoesNotThrowWithSupplierThatThrowsACheckedException() {
+		try {
+			assumeDoesNotThrow((ThrowingSupplier<?>) () -> {
+				throw new IOException();
+			});
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithSupplierThatThrowsARuntimeException() {
+		try {
+			assumeDoesNotThrow((ThrowingSupplier<?>) () -> {
+				throw new IllegalStateException();
+			});
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithSupplierThatThrowsAnError() {
+		try {
+			assumeDoesNotThrow((ThrowingSupplier<?>) () -> {
+				throw new StackOverflowError();
+			});
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithSupplierThatThrowsAnExceptionWithMessageString() {
+		try {
+			assumeDoesNotThrow((ThrowingSupplier<?>) () -> {
+				throw new IllegalStateException();
+			}, "Custom message");
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed: Custom message");
+		}
+	}
+
+	@Test
+	void assumeDoesNotThrowWithSupplierThatThrowsAnExceptionWithMessageSupplier() {
+		try {
+			assumeDoesNotThrow((ThrowingSupplier<?>) () -> {
+				throw new IllegalStateException();
+			}, () -> "Custom message");
+			expectTestAbortedException();
+		}
+		catch (TestAbortedException ex) {
+			assertMessageEquals(ex, "Assumption failed: Custom message");
+		}
+	}
+
 	// -------------------------------------------------------------------
 
 	private static void assertAssumptionFailure(String msg, Executable executable) {
@@ -205,7 +479,7 @@ class AssumptionsTests {
 		catch (Throwable ex) {
 			assertTrue(ex instanceof TestAbortedException);
 			assertMessageEquals((TestAbortedException) ex,
-				msg == null ? "Assumption failed" : "Assumption failed: " + msg);
+					msg == null ? "Assumption failed" : "Assumption failed: " + msg);
 		}
 	}
 
@@ -216,8 +490,24 @@ class AssumptionsTests {
 	private static void assertMessageEquals(TestAbortedException ex, String msg) throws AssertionError {
 		if (!msg.equals(ex.getMessage())) {
 			throw new AssertionError(
-				"Message in TestAbortedException should be [" + msg + "], but was [" + ex.getMessage() + "].");
+					"Message in TestAbortedException should be [" + msg + "], but was [" + ex.getMessage() + "].");
 		}
+	}
+
+	// -------------------------------------------------------------------------
+
+	private static class Foo {
+
+		void normalMethod() {
+		}
+
+		void overloaded() {
+		}
+
+		@SuppressWarnings("unused")
+		void overloaded(int i) {
+		}
+
 	}
 
 }


### PR DESCRIPTION
## Overview

I added assumeDoesNotThrow in Assumptions.java according to the behavior of assertDoesNotThrow in Assertions.java, which also support both ThrowingSupplier and Executable. I've also added related tests in AssumptionsTests.java, parallel to the tests in AssertDoesNotThrowAssertionsTests.java. Hopefully, this could be helpful to your work. My pleasure to contribute!

Resolves #2482 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
