### PR TITLE
Try to give a switch that forces a unique order

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -57,290 +57,292 @@ import org.junit.platform.commons.util.ClassUtils;
 @API(status = STABLE, since = "5.7")
 public interface MethodOrderer {
 
-    /**
-     * Property name used to set the default method orderer class name: {@value}
-     *
-     * <h4>Supported Values</h4>
-     *
-     * <p>Supported values include fully qualified class names for types that
-     * implement {@link org.junit.jupiter.api.MethodOrderer}.
-     *
-     * <p>If not specified, test methods will be ordered using an algorithm that
-     * is deterministic but intentionally non-obvious.
-     *
-     * @since 5.7
-     */
-    @API(status = STABLE, since = "5.9")
-    String DEFAULT_ORDER_PROPERTY_NAME = "junit.jupiter.testmethod.order.default";
+	/**
+	 * Property name used to set the default method orderer class name: {@value}
+	 *
+	 * <h4>Supported Values</h4>
+	 *
+	 * <p>Supported values include fully qualified class names for types that
+	 * implement {@link org.junit.jupiter.api.MethodOrderer}.
+	 *
+	 * <p>If not specified, test methods will be ordered using an algorithm that
+	 * is deterministic but intentionally non-obvious.
+	 *
+	 * @since 5.7
+	 */
+	@API(status = STABLE, since = "5.9")
+	String DEFAULT_ORDER_PROPERTY_NAME = "junit.jupiter.testmethod.order.default";
 
-    /**
-     * Order the methods encapsulated in the supplied {@link MethodOrdererContext}.
-     *
-     * <p>The methods to order or sort are made indirectly available via
-     * {@link MethodOrdererContext#getMethodDescriptors()}. Since this method
-     * has a {@code void} return type, the list of method descriptors must be
-     * modified directly.
-     *
-     * <p>For example, a simplified implementation of the {@link Random}
-     * {@code MethodOrderer} might look like the following.
-     *
-     * <pre class="code">
-     * public void orderMethods(MethodOrdererContext context) {
-     *     Collections.shuffle(context.getMethodDescriptors());
-     * }
-     * </pre>
-     *
-     * @param context the {@code MethodOrdererContext} containing the
-     *                {@linkplain MethodDescriptor method descriptors} to order; never {@code null}
-     * @see #getDefaultExecutionMode()
-     */
-    void orderMethods(MethodOrdererContext context);
+	/**
+	 * Order the methods encapsulated in the supplied {@link MethodOrdererContext}.
+	 *
+	 * <p>The methods to order or sort are made indirectly available via
+	 * {@link MethodOrdererContext#getMethodDescriptors()}. Since this method
+	 * has a {@code void} return type, the list of method descriptors must be
+	 * modified directly.
+	 *
+	 * <p>For example, a simplified implementation of the {@link Random}
+	 * {@code MethodOrderer} might look like the following.
+	 *
+	 * <pre class="code">
+	 * public void orderMethods(MethodOrdererContext context) {
+	 *     Collections.shuffle(context.getMethodDescriptors());
+	 * }
+	 * </pre>
+	 *
+	 * @param context the {@code MethodOrdererContext} containing the
+	 *                {@linkplain MethodDescriptor method descriptors} to order; never {@code null}
+	 * @see #getDefaultExecutionMode()
+	 */
+	void orderMethods(MethodOrdererContext context);
 
-    /**
-     * Get the <em>default</em> {@link ExecutionMode} for the test class
-     * configured with this {@link MethodOrderer}.
-     *
-     * <p>This method is guaranteed to be invoked after
-     * {@link #orderMethods(MethodOrdererContext)} which allows implementations
-     * of this method to determine the appropriate return value programmatically,
-     * potentially based on actions that were taken in {@code orderMethods()}.
-     *
-     * <p>Defaults to {@link ExecutionMode#SAME_THREAD SAME_THREAD}, since
-     * ordered methods are typically sorted in a fashion that would conflict
-     * with concurrent execution.
-     *
-     * <p>In case the ordering does not conflict with concurrent execution,
-     * implementations should return an empty {@link Optional} to signal that
-     * the engine should decide which execution mode to use.
-     *
-     * <p>Can be overridden via an explicit
-     * {@link org.junit.jupiter.api.parallel.Execution @Execution} declaration
-     * on the test class or in concrete implementations of the
-     * {@code MethodOrderer} API.
-     *
-     * @return the default {@code ExecutionMode}; never {@code null} but
-     * potentially empty
-     * @see #orderMethods(MethodOrdererContext)
-     */
-    default Optional<ExecutionMode> getDefaultExecutionMode() {
-        return Optional.of(ExecutionMode.SAME_THREAD);
-    }
+	/**
+	 * Get the <em>default</em> {@link ExecutionMode} for the test class
+	 * configured with this {@link MethodOrderer}.
+	 *
+	 * <p>This method is guaranteed to be invoked after
+	 * {@link #orderMethods(MethodOrdererContext)} which allows implementations
+	 * of this method to determine the appropriate return value programmatically,
+	 * potentially based on actions that were taken in {@code orderMethods()}.
+	 *
+	 * <p>Defaults to {@link ExecutionMode#SAME_THREAD SAME_THREAD}, since
+	 * ordered methods are typically sorted in a fashion that would conflict
+	 * with concurrent execution.
+	 *
+	 * <p>In case the ordering does not conflict with concurrent execution,
+	 * implementations should return an empty {@link Optional} to signal that
+	 * the engine should decide which execution mode to use.
+	 *
+	 * <p>Can be overridden via an explicit
+	 * {@link org.junit.jupiter.api.parallel.Execution @Execution} declaration
+	 * on the test class or in concrete implementations of the
+	 * {@code MethodOrderer} API.
+	 *
+	 * @return the default {@code ExecutionMode}; never {@code null} but
+	 * potentially empty
+	 * @see #orderMethods(MethodOrdererContext)
+	 */
+	default Optional<ExecutionMode> getDefaultExecutionMode() {
+		return Optional.of(ExecutionMode.SAME_THREAD);
+	}
 
-    /**
-     * {@code MethodOrderer} that sorts methods alphanumerically based on their
-     * names using {@link String#compareTo(String)}.
-     *
-     * <p>If two methods have the same name, {@code String} representations of
-     * their formal parameter lists will be used as a fallback for comparing the
-     * methods.
-     *
-     * @since 5.4
-     * @deprecated as of JUnit Jupiter 5.7 in favor of {@link MethodOrderer.MethodName};
-     * to be removed in 6.0
-     */
-    @API(status = DEPRECATED, since = "5.7")
-    @Deprecated
-    class Alphanumeric extends MethodName {
+	/**
+	 * {@code MethodOrderer} that sorts methods alphanumerically based on their
+	 * names using {@link String#compareTo(String)}.
+	 *
+	 * <p>If two methods have the same name, {@code String} representations of
+	 * their formal parameter lists will be used as a fallback for comparing the
+	 * methods.
+	 *
+	 * @since 5.4
+	 * @deprecated as of JUnit Jupiter 5.7 in favor of {@link MethodOrderer.MethodName};
+	 * to be removed in 6.0
+	 */
+	@API(status = DEPRECATED, since = "5.7")
+	@Deprecated
+	class Alphanumeric extends MethodName {
 
-        public Alphanumeric() {
-        }
-    }
+		public Alphanumeric() {
+		}
+	}
 
-    /**
-     * {@code MethodOrderer} that sorts methods alphanumerically based on their
-     * names using {@link String#compareTo(String)}.
-     *
-     * <p>If two methods have the same name, {@code String} representations of
-     * their formal parameter lists will be used as a fallback for comparing the
-     * methods.
-     *
-     * @since 5.7
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    class MethodName implements MethodOrderer {
+	/**
+	 * {@code MethodOrderer} that sorts methods alphanumerically based on their
+	 * names using {@link String#compareTo(String)}.
+	 *
+	 * <p>If two methods have the same name, {@code String} representations of
+	 * their formal parameter lists will be used as a fallback for comparing the
+	 * methods.
+	 *
+	 * @since 5.7
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	class MethodName implements MethodOrderer {
 
-        public MethodName() {
-        }
+		public MethodName() {
+		}
 
-        /**
-         * Sort the methods encapsulated in the supplied
-         * {@link MethodOrdererContext} alphanumerically based on their names
-         * and formal parameter lists.
-         */
-        @Override
-        public void orderMethods(MethodOrdererContext context) {
-            context.getMethodDescriptors().sort(comparator);
-        }
+		/**
+		 * Sort the methods encapsulated in the supplied
+		 * {@link MethodOrdererContext} alphanumerically based on their names
+		 * and formal parameter lists.
+		 */
+		@Override
+		public void orderMethods(MethodOrdererContext context) {
+			context.getMethodDescriptors().sort(comparator);
+		}
 
-        private static final Comparator<MethodDescriptor> comparator = Comparator.<MethodDescriptor, String> //
-                comparing(descriptor -> descriptor.getMethod().getName())//
-                .thenComparing(descriptor -> parameterList(descriptor.getMethod()));
+		private static final Comparator<MethodDescriptor> comparator = Comparator.<MethodDescriptor, String> //
+				comparing(descriptor -> descriptor.getMethod().getName())//
+				.thenComparing(descriptor -> parameterList(descriptor.getMethod()));
 
-        private static String parameterList(Method method) {
-            return ClassUtils.nullSafeToString(method.getParameterTypes());
-        }
-    }
+		private static String parameterList(Method method) {
+			return ClassUtils.nullSafeToString(method.getParameterTypes());
+		}
+	}
 
