### PR TITLE
Fix display name and improve assertions for `@TempDir` test case

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -193,6 +193,7 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	@DisplayName("only attempts to delete undeletable directories once")
 	void onlyAttemptsToDeleteUndeletableDirectoriesOnce() {
 		var results = executeTestsForClass(UndeletableDirectoryTestCase.class);
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.extension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -410,12 +411,16 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 		Path pathTempDir;
 
 		@Test
-		@DisplayName("and injected File and Path reference the same temp directory")
+		@DisplayName("and injected File and Path do not reference the same temp directory")
 		void checkFile(@TempDir File tempDir, @TempDir Path ref) {
-			assertNotNull(tempDir);
-			assertNotNull(ref);
-			assertNotNull(this.fileTempDir);
-			assertNotNull(this.pathTempDir);
+			assertFileAndPathAreNotEqual(tempDir, ref);
+			assertFileAndPathAreNotEqual(this.fileTempDir, this.pathTempDir);
+		}
+
+		private static void assertFileAndPathAreNotEqual(File tempDir, Path ref) {
+			Path path = tempDir.toPath();
+			assertNotEquals(ref.toAbsolutePath(), path.toAbsolutePath());
+			assertTrue(Files.exists(path));
 		}
 
 	}


### PR DESCRIPTION
I guess this:

https://github.com/junit-team/junit5/blob/7416e56237d3eefc890d3b36164a1b4a22fd5941/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java#L412-L419

was originally inspired by:

https://github.com/junit-team/junit5/blob/7416e56237d3eefc890d3b36164a1b4a22fd5941/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerContextTests.java#L786-L797

but the former is not really verifying what the display name says.

This is my attempt to fix it.