### PR TITLE
Improve documentation about registering a `LauncherSessionListener'

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/launcher-api.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/launcher-api.adoc
@@ -93,8 +93,14 @@ file is loaded and applied automatically.
 ==== Registering a LauncherSessionListener
 
 Registered implementations of `{LauncherSessionListener}` are notified when a
-`{LauncherSession}` is opened (before a `{Launcher}` first discovers and executes tests)
-and closed (when no more tests will be discovered or executed). They can be registered
+`{LauncherSession}` is opened and closed -- 4 notifications in total:
+
+1. Before a `{Launcher}` first discovers the tests
+2. When no more tests will be discovered
+3. Before the tests are executed
+4. After the tests are executed
+
+They can be registered
 programmatically via the `{LauncherConfig}` that is passed to the `{LauncherFactory}`, or
 they can be discovered at runtime via Java's `{ServiceLoader}` mechanism and automatically
 registered with `LauncherSession` (unless automatic registration is disabled.)


### PR DESCRIPTION
## Overview
Addresses #2826

Explicitly states the order and amount of notifications the `LauncherSessionListener` receives.

## Before
![before](https://user-images.githubusercontent.com/23459549/174137296-0ed7ef04-8309-48dd-8eff-58127965fd98.png)

## After
![after](https://user-images.githubusercontent.com/23459549/174137333-d48729a9-b57e-46e0-b546-c735f3de19e7.png)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