-    /**
-     * {@code MethodOrderer} that sorts methods alphanumerically based on their
-     * display names using {@link String#compareTo(String)}
-     *
-     * @since 5.7
-     */
-    @API(status = EXPERIMENTAL, since = "5.7")
-    class DisplayName implements MethodOrderer {
+	/**
+	 * {@code MethodOrderer} that sorts methods alphanumerically based on their
+	 * display names using {@link String#compareTo(String)}
+	 *
+	 * @since 5.7
+	 */
+	@API(status = EXPERIMENTAL, since = "5.7")
+	class DisplayName implements MethodOrderer {
 
-        public DisplayName() {
-        }
+		public DisplayName() {
+		}
 
-        /**
-         * Sort the methods encapsulated in the supplied
-         * {@link MethodOrdererContext} alphanumerically based on their display
-         * names.
-         */
-        @Override
-        public void orderMethods(MethodOrdererContext context) {
-            context.getMethodDescriptors().sort(comparator);
-        }
+		/**
+		 * Sort the methods encapsulated in the supplied
+		 * {@link MethodOrdererContext} alphanumerically based on their display
+		 * names.
+		 */
+		@Override
+		public void orderMethods(MethodOrdererContext context) {
+			context.getMethodDescriptors().sort(comparator);
+		}
 
-        private static final Comparator<MethodDescriptor> comparator = Comparator.comparing(
-                MethodDescriptor::getDisplayName);
-    }
+		private static final Comparator<MethodDescriptor> comparator = Comparator.comparing(
+			MethodDescriptor::getDisplayName);
+	}
 
