### PR TITLE
Declarative timeout does not interrupt code running in infinite loop #2087

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which
@@ -41,36 +41,34 @@ import org.apiguardian.api.API;
  * default timeout is defined via one of the following configuration parameters:
  *
  * <dl>
- *     <dt>{@value #DEFAULT_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.default}</dt>
  *     <dd>Default timeout for all testable and lifecycle methods</dd>
- *     <dt>{@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.testable.method.default}</dt>
  *     <dd>Default timeout for all testable methods</dd>
- *     <dt>{@value #DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.test.method.default}</dt>
  *     <dd>Default timeout for {@link Test @Test} methods</dd>
- *     <dt>{@value #DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.testtemplate.method.default}</dt>
  *     <dd>Default timeout for {@link TestTemplate @TestTemplate} methods</dd>
- *     <dt>{@value DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.testfactory.method.default}</dt>
  *     <dd>Default timeout for {@link TestFactory @TestFactory} methods</dd>
- *     <dt>{@value DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.lifecycle.method.default}</dt>
  *     <dd>Default timeout for all lifecycle methods</dd>
- *     <dt>{@value #DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.beforeall.method.default}</dt>
  *     <dd>Default timeout for {@link BeforeAll @BeforeAll} methods</dd>
- *     <dt>{@value #DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.beforeeach.method.default}</dt>
  *     <dd>Default timeout for {@link BeforeEach @BeforeEach} methods</dd>
- *     <dt>{@value #DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.aftereach.method.default}</dt>
  *     <dd>Default timeout for {@link AfterEach @AfterEach} methods</dd>
- *     <dt>{@value #DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME}</dt>
+ *     <dt>{@code junit.jupiter.execution.timeout.afterall.method.default}</dt>
  *     <dd>Default timeout for {@link AfterAll @AfterAll} methods</dd>
  * </dl>
  *
  * <p>More specific configuration parameters override less specific ones. For
- * example, {@value #DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME}
- * overrides {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME}
- * which overrides {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}.
+ * example, {@code junit.jupiter.execution.timeout.test.method.default}
+ * overrides {@code junit.jupiter.execution.timeout.testable.method.default}
+ * which overrides {@code junit.jupiter.execution.timeout.default}.
  *
- * <h3 id="supported-values">Supported Values</h3>
- *
- * <p>Values for timeouts must be in the following, case-insensitive format:
+ * <p>Values must be in the following, case-insensitive format:
  * {@code <number> [ns|μs|ms|s|m|h|d]}. The space between the number and the
  * unit may be omitted. Specifying no unit is equivalent to using seconds.
  *
@@ -86,18 +84,6 @@ import org.apiguardian.api.API;
  * <tr><td> {@code 42 d}  </td><td> {@code @Timeout(value = 42, unit = DAYS)}         </td></tr>
  * </table>
  *
- * <h3>Disabling Timeouts</h3>
- *
- * <p>You may use the {@value #TIMEOUT_MODE_PROPERTY_NAME} configuration
- * parameter to explicitly enable or disable timeouts.
- *
- * <p>Supported values:
- * <ul>
- * <li>{@code enabled}: enables timeouts
- * <li>{@code disabled}: disables timeouts
- * <li>{@code disabled_on_debug}: disables timeouts while debugging
- * </ul>
- *
  * @since 5.5
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
@@ -106,214 +92,6 @@ import org.apiguardian.api.API;
 @Inherited
 @API(status = STABLE, since = "5.7")
 public @interface Timeout {
-
-	/**
-	 * Property name used to set the default timeout for all testable and
-	 * lifecycle methods: {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a more
-	 * specific property or a {@link Timeout @Timeout}
-	 * annotation present on the method or on an enclosing test class (for
-	 * testable methods).
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.default";
-
-	/**
-	 * Property name used to set the default timeout for all testable methods:
-	 * {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a more
-	 * specific property or a {@link Timeout @Timeout}
-	 * annotation present on the testable method or on an enclosing test class.
-	 *
-	 * <p>This property overrides the {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}
-	 * property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testable.method.default";
-
-	/**
-	 * Property name used to set the default timeout for all {@link Test @Test}
-	 * methods: {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link Timeout @Timeout} annotation present on the {@link Test @Test}
-	 * method or on an enclosing test class.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.test.method.default";
-
-	/**
-	 * Property name used to set the default timeout for all
-	 * {@link TestTemplate @TestTemplate} methods: {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link Timeout @Timeout} annotation present on the
-	 * {@link TestTemplate @TestTemplate} method or on an enclosing test class.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testtemplate.method.default";
-
-	/**
-	 * Property name used to set the default timeout for all
-	 * {@link TestFactory @TestFactory} methods: {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link Timeout @Timeout} annotation present on the
-	 * {@link TestFactory @TestFactory} method or on an enclosing test class.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_TESTABLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_TEST_FACTORY_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.testfactory.method.default";
-
-	/**
-	 * Property name used to set the default timeout for all lifecycle methods:
-	 * {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a more
-	 * specific property or a {@link Timeout @Timeout} annotation present on the
-	 * lifecycle method.
-	 *
-	 * <p>This property overrides the {@value #DEFAULT_TIMEOUT_PROPERTY_NAME}
-	 * property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.lifecycle.method.default";
-
-	/**
-	 * Property name used to set the default timeout for all
-	 * {@link BeforeAll @BeforeAll} methods: {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link Timeout @Timeout} annotation present on the
-	 * {@link BeforeAll @BeforeAll} method.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.beforeall.method.default";
-
-	/**
-	 * Property name used to set the default timeout for all
-	 * {@link BeforeEach @BeforeEach} methods: {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link Timeout @Timeout} annotation present on the
-	 * {@link BeforeEach @BeforeEach} method.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_BEFORE_EACH_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.beforeeach.method.default";
-
-	/**
-	 * Property name used to set the default timeout for all
-	 * {@link AfterEach @AfterEach} methods: {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link Timeout @Timeout} annotation present on the
-	 * {@link AfterEach @AfterEach} method.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.aftereach.method.default";
-
-	/**
-	 * Property name used to set the default timeout for all
-	 * {@link AfterAll @AfterAll} methods: {@value}.
-	 *
-	 * <p>The value of this property will be used unless overridden by a
-	 * {@link Timeout @Timeout} annotation present on the
-	 * {@link AfterAll @AfterAll} method.
-	 *
-	 * <p>This property overrides the
-	 * {@value #DEFAULT_LIFECYCLE_METHOD_TIMEOUT_PROPERTY_NAME} property.
-	 *
-	 * <p>Please refer to the <a href="#supported-values">class
-	 * description</a> for the definition of supported values.
-	 *
-	 * @since 5.5
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME = "junit.jupiter.execution.timeout.afterall.method.default";
-
-	/**
-	 * Property used to determine if timeouts are applied to tests: {@value}.
-	 *
-	 * <p>The value of this property will be used to toggle whether
-	 * {@link Timeout @Timeout} is applied to tests.</p>
-	 *
-	 * <h4>Supported timeout mode values:</h4>
-	 * <ul>
-	 * <li>{@code enabled}: enables timeouts
-	 * <li>{@code disabled}: disables timeouts
-	 * <li>{@code disabled_on_debug}: disables timeouts while debugging
-	 * </ul>
-	 *
-	 * <p>If not specified, the default is {@code enabled}.
-	 *
-	 * @since 5.6
-	 */
-	@API(status = STABLE, since = "5.9")
-	String TIMEOUT_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.mode";
 
 	/**
 	 * The duration of this timeout.
@@ -329,5 +107,14 @@ public @interface Timeout {
 	 * @see TimeUnit
 	 */
 	TimeUnit unit() default TimeUnit.SECONDS;
+
+	/**
+	 * The type of thread for invocation.
+	 *
+	 * @return timeout invocation mode
+	 * @see TimeoutInvocationMode
+	 */
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2087
+	TimeoutInvocationMode timeoutMode() default TimeoutInvocationMode.INFERRED;
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TimeoutInvocationMode.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TimeoutInvocationMode.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+// CS304 Issue link: https://github.com/junit-team/junit5/issues/2087
+/**
+ * Enumeration of invocation modes for a {@code Timeout}.
+ *
+ * <p>When a test can stuck in infinite loop it might be useful in
+ * some cases to be able to run the test code in a separate thread. In this case
+ * this test will be reported as failed, when running test code in the same thread will
+ * wait indefinitely for the test code completion. This behaviour occurs because thread
+ * stop is used with {@link Thread#interrupt()}. If code in the test ignores interrupts it
+ * will run indefinitely.
+ *
+ * @since 5.9
+ * @see Timeout
+ */
+@API(status = EXPERIMENTAL, since = "5.9")
+public enum TimeoutInvocationMode {
+
+	/**
+	 * Defer to the configured timeout invocation mode.
+	 */
+	INFERRED,
+
+	/**
+	 * Execute a test code in same thread as the JUnit execution.
+	 */
+	SAME_THREAD,
+
+	/**
+	 * Execute a test code in different thread from the JUnit execution.
+	 */
+	SEPARATE_THREAD
+}


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---
Declarative timeout does not interrupt code running in infinite loop #2087
I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
