### PR TITLE
provide a AllBooleanCombinationsSource arguments provider #2878

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AllBooleanCombinationsArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AllBooleanCombinationsArgumentsProvider.java
@@ -1,0 +1,55 @@
+package org.junit.jupiter.params.provider;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+class AllBooleanCombinationsArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<AllBooleanCombinationsSource> {
+    private AllBooleanCombinationsSource annotation;
+
+    @Override
+    public void accept(AllBooleanCombinationsSource annotation) {
+        this.annotation = annotation;
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return parseValue();
+    }
+
+    private Stream<Arguments> parseValue() {
+        List<Arguments> argumentsList = new ArrayList<>();
+        int value = this.annotation.value();
+
+        AtomicInteger index = new AtomicInteger(0);
+        int upperBound = (int) Math.pow(2, value);
+        while (index.intValue() < upperBound) {
+            int recordIndex = 0;
+            String binaryIndex = Integer.toBinaryString(index.intValue());
+            int binaryLength = binaryIndex.length();
+            Boolean[] booleanRecord = new Boolean[value];
+            while (binaryLength < value) {
+                booleanRecord[recordIndex] = Boolean.FALSE;
+                binaryLength++;
+                recordIndex++;
+            }
+            char[] binChars = binaryIndex.toCharArray();
+            for (char c : binChars) {
+                booleanRecord[recordIndex] = (c == '1');
+                recordIndex++;
+            }
+            argumentsList.add(processAllBooleanRecord(booleanRecord));
+            index.incrementAndGet();
+        }
+        return argumentsList.stream();
+    }
+
+    static Arguments processAllBooleanRecord(Object[] allBooleanRecord) {
+        return Arguments.of(allBooleanRecord);
+    }
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AllBooleanCombinationsSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AllBooleanCombinationsSource.java
@@ -1,0 +1,33 @@
+package org.junit.jupiter.params.provider;
+
+import org.apiguardian.api.API;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+/**
+ * {@code @AllBooleanCombinationsSource} is an {@link ArgumentsSource} for
+ * constants of an {@link Boolean}.
+ *
+ * <p>The boolean combinations will be provided as arguments to the annotated
+ * {@code @ParameterizedTest} method.
+ *
+ * <p>The count of boolean values can be specified explicitly using the
+ * {@link #value} attribute. Otherwise, 1 is used.
+ *
+ * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see org.junit.jupiter.params.ParameterizedTest
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@API(status = EXPERIMENTAL, since = "5.8.2")
+@ArgumentsSource(AllBooleanCombinationsArgumentsProvider.class)
+public @interface AllBooleanCombinationsSource {
+    int value() default 1;
+}


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
I provide a AllBooleanCombinationsSource arguments provider. 
Resolve #2878 
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