-    /**
-     * {@code MethodOrderer} that sorts methods based on the {@link Order @Order}
-     * annotation.
-     *
-     * <p>Any methods that are assigned the same order value will be sorted
-     * arbitrarily adjacent to each other.
-     *
-     * <p>Any methods not annotated with {@code @Order} will be assigned the
-     * {@linkplain Order#DEFAULT default order} value which will effectively cause them
-     * to appear at the end of the sorted list, unless certain methods are assigned
-     * an explicit order value greater than the default order value. Any methods
-     * assigned an explicit order value greater than the default order value will
-     * appear after non-annotated methods in the sorted list.
-     */
-    class OrderAnnotation implements MethodOrderer {
+	/**
+	 * {@code MethodOrderer} that sorts methods based on the {@link Order @Order}
+	 * annotation.
+	 *
+	 * <p>Any methods that are assigned the same order value will be sorted
+	 * arbitrarily adjacent to each other.
+	 *
+	 * <p>Any methods not annotated with {@code @Order} will be assigned the
+	 * {@linkplain Order#DEFAULT default order} value which will effectively cause them
+	 * to appear at the end of the sorted list, unless certain methods are assigned
+	 * an explicit order value greater than the default order value. Any methods
+	 * assigned an explicit order value greater than the default order value will
+	 * appear after non-annotated methods in the sorted list.
+	 */
+	class OrderAnnotation implements MethodOrderer {
 
-        public OrderAnnotation() {
-        }
+		public OrderAnnotation() {
+		}
 
-        /**
-         * Sort the methods encapsulated in the supplied
-         * {@link MethodOrdererContext} based on the {@link Order @Order}
-         * annotation.
-         */
-        @Override
-        public void orderMethods(MethodOrdererContext context) {
-            List<? extends MethodDescriptor> descriptors = context.getMethodDescriptors();
-            Set<Integer> removeDuplicate = new HashSet<>();
-            for (MethodDescriptor descriptor : descriptors) {
-                if (descriptor.findAnnotation(TestMethodOrder.class).isPresent() &&
-                        descriptor.findAnnotation(TestMethodOrder.class).get().enforceUniqueOrder()) {
-                    removeDuplicate.add(getOrder(descriptor));
-                }
-            }
+		/**
+		 * Sort the methods encapsulated in the supplied
+		 * {@link MethodOrdererContext} based on the {@link Order @Order}
+		 * annotation.
+		 */
+		@Override
+		public void orderMethods(MethodOrdererContext context) {
+			List<? extends MethodDescriptor> descriptors = context.getMethodDescriptors();
+			Set<Integer> removeDuplicate = new HashSet<>();
+			for (MethodDescriptor descriptor : descriptors) {
+				if (descriptor.findAnnotation(TestMethodOrder.class).isPresent()
+						&& descriptor.findAnnotation(TestMethodOrder.class).get().enforceUniqueOrder()) {
+					removeDuplicate.add(getOrder(descriptor));
+				}
+			}
 
-            long distinctOrderCnt = removeDuplicate.size();
-            long methodCnt = descriptors.size();
+			long distinctOrderCnt = removeDuplicate.size();
+			long methodCnt = descriptors.size();
 
-            if (methodCnt != distinctOrderCnt && distinctOrderCnt !=0)
-                throw new IllegalArgumentException("duplicate order" + "expected: <" + methodCnt + "> but was: <" + distinctOrderCnt + ">");
+			if (methodCnt != distinctOrderCnt && distinctOrderCnt != 0)
+				throw new IllegalArgumentException(
+					"duplicate order" + "expected: <" + methodCnt + "> but was: <" + distinctOrderCnt + ">");
 
-            context.getMethodDescriptors().sort(comparingInt(OrderAnnotation::getOrder));
-        }
+			context.getMethodDescriptors().sort(comparingInt(OrderAnnotation::getOrder));
+		}
 
-        private static int getOrder(MethodDescriptor descriptor) {
-            return descriptor.findAnnotation(Order.class).map(Order::value).orElse(Order.DEFAULT);
-        }
-    }
+		private static int getOrder(MethodDescriptor descriptor) {
+			return descriptor.findAnnotation(Order.class).map(Order::value).orElse(Order.DEFAULT);
+		}
+	}
 
