### PR TITLE
Document configuration parameters for parallel test execution in Jupiter

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2362,7 +2362,7 @@ a|
 |```same_thread```
 
 | ```junit.jupiter.execution.parallel.config.strategy```
-|Set execution strategy for desired paralellism and maximum pool size
+|Set execution strategy for desired parallelism and maximum pool size
 a|
 * `dynamic`
 * `fixed`

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2333,6 +2333,58 @@ to the same shared resource is running.
 include::{testDir}/example/SharedResourcesDemo.java[tags=user_guide]
 ----
 
+==== Relevant properties
+
+The below table lists out relevant parallel execution `junit-platform.properties`.
+[cols="1,2,1,1"]
+|===
+|Property |Description |Acceptable values |Default value
+
+|junit.jupiter.execution.parallel.enabled
+|Enable parallel test exection
+a|
+* `true`
+* `false`
+|```false```
+
+|junit.jupiter.execution.parallel.mode.default
+|Set execution mode of the nodes in the test tree
+a|
+* `concurrent`
+* `same_thread`
+|```same_thread```
+
+|junit.jupiter.execution.parallel.mode.classes.default
+|Set execution mode of the top-level classes
+a|
+* `concurrent`
+* `same_thread`
+|```same_thread```
+
+|junit.jupiter.execution.parallel.config.strategy
+|Set execution strategy for desired paralellism and maximum pool size
+a|
+* `dynamic`
+* `fixed`
+* `custom`
+| ```dynamic```
+
+|junit.jupiter.execution.parallel.config.dynamic.factor
+|Set the factor to be multiplied with the number of available processors/cores to determine the desired parallelism for the dynamic configuration strategy
+|Must be a decimal number
+| ```1```
+
+
+|junit.jupiter.execution.parallel.config.fixed.parallelism
+|Set the desired parallelism for the fixed configuration strategy
+|Must be an integer
+|No default value
+
+|junit.jupiter.execution.parallel.config.custom.class
+|Specify the fully qualified class name of the ```ParallelExecutionConfigurationStrategy``` to be used for the custom configuration strategy
+|for instance ```org.example.CustomStrategy```
+|
+|===
 
 [[writing-tests-built-in-extensions]]
 === Built-in Extensions

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2294,46 +2294,7 @@ behind the scenes may spawn additional threads to ensure execution continues wit
 sufficient parallelism. Thus, if you require such guarantees in a test class, please use
 your own means of controlling concurrency.
 
-[[writing-tests-parallel-execution-synchronization]]
-==== Synchronization
-
-In addition to controlling the execution mode using the `{Execution}` annotation, JUnit
-Jupiter provides another annotation-based declarative synchronization mechanism. The
-`{ResourceLock}` annotation allows you to declare that a test class or method uses a
-specific shared resource that requires synchronized access to ensure reliable test
-execution. The shared resource is identified by a unique name which is a `String`. The
-name can be user-defined or one of the predefined constants in `{Resources}`:
-`SYSTEM_PROPERTIES`, `SYSTEM_OUT`, `SYSTEM_ERR`, `LOCALE`, or `TIME_ZONE`.
-
-If the tests in the following example were run in parallel _without_ the use of
-{ResourceLock}, they would be _flaky_. Sometimes they would pass, and at other times they
-would fail due to the inherent race condition of writing and then reading the same JVM
-System Property.
-
-When access to shared resources is declared using the `{ResourceLock}` annotation, the
-JUnit Jupiter engine uses this information to ensure that no conflicting tests are run in
-parallel.
-
-[NOTE]
-.Running tests in isolation
-====
-If most of your test classes can be run in parallel without any synchronization but you
-have some test classes that need to run in isolation, you can mark the latter with the
-`{Isolated}` annotation. Tests in such classes are executed sequentially without any other
-tests running at the same time.
-====
-
-In addition to the `String` that uniquely identifies the shared resource, you may specify
-an access mode. Two tests that require `READ` access to a shared resource may run in
-parallel with each other but not while any other test that requires `READ_WRITE` access
-to the same shared resource is running.
-
-[source,java]
-----
-include::{testDir}/example/SharedResourcesDemo.java[tags=user_guide]
-----
-
-==== Relevant properties
+===== Relevant properties
 
 The below table lists out relevant parallel execution properties in `junit-platform.properties`.
 [cols="1,2,1,1"]
@@ -2385,6 +2346,45 @@ a|
 |for instance ```org.example.CustomStrategy```
 |No default value
 |===
