### PR TITLE
Add thread mode to @Timeout

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0-M2.adoc
@@ -44,6 +44,13 @@ on GitHub.
   `@ParameterizedTest` method that is inferred as the factory method when no explicit
   factory method is specified in the `@MethodSource` annotation.
 
+* Thread mode can be set on `@Timeout` annotation. It allows to configure whether the test code
+  is executed in the thread of the calling code or in a separate thread, the modes are:
+  `INFERRED` (default) which resolves the thread mode configured via the
+  property `junit.jupiter.execution.timeout.thread.mode.default`, `SAME_THREAD` that executes
+  the test code in the same thread than the calling code, and `SEPARATE_THREAD` which
+  executes the test code in a separate thread.
+
 
 [[release-notes-5.9.0-M2-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -251,11 +251,10 @@ include::{testDir}/example/AssertionsDemo.java[tags=user_guide]
 [WARNING]
 .Preemptive Timeouts with `assertTimeoutPreemptively()`
 ====
-Contrary to <<writing-tests-declarative-timeouts, declarative timeouts>>, the various
-`assertTimeoutPreemptively()` methods in the `Assertions` class execute the provided
-`executable` or `supplier` in a different thread than that of the calling code. This
-behavior can lead to undesirable side effects if the code that is executed within the
-`executable` or `supplier` relies on `java.lang.ThreadLocal` storage.
+The various`assertTimeoutPreemptively()` methods in the `Assertions` class execute
+the provided `executable` or `supplier` in a different thread than that of the calling
+code. This behavior can lead to undesirable side effects if the code that is executed
+within the `executable` or `supplier` relies on `java.lang.ThreadLocal` storage.
 
 One common example of this is the transactional testing support in the Spring Framework.
 Specifically, Spring's testing support binds transaction state to the current thread (via
@@ -2026,11 +2025,22 @@ The following example shows how `@Timeout` is applied to lifecycle and test meth
 include::{testDir}/example/TimeoutDemo.java[tags=user_guide]
 ----
 
-Contrary to the `assertTimeoutPreemptively()` assertion, the execution of the annotated
-method proceeds in the main thread of the test. If the timeout is exceeded, the main
-thread is interrupted from another thread. This is done to ensure interoperability with
-frameworks such as Spring that make use of mechanisms that are sensitive to the currently
-running thread — for example, `ThreadLocal` transaction management.
+The timeout can be executed using one of the following three thread modes: `SAME_THREAD`,
+`SEPARATE_THREAD` or `INFRERRED`.
+
+When `SAME_THREAD` is used, the execution of the annotated method proceeds in the main
+thread of the test. If the timeout is exceeded, the main thread is interrupted from
+another thread. This is done to ensure interoperability with frameworks such as Spring
+that make use of mechanisms that are sensitive to the currently running thread — for
+example, ThreadLocal transaction management.
+
+On the contrary when `SEPARATE_THREAD` is used, like the `assertTimeoutPreemptively()`
+assertion, the execution of the annotated method proceeds in a separate thread, this
+can lead to undesirable side effects, see <<writing-tests-assertions-preemptive-timeouts>>.
+
+When `INFERRED` (default) thread mode is used, the thread mode is resolved via configuration
+parameter, if the provided configuration parameter is invalid or not present then
+`SAME_THREAD` is used as fallback.
 
 To apply the same timeout to all test methods within a test class and all of its `@Nested`
 classes, you can declare the `@Timeout` annotation at the class level. It will then be
@@ -2071,6 +2081,7 @@ test class is annotated with `@Timeout`:
     Default timeout for `@AfterEach` methods
 `junit.jupiter.execution.timeout.afterall.method.default`::
     Default timeout for `@AfterAll` methods
+`junit.jupiter.execution.timeout.thread.mode.default`:: Default timeout thread mode
 
 More specific configuration parameters override less specific ones. For example,
 `junit.jupiter.execution.timeout.test.method.default` overrides

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2026,7 +2026,7 @@ include::{testDir}/example/TimeoutDemo.java[tags=user_guide]
 ----
 
 The timeout can be executed using one of the following three thread modes: `SAME_THREAD`,
-`SEPARATE_THREAD` or `INFRERRED`.
+`SEPARATE_THREAD` or `INFERRED`.
 
 When `SAME_THREAD` is used, the execution of the annotated method proceeds in the main
 thread of the test. If the timeout is exceeded, the main thread is interrupted from

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2025,23 +2025,6 @@ The following example shows how `@Timeout` is applied to lifecycle and test meth
 include::{testDir}/example/TimeoutDemo.java[tags=user_guide]
 ----
 
-The timeout can be executed using one of the following three thread modes: `SAME_THREAD`,
-`SEPARATE_THREAD` or `INFERRED`.
-
-When `SAME_THREAD` is used, the execution of the annotated method proceeds in the main
-thread of the test. If the timeout is exceeded, the main thread is interrupted from
-another thread. This is done to ensure interoperability with frameworks such as Spring
-that make use of mechanisms that are sensitive to the currently running thread — for
-example, ThreadLocal transaction management.
-
-On the contrary when `SEPARATE_THREAD` is used, like the `assertTimeoutPreemptively()`
-assertion, the execution of the annotated method proceeds in a separate thread, this
-can lead to undesirable side effects, see <<writing-tests-assertions-preemptive-timeouts>>.
-
-When `INFERRED` (default) thread mode is used, the thread mode is resolved via configuration
-parameter, if the provided configuration parameter is invalid or not present then
-`SAME_THREAD` is used as fallback.
-
 To apply the same timeout to all test methods within a test class and all of its `@Nested`
 classes, you can declare the `@Timeout` annotation at the class level. It will then be
 applied to all test, test factory, and test template methods within that class and its
@@ -2057,8 +2040,32 @@ within the specified duration but does not verify the execution time of each ind
 If `@Timeout` is present on a `@TestTemplate` method — for example, a `@RepeatedTest` or
 `@ParameterizedTest` — each invocation will have the given timeout applied to it.
 
+[[writing-tests-declarative-timeouts-thread-mode]]
+==== Thread mode
+
+The timeout can be applied using one of the following three thread modes: `SAME_THREAD`,
+`SEPARATE_THREAD`, or `INFERRED`.
+
+When `SAME_THREAD` is used, the execution of the annotated method proceeds in the main
+thread of the test. If the timeout is exceeded, the main thread is interrupted from
+another thread. This is done to ensure interoperability with frameworks such as Spring
+that make use of mechanisms that are sensitive to the currently running thread — for
+example, `ThreadLocal` transaction management.
+
+On the contrary when `SEPARATE_THREAD` is used, like the `assertTimeoutPreemptively()`
+assertion, the execution of the annotated method proceeds in a separate thread, this
+can lead to undesirable side effects, see <<writing-tests-assertions-preemptive-timeouts>>.
+
+When `INFERRED` (default) thread mode is used, the thread mode is resolved via the
+`junit.jupiter.execution.timeout.thread.mode.default` configuration parameter. If the
+provided configuration parameter is invalid or not present then `SAME_THREAD` is used as
+fallback.
+
+[[writing-tests-declarative-timeouts-default-timeouts]]
+==== Default Timeouts
+
 The following <<running-tests-config-params, configuration parameters>> can be used to
-specify global timeouts for all methods of a certain category unless they or an enclosing
+specify default timeouts for all methods of a certain category unless they or an enclosing
 test class is annotated with `@Timeout`:
 
 `junit.jupiter.execution.timeout.default`::

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2088,7 +2088,6 @@ test class is annotated with `@Timeout`:
     Default timeout for `@AfterEach` methods
 `junit.jupiter.execution.timeout.afterall.method.default`::
     Default timeout for `@AfterAll` methods
-`junit.jupiter.execution.timeout.thread.mode.default`:: Default timeout thread mode
 
 More specific configuration parameters override less specific ones. For example,
 `junit.jupiter.execution.timeout.test.method.default` overrides

--- a/documentation/src/test/java/example/TimeoutDemo.java
+++ b/documentation/src/test/java/example/TimeoutDemo.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
 
 // tag::user_guide[]
 class TimeoutDemo {
@@ -29,6 +30,12 @@ class TimeoutDemo {
 	@Timeout(value = 100, unit = TimeUnit.MILLISECONDS)
 	void failsIfExecutionTimeExceeds100Milliseconds() {
 		// fails if execution time exceeds 100 milliseconds
+	}
+
+	@Test
+	@Timeout(value = 100, unit = TimeUnit.MILLISECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+	void failsIfExecutionTimeExceeds100MillisecondsInSeparateThread() {
+		// fails if execution time exceeds 100 milliseconds, the test code is executed in a separate thread
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
@@ -317,6 +317,21 @@ public @interface Timeout {
 	String TIMEOUT_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.mode";
 
 	/**
+	 * Property name used to set the default thread mode for all testable and lifecycle
+	 * methods: "junit.jupiter.execution.timeout.thread.mode.default".
+	 *
+	 * <p>The value of this property will be used unless overridden by a {@link Timeout @Timeout}
+	 * annotation present on the method or on an enclosing test class (for testable methods).
+	 *
+	 * <p>The supported values are {@code SAME_THREAD} or {@code SEPARATE_THREAD}, if none is provided
+	 * {@code SAME_THREAD} is used as default.
+	 *
+	 * @since 5.9
+	 */
+	@API(status = STABLE, since = "5.9")
+	String DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.thread.mode.default";
+
+	/**
 	 * The duration of this timeout.
 	 *
 	 * @return timeout duration; must be a positive number
@@ -330,5 +345,40 @@ public @interface Timeout {
 	 * @see TimeUnit
 	 */
 	TimeUnit unit() default TimeUnit.SECONDS;
+
+	/**
+	 * The thread mode of this timeout.
+	 *
+	 * @return thread mode
+	* @see ThreadMode
+	 */
+	ThreadMode threadMode() default ThreadMode.INFERRED;
+
+	/**
+	 * {@code ThreadMode} is use to define whether the test code should be executed in the thread
+	 * of the calling code or in a separated thread.
+	 *
+	 * @since 5.9
+	 */
+	enum ThreadMode {
+		/**
+		 * The thread mode is determined using the parameter configured in property
+		 * {@code DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME}.
+		 */
+		INFERRED,
+
+		/**
+		 * The test code is executed in the thread of the calling code.
+		 */
+		SAME_THREAD,
+
+		/**
+		 * The test code is executed in a different thread than that of the calling code. Furthermore,
+		 * execution of the test code will be preemptively aborted if the timeout is exceeded. See the
+		 * {@linkplain Assertions Preemptive Timeouts} section of the class-level
+		 * Javadoc for a discussion of possible undesirable side effects.
+		 */
+		SEPARATE_THREAD,
+	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -328,7 +329,7 @@ public @interface Timeout {
 	 *
 	 * @since 5.9
 	 */
-	@API(status = STABLE, since = "5.9")
+	@API(status = EXPERIMENTAL, since = "5.9")
 	String DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME = "junit.jupiter.execution.timeout.thread.mode.default";
 
 	/**
@@ -350,8 +351,10 @@ public @interface Timeout {
 	 * The thread mode of this timeout.
 	 *
 	 * @return thread mode
-	* @see ThreadMode
+	 * @since 5.9
+	 * @see ThreadMode
 	 */
+	@API(status = EXPERIMENTAL, since = "5.9")
 	ThreadMode threadMode() default ThreadMode.INFERRED;
 
 	/**
@@ -360,11 +363,11 @@ public @interface Timeout {
 	 *
 	 * @since 5.9
 	 */
-	@API(status = STABLE, since = "5.9")
+	@API(status = EXPERIMENTAL, since = "5.9")
 	enum ThreadMode {
 		/**
 		 * The thread mode is determined using the parameter configured in property
-		 * {@code DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME}.
+		 * {@value Timeout#DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME}.
 		 */
 		INFERRED,
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Timeout.java
@@ -360,6 +360,7 @@ public @interface Timeout {
 	 *
 	 * @since 5.9
 	 */
+	@API(status = STABLE, since = "5.9")
 	enum ThreadMode {
 		/**
 		 * The thread mode is determined using the parameter configured in property

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -313,6 +313,15 @@ public final class Constants {
 	@SuppressWarnings("deprecation")
 	public static final String TEMP_DIR_SCOPE_PROPERTY_NAME = TempDir.SCOPE_PROPERTY_NAME;
 
+	/**
+	 * Property name used to set the default timeout thread mode.
+	 *
+	 * @see Timeout
+	 * @see Timeout.ThreadMode
+	 */
+	@API(status = EXPERIMENTAL, since = "5.9")
+	public static final String DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME = Timeout.DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME;
+
 	private Constants() {
 		/* no-op */
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -319,7 +319,7 @@ public final class Constants {
 	 * @see Timeout
 	 * @see Timeout.ThreadMode
 	 */
-	@API(status = EXPERIMENTAL, since = "5.9")
+	@API(status = STABLE, since = "5.9")
 	public static final String DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME = Timeout.DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME;
 
 	private Constants() {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -316,10 +316,11 @@ public final class Constants {
 	/**
 	 * Property name used to set the default timeout thread mode.
 	 *
+	 * @since 5.9
 	 * @see Timeout
 	 * @see Timeout.ThreadMode
 	 */
-	@API(status = STABLE, since = "5.9")
+	@API(status = EXPERIMENTAL, since = "5.9")
 	public static final String DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME = Timeout.DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME;
 
 	private Constants() {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
@@ -10,14 +10,13 @@
 
 package org.junit.jupiter.engine.extension;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
-import org.junit.platform.commons.util.UnrecoverableExceptions;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * @since 5.9
@@ -26,95 +25,24 @@ class SeparateThreadTimeoutInvocation<T> implements Invocation<T> {
 
 	private final Invocation<T> delegate;
 	private final TimeoutDuration timeout;
-	private final ScheduledExecutorService executor;
 	private final Supplier<String> descriptionSupplier;
 
-	SeparateThreadTimeoutInvocation(Invocation<T> delegate, TimeoutDuration timeout, ScheduledExecutorService executor,
+	SeparateThreadTimeoutInvocation(Invocation<T> delegate, TimeoutDuration timeout,
 			Supplier<String> descriptionSupplier) {
 		this.delegate = delegate;
 		this.timeout = timeout;
-		this.executor = executor;
 		this.descriptionSupplier = descriptionSupplier;
 	}
 
 	@Override
 	public T proceed() throws Throwable {
-		DelegateCallable<T> delegateCallable = new DelegateCallable<>(delegate);
-
-		InvocationResult<T> result = invoke(delegateCallable);
-
-		return result.getResultOrThrowFailure();
-	}
-
-	private InvocationResult<T> invoke(DelegateCallable<T> delegateCallable) {
-		Future<T> future = executor.submit(delegateCallable);
 		try {
-			return InvocationResult.success(future.get(timeout.getValue(), timeout.getUnit()));
+			return assertTimeoutPreemptively(timeout.toDuration(), delegate::proceed, descriptionSupplier);
 		}
-		catch (TimeoutException ignored) {
-			return InvocationResult.failure(TimeoutExceptionFactory.create(descriptionSupplier.get(), timeout));
-		}
-		catch (Throwable throwable) {
-			Throwable wrappedInvocationException = throwable.getCause();
-			UnrecoverableExceptions.rethrowIfUnrecoverable(wrappedInvocationException.getCause());
-			return InvocationResult.failure(wrappedInvocationException.getCause());
-		}
-	}
-
-	private static class InvocationResult<T> {
-
-		private T success;
-		private Throwable failure;
-
-		InvocationResult(T success) {
-			this.success = success;
-		}
-
-		InvocationResult(Throwable failure) {
-			this.failure = failure;
-		}
-
-		static <T> InvocationResult<T> success(T result) {
-			return new InvocationResult<>(result);
-		}
-
-		static <T> InvocationResult<T> failure(Throwable throwable) {
-			return new InvocationResult<>(throwable);
-		}
-
-		T getResultOrThrowFailure() throws Throwable {
-			if (failure != null) {
-				throw failure;
-			}
-			return success;
-		}
-	}
-
-	private static class DelegateCallable<T> implements Callable<T> {
-
-		private final Invocation<T> delegate;
-
-		DelegateCallable(Invocation<T> delegate) {
-			this.delegate = delegate;
-		}
-
-		@Override
-		public T call() {
-			try {
-				return delegate.proceed();
-			}
-			catch (Throwable e) {
-				throw new ThrowableWrapperException(e);
-			}
-		}
-	}
-
-	private static class ThrowableWrapperException extends RuntimeException {
-
-		private static final long serialVersionUID = -2713519172711648957L;
-
-		ThrowableWrapperException(Throwable e) {
-			super(e);
+		catch (AssertionFailedError failure) {
+			TimeoutException exception = TimeoutExceptionFactory.create(descriptionSupplier.get(), timeout, null);
+			exception.initCause(failure.getCause());
+			throw exception;
 		}
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
+
+/**
+ * @since 5.9
+ */
+class SeparateThreadTimeoutInvocation<T> implements Invocation<T> {
+
+	private final Invocation<T> delegate;
+	private final TimeoutDuration timeout;
+	private final ScheduledExecutorService executor;
+	private final Supplier<String> descriptionSupplier;
+
+	SeparateThreadTimeoutInvocation(Invocation<T> delegate, TimeoutDuration timeout, ScheduledExecutorService executor,
+			Supplier<String> descriptionSupplier) {
+		this.delegate = delegate;
+		this.timeout = timeout;
+		this.executor = executor;
+		this.descriptionSupplier = descriptionSupplier;
+	}
+
+	@Override
+	public T proceed() throws Throwable {
+		DelegateCallable<T> delegateCallable = new DelegateCallable<>(delegate);
+
+		InvocationResult<T> result = invoke(delegateCallable);
+
+		return result.getResultOrThrowFailure();
+	}
+
+	private InvocationResult<T> invoke(DelegateCallable<T> delegateCallable) {
+		Future<T> future = executor.submit(delegateCallable);
+		try {
+			return InvocationResult.success(future.get(timeout.getValue(), timeout.getUnit()));
+		}
+		catch (TimeoutException ignored) {
+			return InvocationResult.failure(TimeoutExceptionFactory.create(descriptionSupplier.get(), timeout));
+		}
+		catch (Throwable throwable) {
+			Throwable wrappedInvocationException = throwable.getCause();
+			UnrecoverableExceptions.rethrowIfUnrecoverable(wrappedInvocationException.getCause());
+			return InvocationResult.failure(wrappedInvocationException.getCause());
+		}
+	}
+
+	private static class InvocationResult<T> {
+
+		private T success;
+		private Throwable failure;
+
+		InvocationResult(T success) {
+			this.success = success;
+		}
+
+		InvocationResult(Throwable failure) {
+			this.failure = failure;
+		}
+
+		static <T> InvocationResult<T> success(T result) {
+			return new InvocationResult<>(result);
+		}
+
+		static <T> InvocationResult<T> failure(Throwable throwable) {
+			return new InvocationResult<>(throwable);
+		}
+
+		T getResultOrThrowFailure() throws Throwable {
+			if (failure != null) {
+				throw failure;
+			}
+			return success;
+		}
+	}
+
+	private static class DelegateCallable<T> implements Callable<T> {
+
+		private final Invocation<T> delegate;
+
+		DelegateCallable(Invocation<T> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public T call() {
+			try {
+				return delegate.proceed();
+			}
+			catch (Throwable e) {
+				throw new ThrowableWrapperException(e);
+			}
+		}
+	}
+
+	private static class ThrowableWrapperException extends RuntimeException {
+
+		private static final long serialVersionUID = -2713519172711648957L;
+
+		ThrowableWrapperException(Throwable e) {
+			super(e);
+		}
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutDuration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutDuration.java
@@ -10,10 +10,13 @@
 
 package org.junit.jupiter.engine.extension;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Timeout;
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.Preconditions;
 
 /**
@@ -68,4 +71,28 @@ class TimeoutDuration {
 		return value + " " + label;
 	}
 
+	public Duration toDuration() {
+		return Duration.of(value, toChronoUnit());
+	}
+
+	private ChronoUnit toChronoUnit() {
+		switch (unit) {
+			case NANOSECONDS:
+				return ChronoUnit.NANOS;
+			case MICROSECONDS:
+				return ChronoUnit.MICROS;
+			case MILLISECONDS:
+				return ChronoUnit.MILLIS;
+			case SECONDS:
+				return ChronoUnit.SECONDS;
+			case MINUTES:
+				return ChronoUnit.MINUTES;
+			case HOURS:
+				return ChronoUnit.HOURS;
+			case DAYS:
+				return ChronoUnit.DAYS;
+			default:
+				throw new JUnitException("Could not map TimeUnit " + unit + " to ChronoUnit");
+		}
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import java.util.concurrent.TimeoutException;
+
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * @since 5.9
+ */
+class TimeoutExceptionFactory {
+
+	private TimeoutExceptionFactory() {
+	}
+
+	static TimeoutException create(String methodSignature, TimeoutDuration timeoutDuration, Throwable failure) {
+		String message = String.format("%s timed out after %s",
+			Preconditions.notNull(methodSignature, "method signature must not be null"),
+			Preconditions.notNull(timeoutDuration, "timeout duration must not be null"));
+		TimeoutException timeoutException = new TimeoutException(message);
+		if (failure != null) {
+			timeoutException.addSuppressed(failure);
+		}
+		return timeoutException;
+	}
+
+	static TimeoutException create(String methodSignature, TimeoutDuration timeoutDuration) {
+		return create(methodSignature, timeoutDuration, null);
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.junit.jupiter.api.Timeout.ThreadMode;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * @since 5.9
+ */
+class TimeoutInvocationFactory {
+
+	private final Store store;
+
+	TimeoutInvocationFactory(Store store) {
+		this.store = Preconditions.notNull(store, "store must not be null");
+	}
+
+	<T> Invocation<T> create(ThreadMode threadMode, TimeoutInvocationParameters<T> timeoutInvocationParameters) {
+		Preconditions.notNull(threadMode, "thread mode must not be null");
+		Preconditions.notNull(timeoutInvocationParameters, "timeout invocation parameters must not be null");
+		if (threadMode == ThreadMode.SEPARATE_THREAD) {
+			return new SeparateThreadTimeoutInvocation<>(timeoutInvocationParameters.getInvocation(),
+				timeoutInvocationParameters.getTimeoutDuration(), getThreadPoolExecutor(),
+				timeoutInvocationParameters.getDescriptionSupplier());
+		}
+		return new SameThreadTimeoutInvocation<>(timeoutInvocationParameters.getInvocation(),
+			timeoutInvocationParameters.getTimeoutDuration(), getSingleThreadExecutor(),
+			timeoutInvocationParameters.getDescriptionSupplier());
+	}
+
+	private ScheduledExecutorService getSingleThreadExecutor() {
+		return store.getOrComputeIfAbsent(SingleThreadExecutorResource.class).get();
+	}
+
+	private ScheduledExecutorService getThreadPoolExecutor() {
+		return store.getOrComputeIfAbsent(ThreadPoolExecutorResource.class).get();
+	}
+
+	private static abstract class ExecutorResource implements CloseableResource {
+
+		private final ScheduledExecutorService executor;
+
+		ExecutorResource(ScheduledExecutorService executor) {
+			this.executor = executor;
+		}
+
+		ScheduledExecutorService get() {
+			return executor;
+		}
+
+		@Override
+		public void close() throws Throwable {
+			executor.shutdown();
+			boolean terminated = executor.awaitTermination(5, TimeUnit.SECONDS);
+			if (!terminated) {
+				executor.shutdownNow();
+				throw new JUnitException("Scheduled executor could not be stopped in an orderly manner");
+			}
+		}
+	}
+
+	static class SingleThreadExecutorResource extends ExecutorResource {
+
+		@SuppressWarnings("unused")
+		SingleThreadExecutorResource() {
+			super(Executors.newSingleThreadScheduledExecutor(runnable -> {
+				Thread thread = new Thread(runnable, "junit-jupiter-timeout-watcher");
+				thread.setPriority(Thread.MAX_PRIORITY);
+				return thread;
+			}));
+		}
+	}
+
+	static class ThreadPoolExecutorResource extends ExecutorResource {
+
+		@SuppressWarnings("unused")
+		ThreadPoolExecutorResource() {
+			super(Executors.newScheduledThreadPool(5, runnable -> {
+				Thread thread = new Thread(runnable);
+				thread.setName("junit-jupiter-timeout-invocation-runner-" + thread.getId());
+				thread.setPriority(Thread.MAX_PRIORITY);
+				return thread;
+			}));
+		}
+	}
+
+	static class TimeoutInvocationParameters<T> {
+
+		private final Invocation<T> invocation;
+		private final TimeoutDuration timeout;
+		private final Supplier<String> descriptionSupplier;
+
+		TimeoutInvocationParameters(Invocation<T> invocation, TimeoutDuration timeout,
+				Supplier<String> descriptionSupplier) {
+			this.invocation = invocation;
+			this.timeout = timeout;
+			this.descriptionSupplier = descriptionSupplier;
+		}
+
+		public Invocation<T> getInvocation() {
+			return invocation;
+		}
+
+		public TimeoutDuration getTimeoutDuration() {
+			return timeout;
+		}
+
+		public Supplier<String> getDescriptionSupplier() {
+			return descriptionSupplier;
+		}
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.engine.extension;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocationTests.java
@@ -27,14 +27,14 @@ import org.junit.jupiter.api.function.ThrowingConsumer;
 /**
  * @since 5.5
  */
-class TimeoutInvocationTests {
+class SameThreadTimeoutInvocationTests {
 
 	@Test
 	void resetsInterruptFlag() {
 		var exception = assertThrows(TimeoutException.class, () -> withExecutor(executor -> {
 			var delegate = new EventuallyInterruptibleInvocation();
 			var duration = new TimeoutDuration(1, NANOSECONDS);
-			var timeoutInvocation = new TimeoutInvocation<>(delegate, duration, executor, () -> "execution");
+			var timeoutInvocation = new SameThreadTimeoutInvocation<>(delegate, duration, executor, () -> "execution");
 			timeoutInvocation.proceed();
 		}));
 		assertFalse(Thread.currentThread().isInterrupted());

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,14 +35,17 @@ class SeparateThreadTimeoutInvocationTest {
 	@Test
 	@DisplayName("throws timeout exception when timeout duration is exceeded")
 	void throwsTimeoutException() {
+		AtomicReference<String> threadName = new AtomicReference<>();
 		var invocation = aSeparateThreadInvocation(() -> {
+			threadName.set(Thread.currentThread().getName());
 			Thread.sleep(100);
 			return null;
 		});
 
 		assertThatThrownBy(invocation::proceed) //
 				.hasMessage("method() timed out after 10 milliseconds") //
-				.isInstanceOf(TimeoutException.class);
+				.isInstanceOf(TimeoutException.class) //
+				.hasRootCauseMessage("Execution timed out in thread " + threadName.get());
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
@@ -43,7 +43,7 @@ class SeparateThreadTimeoutInvocationTest {
 	@DisplayName("throws timeout exception when timeout duration is exceeded")
 	void throwsTimeoutException() {
 		SeparateThreadTimeoutInvocation<Object> separateThreadTimeoutInvocation = aSeparateThreadInvocation(() -> {
-			Thread.sleep(12);
+			Thread.sleep(100);
 			return null;
 		});
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutConfigurationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutConfigurationTests.java
@@ -18,6 +18,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 import static org.junit.jupiter.engine.Constants.DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_FACTORY_METHOD_TIM
 import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_METHOD_TIMEOUT_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_TEMPLATE_METHOD_TIMEOUT_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_TIMEOUT_PROPERTY_NAME;
+import static org.junit.jupiter.engine.Constants.DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,6 +59,7 @@ class TimeoutConfigurationTests {
 		assertThat(config.getDefaultTestFactoryMethodTimeout()).isEmpty();
 		assertThat(config.getDefaultAfterEachMethodTimeout()).isEmpty();
 		assertThat(config.getDefaultAfterAllMethodTimeout()).isEmpty();
+		assertThat(config.getDefaultTimeoutThreadMode()).isEmpty();
 	}
 
 	@Test
@@ -130,5 +133,24 @@ class TimeoutConfigurationTests {
 		assertThat(logRecordListener.stream(Level.WARNING).map(LogRecord::getMessage)) //
 				.containsExactly(
 					"Ignored invalid timeout 'invalid' set via the 'junit.jupiter.execution.timeout.test.method.default' configuration parameter.");
+	}
+
+	@Test
+	void specificThreadModeIsUsed() {
+		when(extensionContext.getConfigurationParameter(DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME)).thenReturn(
+			Optional.of("SEPARATE_THREAD"));
+		assertThat(config.getDefaultTimeoutThreadMode()).isEqualTo(Optional.of(SEPARATE_THREAD));
+	}
+
+	@Test
+	@TrackLogRecords
+	void logsInvalidThreadModeValueAndReturnEmpty(LogRecordListener logRecordListener) {
+		when(extensionContext.getConfigurationParameter(DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME)).thenReturn(
+			Optional.of("invalid"));
+
+		assertThat(config.getDefaultTimeoutThreadMode()).isEqualTo(Optional.empty());
+		assertThat(logRecordListener.stream(Level.WARNING).map(LogRecord::getMessage)) //
+				.containsExactly(
+					"Invalid timeout thread mode 'invalid' set via the 'junit.jupiter.execution.timeout.thread.mode.default' configuration parameter.");
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactoryTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.engine.extension.TimeoutExceptionFactory.create;
+
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @since 5.9
+ */
+@DisplayName("TimeoutExceptionFactory")
+class TimeoutExceptionFactoryTest {
+
+	private static final TimeoutDuration tenMillisDuration = new TimeoutDuration(10, MILLISECONDS);
+	private static final Exception suppressedException = new Exception("Winke!");
+	private static final String methodSignature = "test()";
+
+	@Test
+	@DisplayName("creates exception with method signature and timeout")
+	void createExceptionWithMethodSignatureTimeout() {
+		TimeoutException exception = create(methodSignature, tenMillisDuration);
+
+		assertThat(exception.getMessage()).isEqualTo("test() timed out after 10 milliseconds");
+		assertThat(exception.getSuppressed()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("creates exception with method signature, timeout and throwable")
+	void createExceptionWithMethodSignatureTimeoutAndThrowable() {
+		TimeoutException exception = create(methodSignature, tenMillisDuration, suppressedException);
+
+		assertThat(exception.getMessage()).isEqualTo("test() timed out after 10 milliseconds");
+		assertThat(exception.getSuppressed()).containsExactly(suppressedException);
+	}
+
+	@Nested
+	@DisplayName("throws exception when")
+	class ThrowException {
+
+		@Test
+		@DisplayName("method signature is null")
+		void methodSignatureIsnull() {
+			assertThatThrownBy(() -> create(null, tenMillisDuration, suppressedException)).hasMessage(
+				"method signature must not be null");
+		}
+
+		@Test
+		@DisplayName("method timeout duration is null")
+		void timeoutDurationIsnull() {
+			assertThatThrownBy(() -> create(methodSignature, null, suppressedException)).hasMessage(
+				"timeout duration must not be null");
+		}
+	}
+
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactoryTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactoryTest.java
@@ -36,8 +36,9 @@ class TimeoutExceptionFactoryTest {
 	void createExceptionWithMethodSignatureTimeout() {
 		TimeoutException exception = create(methodSignature, tenMillisDuration);
 
-		assertThat(exception.getMessage()).isEqualTo("test() timed out after 10 milliseconds");
-		assertThat(exception.getSuppressed()).isEmpty();
+		assertThat(exception) //
+				.hasMessage("test() timed out after 10 milliseconds") //
+				.hasNoSuppressedExceptions();
 	}
 
 	@Test
@@ -45,8 +46,9 @@ class TimeoutExceptionFactoryTest {
 	void createExceptionWithMethodSignatureTimeoutAndThrowable() {
 		TimeoutException exception = create(methodSignature, tenMillisDuration, suppressedException);
 
-		assertThat(exception.getMessage()).isEqualTo("test() timed out after 10 milliseconds");
-		assertThat(exception.getSuppressed()).containsExactly(suppressedException);
+		assertThat(exception) //
+				.hasMessage("test() timed out after 10 milliseconds") //
+				.hasSuppressedException(suppressedException);
 	}
 
 	@Nested
@@ -56,15 +58,15 @@ class TimeoutExceptionFactoryTest {
 		@Test
 		@DisplayName("method signature is null")
 		void methodSignatureIsnull() {
-			assertThatThrownBy(() -> create(null, tenMillisDuration, suppressedException)).hasMessage(
-				"method signature must not be null");
+			assertThatThrownBy(() -> create(null, tenMillisDuration, suppressedException)) //
+					.hasMessage("method signature must not be null");
 		}
 
 		@Test
 		@DisplayName("method timeout duration is null")
 		void timeoutDurationIsnull() {
-			assertThatThrownBy(() -> create(methodSignature, null, suppressedException)).hasMessage(
-				"timeout duration must not be null");
+			assertThatThrownBy(() -> create(methodSignature, null, suppressedException)) //
+					.hasMessage("timeout duration must not be null");
 		}
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
@@ -355,8 +355,8 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 		@Test
 		@DisplayName("non timeout exceeded")
 		void nonTimeoutExceededInSeparateThread() {
-			executeTestsForClass(NonTimeoutExceedingSeparateThreadTestCase.class).allEvents().assertStatistics(
-				stats -> stats.failed(0));
+			executeTestsForClass(NonTimeoutExceedingSeparateThreadTestCase.class).allEvents() //
+					.assertStatistics(stats -> stats.failed(0));
 		}
 
 		@Test
@@ -470,8 +470,8 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 			@Test
 			@DisplayName("non timeout exceeded")
 			void nonTimeoutExceededInSeparateThreadOnClassLevel() {
-				executeTestsForClass(NonTimeoutExceededOnClassLevelTestCase.class).allEvents().assertStatistics(
-					stats -> stats.failed(0));
+				executeTestsForClass(NonTimeoutExceededOnClassLevelTestCase.class).allEvents() //
+						.assertStatistics(stats -> stats.failed(0));
 			}
 		}
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
@@ -16,6 +16,8 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SAME_THREAD;
+import static org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD;
 import static org.junit.jupiter.engine.Constants.DEFAULT_AFTER_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_AFTER_EACH_METHOD_TIMEOUT_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_BEFORE_ALL_METHOD_TIMEOUT_PROPERTY_NAME;
@@ -42,14 +44,18 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.RuntimeUtils;
+import org.junit.platform.engine.TestExecutionResult.Status;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.Events;
 import org.junit.platform.testkit.engine.Execution;
@@ -332,6 +338,144 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 				.collect(toList()));
 	}
 
+	@Nested
+	@DisplayName("separate thread")
+	class SeparateThread {
+		@Test
+		@DisplayName("timeout exceeded")
+		void timeoutExceededInSeparateThread() {
+			EngineExecutionResults results = executeTestsForClass(TimeoutExceedingSeparateThreadTestCase.class);
+
+			Execution execution = findExecution(results.testEvents(), "testMethod()");
+			assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+					.isInstanceOf(TimeoutException.class) //
+					.hasMessage("testMethod() timed out after 10 milliseconds");
+		}
+
+		@Test
+		@DisplayName("non timeout exceeded")
+		void nonTimeoutExceededInSeparateThread() {
+			executeTestsForClass(NonTimeoutExceedingSeparateThreadTestCase.class).allEvents().assertStatistics(
+				stats -> stats.failed(0));
+		}
+
+		@Test
+		@DisplayName("does not swallow unrecoverable exceptions")
+		void separateThreadDoesNotSwallowUnrecoverableExceptions() {
+			assertThrows(OutOfMemoryError.class,
+				() -> executeTestsForClass(UnrecoverableExceptionInSeparateThreadTestCase.class));
+		}
+
+		@Test
+		@DisplayName("handles invocation exceptions")
+		void separateThreadHandlesInvocationExceptions() {
+			EngineExecutionResults results = executeTests(request() //
+					.selectors(selectMethod(ExceptionInSeparateThreadTestCase.class, "test")) //
+					.build());
+
+			Execution execution = findExecution(results.testEvents(), "test()");
+			assertThat(execution.getDuration()) //
+					.isLessThanOrEqualTo(Duration.ofMillis(10));
+			assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+					.isInstanceOf(RuntimeException.class) //
+					.hasMessage("Oppps!");
+		}
+
+		@Test
+		@DisplayName("when one test is stuck \"forever\" the next tests should not stuck")
+		void oneThreadStuckForever() {
+			EngineExecutionResults results = executeTestsForClass(OneTestStuckForeverAndTheOthersNotTestCase.class);
+
+			Execution stuckExecution = findExecution(results.testEvents(), "stuck()");
+			assertThat(stuckExecution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+					.isInstanceOf(TimeoutException.class) //
+					.hasMessage("stuck() timed out after 10 milliseconds");
+
+			Execution testZeroExecution = findExecution(results.testEvents(), "testZero()");
+			assertThat(testZeroExecution.getTerminationInfo().getExecutionResult().getStatus()) //
+					.isEqualTo(Status.SUCCESSFUL);
+
+			Execution testOneExecution = findExecution(results.testEvents(), "testOne()");
+			assertThat(testOneExecution.getTerminationInfo().getExecutionResult().getStatus()) //
+					.isEqualTo(Status.SUCCESSFUL);
+		}
+
+		@Test
+		@DisplayName("mixed same thread and separate thread tests")
+		void mixedSameThreadAndSeparateThreadTests() {
+			EngineExecutionResults results = executeTestsForClass(MixedSameThreadAndSeparateThreadTestCase.class);
+
+			Execution stuck = findExecution(results.testEvents(), "testZero()");
+			assertThat(stuck.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+					.isInstanceOf(TimeoutException.class) //
+					.hasMessage("testZero() timed out after 10 milliseconds");
+
+			Execution testZeroExecution = findExecution(results.testEvents(), "testOne()");
+			assertThat(testZeroExecution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+					.isInstanceOf(TimeoutException.class) //
+					.hasMessage("testOne() timed out after 10 milliseconds");
+
+			Execution testOneExecution = findExecution(results.testEvents(), "testTwo()");
+			assertThat(testOneExecution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+					.isInstanceOf(TimeoutException.class) //
+					.hasMessage("testTwo() timed out after 10 milliseconds");
+		}
+
+		@Test
+		@DisplayName("one test is stuck \"forever\" in separate thread and other tests in same thread not")
+		void oneThreadStuckForeverAndOtherTestsInSameThread() {
+			EngineExecutionResults results = executeTestsForClass(
+				OneTestStuckForeverAndTheOthersInSameThreadNotTestCase.class);
+
+			Execution stuckExecution = findExecution(results.testEvents(), "stuck()");
+			assertThat(stuckExecution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+					.isInstanceOf(TimeoutException.class) //
+					.hasMessage("stuck() timed out after 10 milliseconds");
+
+			Execution testZeroExecution = findExecution(results.testEvents(), "testZero()");
+			assertThat(testZeroExecution.getTerminationInfo().getExecutionResult().getStatus()) //
+					.isEqualTo(Status.SUCCESSFUL);
+
+			Execution testOneExecution = findExecution(results.testEvents(), "testOne()");
+			assertThat(testOneExecution.getTerminationInfo().getExecutionResult().getStatus()) //
+					.isEqualTo(Status.SUCCESSFUL);
+		}
+
+		@Test
+		@DisplayName("is not applied on annotated @Test methods using timeout mode: disabled")
+		void doesNotApplyTimeoutOnAnnotatedTestMethodsUsingDisabledTimeoutMode() {
+			EngineExecutionResults results = executeTests(request() //
+					.selectors(selectMethod(TimeoutExceedingSeparateThreadTestCase.class, "testMethod")) //
+					.configurationParameter(TIMEOUT_MODE_PROPERTY_NAME, "disabled").build());
+
+			Execution execution = findExecution(results.testEvents(), "testMethod()");
+			assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable()) //
+					.isEmpty();
+		}
+
+		@Nested
+		@DisplayName("on class level")
+		class OnClassLevel {
+			@Test
+			@DisplayName("timeout exceeded")
+			void timeoutExceededInSeparateThreadOnClassLevel() {
+				EngineExecutionResults results = executeTestsForClass(TimeoutExceededOnClassLevelTestCase.class);
+
+				Execution execution = findExecution(results.testEvents(), "exceptionThrown()");
+				assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+						.isInstanceOf(TimeoutException.class) //
+						.hasMessage("exceptionThrown() timed out after 10 milliseconds");
+			}
+
+			@Test
+			@DisplayName("non timeout exceeded")
+			void nonTimeoutExceededInSeparateThreadOnClassLevel() {
+				executeTestsForClass(NonTimeoutExceededOnClassLevelTestCase.class).allEvents().assertStatistics(
+					stats -> stats.failed(0));
+			}
+		}
+	}
+
 	static class TimeoutAnnotatedTestMethodTestCase {
 		@Test
 		@Timeout(value = 10, unit = MILLISECONDS)
@@ -543,4 +687,137 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 
 	}
 
+	static class TimeoutExceedingWithInferredThreadModeTestCase {
+		@Test
+		@Timeout(value = 10, unit = MILLISECONDS)
+		void testMethod() throws InterruptedException {
+			Thread.sleep(100);
+		}
+	}
+
+	static class TimeoutExceedingSeparateThreadTestCase {
+		@Test
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void testMethod() throws InterruptedException {
+			Thread.sleep(100);
+		}
+	}
+
+	static class NonTimeoutExceedingSeparateThreadTestCase {
+		@Test
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void testMethod() {
+		}
+	}
+
+	static class UnrecoverableExceptionInSeparateThreadTestCase {
+		@Test
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void test() {
+			throw new OutOfMemoryError();
+		}
+	}
+
+	static class ExceptionInSeparateThreadTestCase {
+		@Test
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void test() {
+			throw new RuntimeException("Oppps!");
+		}
+	}
+
+	@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+	static class TimeoutExceededOnClassLevelTestCase {
+		@Test
+		void exceptionThrown() throws InterruptedException {
+			Thread.sleep(15);
+		}
+	}
+
+	@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+	static class NonTimeoutExceededOnClassLevelTestCase {
+		@Test
+		void test() {
+		}
+	}
+
+	@TestMethodOrder(OrderAnnotation.class)
+	static class OneTestStuckForeverAndTheOthersNotTestCase {
+		private static final CountDownLatch latch = new CountDownLatch(1);
+
+		@Test
+		@Order(0)
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void stuck() throws InterruptedException {
+			latch.await();
+		}
+
+		@Test
+		@Order(1)
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void testZero() {
+		}
+
+		@Test
+		@Order(2)
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void testOne() {
+		}
+
+		@AfterAll
+		static void stopLooper() throws InterruptedException {
+			Thread.sleep(11);
+			latch.countDown();
+		}
+	}
+
+	static class MixedSameThreadAndSeparateThreadTestCase {
+		@Test
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void testZero() throws InterruptedException {
+			Thread.sleep(12);
+		}
+
+		@Test
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SAME_THREAD)
+		void testOne() throws InterruptedException {
+			Thread.sleep(12);
+		}
+
+		@Test
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void testTwo() throws InterruptedException {
+			Thread.sleep(12);
+		}
+	}
+
+	@TestMethodOrder(OrderAnnotation.class)
+	static class OneTestStuckForeverAndTheOthersInSameThreadNotTestCase {
+		private static final CountDownLatch latch = new CountDownLatch(1);
+
+		@Test
+		@Order(0)
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		void stuck() throws InterruptedException {
+			latch.await();
+		}
+
+		@Test
+		@Order(1)
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SAME_THREAD)
+		void testZero() {
+		}
+
+		@Test
+		@Order(2)
+		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SAME_THREAD)
+		void testOne() {
+		}
+
+		@AfterAll
+		static void stopLooper() throws InterruptedException {
+			Thread.sleep(11);
+			latch.countDown();
+		}
+	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
@@ -730,7 +730,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 	static class TimeoutExceededOnClassLevelTestCase {
 		@Test
 		void exceptionThrown() throws InterruptedException {
-			Thread.sleep(15);
+			Thread.sleep(100);
 		}
 	}
 
@@ -765,8 +765,8 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@AfterAll
-		static void stopLooper() throws InterruptedException {
-			Thread.sleep(11);
+		static void stop() throws InterruptedException {
+			Thread.sleep(100);
 			latch.countDown();
 		}
 	}
@@ -775,19 +775,19 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 		@Test
 		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
 		void testZero() throws InterruptedException {
-			Thread.sleep(12);
+			Thread.sleep(100);
 		}
 
 		@Test
 		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SAME_THREAD)
 		void testOne() throws InterruptedException {
-			Thread.sleep(12);
+			Thread.sleep(100);
 		}
 
 		@Test
 		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
 		void testTwo() throws InterruptedException {
-			Thread.sleep(12);
+			Thread.sleep(100);
 		}
 	}
 
@@ -815,8 +815,8 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@AfterAll
-		static void stopLooper() throws InterruptedException {
-			Thread.sleep(11);
+		static void stop() throws InterruptedException {
+			Thread.sleep(100);
 			latch.countDown();
 		}
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
@@ -13,12 +13,12 @@ package org.junit.jupiter.engine.extension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout.ThreadMode;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.engine.execution.ExtensionValuesStore;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
-import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.SingleThreadExecutorResource;
-import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.ThreadPoolExecutorResource;
+import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.ExecutorResource;
 import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.TimeoutInvocationParameters;
 
 @DisplayName("TimeoutInvocationFactory")
@@ -74,7 +73,7 @@ class TimeoutInvocationFactoryTest {
 		Invocation<String> invocation = timeoutInvocationFactory.create(ThreadMode.SAME_THREAD,
 			timeoutInvocationParameters);
 		assertThat(invocation).isInstanceOf(SameThreadTimeoutInvocation.class);
-		verify(store).getOrComputeIfAbsent(SingleThreadExecutorResource.class);
+		verify(store).getOrComputeIfAbsent(ExecutorResource.class);
 	}
 
 	@Test
@@ -83,7 +82,7 @@ class TimeoutInvocationFactoryTest {
 		Invocation<String> invocation = timeoutInvocationFactory.create(ThreadMode.SEPARATE_THREAD,
 			timeoutInvocationParameters);
 		assertThat(invocation).isInstanceOf(SeparateThreadTimeoutInvocation.class);
-		verify(store).getOrComputeIfAbsent(ThreadPoolExecutorResource.class);
+		verify(store, never()).getOrComputeIfAbsent(ExecutorResource.class);
 	}
 
 	private interface InvocationWithStringResult extends Invocation<String> {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
@@ -84,8 +84,6 @@ class TimeoutInvocationFactoryTest {
 	void shouldCreateTimeoutInvocationForSeparateThreadTimeoutThreadMode() {
 		var invocation = timeoutInvocationFactory.create(ThreadMode.SEPARATE_THREAD, parameters);
 		assertThat(invocation).isInstanceOf(SeparateThreadTimeoutInvocation.class);
-		verify(store).getOrComputeIfAbsent(matches("junit\\-jupiter\\-timeout\\-invocation\\-runner\\-\\d+"), any(),
-			eq(SeparateThreadExecutorResource.class));
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout.ThreadMode;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
+import org.junit.jupiter.engine.execution.ExtensionValuesStore;
+import org.junit.jupiter.engine.execution.NamespaceAwareStore;
+import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.SingleThreadExecutorResource;
+import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.ThreadPoolExecutorResource;
+import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.TimeoutInvocationParameters;
+
+@DisplayName("TimeoutInvocationFactory")
+class TimeoutInvocationFactoryTest {
+
+	private final Store store = spy(new NamespaceAwareStore(new ExtensionValuesStore(null),
+		ExtensionContext.Namespace.create(TimeoutInvocationFactoryTest.class)));
+	private final Invocation<String> invocation = mock(InvocationWithStringResult.class);
+	private final TimeoutDuration timeoutDuration = mock(TimeoutDuration.class);
+	private TimeoutInvocationFactory timeoutInvocationFactory;
+	private TimeoutInvocationParameters<String> timeoutInvocationParameters;
+
+	@BeforeEach
+	void setUp() {
+		;
+		timeoutInvocationParameters = new TimeoutInvocationParameters<>(invocation, timeoutDuration,
+			() -> "description");
+		timeoutInvocationFactory = new TimeoutInvocationFactory(store);
+	}
+
+	@Test
+	@DisplayName("throws exception when null store is provided on create")
+	void shouldThrowExceptionWhenInstantiatingWithNullStore() {
+		assertThatThrownBy(() -> new TimeoutInvocationFactory(null)).hasMessage("store must not be null");
+	}
+
+	@Test
+	@DisplayName("throws exception when null timeout thread mode is provided on create")
+	void shouldThrowExceptionWhenNullTimeoutThreadModeIsProvidedWhenCreate() {
+		assertThatThrownBy(() -> timeoutInvocationFactory.create(null, timeoutInvocationParameters)).hasMessage(
+			"thread mode must not be null");
+	}
+
+	@Test
+	@DisplayName("throws exception when null timeout invocation parameters is provided on create")
+	void shouldThrowExceptionWhenNullTimeoutInvocationParametersIsProvidedWhenCreate() {
+		assertThatThrownBy(() -> timeoutInvocationFactory.create(ThreadMode.SAME_THREAD, null)).hasMessage(
+			"timeout invocation parameters must not be null");
+	}
+
+	@Test
+	@DisplayName("creates timeout invocation for SAME_THREAD thread mode")
+	void shouldCreateTimeoutInvocationForSameThreadTimeoutThreadMode() {
+		Invocation<String> invocation = timeoutInvocationFactory.create(ThreadMode.SAME_THREAD,
+			timeoutInvocationParameters);
+		assertThat(invocation).isInstanceOf(SameThreadTimeoutInvocation.class);
+		verify(store).getOrComputeIfAbsent(SingleThreadExecutorResource.class);
+	}
+
+	@Test
+	@DisplayName("creates timeout invocation for SEPARATE_THREAD thread mode")
+	void shouldCreateTimeoutInvocationForSeparateThreadTimeoutThreadMode() {
+		Invocation<String> invocation = timeoutInvocationFactory.create(ThreadMode.SEPARATE_THREAD,
+			timeoutInvocationParameters);
+		assertThat(invocation).isInstanceOf(SeparateThreadTimeoutInvocation.class);
+		verify(store).getOrComputeIfAbsent(ThreadPoolExecutorResource.class);
+	}
+
+	private interface InvocationWithStringResult extends Invocation<String> {
+
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
@@ -12,8 +12,10 @@ package org.junit.jupiter.engine.extension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -26,7 +28,8 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.engine.execution.ExtensionValuesStore;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
-import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.ExecutorResource;
+import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.SeparateThreadExecutorResource;
+import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.SingleThreadExecutorResource;
 import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.TimeoutInvocationParameters;
 
 @DisplayName("TimeoutInvocationFactory")
@@ -41,7 +44,6 @@ class TimeoutInvocationFactoryTest {
 
 	@BeforeEach
 	void setUp() {
-		;
 		timeoutInvocationParameters = new TimeoutInvocationParameters<>(invocation, timeoutDuration,
 			() -> "description");
 		timeoutInvocationFactory = new TimeoutInvocationFactory(store);
@@ -73,7 +75,7 @@ class TimeoutInvocationFactoryTest {
 		Invocation<String> invocation = timeoutInvocationFactory.create(ThreadMode.SAME_THREAD,
 			timeoutInvocationParameters);
 		assertThat(invocation).isInstanceOf(SameThreadTimeoutInvocation.class);
-		verify(store).getOrComputeIfAbsent(ExecutorResource.class);
+		verify(store).getOrComputeIfAbsent(SingleThreadExecutorResource.class);
 	}
 
 	@Test
@@ -82,7 +84,8 @@ class TimeoutInvocationFactoryTest {
 		Invocation<String> invocation = timeoutInvocationFactory.create(ThreadMode.SEPARATE_THREAD,
 			timeoutInvocationParameters);
 		assertThat(invocation).isInstanceOf(SeparateThreadTimeoutInvocation.class);
-		verify(store, never()).getOrComputeIfAbsent(ExecutorResource.class);
+		verify(store).getOrComputeIfAbsent(matches("junit\\-jupiter\\-timeout\\-invocation\\-runner\\-\\d+"), any(),
+			eq(SeparateThreadExecutorResource.class));
 	}
 
 	private interface InvocationWithStringResult extends Invocation<String> {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTest.java
@@ -12,68 +12,69 @@ package org.junit.jupiter.engine.extension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.matches;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout.ThreadMode;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.engine.execution.ExtensionValuesStore;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
-import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.SeparateThreadExecutorResource;
 import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.SingleThreadExecutorResource;
 import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.TimeoutInvocationParameters;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayName("TimeoutInvocationFactory")
+@ExtendWith(MockitoExtension.class)
 class TimeoutInvocationFactoryTest {
 
-	private final Store store = spy(new NamespaceAwareStore(new ExtensionValuesStore(null),
-		ExtensionContext.Namespace.create(TimeoutInvocationFactoryTest.class)));
-	private final Invocation<String> invocation = mock(InvocationWithStringResult.class);
-	private final TimeoutDuration timeoutDuration = mock(TimeoutDuration.class);
+	@Spy
+	private final Store store = new NamespaceAwareStore(new ExtensionValuesStore(null),
+		ExtensionContext.Namespace.create(TimeoutInvocationFactoryTest.class));
+	@Mock
+	private Invocation<String> invocation;
+	@Mock
+	private TimeoutDuration timeoutDuration;
 	private TimeoutInvocationFactory timeoutInvocationFactory;
-	private TimeoutInvocationParameters<String> timeoutInvocationParameters;
+	private TimeoutInvocationParameters<String> parameters;
 
 	@BeforeEach
 	void setUp() {
-		timeoutInvocationParameters = new TimeoutInvocationParameters<>(invocation, timeoutDuration,
-			() -> "description");
+		parameters = new TimeoutInvocationParameters<>(invocation, timeoutDuration, () -> "description");
 		timeoutInvocationFactory = new TimeoutInvocationFactory(store);
 	}
 
 	@Test
 	@DisplayName("throws exception when null store is provided on create")
 	void shouldThrowExceptionWhenInstantiatingWithNullStore() {
-		assertThatThrownBy(() -> new TimeoutInvocationFactory(null)).hasMessage("store must not be null");
+		assertThatThrownBy(() -> new TimeoutInvocationFactory(null)) //
+				.hasMessage("store must not be null");
 	}
 
 	@Test
 	@DisplayName("throws exception when null timeout thread mode is provided on create")
 	void shouldThrowExceptionWhenNullTimeoutThreadModeIsProvidedWhenCreate() {
-		assertThatThrownBy(() -> timeoutInvocationFactory.create(null, timeoutInvocationParameters)).hasMessage(
-			"thread mode must not be null");
+		assertThatThrownBy(() -> timeoutInvocationFactory.create(null, parameters)) //
+				.hasMessage("thread mode must not be null");
 	}
 
 	@Test
 	@DisplayName("throws exception when null timeout invocation parameters is provided on create")
 	void shouldThrowExceptionWhenNullTimeoutInvocationParametersIsProvidedWhenCreate() {
-		assertThatThrownBy(() -> timeoutInvocationFactory.create(ThreadMode.SAME_THREAD, null)).hasMessage(
-			"timeout invocation parameters must not be null");
+		assertThatThrownBy(() -> timeoutInvocationFactory.create(ThreadMode.SAME_THREAD, null)) //
+				.hasMessage("timeout invocation parameters must not be null");
 	}
 
 	@Test
 	@DisplayName("creates timeout invocation for SAME_THREAD thread mode")
 	void shouldCreateTimeoutInvocationForSameThreadTimeoutThreadMode() {
-		Invocation<String> invocation = timeoutInvocationFactory.create(ThreadMode.SAME_THREAD,
-			timeoutInvocationParameters);
+		var invocation = timeoutInvocationFactory.create(ThreadMode.SAME_THREAD, parameters);
 		assertThat(invocation).isInstanceOf(SameThreadTimeoutInvocation.class);
 		verify(store).getOrComputeIfAbsent(SingleThreadExecutorResource.class);
 	}
@@ -81,14 +82,10 @@ class TimeoutInvocationFactoryTest {
 	@Test
 	@DisplayName("creates timeout invocation for SEPARATE_THREAD thread mode")
 	void shouldCreateTimeoutInvocationForSeparateThreadTimeoutThreadMode() {
-		Invocation<String> invocation = timeoutInvocationFactory.create(ThreadMode.SEPARATE_THREAD,
-			timeoutInvocationParameters);
+		var invocation = timeoutInvocationFactory.create(ThreadMode.SEPARATE_THREAD, parameters);
 		assertThat(invocation).isInstanceOf(SeparateThreadTimeoutInvocation.class);
 		verify(store).getOrComputeIfAbsent(matches("junit\\-jupiter\\-timeout\\-invocation\\-runner\\-\\d+"), any(),
 			eq(SeparateThreadExecutorResource.class));
 	}
 
-	private interface InvocationWithStringResult extends Invocation<String> {
-
-	}
 }


### PR DESCRIPTION
## Overview

This PR is an attempt to solve the issue #2087, allowing to set the thread mode in the `@Timeout` annotation. 

Instead of calling the enum `Mode`, I called it `ThreadMode` since there was already a configuration parameter called `TIMEOUT_MODE_PROPERTY_NAME` which can lead to confusion.

`INFERRED` is used as default, in case no thread mode is provided by the configuration parameter `SAME_THREAD` is used as default.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