-    /**
-     * {@code MethodOrderer} that orders methods pseudo-randomly.
-     *
-     * <h4>Custom Seed</h4>
-     *
-     * <p>By default, the random <em>seed</em> used for ordering methods is the
-     * value returned by {@link System#nanoTime()} during static initialization
-     * of this class. In order to support repeatable builds, the value of the
-     * default random seed is logged at {@code CONFIG} level. In addition, a
-     * custom seed (potentially the default seed from the previous test plan
-     * execution) may be specified via the {@value ClassOrderer.Random#RANDOM_SEED_PROPERTY_NAME}
-     * <em>configuration parameter</em> which can be supplied via the {@code Launcher}
-     * API, build tools (e.g., Gradle and Maven), a JVM system property, or the JUnit
-     * Platform configuration file (i.e., a file named {@code junit-platform.properties}
-     * in the root of the class path). Consult the User Guide for further information.
-     *
-     * @see Random#RANDOM_SEED_PROPERTY_NAME
-     * @see java.util.Random
-     */
-    class Random implements MethodOrderer {
+	/**
+	 * {@code MethodOrderer} that orders methods pseudo-randomly.
+	 *
+	 * <h4>Custom Seed</h4>
+	 *
+	 * <p>By default, the random <em>seed</em> used for ordering methods is the
+	 * value returned by {@link System#nanoTime()} during static initialization
+	 * of this class. In order to support repeatable builds, the value of the
+	 * default random seed is logged at {@code CONFIG} level. In addition, a
+	 * custom seed (potentially the default seed from the previous test plan
+	 * execution) may be specified via the {@value ClassOrderer.Random#RANDOM_SEED_PROPERTY_NAME}
+	 * <em>configuration parameter</em> which can be supplied via the {@code Launcher}
+	 * API, build tools (e.g., Gradle and Maven), a JVM system property, or the JUnit
+	 * Platform configuration file (i.e., a file named {@code junit-platform.properties}
+	 * in the root of the class path). Consult the User Guide for further information.
+	 *
+	 * @see Random#RANDOM_SEED_PROPERTY_NAME
+	 * @see java.util.Random
+	 */
+	class Random implements MethodOrderer {
 
-        private static final Logger logger = LoggerFactory.getLogger(Random.class);
+		private static final Logger logger = LoggerFactory.getLogger(Random.class);
 
-        /**
-         * Default seed, which is generated during initialization of this class
-         * via {@link System#nanoTime()} for reproducibility of tests.
-         */
-        private static final long DEFAULT_SEED;
+		/**
+		 * Default seed, which is generated during initialization of this class
+		 * via {@link System#nanoTime()} for reproducibility of tests.
+		 */
+		private static final long DEFAULT_SEED;
 
-        static {
-            DEFAULT_SEED = System.nanoTime();
-            logger.config(() -> "MethodOrderer.Random default seed: " + DEFAULT_SEED);
-        }
+		static {
+			DEFAULT_SEED = System.nanoTime();
+			logger.config(() -> "MethodOrderer.Random default seed: " + DEFAULT_SEED);
+		}
 
-        /**
-         * Property name used to set the random seed used by this
-         * {@code MethodOrderer}: {@value}
-         *
-         * <p>The same property is used by {@link ClassOrderer.Random} for
-         * consistency between the two random orderers.
-         *
-         * <h4>Supported Values</h4>
-         *
-         * <p>Supported values include any string that can be converted to a
-         * {@link Long} via {@link Long#valueOf(String)}.
-         *
-         * <p>If not specified or if the specified value cannot be converted to
-         * a {@link Long}, the default random seed will be used (see the
-         * {@linkplain Random class-level Javadoc} for details).
-         *
-         * @see ClassOrderer.Random
-         */
-        public static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
+		/**
+		 * Property name used to set the random seed used by this
+		 * {@code MethodOrderer}: {@value}
+		 *
+		 * <p>The same property is used by {@link ClassOrderer.Random} for
+		 * consistency between the two random orderers.
+		 *
+		 * <h4>Supported Values</h4>
+		 *
+		 * <p>Supported values include any string that can be converted to a
+		 * {@link Long} via {@link Long#valueOf(String)}.
+		 *
+		 * <p>If not specified or if the specified value cannot be converted to
+		 * a {@link Long}, the default random seed will be used (see the
+		 * {@linkplain Random class-level Javadoc} for details).
+		 *
+		 * @see ClassOrderer.Random
+		 */
+		public static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
 
-        public Random() {
-        }
+		public Random() {
+		}
 
-        /**
-         * Order the methods encapsulated in the supplied
-         * {@link MethodOrdererContext} pseudo-randomly.
-         */
-        @Override
-        public void orderMethods(MethodOrdererContext context) {
-            Collections.shuffle(context.getMethodDescriptors(),
-                    new java.util.Random(getCustomSeed(context).orElse(DEFAULT_SEED)));
-        }
+		/**
+		 * Order the methods encapsulated in the supplied
+		 * {@link MethodOrdererContext} pseudo-randomly.
+		 */
+		@Override
+		public void orderMethods(MethodOrdererContext context) {
+			Collections.shuffle(context.getMethodDescriptors(),
+				new java.util.Random(getCustomSeed(context).orElse(DEFAULT_SEED)));
+		}
 
-        private Optional<Long> getCustomSeed(MethodOrdererContext context) {
-            return context.getConfigurationParameter(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
-                Long seed = null;
-                try {
-                    seed = Long.valueOf(configurationParameter);
-                    logger.config(
-                            () -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
-                                    RANDOM_SEED_PROPERTY_NAME, configurationParameter));
-                } catch (NumberFormatException ex) {
-                    logger.warn(ex,
-                            () -> String.format(
-                                    "Failed to convert configuration parameter [%s] with value [%s] to a long. "
-                                            + "Using default seed [%s] as fallback.",
-                                    RANDOM_SEED_PROPERTY_NAME, configurationParameter, DEFAULT_SEED));
-                }
-                return seed;
-            });
-        }
-    }
+		private Optional<Long> getCustomSeed(MethodOrdererContext context) {
+			return context.getConfigurationParameter(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
+				Long seed = null;
+				try {
+					seed = Long.valueOf(configurationParameter);
+					logger.config(
+						() -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
+							RANDOM_SEED_PROPERTY_NAME, configurationParameter));
+				}
+				catch (NumberFormatException ex) {
+					logger.warn(ex,
+						() -> String.format(
+							"Failed to convert configuration parameter [%s] with value [%s] to a long. "
+									+ "Using default seed [%s] as fallback.",
+							RANDOM_SEED_PROPERTY_NAME, configurationParameter, DEFAULT_SEED));
+				}
+				return seed;
+			});
+		}
+	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -16,9 +16,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Optional;
+import java.util.*;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -50,285 +48,299 @@ import org.junit.platform.commons.util.ClassUtils;
  * <li>{@link Random}</li>
  * </ul>
  *
