### PR TITLE
Allow @RepeatedTest to stop after a certain number of failures

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepeatedTest.java
@@ -121,6 +121,15 @@ public @interface RepeatedTest {
 	int value();
 
 	/**
+	 * The number of tolerable failures.
+	 *
+	 * @return the number of tolerable failures; must be non-negative;
+	 * zero means that tests will not stop when they fail
+	 */
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	int stopAfterFailure() default 0;
+
+	/**
 	 * The display name for each repetition of the repeated test.
 	 *
 	 * <h4>Supported placeholders</h4>

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepetitionInfo.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RepetitionInfo.java
@@ -50,4 +50,13 @@ public interface RepetitionInfo {
 	 */
 	int getTotalRepetitions();
 
+	/**
+	 * Get the number of tolerable failures
+	 * {@link RepeatedTest @RepeatedTest} method.
+	 *
+	 * @see RepeatedTest#stopAfterFailure
+	 */
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	int getStopAfterFailure();
+
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -107,11 +107,9 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 		final int[] hasFailed = { 0 };
 		Method testMethod = extensionContext.getRequiredTestMethod();
 		if (isAnnotated(testMethod, RepeatedTest.class)) {
-			if(AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).isPresent()){
-				RepeatedTest repeatedTest = AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).get();
-				hasFailed[0] = repeatedTest.stopAfterFailure();
-				temp = repeatedTest.stopAfterFailure() != 0;
-			}
+			RepeatedTest repeatedTest = AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).get();
+			hasFailed[0] = repeatedTest.stopAfterFailure();
+			temp = repeatedTest.stopAfterFailure() != 0;
 		}
 		final boolean StopFlag = temp;
 		List<TestTemplateInvocationContextProvider> providers = validateProviders(extensionContext,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -107,9 +107,11 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 		final int[] hasFailed = { 0 };
 		Method testMethod = extensionContext.getRequiredTestMethod();
 		if (isAnnotated(testMethod, RepeatedTest.class)) {
-			RepeatedTest repeatedTest = AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).get();
-			hasFailed[0] = repeatedTest.stopAfterFailure();
-			temp = repeatedTest.stopAfterFailure() != 0;
+			if(AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).isPresent()){
+				RepeatedTest repeatedTest = AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).get();
+				hasFailed[0] = repeatedTest.stopAfterFailure();
+				temp = repeatedTest.stopAfterFailure() != 0;
+			}
 		}
 		final boolean StopFlag = temp;
 		List<TestTemplateInvocationContextProvider> providers = validateProviders(extensionContext,
@@ -121,20 +123,18 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 				.map(invocationContext -> createInvocationTestDescriptor(invocationContext, invocationIndex.incrementAndGet()))
 				.filter(Optional::isPresent)
 				.map(Optional::get)
-				.forEach(invocationTestDescriptor ->
-						{
-							if(StopFlag){
-								if(hasFailed[0] > 0){
-									execute(dynamicTestExecutor, invocationTestDescriptor);
-									if(invocationTestDescriptor.getTestExecutionResult().getStatus() == FAILED){
-										hasFailed[0]--;
-									}
-								}
-							}else {
-								execute(dynamicTestExecutor, invocationTestDescriptor);
+				.forEach(invocationTestDescriptor -> {
+					if(StopFlag){
+						if(hasFailed[0] > 0){
+							execute(dynamicTestExecutor, invocationTestDescriptor);
+							if(invocationTestDescriptor.getTestExecutionResult().getStatus() == FAILED){
+								hasFailed[0]--;
 							}
 						}
-				);
+					}else {
+						execute(dynamicTestExecutor, invocationTestDescriptor);
+					}
+				});
 		// @formatter:on
 		validateWasAtLeastInvokedOnce(invocationIndex.get(), providers);
 		return context;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
@@ -43,11 +43,12 @@ class RepeatedTestExtension implements TestTemplateInvocationContextProvider {
 		RepeatedTest repeatedTest = AnnotationUtils.findAnnotation(testMethod, RepeatedTest.class).get();
 		int totalRepetitions = totalRepetitions(repeatedTest, testMethod);
 		RepeatedTestDisplayNameFormatter formatter = displayNameFormatter(repeatedTest, testMethod, displayName);
-
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		int stopAfterFailure = repeatedTest.stopAfterFailure();
 		// @formatter:off
 		return IntStream
 				.rangeClosed(1, totalRepetitions)
-				.mapToObj(repetition -> new RepeatedTestInvocationContext(repetition, totalRepetitions, formatter));
+				.mapToObj(repetition -> new RepeatedTestInvocationContext(repetition, totalRepetitions, stopAfterFailure, formatter));
 		// @formatter:on
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestInvocationContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestInvocationContext.java
@@ -42,7 +42,7 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 
 	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
 	public RepeatedTestInvocationContext(int currentRepetition, int totalRepetitions, int stopAfterFailure,
-										 RepeatedTestDisplayNameFormatter formatter) {
+			RepeatedTestDisplayNameFormatter formatter) {
 
 		this.currentRepetition = currentRepetition;
 		this.totalRepetitions = totalRepetitions;
@@ -59,7 +59,7 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 	public List<Extension> getAdditionalExtensions() {
 		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
 		return singletonList(
-				new RepetitionInfoParameterResolver(this.currentRepetition, this.totalRepetitions, this.stopAfterFailure));
+			new RepetitionInfoParameterResolver(this.currentRepetition, this.totalRepetitions, this.stopAfterFailure));
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestInvocationContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestInvocationContext.java
@@ -26,6 +26,8 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 
 	private final int currentRepetition;
 	private final int totalRepetitions;
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	private final int stopAfterFailure;
 	private final RepeatedTestDisplayNameFormatter formatter;
 
 	public RepeatedTestInvocationContext(int currentRepetition, int totalRepetitions,
@@ -33,6 +35,18 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 
 		this.currentRepetition = currentRepetition;
 		this.totalRepetitions = totalRepetitions;
+		this.formatter = formatter;
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		this.stopAfterFailure = 0;
+	}
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	public RepeatedTestInvocationContext(int currentRepetition, int totalRepetitions, int stopAfterFailure,
+										 RepeatedTestDisplayNameFormatter formatter) {
+
+		this.currentRepetition = currentRepetition;
+		this.totalRepetitions = totalRepetitions;
+		this.stopAfterFailure = stopAfterFailure;
 		this.formatter = formatter;
 	}
 
@@ -43,7 +57,9 @@ class RepeatedTestInvocationContext implements TestTemplateInvocationContext {
 
 	@Override
 	public List<Extension> getAdditionalExtensions() {
-		return singletonList(new RepetitionInfoParameterResolver(this.currentRepetition, this.totalRepetitions));
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		return singletonList(
+				new RepetitionInfoParameterResolver(this.currentRepetition, this.totalRepetitions, this.stopAfterFailure));
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java
@@ -92,7 +92,9 @@ class RepetitionInfoParameterResolver implements ParameterResolver {
 
 		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
 		@Override
-		public int getStopAfterFailure() { return this.stopAfterFailure; }
+		public int getStopAfterFailure() {
+			return this.stopAfterFailure;
+		}
 
 		@Override
 		public String toString() {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionInfoParameterResolver.java
@@ -26,10 +26,21 @@ class RepetitionInfoParameterResolver implements ParameterResolver {
 
 	private final int currentRepetition;
 	private final int totalRepetitions;
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	private final int stopAfterFailure;
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	public RepetitionInfoParameterResolver(int currentRepetition, int totalRepetitions, int stopAfterFailure) {
+		this.currentRepetition = currentRepetition;
+		this.totalRepetitions = totalRepetitions;
+		this.stopAfterFailure = stopAfterFailure;
+	}
 
 	public RepetitionInfoParameterResolver(int currentRepetition, int totalRepetitions) {
 		this.currentRepetition = currentRepetition;
 		this.totalRepetitions = totalRepetitions;
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		this.stopAfterFailure = 0;
 	}
 
 	@Override
@@ -39,17 +50,34 @@ class RepetitionInfoParameterResolver implements ParameterResolver {
 
 	@Override
 	public RepetitionInfo resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		return new DefaultRepetitionInfo(this.currentRepetition, this.totalRepetitions);
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		return new DefaultRepetitionInfo(this.currentRepetition, this.totalRepetitions, this.stopAfterFailure);
+	}
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	public int getStopAfterFailure() {
+		return this.stopAfterFailure;
 	}
 
 	private static class DefaultRepetitionInfo implements RepetitionInfo {
 
 		private final int currentRepetition;
 		private final int totalRepetitions;
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		private final int stopAfterFailure;
 
 		DefaultRepetitionInfo(int currentRepetition, int totalRepetitions) {
 			this.currentRepetition = currentRepetition;
 			this.totalRepetitions = totalRepetitions;
+			// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+			this.stopAfterFailure = 0;
+		}
+
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		DefaultRepetitionInfo(int currentRepetition, int totalRepetitions, int stopAfterFailure) {
+			this.currentRepetition = currentRepetition;
+			this.totalRepetitions = totalRepetitions;
+			this.stopAfterFailure = stopAfterFailure;
 		}
 
 		@Override
@@ -61,6 +89,10 @@ class RepetitionInfoParameterResolver implements ParameterResolver {
 		public int getTotalRepetitions() {
 			return this.totalRepetitions;
 		}
+
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		@Override
+		public int getStopAfterFailure() { return this.stopAfterFailure; }
 
 		@Override
 		public String toString() {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -40,6 +40,23 @@ public interface TestDescriptor {
 	 */
 	UniqueId getUniqueId();
 
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	/**
+	 * Get the test execution result for this descriptor.
+	 *
+	 * @return the {@code TestExecutionResult} for this descriptor; never
+	 * {@code null}
+	 */
+	TestExecutionResult getTestExecutionResult();
+
+	/**
+	 * Set the test execution result for this descriptor.
+	 *
+	 * @param result the {@code TestExecutionResult} of the current testDescriptor; never
+	 * {@code null}
+	 */
+	void setTestExecutionResult(TestExecutionResult result);
+
 	/**
 	 * Get the display name for this descriptor.
 	 *

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
@@ -40,6 +41,9 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	private final UniqueId uniqueId;
 
 	private final String displayName;
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	private TestExecutionResult result;
 
 	private final TestSource source;
 
@@ -99,6 +103,14 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	public final String getDisplayName() {
 		return this.displayName;
 	}
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	@Override
+	public final TestExecutionResult getTestExecutionResult() { return result; }
+
+	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+	@Override
+	public final void setTestExecutionResult(TestExecutionResult result) { this.result = result; }
 
 	@Override
 	public Set<TestTag> getTags() {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -106,11 +106,15 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
 	@Override
-	public final TestExecutionResult getTestExecutionResult() { return result; }
+	public final TestExecutionResult getTestExecutionResult() {
+		return result;
+	}
 
 	// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
 	@Override
-	public final void setTestExecutionResult(TestExecutionResult result) { this.result = result; }
+	public final void setTestExecutionResult(TestExecutionResult result) {
+		this.result = result;
+	}
 
 	@Override
 	public Set<TestTag> getTags() {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -193,6 +193,8 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 				() -> String.format("Failed to invoke nodeFinished() on Node %s", testDescriptor.getUniqueId()));
 		}
 		taskContext.getListener().executionFinished(testDescriptor, throwableCollector.toTestExecutionResult());
+		// CS304 Issue link: https://github.com/junit-team/junit5/issues/2925
+		testDescriptor.setTestExecutionResult(throwableCollector.toTestExecutionResult());
 		throwableCollector = null;
 	}
 


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
Add the field stopAfterFailure in @RepeatedTest to allow @RepeatedTest to stop after a certain number of failures (issue https://github.com/junit-team/junit5/issues/2925), but the implementation is to skip the remaining tests after meeting a fail, rather than to stop them.
---

Related issue [#2925](https://github.com/junit-team/junit5/issues/2925)
I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
