### PR TITLE
Improve stability of timeout tests

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.extension;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -20,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout.ThreadMode;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.engine.execution.ExtensionValuesStore;
@@ -32,18 +34,20 @@ import org.junit.jupiter.engine.extension.TimeoutInvocationFactory.TimeoutInvoca
 @DisplayName("SeparateThreadTimeoutInvocation")
 class SeparateThreadTimeoutInvocationTest {
 
+	private static final long PREEMPTIVE_TIMEOUT_MILLIS = OS.current() == WINDOWS ? 1000 : 100;
+
 	@Test
 	@DisplayName("throws timeout exception when timeout duration is exceeded")
 	void throwsTimeoutException() {
 		AtomicReference<String> threadName = new AtomicReference<>();
 		var invocation = aSeparateThreadInvocation(() -> {
 			threadName.set(Thread.currentThread().getName());
-			Thread.sleep(100);
+			Thread.sleep(PREEMPTIVE_TIMEOUT_MILLIS * 2);
 			return null;
 		});
 
 		assertThatThrownBy(invocation::proceed) //
-				.hasMessage("method() timed out after 10 milliseconds") //
+				.hasMessage("method() timed out after " + PREEMPTIVE_TIMEOUT_MILLIS + " milliseconds") //
 				.isInstanceOf(TimeoutException.class) //
 				.hasRootCauseMessage("Execution timed out in thread " + threadName.get());
 	}
@@ -69,8 +73,8 @@ class SeparateThreadTimeoutInvocationTest {
 	private static <T> SeparateThreadTimeoutInvocation<T> aSeparateThreadInvocation(Invocation<T> invocation) {
 		var namespace = ExtensionContext.Namespace.create(SeparateThreadTimeoutInvocationTest.class);
 		var store = new NamespaceAwareStore(new ExtensionValuesStore(null), namespace);
-		var parameters = new TimeoutInvocationParameters<>(invocation, new TimeoutDuration(10, MILLISECONDS),
-			() -> "method()");
+		var parameters = new TimeoutInvocationParameters<>(invocation,
+			new TimeoutDuration(PREEMPTIVE_TIMEOUT_MILLIS, MILLISECONDS), () -> "method()");
 		return (SeparateThreadTimeoutInvocation<T>) new TimeoutInvocationFactory(store) //
 				.create(ThreadMode.SEPARATE_THREAD, parameters);
 	}


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