- * @since 5.4
  * @see TestMethodOrder
  * @see MethodOrdererContext
  * @see #orderMethods(MethodOrdererContext)
  * @see ClassOrderer
+ * @since 5.4
  */
 @API(status = STABLE, since = "5.7")
 public interface MethodOrderer {
 
-	/**
-	 * Property name used to set the default method orderer class name: {@value}
-	 *
-	 * <h4>Supported Values</h4>
-	 *
-	 * <p>Supported values include fully qualified class names for types that
-	 * implement {@link org.junit.jupiter.api.MethodOrderer}.
-	 *
-	 * <p>If not specified, test methods will be ordered using an algorithm that
-	 * is deterministic but intentionally non-obvious.
-	 *
-	 * @since 5.7
-	 */
-	@API(status = STABLE, since = "5.9")
-	String DEFAULT_ORDER_PROPERTY_NAME = "junit.jupiter.testmethod.order.default";
+    /**
+     * Property name used to set the default method orderer class name: {@value}
+     *
+     * <h4>Supported Values</h4>
+     *
+     * <p>Supported values include fully qualified class names for types that
+     * implement {@link org.junit.jupiter.api.MethodOrderer}.
+     *
+     * <p>If not specified, test methods will be ordered using an algorithm that
+     * is deterministic but intentionally non-obvious.
+     *
+     * @since 5.7
+     */
+    @API(status = STABLE, since = "5.9")
+    String DEFAULT_ORDER_PROPERTY_NAME = "junit.jupiter.testmethod.order.default";
 
-	/**
-	 * Order the methods encapsulated in the supplied {@link MethodOrdererContext}.
-	 *
-	 * <p>The methods to order or sort are made indirectly available via
-	 * {@link MethodOrdererContext#getMethodDescriptors()}. Since this method
-	 * has a {@code void} return type, the list of method descriptors must be
-	 * modified directly.
-	 *
-	 * <p>For example, a simplified implementation of the {@link Random}
-	 * {@code MethodOrderer} might look like the following.
-	 *
-	 * <pre class="code">
-	 * public void orderMethods(MethodOrdererContext context) {
-	 *     Collections.shuffle(context.getMethodDescriptors());
-	 * }
-	 * </pre>
-	 *
-	 * @param context the {@code MethodOrdererContext} containing the
-	 * {@linkplain MethodDescriptor method descriptors} to order; never {@code null}
-	 * @see #getDefaultExecutionMode()
-	 */
-	void orderMethods(MethodOrdererContext context);
+    /**
+     * Order the methods encapsulated in the supplied {@link MethodOrdererContext}.
+     *
+     * <p>The methods to order or sort are made indirectly available via
+     * {@link MethodOrdererContext#getMethodDescriptors()}. Since this method
+     * has a {@code void} return type, the list of method descriptors must be
+     * modified directly.
+     *
+     * <p>For example, a simplified implementation of the {@link Random}
+     * {@code MethodOrderer} might look like the following.
+     *
+     * <pre class="code">
+     * public void orderMethods(MethodOrdererContext context) {
+     *     Collections.shuffle(context.getMethodDescriptors());
+     * }
+     * </pre>
+     *
+     * @param context the {@code MethodOrdererContext} containing the
+     *                {@linkplain MethodDescriptor method descriptors} to order; never {@code null}
+     * @see #getDefaultExecutionMode()
+     */
+    void orderMethods(MethodOrdererContext context);
 
-	/**
-	 * Get the <em>default</em> {@link ExecutionMode} for the test class
-	 * configured with this {@link MethodOrderer}.
-	 *
-	 * <p>This method is guaranteed to be invoked after
-	 * {@link #orderMethods(MethodOrdererContext)} which allows implementations
-	 * of this method to determine the appropriate return value programmatically,
-	 * potentially based on actions that were taken in {@code orderMethods()}.
-	 *
-	 * <p>Defaults to {@link ExecutionMode#SAME_THREAD SAME_THREAD}, since
-	 * ordered methods are typically sorted in a fashion that would conflict
-	 * with concurrent execution.
-	 *
-	 * <p>In case the ordering does not conflict with concurrent execution,
-	 * implementations should return an empty {@link Optional} to signal that
-	 * the engine should decide which execution mode to use.
-	 *
-	 * <p>Can be overridden via an explicit
-	 * {@link org.junit.jupiter.api.parallel.Execution @Execution} declaration
-	 * on the test class or in concrete implementations of the
-	 * {@code MethodOrderer} API.
-	 *
-	 * @return the default {@code ExecutionMode}; never {@code null} but
-	 * potentially empty
-	 * @see #orderMethods(MethodOrdererContext)
-	 */
-	default Optional<ExecutionMode> getDefaultExecutionMode() {
-		return Optional.of(ExecutionMode.SAME_THREAD);
-	}
+    /**
+     * Get the <em>default</em> {@link ExecutionMode} for the test class
+     * configured with this {@link MethodOrderer}.
+     *
+     * <p>This method is guaranteed to be invoked after
+     * {@link #orderMethods(MethodOrdererContext)} which allows implementations
+     * of this method to determine the appropriate return value programmatically,
+     * potentially based on actions that were taken in {@code orderMethods()}.
+     *
+     * <p>Defaults to {@link ExecutionMode#SAME_THREAD SAME_THREAD}, since
+     * ordered methods are typically sorted in a fashion that would conflict
+     * with concurrent execution.
+     *
+     * <p>In case the ordering does not conflict with concurrent execution,
+     * implementations should return an empty {@link Optional} to signal that
+     * the engine should decide which execution mode to use.
+     *
+     * <p>Can be overridden via an explicit
+     * {@link org.junit.jupiter.api.parallel.Execution @Execution} declaration
+     * on the test class or in concrete implementations of the
+     * {@code MethodOrderer} API.
+     *
+     * @return the default {@code ExecutionMode}; never {@code null} but
+     * potentially empty
+     * @see #orderMethods(MethodOrdererContext)
+     */
+    default Optional<ExecutionMode> getDefaultExecutionMode() {
+        return Optional.of(ExecutionMode.SAME_THREAD);
+    }
 
-	/**
-	 * {@code MethodOrderer} that sorts methods alphanumerically based on their
-	 * names using {@link String#compareTo(String)}.
-	 *
-	 * <p>If two methods have the same name, {@code String} representations of
-	 * their formal parameter lists will be used as a fallback for comparing the
-	 * methods.
-	 *
-	 * @since 5.4
-	 * @deprecated as of JUnit Jupiter 5.7 in favor of {@link MethodOrderer.MethodName};
-	 * to be removed in 6.0
-	 */
-	@API(status = DEPRECATED, since = "5.7")
-	@Deprecated
-	class Alphanumeric extends MethodName {
+    /**
+     * {@code MethodOrderer} that sorts methods alphanumerically based on their
+     * names using {@link String#compareTo(String)}.
+     *
+     * <p>If two methods have the same name, {@code String} representations of
+     * their formal parameter lists will be used as a fallback for comparing the
+     * methods.
+     *
+     * @since 5.4
+     * @deprecated as of JUnit Jupiter 5.7 in favor of {@link MethodOrderer.MethodName};
+     * to be removed in 6.0
+     */
+    @API(status = DEPRECATED, since = "5.7")
+    @Deprecated
+    class Alphanumeric extends MethodName {
 
-		public Alphanumeric() {
-		}
-	}
+        public Alphanumeric() {
+        }
+    }
 
-	/**
-	 * {@code MethodOrderer} that sorts methods alphanumerically based on their
-	 * names using {@link String#compareTo(String)}.
-	 *
-	 * <p>If two methods have the same name, {@code String} representations of
-	 * their formal parameter lists will be used as a fallback for comparing the
-	 * methods.
-	 *
-	 * @since 5.7
-	 */
-	@API(status = EXPERIMENTAL, since = "5.7")
-	class MethodName implements MethodOrderer {
+    /**
+     * {@code MethodOrderer} that sorts methods alphanumerically based on their
+     * names using {@link String#compareTo(String)}.
+     *
+     * <p>If two methods have the same name, {@code String} representations of
+     * their formal parameter lists will be used as a fallback for comparing the
+     * methods.
+     *
+     * @since 5.7
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    class MethodName implements MethodOrderer {
 
-		public MethodName() {
-		}
+        public MethodName() {
+        }
 
-		/**
-		 * Sort the methods encapsulated in the supplied
-		 * {@link MethodOrdererContext} alphanumerically based on their names
-		 * and formal parameter lists.
-		 */
-		@Override
-		public void orderMethods(MethodOrdererContext context) {
-			context.getMethodDescriptors().sort(comparator);
-		}
+        /**
+         * Sort the methods encapsulated in the supplied
+         * {@link MethodOrdererContext} alphanumerically based on their names
+         * and formal parameter lists.
+         */
+        @Override
+        public void orderMethods(MethodOrdererContext context) {
+            context.getMethodDescriptors().sort(comparator);
+        }
 
-		private static final Comparator<MethodDescriptor> comparator = Comparator.<MethodDescriptor, String> //
-				comparing(descriptor -> descriptor.getMethod().getName())//
-				.thenComparing(descriptor -> parameterList(descriptor.getMethod()));
+        private static final Comparator<MethodDescriptor> comparator = Comparator.<MethodDescriptor, String> //
+                comparing(descriptor -> descriptor.getMethod().getName())//
+                .thenComparing(descriptor -> parameterList(descriptor.getMethod()));
 
-		private static String parameterList(Method method) {
-			return ClassUtils.nullSafeToString(method.getParameterTypes());
-		}
-	}
+        private static String parameterList(Method method) {
+            return ClassUtils.nullSafeToString(method.getParameterTypes());
+        }
+    }
 
