### PR TITLE
Track already visited pairs of Iterables to avoid stack overflow

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -84,28 +84,43 @@ class AssertIterableEquals {
 
 	private static void assertIterableElementsEqual(Object expected, Object actual, Deque<Integer> indexes,
 			Object messageOrSupplier, Map<Pair, Status> investigatedElements) {
+
+		// If both are equal, we don't need to check recursively.
 		if (Objects.equals(expected, actual)) {
 			return;
 		}
+
+		// If both are iterables, we need to check whether they contain the same elements.
 		if (expected instanceof Iterable && actual instanceof Iterable) {
 
 			Pair pair = new Pair(expected, actual);
+
+			// Before comparing their elements, we check whether we have already checked this pair.
 			Status status = investigatedElements.get(pair);
+
+			// If we've already determined that both contain the same elements, we don't need to check them again.
 			if (status == Status.CONTAIN_SAME_ELEMENTS) {
 				return;
 			}
+
+			// If the pair is already under investigation, we fail to avoid infinite recursion.
 			if (status == Status.UNDER_INVESTIGATION) {
 				indexes.removeLast();
 				failIterablesNotEqual(expected, actual, indexes, messageOrSupplier);
 			}
 
+			// Otherwise, we put the pair under investigation and recurse.
 			investigatedElements.put(pair, Status.UNDER_INVESTIGATION);
 
 			assertIterableEquals((Iterable<?>) expected, (Iterable<?>) actual, indexes, messageOrSupplier,
 				investigatedElements);
 
+			// If we reach this point, we've checked that the two iterables contain the same elements so we store this information
+			// in case we come across the same pair again.
 			investigatedElements.put(pair, Status.CONTAIN_SAME_ELEMENTS);
 		}
+
+		// Otherwise, they are neither equal nor iterables, so we fail.
 		else {
 			assertIterablesNotNull(expected, actual, indexes, messageOrSupplier);
 			failIterablesNotEqual(expected, actual, indexes, messageOrSupplier);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -77,7 +77,7 @@ class AssertIterableEquals {
 
 			Pair pair = new Pair(expectedElement, actualElement);
 			Status status = investigatedElements.get(pair);
-			if (status == Status.SAME_ELEMENTS) {
+			if (status == Status.CONTAIN_SAME_ELEMENTS) {
 				continue;
 			}
 			if (status == Status.UNDER_INVESTIGATION) {
@@ -88,7 +88,7 @@ class AssertIterableEquals {
 			investigatedElements.put(pair, Status.UNDER_INVESTIGATION);
 			assertIterableElementsEqual(expectedElement, actualElement, indexes, messageOrSupplier,
 				investigatedElements);
-			investigatedElements.put(pair, Status.SAME_ELEMENTS);
+			investigatedElements.put(pair, Status.CONTAIN_SAME_ELEMENTS);
 			indexes.removeLast();
 		}
 
@@ -178,7 +178,7 @@ class AssertIterableEquals {
 	}
 
 	private enum Status {
-		UNDER_INVESTIGATION, SAME_ELEMENTS
+		UNDER_INVESTIGATION, CONTAIN_SAME_ELEMENTS
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
@@ -83,6 +83,7 @@ class AssertIterableEqualsAssertionsTests {
 			listOf(listOf(1), listOf(2), listOf(listOf(3, listOf(4)))));
 		assertIterableEquals(setOf(setOf(1), setOf(2), setOf(setOf(3, setOf(4)))),
 			setOf(setOf(1), setOf(2), setOf(setOf(3, setOf(4)))));
+		assertIterableEquals(listOf(listOf(1), listOf(listOf(1))), setOf(setOf(1), setOf(setOf(1))));
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
@@ -460,4 +460,18 @@ class AssertIterableEqualsAssertionsTests {
 		assertThrows(StackOverflowError.class, () -> assertIterableEquals(expected, actual));
 	}
 
+	// https://github.com/junit-team/junit5/issues/2915
+	@Test
+	void assertIterableEqualsWithDifferentListOfPath() {
+		try {
+			var expected = listOf(Path.of("1"), Path.of("2").resolve("3"), Path.of("5"));
+			var actual = listOf(Path.of("1"), Path.of("2").resolve("4"), Path.of("5"));
+			assertIterableEquals(expected, actual);
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageEquals(ex, "iterable contents differ at index [1][1][0], expected: <3> but was: <4>");
+		}
+	}
+
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
@@ -461,17 +461,17 @@ class AssertIterableEqualsAssertionsTests {
 		assertThrows(StackOverflowError.class, () -> assertIterableEquals(expected, actual));
 	}
 
-	// https://github.com/junit-team/junit5/issues/2915
 	@Test
+	// https://github.com/junit-team/junit5/issues/2915
 	void assertIterableEqualsWithDifferentListOfPath() {
 		try {
-			var expected = listOf(Path.of("1"), Path.of("2").resolve("3"), Path.of("5"));
-			var actual = listOf(Path.of("1"), Path.of("2").resolve("4"), Path.of("5"));
+			var expected = listOf(Path.of("1").resolve("2"));
+			var actual = listOf(Path.of("1").resolve("3"));
 			assertIterableEquals(expected, actual);
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageEquals(ex, "iterable contents differ at index [1][1][0], expected: <3> but was: <4>");
+			assertMessageEquals(ex, "iterable contents differ at index [0][1], expected: <2> but was: <3>");
 		}
 	}
 


### PR DESCRIPTION
Issue: #2915

## Overview

The visited `Iterable` are tracked and the assert fails if a already visited `Iterable` is visited again. This avoids a StackOverflowError.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
