### PR TITLE
Fix support for absolute path entries on Windows

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M2.adoc
@@ -15,7 +15,7 @@ on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Absolute path entries are now supported in JUnit's Platform Console Launcher on Windows.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -97,14 +97,15 @@ class AvailableOptions {
 	static class SelectorOptions {
 
 		@Option(names = { "--scan-classpath",
-				"--scan-class-path" }, split = ";|:", paramLabel = "PATH", arity = "0..1", description = "Scan all directories on the classpath or explicit classpath roots. " //
+				"--scan-class-path" }, converter = ClasspathEntriesConverter.class, paramLabel = "PATH", arity = "0..1", description = "Scan all directories on the classpath or explicit classpath roots. " //
 						+ "Without arguments, only directories on the system classpath as well as additional classpath " //
 						+ "entries supplied via -" + CP_OPTION + " (directories and JAR files) are scanned. " //
 						+ "Explicit classpath roots that are not on the classpath will be silently ignored. " //
 						+ "This option can be repeated.")
 		private List<Path> selectedClasspathEntries = new ArrayList<>();
 
-		@Option(names = { "-scan-class-path", "-scan-classpath" }, split = ";|:", arity = "0..1", hidden = true)
+		@Option(names = { "-scan-class-path",
+				"-scan-classpath" }, converter = ClasspathEntriesConverter.class, arity = "0..1", hidden = true)
 		private List<Path> selectedClasspathEntries2 = new ArrayList<>();
 
 		@Option(names = "--scan-modules", description = "EXPERIMENTAL: Scan all resolved modules for test discovery.")
@@ -282,11 +283,12 @@ class AvailableOptions {
 	static class RuntimeConfigurationOptions {
 
 		@Option(names = { "-" + CP_OPTION, "--classpath",
-				"--class-path" }, split = ";|:", paramLabel = "PATH", arity = "1", description = "Provide additional classpath entries "
+				"--class-path" }, converter = ClasspathEntriesConverter.class, paramLabel = "PATH", arity = "1", description = "Provide additional classpath entries "
 						+ "-- for example, for adding engines and their dependencies. This option can be repeated.")
 		private List<Path> additionalClasspathEntries = new ArrayList<>();
 
-		@Option(names = { "--cp", "-classpath", "-class-path" }, split = ";|:", hidden = true)
+		@Option(names = { "--cp", "-classpath",
+				"-class-path" }, converter = ClasspathEntriesConverter.class, hidden = true)
 		private List<Path> additionalClasspathEntries2 = new ArrayList<>();
 
 		// Implementation note: the @Option annotation is on a setter method to allow validation.

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/ClasspathEntriesConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/ClasspathEntriesConverter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console.options;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import picocli.CommandLine;
+
+class ClasspathEntriesConverter implements CommandLine.ITypeConverter<List<Path>> {
+	@Override
+	public List<Path> convert(String value) {
+		return Stream.of(value.split(File.pathSeparator)).map(Paths::get).collect(Collectors.toList());
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/console/options/PicocliCommandLineOptionsParserTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/PicocliCommandLineOptionsParserTests.java
@@ -43,6 +43,8 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.platform.commons.JUnitException;
@@ -290,6 +292,15 @@ class PicocliCommandLineOptionsParserTests {
 			() -> assertEquals(List.of(dir, Path.of("lib/some.jar")), type.parseArgLine("-cp ." + File.pathSeparator + "lib/some.jar").getAdditionalClasspathEntries())
 		);
 		// @formatter:on
+	}
+
+	@Test
+	@EnabledOnOs(OS.WINDOWS)
+	void parseValidAndAbsoluteAdditionalClasspathEntries() throws Exception {
+		ArgsType type = ArgsType.args;
+		assertEquals(List.of(Path.of("C:\\a.jar")), type.parseArgLine("-cp C:\\a.jar").getAdditionalClasspathEntries());
+		assertEquals(List.of(Path.of("C:\\foo.jar"), Path.of("D:\\bar.jar")),
+			type.parseArgLine("-cp C:\\foo.jar;D:\\bar.jar").getAdditionalClasspathEntries());
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

Prior this commit absolute paths on Windows starting with a drive letter like `C:\foo.jar` were always split into two path entries:
  - `C`
  - `foo.jar`

This commit replaces the too simplistic `split = ";|:"` option conversion with a custom converter for classpath entries taking
current platform's path separator character into account.

Fixes #2905
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