-	/**
-	 * {@code MethodOrderer} that sorts methods alphanumerically based on their
-	 * display names using {@link String#compareTo(String)}
-	 *
-	 * @since 5.7
-	 */
-	@API(status = EXPERIMENTAL, since = "5.7")
-	class DisplayName implements MethodOrderer {
+    /**
+     * {@code MethodOrderer} that sorts methods alphanumerically based on their
+     * display names using {@link String#compareTo(String)}
+     *
+     * @since 5.7
+     */
+    @API(status = EXPERIMENTAL, since = "5.7")
+    class DisplayName implements MethodOrderer {
 
-		public DisplayName() {
-		}
+        public DisplayName() {
+        }
 
-		/**
-		 * Sort the methods encapsulated in the supplied
-		 * {@link MethodOrdererContext} alphanumerically based on their display
-		 * names.
-		 */
-		@Override
-		public void orderMethods(MethodOrdererContext context) {
-			context.getMethodDescriptors().sort(comparator);
-		}
+        /**
+         * Sort the methods encapsulated in the supplied
+         * {@link MethodOrdererContext} alphanumerically based on their display
+         * names.
+         */
+        @Override
+        public void orderMethods(MethodOrdererContext context) {
+            context.getMethodDescriptors().sort(comparator);
+        }
 
-		private static final Comparator<MethodDescriptor> comparator = Comparator.comparing(
-			MethodDescriptor::getDisplayName);
-	}
+        private static final Comparator<MethodDescriptor> comparator = Comparator.comparing(
+                MethodDescriptor::getDisplayName);
+    }
 
