### PR TITLE
Add Assumptions.assumeInstanceOf

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.api;
 
 import static org.apiguardian.api.API.Status.STABLE;
+import static org.junit.jupiter.api.AssertionUtils.*;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -258,4 +259,89 @@ public class Assumptions {
 			StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
 	}
 
+	// --- assumeInstanceOf --------------------------------------------------
+
+	/**
+	 * Validate that the supplied object is of the expected type; in other words, check if it can
+	 * be assigned to the expected type
+	 *
+	 * @param expectedType the expected type of which the supplied object {@code actualValue} is
+	 * expected to be an instance
+	 * @param actualValue the supplied object to be validated whether it can be assigned to the
+	 * expected type {@code expectedType}
+	 * @return the supplied object after casting to the expected type, or null if it is null
+	 * @throws TestAbortedException if the supplied object can't be assigned to the expected type
+	 */
+	public static <T> T assumeInstanceOf(Class<T> expectedType, Object actualValue) {
+		return assumeInstanceOf(expectedType, actualValue, (Object) null);
+	}
+
+	/**
+	 * Validate that the supplied object is of the expected type; in other words, check if it can
+	 * be assigned to the expected type
+	 *
+	 * @param expectedType the expected type of which the supplied object {@code actualValue} is
+	 * expected to be an instance
+	 * @param actualValue the supplied object to be validated whether it can be assigned to the
+	 * expected type {@code expectedType}
+	 * @param message the message to be included in the {@code TestAbortedException} if the
+	 * assumption is invalid
+	 * @return the supplied object after casting to the expected type, or null if it is null
+	 * @throws TestAbortedException if the supplied object can't be assigned to the expected type
+	 */
+	public static <T> T assumeInstanceOf(Class<T> expectedType, Object actualValue, String message) {
+		return assumeInstanceOf(expectedType, actualValue, (Object) message);
+	}
+
+	/**
+	 * Validate that the supplied object is of the expected type; in other words, check if it can
+	 * be assigned to the expected type
+	 *
+	 * @param expectedType the expected type of which the supplied object {@code actualValue} is
+	 * expected to be an instance
+	 * @param actualValue the supplied object to be validated whether it can be assigned to the
+	 * expected type {@code expectedType}
+	 * @param messageSupplier the supplier of the message to be included in the
+	 * {@code TestAbortedException} if the assumption is invalid
+	 * @return the supplied object after casting to the expected type, or null if it is null
+	 * @throws TestAbortedException if the supplied object can't be assigned to the expected type
+	 */
+	public static <T> T assumeInstanceOf(Class<T> expectedType, Object actualValue, Supplier<String> messageSupplier) {
+		return assumeInstanceOf(expectedType, actualValue, (Object) messageSupplier);
+	}
+
+	/**
+	 * Validate that the supplied object is of the expected type; in other words, check if it can
+	 * be assigned to the expected type
+	 *
+	 * @param expectedType the expected type of which the supplied object {@code actualValue} is
+	 * expected to be an instance
+	 * @param actualValue the supplied object to be validated whether it can be assigned to the
+	 * expected type {@code expectedType}
+	 * @param messageOrSupplier the message itself or the supplier of the message to be included in
+	 * the {@code TestAbortedException} if the execution throws an exception
+	 * @return the supplied object after casting to the expected type, or null if it is null
+	 * @throws TestAbortedException if the supplied object can't be assigned to the expected type
+	 */
+	public static <T> T assumeInstanceOf(Class<T> expectedType, Object actualValue, Object messageOrSupplier) {
+		if (!expectedType.isInstance(actualValue)) {
+			String reason = (actualValue == null ? "Unexpected null value" : "Unexpected type");
+			String message = formatForFailingAssumeInstanceOf(messageOrSupplier, reason, expectedType, actualValue);
+			throwTestAbortedException(message);
+		}
+		return expectedType.cast(actualValue);
+	}
+
+	private static <T> String formatForFailingAssumeInstanceOf(Object messageOrSupplier, String reason,
+			Class<T> expectedType, Object actualValue) {
+		String messageWithPrefix = buildPrefix(nullSafeGet(messageOrSupplier));
+		String reasonWithPrefix = buildPrefix(reason);
+		String detail = formatValues(expectedType, actualValue == null ? null : actualValue.getClass());
+		return messageWithPrefix + reasonWithPrefix + detail;
+	}
+
+	private static void throwTestAbortedExceptionDemo(String message) {
+		throw new TestAbortedException(
+			StringUtils.isNotBlank(message) ? ("Assumption failed: " + message) : "Assumption failed");
+	}
 }


### PR DESCRIPTION
## Overview

I added ``assumeInstanceOf()`` in ``Assumptions.java`` according to the behavior of ``Assertions.assertInstanceOf()``, adapting to the form of other assumptions. I've also added related tests in AssumptionsTests.java, parallel to the tests in ``AssertInstanceOfAssertionsTests.java``. Hopefully, this could be helpful or at least can ease your work to some extent. My pleasure to contribute if accepted.

Resolves #2926
 
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