+
+[[writing-tests-parallel-execution-synchronization]]
+==== Synchronization
+
+In addition to controlling the execution mode using the `{Execution}` annotation, JUnit
+Jupiter provides another annotation-based declarative synchronization mechanism. The
+`{ResourceLock}` annotation allows you to declare that a test class or method uses a
+specific shared resource that requires synchronized access to ensure reliable test
+execution. The shared resource is identified by a unique name which is a `String`. The
+name can be user-defined or one of the predefined constants in `{Resources}`:
+`SYSTEM_PROPERTIES`, `SYSTEM_OUT`, `SYSTEM_ERR`, `LOCALE`, or `TIME_ZONE`.
+
+If the tests in the following example were run in parallel _without_ the use of
+{ResourceLock}, they would be _flaky_. Sometimes they would pass, and at other times they
+would fail due to the inherent race condition of writing and then reading the same JVM
+System Property.
+
+When access to shared resources is declared using the `{ResourceLock}` annotation, the
+JUnit Jupiter engine uses this information to ensure that no conflicting tests are run in
+parallel.
+
+[NOTE]
+.Running tests in isolation
+====
+If most of your test classes can be run in parallel without any synchronization but you
+have some test classes that need to run in isolation, you can mark the latter with the
+`{Isolated}` annotation. Tests in such classes are executed sequentially without any other
+tests running at the same time.
+====
+
+In addition to the `String` that uniquely identifies the shared resource, you may specify
+an access mode. Two tests that require `READ` access to a shared resource may run in
+parallel with each other but not while any other test that requires `READ_WRITE` access
+to the same shared resource is running.
+
+[source,java]
+----
+include::{testDir}/example/SharedResourcesDemo.java[tags=user_guide]
+----
 
 [[writing-tests-built-in-extensions]]
 === Built-in Extensions

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2335,33 +2335,33 @@ include::{testDir}/example/SharedResourcesDemo.java[tags=user_guide]
 
 ==== Relevant properties
 
-The below table lists out relevant parallel execution `junit-platform.properties`.
+The below table lists out relevant parallel execution properties in `junit-platform.properties`.
 [cols="1,2,1,1"]
 |===
 |Property |Description |Acceptable values |Default value
 
-|junit.jupiter.execution.parallel.enabled
+| ```junit.jupiter.execution.parallel.enabled```
 |Enable parallel test exection
 a|
 * `true`
 * `false`
 |```false```
 
-|junit.jupiter.execution.parallel.mode.default
+| ```junit.jupiter.execution.parallel.mode.default```
 |Set execution mode of the nodes in the test tree
 a|
 * `concurrent`
 * `same_thread`
 |```same_thread```
 
-|junit.jupiter.execution.parallel.mode.classes.default
+| ```junit.jupiter.execution.parallel.mode.classes.default```
 |Set execution mode of the top-level classes
 a|
 * `concurrent`
 * `same_thread`
 |```same_thread```
 
-|junit.jupiter.execution.parallel.config.strategy
+| ```junit.jupiter.execution.parallel.config.strategy```
 |Set execution strategy for desired paralellism and maximum pool size
 a|
 * `dynamic`
@@ -2369,21 +2369,21 @@ a|
 * `custom`
 | ```dynamic```
 
-|junit.jupiter.execution.parallel.config.dynamic.factor
+| ```junit.jupiter.execution.parallel.config.dynamic.factor```
 |Set the factor to be multiplied with the number of available processors/cores to determine the desired parallelism for the dynamic configuration strategy
 |Must be a decimal number
 | ```1```
 
 
-|junit.jupiter.execution.parallel.config.fixed.parallelism
+| ```junit.jupiter.execution.parallel.config.fixed.parallelism```
 |Set the desired parallelism for the fixed configuration strategy
 |Must be an integer
 |No default value
 
-|junit.jupiter.execution.parallel.config.custom.class
+| ```junit.jupiter.execution.parallel.config.custom.class```
 |Specify the fully qualified class name of the ```ParallelExecutionConfigurationStrategy``` to be used for the custom configuration strategy
 |for instance ```org.example.CustomStrategy```
-|
+|No default value
 |===
 
 [[writing-tests-built-in-extensions]]


### PR DESCRIPTION
## Overview

Partially addresses #2669. 

Introduces a new table with relevant parallel execution properties in `junit-platform.properties`.

## How the addition looks like

![Screenshot from 2022-06-16 19-56-18](https://user-images.githubusercontent.com/23459549/174135390-21b5453a-1294-42e1-b2e1-cc18f7e9a617.png)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