-	/**
-	 * {@code MethodOrderer} that sorts methods based on the {@link Order @Order}
-	 * annotation.
-	 *
-	 * <p>Any methods that are assigned the same order value will be sorted
-	 * arbitrarily adjacent to each other.
-	 *
-	 * <p>Any methods not annotated with {@code @Order} will be assigned the
-	 * {@linkplain Order#DEFAULT default order} value which will effectively cause them
-	 * to appear at the end of the sorted list, unless certain methods are assigned
-	 * an explicit order value greater than the default order value. Any methods
-	 * assigned an explicit order value greater than the default order value will
-	 * appear after non-annotated methods in the sorted list.
-	 */
-	class OrderAnnotation implements MethodOrderer {
+    /**
+     * {@code MethodOrderer} that sorts methods based on the {@link Order @Order}
+     * annotation.
+     *
+     * <p>Any methods that are assigned the same order value will be sorted
+     * arbitrarily adjacent to each other.
+     *
+     * <p>Any methods not annotated with {@code @Order} will be assigned the
+     * {@linkplain Order#DEFAULT default order} value which will effectively cause them
+     * to appear at the end of the sorted list, unless certain methods are assigned
+     * an explicit order value greater than the default order value. Any methods
+     * assigned an explicit order value greater than the default order value will
+     * appear after non-annotated methods in the sorted list.
+     */
+    class OrderAnnotation implements MethodOrderer {
 
-		public OrderAnnotation() {
-		}
+        public OrderAnnotation() {
+        }
 
-		/**
-		 * Sort the methods encapsulated in the supplied
-		 * {@link MethodOrdererContext} based on the {@link Order @Order}
-		 * annotation.
-		 */
-		@Override
-		public void orderMethods(MethodOrdererContext context) {
-			context.getMethodDescriptors().sort(comparingInt(OrderAnnotation::getOrder));
-		}
+        /**
+         * Sort the methods encapsulated in the supplied
+         * {@link MethodOrdererContext} based on the {@link Order @Order}
+         * annotation.
+         */
+        @Override
+        public void orderMethods(MethodOrdererContext context) {
+            List<? extends MethodDescriptor> descriptors = context.getMethodDescriptors();
+            Set<Integer> removeDuplicate = new HashSet<>();
+            for (MethodDescriptor descriptor : descriptors) {
+                if (descriptor.findAnnotation(TestMethodOrder.class).isPresent() &&
+                        descriptor.findAnnotation(TestMethodOrder.class).get().enforceUniqueOrder()) {
+                    removeDuplicate.add(getOrder(descriptor));
+                }
+            }
 
-		private static int getOrder(MethodDescriptor descriptor) {
-			return descriptor.findAnnotation(Order.class).map(Order::value).orElse(Order.DEFAULT);
-		}
-	}
+            long distinctOrderCnt = removeDuplicate.size();
+            long methodCnt = descriptors.size();
 
-	/**
-	 * {@code MethodOrderer} that orders methods pseudo-randomly.
-	 *
-	 * <h4>Custom Seed</h4>
-	 *
-	 * <p>By default, the random <em>seed</em> used for ordering methods is the
-	 * value returned by {@link System#nanoTime()} during static initialization
-	 * of this class. In order to support repeatable builds, the value of the
-	 * default random seed is logged at {@code CONFIG} level. In addition, a
-	 * custom seed (potentially the default seed from the previous test plan
-	 * execution) may be specified via the {@value ClassOrderer.Random#RANDOM_SEED_PROPERTY_NAME}
-	 * <em>configuration parameter</em> which can be supplied via the {@code Launcher}
-	 * API, build tools (e.g., Gradle and Maven), a JVM system property, or the JUnit
-	 * Platform configuration file (i.e., a file named {@code junit-platform.properties}
-	 * in the root of the class path). Consult the User Guide for further information.
-	 *
-	 * @see Random#RANDOM_SEED_PROPERTY_NAME
-	 * @see java.util.Random
-	 */
-	class Random implements MethodOrderer {
+            if (methodCnt != distinctOrderCnt && distinctOrderCnt !=0)
+                throw new IllegalArgumentException("duplicate order" + "expected: <" + methodCnt + "> but was: <" + distinctOrderCnt + ">");
 
-		private static final Logger logger = LoggerFactory.getLogger(Random.class);
+            context.getMethodDescriptors().sort(comparingInt(OrderAnnotation::getOrder));
+        }
 
-		/**
-		 * Default seed, which is generated during initialization of this class
-		 * via {@link System#nanoTime()} for reproducibility of tests.
-		 */
-		private static final long DEFAULT_SEED;
+        private static int getOrder(MethodDescriptor descriptor) {
+            return descriptor.findAnnotation(Order.class).map(Order::value).orElse(Order.DEFAULT);
+        }
+    }
 
-		static {
-			DEFAULT_SEED = System.nanoTime();
-			logger.config(() -> "MethodOrderer.Random default seed: " + DEFAULT_SEED);
-		}
+    /**
+     * {@code MethodOrderer} that orders methods pseudo-randomly.
+     *
+     * <h4>Custom Seed</h4>
+     *
+     * <p>By default, the random <em>seed</em> used for ordering methods is the
+     * value returned by {@link System#nanoTime()} during static initialization
+     * of this class. In order to support repeatable builds, the value of the
+     * default random seed is logged at {@code CONFIG} level. In addition, a
+     * custom seed (potentially the default seed from the previous test plan
+     * execution) may be specified via the {@value ClassOrderer.Random#RANDOM_SEED_PROPERTY_NAME}
+     * <em>configuration parameter</em> which can be supplied via the {@code Launcher}
+     * API, build tools (e.g., Gradle and Maven), a JVM system property, or the JUnit
+     * Platform configuration file (i.e., a file named {@code junit-platform.properties}
+     * in the root of the class path). Consult the User Guide for further information.
+     *
+     * @see Random#RANDOM_SEED_PROPERTY_NAME
+     * @see java.util.Random
+     */
+    class Random implements MethodOrderer {
 
-		/**
-		 * Property name used to set the random seed used by this
-		 * {@code MethodOrderer}: {@value}
-		 *
-		 * <p>The same property is used by {@link ClassOrderer.Random} for
-		 * consistency between the two random orderers.
-		 *
-		 * <h4>Supported Values</h4>
-		 *
-		 * <p>Supported values include any string that can be converted to a
-		 * {@link Long} via {@link Long#valueOf(String)}.
-		 *
-		 * <p>If not specified or if the specified value cannot be converted to
-		 * a {@link Long}, the default random seed will be used (see the
-		 * {@linkplain Random class-level Javadoc} for details).
-		 *
-		 * @see ClassOrderer.Random
-		 */
-		public static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
+        private static final Logger logger = LoggerFactory.getLogger(Random.class);
 
-		public Random() {
-		}
+        /**
+         * Default seed, which is generated during initialization of this class
+         * via {@link System#nanoTime()} for reproducibility of tests.
+         */
+        private static final long DEFAULT_SEED;
 
-		/**
-		 * Order the methods encapsulated in the supplied
-		 * {@link MethodOrdererContext} pseudo-randomly.
-		 */
-		@Override
-		public void orderMethods(MethodOrdererContext context) {
-			Collections.shuffle(context.getMethodDescriptors(),
-				new java.util.Random(getCustomSeed(context).orElse(DEFAULT_SEED)));
-		}
+        static {
+            DEFAULT_SEED = System.nanoTime();
+            logger.config(() -> "MethodOrderer.Random default seed: " + DEFAULT_SEED);
+        }
 
-		private Optional<Long> getCustomSeed(MethodOrdererContext context) {
-			return context.getConfigurationParameter(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
-				Long seed = null;
-				try {
-					seed = Long.valueOf(configurationParameter);
-					logger.config(
-						() -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
-							RANDOM_SEED_PROPERTY_NAME, configurationParameter));
-				}
-				catch (NumberFormatException ex) {
-					logger.warn(ex,
-						() -> String.format(
-							"Failed to convert configuration parameter [%s] with value [%s] to a long. "
-									+ "Using default seed [%s] as fallback.",
-							RANDOM_SEED_PROPERTY_NAME, configurationParameter, DEFAULT_SEED));
-				}
-				return seed;
-			});
-		}
-	}
+        /**
+         * Property name used to set the random seed used by this
+         * {@code MethodOrderer}: {@value}
+         *
+         * <p>The same property is used by {@link ClassOrderer.Random} for
+         * consistency between the two random orderers.
+         *
+         * <h4>Supported Values</h4>
+         *
+         * <p>Supported values include any string that can be converted to a
+         * {@link Long} via {@link Long#valueOf(String)}.
+         *
+         * <p>If not specified or if the specified value cannot be converted to
+         * a {@link Long}, the default random seed will be used (see the
+         * {@linkplain Random class-level Javadoc} for details).
+         *
+         * @see ClassOrderer.Random
+         */
+        public static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
+
+        public Random() {
+        }
+
+        /**
+         * Order the methods encapsulated in the supplied
+         * {@link MethodOrdererContext} pseudo-randomly.
+         */
+        @Override
+        public void orderMethods(MethodOrdererContext context) {
+            Collections.shuffle(context.getMethodDescriptors(),
+                    new java.util.Random(getCustomSeed(context).orElse(DEFAULT_SEED)));
+        }
+
+        private Optional<Long> getCustomSeed(MethodOrdererContext context) {
+            return context.getConfigurationParameter(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
+                Long seed = null;
+                try {
+                    seed = Long.valueOf(configurationParameter);
+                    logger.config(
+                            () -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
+                                    RANDOM_SEED_PROPERTY_NAME, configurationParameter));
+                } catch (NumberFormatException ex) {
+                    logger.warn(ex,
+                            () -> String.format(
+                                    "Failed to convert configuration parameter [%s] with value [%s] to a long. "
+                                            + "Using default seed [%s] as fallback.",
+                                    RANDOM_SEED_PROPERTY_NAME, configurationParameter, DEFAULT_SEED));
+                }
+                return seed;
+            });
+        }
+    }
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestMethodOrder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestMethodOrder.java
@@ -86,4 +86,5 @@ public @interface TestMethodOrder {
 	 */
 	Class<? extends MethodOrderer> value();
 
+	boolean enforceUniqueOrder() default false;
 }


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---
I try to give a switch called enforceUniqueOrder for @TestMethodOder, so that it can be used in some cases
This is mainly to resolve #2930 and #2757
### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
