### PR TITLE
Add assertEquals with BinaryPredicate

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertEquals.java
@@ -17,6 +17,8 @@ import static org.junit.jupiter.api.AssertionUtils.objectsAreEqual;
 
 import java.util.function.Supplier;
 
+import org.junit.jupiter.api.function.BinaryPredicate;
+
 /**
  * {@code AssertEquals} is a collection of utility methods that support asserting
  * equality on objects and primitives in tests.
@@ -189,4 +191,21 @@ class AssertEquals {
 		}
 	}
 
+	static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals) {
+		if (!equals.test(expected, actual)) {
+			failNotEqual(expected, actual, (String) null);
+		}
+	}
+
+	static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals, String message) {
+		if (!equals.test(expected, actual)) {
+			failNotEqual(expected, actual, message);
+		}
+	}
+
+	static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals, Supplier<String> messageSupplier) {
+		if (!equals.test(expected, actual)) {
+			failNotEqual(expected, actual, messageSupplier);
+		}
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3573,14 +3573,17 @@ public class Assertions {
 		return AssertInstanceOf.assertInstanceOf(expectedType, actualValue, messageSupplier);
 	}
 
+	@API(status = EXPERIMENTAL, since = "5.10")
 	public static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals) {
 		AssertEquals.assertEquals(expected, actual, equals);
 	}
 
+	@API(status = EXPERIMENTAL, since = "5.10")
 	public static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals, String message) {
 		AssertEquals.assertEquals(expected, actual, equals, message);
 	}
 
+	@API(status = EXPERIMENTAL, since = "5.10")
 	public static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals,
 			Supplier<String> messageSupplier) {
 		AssertEquals.assertEquals(expected, actual, equals, messageSupplier);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.function.BinaryPredicate;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.opentest4j.MultipleFailuresError;
@@ -3572,4 +3573,16 @@ public class Assertions {
 		return AssertInstanceOf.assertInstanceOf(expectedType, actualValue, messageSupplier);
 	}
 
+	public static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals) {
+		AssertEquals.assertEquals(expected, actual, equals);
+	}
+
+	public static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals, String message) {
+		AssertEquals.assertEquals(expected, actual, equals, message);
+	}
+
+	public static <T> void assertEquals(T expected, T actual, BinaryPredicate<T> equals,
+			Supplier<String> messageSupplier) {
+		AssertEquals.assertEquals(expected, actual, equals, messageSupplier);
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/BinaryPredicate.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/BinaryPredicate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.function;
+
+import java.util.Comparator;
+
+public interface BinaryPredicate<T> {
+
+	boolean test(T expected, T actual);
+
+	default BinaryPredicate<T> not() {
+		return not(this);
+	}
+
+	static <T extends Comparable<T>> BinaryPredicate<T> compare() {
+		return compare(Comparable::compareTo);
+	}
+
+	static <T> BinaryPredicate<T> compare(Comparator<T> compare) {
+		return (expected, actual) -> compare.compare(expected, actual) == 0;
+	}
+
+	static <T> BinaryPredicate<T> not(BinaryPredicate<T> predicate) {
+		return (expected, actual) -> !predicate.test(expected, actual);
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/BinaryPredicate.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/BinaryPredicate.java
@@ -12,6 +12,10 @@ package org.junit.jupiter.api.function;
 
 import java.util.Comparator;
 
+import org.apiguardian.api.API;
+
+@FunctionalInterface
+@API(status = API.Status.EXPERIMENTAL, since = "5.10")
 public interface BinaryPredicate<T> {
 
 	boolean test(T expected, T actual);
@@ -31,4 +35,5 @@ public interface BinaryPredicate<T> {
 	static <T> BinaryPredicate<T> not(BinaryPredicate<T> predicate) {
 		return (expected, actual) -> !predicate.test(expected, actual);
 	}
+
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
+import java.util.Comparator;
 import java.util.Optional;
 
 import org.junit.jupiter.api.function.BinaryPredicate;
@@ -661,6 +662,11 @@ class AssertEqualsAssertionsTests {
 						+ "\\Q<Optional[3]> but was: java.util.Optional@\\E" + ".+" + "\\Q<Optional[3]>\\E"),
 				ex.getMessage());
 		}
+	}
+
+	@Test
+	void assertEqualsWithBinaryPredicateOptionalWithMessageSupplier() {
+		assertEquals(4d, 4L, BinaryPredicate.compare(Comparator.comparingDouble(Number::doubleValue)));
 	}
 
 	// -------------------------------------------------------------------------

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
@@ -15,8 +15,9 @@ import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEndsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.function.BinaryPredicate.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -624,13 +625,13 @@ class AssertEqualsAssertionsTests {
 	}
 
 	@Test
-	void assertEqualsWithBinaryPredicate() {
+	void assertEqualsWithBinaryPredicateBigDecimal() {
 		assertEquals(BigDecimal.valueOf(0.3), BigDecimal.valueOf(1.3).subtract(BigDecimal.valueOf(1.0)),
 			BinaryPredicate.compare());
 	}
 
 	@Test
-	void assertEqualsWithBinaryPredicate2() {
+	void assertEqualsWithBinaryPredicateBigDecimalFail() {
 		try {
 			assertEquals(BigDecimal.valueOf(0.3), BigDecimal.valueOf(1.3 - 1.0d), BinaryPredicate.compare());
 		}
@@ -640,7 +641,7 @@ class AssertEqualsAssertionsTests {
 	}
 
 	@Test
-	void assertEqualsWithBinaryPredicate3() {
+	void assertEqualsWithBinaryPredicateOptional() {
 		try {
 			assertEquals(Optional.of(3), Optional.empty(), Optional::equals);
 		}
@@ -650,7 +651,7 @@ class AssertEqualsAssertionsTests {
 	}
 
 	@Test
-	void assertEqualsWithBinaryPredicate3b() {
+	void assertEqualsWithBinaryPredicateOptionalWithStringMessage() {
 		try {
 			assertEquals(Optional.of(3), Optional.of(3), BinaryPredicate.not(Optional::equals), "error message");
 		}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
@@ -15,9 +15,13 @@ import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEndsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.function.BinaryPredicate.not;
 
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.function.BinaryPredicate;
 import org.junit.jupiter.api.function.Executable;
 import org.opentest4j.AssertionFailedError;
 
@@ -616,6 +620,45 @@ class AssertEqualsAssertionsTests {
 		catch (AssertionFailedError ex) {
 			assertMessageStartsWith(ex, "expected: <" + ToStringThrowsException.class.getName() + "@");
 			assertMessageEndsWith(ex, "but was: <foo>");
+		}
+	}
+
+	@Test
+	void assertEqualsWithBinaryPredicate() {
+		assertEquals(BigDecimal.valueOf(0.3), BigDecimal.valueOf(1.3).subtract(BigDecimal.valueOf(1.0)),
+			BinaryPredicate.compare());
+	}
+
+	@Test
+	void assertEqualsWithBinaryPredicate2() {
+		try {
+			assertEquals(BigDecimal.valueOf(0.3), BigDecimal.valueOf(1.3 - 1.0d), BinaryPredicate.compare());
+		}
+		catch (AssertionFailedError ex) {
+			assertEquals("expected: <0.3> but was: <0.30000000000000004>", ex.getMessage());
+		}
+	}
+
+	@Test
+	void assertEqualsWithBinaryPredicate3() {
+		try {
+			assertEquals(Optional.of(3), Optional.empty(), Optional::equals);
+		}
+		catch (AssertionFailedError ex) {
+			assertEquals("expected: <Optional[3]> but was: <Optional.empty>", ex.getMessage());
+		}
+	}
+
+	@Test
+	void assertEqualsWithBinaryPredicate3b() {
+		try {
+			assertEquals(Optional.of(3), Optional.of(3), BinaryPredicate.not(Optional::equals), "error message");
+		}
+		catch (AssertionFailedError ex) {
+			assertTrue(
+				ex.getMessage().matches("\\Qerror message ==> expected: java.util.Optional@\\E" + ".+"
+						+ "\\Q<Optional[3]> but was: java.util.Optional@\\E" + ".+" + "\\Q<Optional[3]>\\E"),
+				ex.getMessage());
 		}
 	}
 


### PR DESCRIPTION
## Overview

Initial PR for #2964 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
