### PR TITLE
Introduce AssertionFailureBuilder

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/index.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/index.adoc
@@ -16,6 +16,8 @@ authors as well as build tool and IDE vendors.
 
 include::{includedir}/link-attributes.adoc[]
 
+include::{basedir}/release-notes-5.9.0.adoc[]
+
 include::{basedir}/release-notes-5.9.0-RC1.adoc[]
 
 include::{basedir}/release-notes-5.9.0-M1.adoc[]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0.adoc
@@ -39,7 +39,8 @@ GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* `AssertionFailureBuilder` allows reusing Jupiter's logic for creating failure messages
+  to assist in writing custom assertion methods.
 
 
 [[release-notes-5.9.0-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0.adoc
@@ -1,0 +1,58 @@
+[[release-notes-5.9.0]]
+== 5.9.0
+
+*Date of Release:* ❓
+
+*Scope:* ❓
+
+For a complete list of all _closed_ issues and pull requests for this release, consult the
+link:{junit5-repo}+/milestone/62?closed=1+[5.9.0] milestone page in the JUnit repository on
+GitHub.
+
+
+[[release-notes-5.9.0-junit-platform]]
+=== JUnit Platform
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓
+
+
+[[release-notes-5.9.0-junit-jupiter]]
+=== JUnit Jupiter
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓
+
+
+[[release-notes-5.9.0-junit-vintage]]
+=== JUnit Vintage
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
@@ -10,11 +10,8 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.fail;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.AssertionUtils.formatIndexes;
-import static org.junit.jupiter.api.AssertionUtils.formatValues;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 import static org.junit.platform.commons.util.ReflectionUtils.isArray;
 
 import java.util.ArrayDeque;
@@ -406,30 +403,41 @@ class AssertArrayEquals {
 	}
 
 	private static void failExpectedArrayIsNull(Deque<Integer> indexes, Object messageOrSupplier) {
-		fail(buildPrefix(nullSafeGet(messageOrSupplier)) + "expected array was <null>" + formatIndexes(indexes));
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("expected array was <null>" + formatIndexes(indexes)) //
+				.buildAndThrow();
 	}
 
 	private static void failActualArrayIsNull(Deque<Integer> indexes, Object messageOrSupplier) {
-		fail(buildPrefix(nullSafeGet(messageOrSupplier)) + "actual array was <null>" + formatIndexes(indexes));
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("actual array was <null>" + formatIndexes(indexes)) //
+				.buildAndThrow();
 	}
 
 	private static void assertArraysHaveSameLength(int expected, int actual, Deque<Integer> indexes,
 			Object messageOrSupplier) {
 
 		if (expected != actual) {
-			String prefix = buildPrefix(nullSafeGet(messageOrSupplier));
-			String message = "array lengths differ" + formatIndexes(indexes) + ", expected: <" + expected
-					+ "> but was: <" + actual + ">";
-			fail(prefix + message);
+			assertionFailure() //
+					.message(messageOrSupplier) //
+					.reason("array lengths differ" + formatIndexes(indexes)) //
+					.expected(expected) //
+					.actual(actual) //
+					.buildAndThrow();
 		}
 	}
 
 	private static void failArraysNotEqual(Object expected, Object actual, Deque<Integer> indexes,
 			Object messageOrSupplier) {
 
-		String prefix = buildPrefix(nullSafeGet(messageOrSupplier));
-		String message = "array contents differ" + formatIndexes(indexes) + ", " + formatValues(expected, actual);
-		fail(prefix + message);
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("array contents differ" + formatIndexes(indexes)) //
+				.expected(expected) //
+				.actual(actual) //
+				.buildAndThrow();
 	}
 
 	private static Deque<Integer> nullSafeIndexes(Deque<Integer> indexes, int newIndex) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
@@ -10,8 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.Supplier;
 
@@ -78,9 +77,11 @@ class AssertDoesNotThrow {
 	}
 
 	private static AssertionFailedError createAssertionFailedError(Object messageOrSupplier, Throwable t) {
-		String message = buildPrefix(nullSafeGet(messageOrSupplier)) + "Unexpected exception thrown: "
-				+ t.getClass().getName() + buildSuffix(t.getMessage());
-		return new AssertionFailedError(message, t);
+		return assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("Unexpected exception thrown: " + t.getClass().getName() + buildSuffix(t.getMessage())) //
+				.cause(t) //
+				.build();
 	}
 
 	private static String buildSuffix(String message) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertEquals.java
@@ -10,8 +10,8 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.AssertionUtils.doublesAreEqual;
-import static org.junit.jupiter.api.AssertionUtils.failNotEqual;
 import static org.junit.jupiter.api.AssertionUtils.floatsAreEqual;
 import static org.junit.jupiter.api.AssertionUtils.objectsAreEqual;
 
@@ -189,4 +189,11 @@ class AssertEquals {
 		}
 	}
 
+	private static void failNotEqual(Object expected, Object actual, Object messageOrSupplier) {
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.expected(expected) //
+				.actual(actual) //
+				.buildAndThrow();
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertFalse.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertFalse.java
@@ -10,9 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.fail;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -25,8 +23,6 @@ import java.util.function.Supplier;
  */
 class AssertFalse {
 
-	private static final String EXPECTED_FALSE = "expected: <false> but was: <true>";
-
 	private AssertFalse() {
 		/* no-op */
 	}
@@ -37,13 +33,13 @@ class AssertFalse {
 
 	static void assertFalse(boolean condition, String message) {
 		if (condition) {
-			fail(buildPrefix(message) + EXPECTED_FALSE, false, true);
+			failNotFalse(message);
 		}
 	}
 
 	static void assertFalse(boolean condition, Supplier<String> messageSupplier) {
 		if (condition) {
-			fail(buildPrefix(nullSafeGet(messageSupplier)) + EXPECTED_FALSE, false, true);
+			failNotFalse(messageSupplier);
 		}
 	}
 
@@ -57,6 +53,14 @@ class AssertFalse {
 
 	static void assertFalse(BooleanSupplier booleanSupplier, Supplier<String> messageSupplier) {
 		assertFalse(booleanSupplier.getAsBoolean(), messageSupplier);
+	}
+
+	private static void failNotFalse(Object messageOrSupplier) {
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.expected(false) //
+				.actual(true) //
+				.buildAndThrow();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertInstanceOf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertInstanceOf.java
@@ -10,13 +10,9 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.format;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.Supplier;
-
-import org.opentest4j.AssertionFailedError;
 
 /**
  * {@code AssertInstanceOf} is a collection of utility methods that support
@@ -45,10 +41,12 @@ class AssertInstanceOf {
 
 	private static <T> T assertInstanceOf(Class<T> expectedType, Object actualValue, Object messageOrSupplier) {
 		if (!expectedType.isInstance(actualValue)) {
-			String reason = (actualValue == null ? "Unexpected null value" : "Unexpected type");
-			String message = buildPrefix(nullSafeGet(messageOrSupplier))
-					+ format(expectedType, actualValue == null ? null : actualValue.getClass(), reason);
-			throw new AssertionFailedError(message);
+			assertionFailure() //
+					.message(messageOrSupplier) //
+					.reason(actualValue == null ? "Unexpected null value" : "Unexpected type") //
+					.expected(expectedType) //
+					.actual(actualValue == null ? null : actualValue.getClass()) //
+					.buildAndThrow();
 		}
 		return expectedType.cast(actualValue);
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -10,11 +10,8 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.fail;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.AssertionUtils.formatIndexes;
-import static org.junit.jupiter.api.AssertionUtils.formatValues;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -139,11 +136,17 @@ class AssertIterableEquals {
 	}
 
 	private static void failExpectedIterableIsNull(Deque<Integer> indexes, Object messageOrSupplier) {
-		fail(buildPrefix(nullSafeGet(messageOrSupplier)) + "expected iterable was <null>" + formatIndexes(indexes));
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("expected iterable was <null>" + formatIndexes(indexes)) //
+				.buildAndThrow();
 	}
 
 	private static void failActualIterableIsNull(Deque<Integer> indexes, Object messageOrSupplier) {
-		fail(buildPrefix(nullSafeGet(messageOrSupplier)) + "actual iterable was <null>" + formatIndexes(indexes));
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("actual iterable was <null>" + formatIndexes(indexes)) //
+				.buildAndThrow();
 	}
 
 	private static void assertIteratorsAreEmpty(Iterator<?> expected, Iterator<?> actual, int processed,
@@ -156,19 +159,24 @@ class AssertIterableEquals {
 			AtomicInteger actualCount = new AtomicInteger(processed);
 			actual.forEachRemaining(e -> actualCount.incrementAndGet());
 
-			String prefix = buildPrefix(nullSafeGet(messageOrSupplier));
-			String message = "iterable lengths differ" + formatIndexes(indexes) + ", expected: <" + expectedCount.get()
-					+ "> but was: <" + actualCount.get() + ">";
-			fail(prefix + message);
+			assertionFailure() //
+					.message(messageOrSupplier) //
+					.reason("iterable lengths differ" + formatIndexes(indexes)) //
+					.expected(expectedCount.get()) //
+					.actual(actualCount.get()) //
+					.buildAndThrow();
 		}
 	}
 
 	private static void failIterablesNotEqual(Object expected, Object actual, Deque<Integer> indexes,
 			Object messageOrSupplier) {
 
-		String prefix = buildPrefix(nullSafeGet(messageOrSupplier));
-		String message = "iterable contents differ" + formatIndexes(indexes) + ", " + formatValues(expected, actual);
-		fail(prefix + message);
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("iterable contents differ" + formatIndexes(indexes)) //
+				.expected(expected) //
+				.actual(actual) //
+				.buildAndThrow();
 	}
 
 	private final static class Pair {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -12,8 +12,7 @@ package org.junit.jupiter.api;
 
 import static java.lang.String.format;
 import static java.lang.String.join;
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.platform.commons.util.Preconditions.condition;
 import static org.junit.platform.commons.util.Preconditions.notNull;
 
@@ -195,8 +194,13 @@ class AssertLinesMatch {
 
 		void fail(String format, Object... args) {
 			String newLine = System.lineSeparator();
-			String message = buildPrefix(nullSafeGet(messageOrSupplier)) + format(format, args);
-			AssertionUtils.fail(message, join(newLine, expectedLines), join(newLine, actualLines));
+			assertionFailure() //
+					.message(messageOrSupplier) //
+					.reason(format(format, args)) //
+					.expected(join(newLine, expectedLines)) //
+					.actual(join(newLine, actualLines)) //
+					.includeValuesInMessage(false) //
+					.buildAndThrow();
 		}
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotEquals.java
@@ -10,11 +10,9 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.AssertionUtils.doublesAreEqual;
-import static org.junit.jupiter.api.AssertionUtils.fail;
 import static org.junit.jupiter.api.AssertionUtils.floatsAreEqual;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 import static org.junit.jupiter.api.AssertionUtils.objectsAreEqual;
 
 import java.util.function.Supplier;
@@ -52,7 +50,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(byte unexpected, byte actual, Supplier<String> messageSupplier) {
 		if (unexpected == actual) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -77,7 +75,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(short unexpected, short actual, Supplier<String> messageSupplier) {
 		if (unexpected == actual) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -102,7 +100,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(int unexpected, int actual, Supplier<String> messageSupplier) {
 		if (unexpected == actual) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -127,7 +125,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(long unexpected, long actual, Supplier<String> messageSupplier) {
 		if (unexpected == actual) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -152,7 +150,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(float unexpected, float actual, Supplier<String> messageSupplier) {
 		if (floatsAreEqual(unexpected, actual)) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -177,7 +175,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(float unexpected, float actual, float delta, Supplier<String> messageSupplier) {
 		if (floatsAreEqual(unexpected, actual, delta)) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -202,7 +200,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(double unexpected, double actual, Supplier<String> messageSupplier) {
 		if (doublesAreEqual(unexpected, actual)) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -227,7 +225,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(double unexpected, double actual, double delta, Supplier<String> messageSupplier) {
 		if (doublesAreEqual(unexpected, actual, delta)) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -252,7 +250,7 @@ class AssertNotEquals {
 	 */
 	static void assertNotEquals(char unexpected, char actual, Supplier<String> messageSupplier) {
 		if (unexpected == actual) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
@@ -268,12 +266,15 @@ class AssertNotEquals {
 
 	static void assertNotEquals(Object unexpected, Object actual, Supplier<String> messageSupplier) {
 		if (objectsAreEqual(unexpected, actual)) {
-			failEqual(actual, nullSafeGet(messageSupplier));
+			failEqual(actual, messageSupplier);
 		}
 	}
 
-	private static void failEqual(Object actual, String message) {
-		fail(buildPrefix(message) + "expected: not equal but was: <" + actual + ">");
+	private static void failEqual(Object actual, Object messageOrSupplier) {
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("expected: not equal but was: <" + actual + ">") //
+				.buildAndThrow();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotNull.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotNull.java
@@ -10,8 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.Supplier;
 
@@ -39,11 +38,14 @@ class AssertNotNull {
 
 	static void assertNotNull(Object actual, Supplier<String> messageSupplier) {
 		if (actual == null) {
-			failNull(nullSafeGet(messageSupplier));
+			failNull(messageSupplier);
 		}
 	}
 
-	private static void failNull(String message) {
-		Assertions.fail(buildPrefix(message) + "expected: not <null>");
+	private static void failNull(Object messageOrSupplier) {
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("expected: not <null>") //
+				.buildAndThrow();
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotSame.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNotSame.java
@@ -10,9 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.fail;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.Supplier;
 
@@ -40,12 +38,15 @@ class AssertNotSame {
 
 	static void assertNotSame(Object unexpected, Object actual, Supplier<String> messageSupplier) {
 		if (unexpected == actual) {
-			failSame(actual, nullSafeGet(messageSupplier));
+			failSame(actual, messageSupplier);
 		}
 	}
 
-	private static void failSame(Object actual, String message) {
-		fail(buildPrefix(message) + "expected: not same but was: <" + actual + ">");
+	private static void failSame(Object actual, Object messageOrSupplier) {
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason("expected: not same but was: <" + actual + ">") //
+				.buildAndThrow();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNull.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertNull.java
@@ -10,10 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.fail;
-import static org.junit.jupiter.api.AssertionUtils.format;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.Supplier;
 
@@ -41,18 +38,16 @@ class AssertNull {
 
 	static void assertNull(Object actual, Supplier<String> messageSupplier) {
 		if (actual != null) {
-			failNotNull(actual, nullSafeGet(messageSupplier));
+			failNotNull(actual, messageSupplier);
 		}
 	}
 
-	private static void failNotNull(Object actual, String message) {
-		String stringRepresentation = actual.toString();
-		if (stringRepresentation == null || stringRepresentation.equals("null")) {
-			fail(format(null, actual, message), null, actual);
-		}
-		else {
-			fail(buildPrefix(message) + "expected: <null> but was: <" + actual + ">", null, actual);
-		}
+	private static void failNotNull(Object actual, Object messageOrSupplier) {
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.expected(null) //
+				.actual(actual) //
+				.buildAndThrow();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertSame.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertSame.java
@@ -10,9 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.fail;
-import static org.junit.jupiter.api.AssertionUtils.format;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.Supplier;
 
@@ -40,12 +38,16 @@ class AssertSame {
 
 	static void assertSame(Object expected, Object actual, Supplier<String> messageSupplier) {
 		if (expected != actual) {
-			failNotSame(expected, actual, nullSafeGet(messageSupplier));
+			failNotSame(expected, actual, messageSupplier);
 		}
 	}
 
-	private static void failNotSame(Object expected, Object actual, String message) {
-		fail(format(expected, actual, message), expected, actual);
+	private static void failNotSame(Object expected, Object actual, Object messageOrSupplier) {
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.expected(expected) //
+				.actual(actual) //
+				.buildAndThrow();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
@@ -63,6 +63,7 @@ class AssertThrows {
 						.expected(expectedType) //
 						.actual(actualException.getClass()) //
 						.reason("Unexpected exception type thrown") //
+						.cause(actualException) //
 						.build();
 			}
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
@@ -10,16 +10,14 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.format;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.function.Executable;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
-import org.opentest4j.AssertionFailedError;
 
 /**
  * {@code AssertThrows} is a collection of utility methods that support asserting
@@ -60,15 +58,18 @@ class AssertThrows {
 			}
 			else {
 				UnrecoverableExceptions.rethrowIfUnrecoverable(actualException);
-				String message = buildPrefix(nullSafeGet(messageOrSupplier))
-						+ format(expectedType, actualException.getClass(), "Unexpected exception type thrown");
-				throw new AssertionFailedError(message, actualException);
+				throw assertionFailure() //
+						.message(messageOrSupplier) //
+						.expected(expectedType) //
+						.actual(actualException.getClass()) //
+						.reason("Unexpected exception type thrown") //
+						.build();
 			}
 		}
-
-		String message = buildPrefix(nullSafeGet(messageOrSupplier))
-				+ String.format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType));
-		throw new AssertionFailedError(message);
+		throw assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason(format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType))) //
+				.build();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
@@ -10,16 +10,14 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.format;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
 
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.function.Executable;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
-import org.opentest4j.AssertionFailedError;
 
 /**
  * {@code AssertThrowsExactly} is a collection of utility methods that support asserting
@@ -60,15 +58,19 @@ class AssertThrowsExactly {
 			}
 			else {
 				UnrecoverableExceptions.rethrowIfUnrecoverable(actualException);
-				String message = buildPrefix(nullSafeGet(messageOrSupplier))
-						+ format(expectedType, actualException.getClass(), "Unexpected exception type thrown");
-				throw new AssertionFailedError(message, actualException);
+				throw assertionFailure() //
+						.message(messageOrSupplier) //
+						.expected(expectedType) //
+						.actual(actualException.getClass()) //
+						.reason("Unexpected exception type thrown") //
+						.build();
 			}
 		}
 
-		String message = buildPrefix(nullSafeGet(messageOrSupplier))
-				+ String.format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType));
-		throw new AssertionFailedError(message);
+		throw assertionFailure() //
+				.message(messageOrSupplier) //
+				.reason(format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType))) //
+				.build();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
@@ -63,6 +63,7 @@ class AssertThrowsExactly {
 						.expected(expectedType) //
 						.actual(actualException.getClass()) //
 						.reason("Unexpected exception type thrown") //
+						.cause(actualException) //
 						.build();
 			}
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTrue.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTrue.java
@@ -10,9 +10,7 @@
 
 package org.junit.jupiter.api;
 
-import static org.junit.jupiter.api.AssertionUtils.buildPrefix;
-import static org.junit.jupiter.api.AssertionUtils.fail;
-import static org.junit.jupiter.api.AssertionUtils.nullSafeGet;
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -25,8 +23,6 @@ import java.util.function.Supplier;
  */
 class AssertTrue {
 
-	private static final String EXPECTED_TRUE = "expected: <true> but was: <false>";
-
 	private AssertTrue() {
 		/* no-op */
 	}
@@ -37,13 +33,13 @@ class AssertTrue {
 
 	static void assertTrue(boolean condition, String message) {
 		if (!condition) {
-			fail(buildPrefix(message) + EXPECTED_TRUE, true, false);
+			failNotTrue(message);
 		}
 	}
 
 	static void assertTrue(boolean condition, Supplier<String> messageSupplier) {
 		if (!condition) {
-			fail(buildPrefix(nullSafeGet(messageSupplier)) + EXPECTED_TRUE, true, false);
+			failNotTrue(messageSupplier);
 		}
 	}
 
@@ -57,6 +53,14 @@ class AssertTrue {
 
 	static void assertTrue(BooleanSupplier booleanSupplier, Supplier<String> messageSupplier) {
 		assertTrue(booleanSupplier.getAsBoolean(), messageSupplier);
+	}
+
+	private static void failNotTrue(Object messageOrSupplier) {
+		assertionFailure() //
+				.message(messageOrSupplier) //
+				.expected(true) //
+				.actual(false) //
+				.buildAndThrow();
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
@@ -12,9 +12,6 @@ package org.junit.jupiter.api;
 
 import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.function.Supplier;
 
 import org.junit.platform.commons.util.StringUtils;
@@ -24,7 +21,6 @@ public class AssertionFailureBuilder {
 
 	private Object message;
 	private Throwable cause;
-	private final List<Throwable> suppressed = new ArrayList<>();
 	private boolean mismatch;
 	private Object expected;
 	private Object actual;
@@ -50,16 +46,6 @@ public class AssertionFailureBuilder {
 
 	public AssertionFailureBuilder cause(Throwable cause) {
 		this.cause = cause;
-		return this;
-	}
-
-	public AssertionFailureBuilder suppressed(Throwable suppressed) {
-		this.suppressed.add(suppressed);
-		return this;
-	}
-
-	public AssertionFailureBuilder suppressed(Throwable... suppressed) {
-		this.suppressed.addAll(Arrays.asList(suppressed));
 		return this;
 	}
 
@@ -93,11 +79,9 @@ public class AssertionFailureBuilder {
 		if (reason != null) {
 			message = buildPrefix(message) + reason;
 		}
-		AssertionFailedError assertionFailedError = mismatch //
+		return mismatch //
 				? new AssertionFailedError(message, expected, actual, cause) //
 				: new AssertionFailedError(message, cause);
-		suppressed.forEach(assertionFailedError::addSuppressed);
-		return assertionFailedError;
 	}
 
 	private static String nullSafeGet(Object messageOrSupplier) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
@@ -10,13 +10,25 @@
 
 package org.junit.jupiter.api;
 
+import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
 
 import java.util.function.Supplier;
 
+import org.apiguardian.api.API;
 import org.junit.platform.commons.util.StringUtils;
 import org.opentest4j.AssertionFailedError;
 
+/**
+ * Builder for {@link AssertionFailedError AssertionFailedErrors}.
+ * <p>
+ * Using this builder ensures consistency in how failure message are formatted
+ * within JUnit Jupiter and for custom user-defined assertions.
+ *
+ * @since 5.9
+ * @see AssertionFailedError
+ */
+@API(status = STABLE, since = "5.9")
 public class AssertionFailureBuilder {
 
 	private Object message;
@@ -27,6 +39,9 @@ public class AssertionFailureBuilder {
 	private String reason;
 	private boolean includeValuesInMessage = true;
 
+	/**
+	 * Create a new {@code AssertionFailureBuilder}.
+	 */
 	public static AssertionFailureBuilder assertionFailure() {
 		return new AssertionFailureBuilder();
 	}
@@ -34,42 +49,95 @@ public class AssertionFailureBuilder {
 	private AssertionFailureBuilder() {
 	}
 
+	/**
+	 * Set the user-defined message of the assertion.
+	 * <p>
+	 * The {@code message} may be passed as a {@link Supplier} or plain
+	 * {@link String}. If any other type is passed, it is converted to
+	 * {@code String} as per {@link StringUtils#nullSafeToString(Object)}.
+	 *
+	 * @param message the user-defined failure message; may be {@code null}
+	 * @return this builder for method chaining
+	 */
 	public AssertionFailureBuilder message(Object message) {
 		this.message = message;
 		return this;
 	}
 
+	/**
+	 * Set the reason why the assertion failed.
+	 *
+	 * @param reason the failure reason; may be {@code null}
+	 * @return this builder for method chaining
+	 */
 	public AssertionFailureBuilder reason(String reason) {
 		this.reason = reason;
 		return this;
 	}
 
+	/**
+	 * Set the cause of the assertion failure.
+	 *
+	 * @param cause the failure cause; may be {@code null}
+	 * @return this builder for method chaining
+	 */
 	public AssertionFailureBuilder cause(Throwable cause) {
 		this.cause = cause;
 		return this;
 	}
 
+	/**
+	 * Set the expected value of the assertion.
+	 *
+	 * @param expected the expected value; may be {@code null}
+	 * @return this builder for method chaining
+	 */
 	public AssertionFailureBuilder expected(Object expected) {
 		this.mismatch = true;
 		this.expected = expected;
 		return this;
 	}
 
+	/**
+	 * Set the actual value of the assertion.
+	 *
+	 * @param actual the actual value; may be {@code null}
+	 * @return this builder for method chaining
+	 */
 	public AssertionFailureBuilder actual(Object actual) {
 		this.mismatch = true;
 		this.actual = actual;
 		return this;
 	}
 
+	/**
+	 * Set whether to include the actual and expected values in the generated
+	 * failure message.
+	 *
+	 * @param includeValuesInMessage whether to include the actual and expected
+	 *                               values
+	 * @return this builder for method chaining
+	 */
 	public AssertionFailureBuilder includeValuesInMessage(boolean includeValuesInMessage) {
 		this.includeValuesInMessage = includeValuesInMessage;
 		return this;
 	}
 
+	/**
+	 * Build the {@link AssertionFailedError AssertionFailedError} and throw it.
+	 *
+	 * @throws AssertionFailedError always
+	 */
 	public void buildAndThrow() throws AssertionFailedError {
 		throw build();
 	}
 
+	/**
+	 * Build the {@link AssertionFailedError AssertionFailedError} without
+	 * throwing it.
+	 *
+	 * @return the built assertion failure
+	 */
 	public AssertionFailedError build() {
 		String reason = nullSafeGet(this.reason);
 		if (mismatch && includeValuesInMessage) {
@@ -90,9 +158,9 @@ public class AssertionFailureBuilder {
 		}
 		if (messageOrSupplier instanceof Supplier) {
 			Object message = ((Supplier<?>) messageOrSupplier).get();
-			return message == null ? null : message.toString();
+			return StringUtils.nullSafeToString(message);
 		}
-		return String.valueOf(messageOrSupplier);
+		return StringUtils.nullSafeToString(messageOrSupplier);
 	}
 
 	private static String buildPrefix(String message) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.junit.platform.commons.util.StringUtils;
+import org.opentest4j.AssertionFailedError;
+
+public class AssertionFailureBuilder {
+
+	private Object message;
+	private Throwable cause;
+	private final List<Throwable> suppressed = new ArrayList<>();
+	private boolean mismatch;
+	private Object expected;
+	private Object actual;
+	private String reason;
+	private boolean includeValuesInMessage = true;
+
+	public static AssertionFailureBuilder assertionFailure() {
+		return new AssertionFailureBuilder();
+	}
+
+	private AssertionFailureBuilder() {
+	}
+
+	public AssertionFailureBuilder message(Object message) {
+		this.message = message;
+		return this;
+	}
+
+	public AssertionFailureBuilder reason(String reason) {
+		this.reason = reason;
+		return this;
+	}
+
+	public AssertionFailureBuilder cause(Throwable cause) {
+		this.cause = cause;
+		return this;
+	}
+
+	public AssertionFailureBuilder suppressed(Throwable suppressed) {
+		this.suppressed.add(suppressed);
+		return this;
+	}
+
+	public AssertionFailureBuilder suppressed(Throwable... suppressed) {
+		this.suppressed.addAll(Arrays.asList(suppressed));
+		return this;
+	}
+
+	public AssertionFailureBuilder expected(Object expected) {
+		this.mismatch = true;
+		this.expected = expected;
+		return this;
+	}
+
+	public AssertionFailureBuilder actual(Object actual) {
+		this.mismatch = true;
+		this.actual = actual;
+		return this;
+	}
+
+	public AssertionFailureBuilder includeValuesInMessage(boolean includeValuesInMessage) {
+		this.includeValuesInMessage = includeValuesInMessage;
+		return this;
+	}
+
+	public void buildAndThrow() throws AssertionFailedError {
+		throw build();
+	}
+
+	public AssertionFailedError build() {
+		String reason = nullSafeGet(this.reason);
+		if (mismatch && includeValuesInMessage) {
+			reason = (reason == null ? "" : reason + ", ") + formatValues(expected, actual);
+		}
+		String message = nullSafeGet(this.message);
+		if (reason != null) {
+			message = buildPrefix(message) + reason;
+		}
+		AssertionFailedError assertionFailedError = mismatch //
+				? new AssertionFailedError(message, expected, actual, cause) //
+				: new AssertionFailedError(message, cause);
+		suppressed.forEach(assertionFailedError::addSuppressed);
+		return assertionFailedError;
+	}
+
+	private static String nullSafeGet(Object messageOrSupplier) {
+		if (messageOrSupplier == null) {
+			return null;
+		}
+		if (messageOrSupplier instanceof Supplier) {
+			Object message = ((Supplier<?>) messageOrSupplier).get();
+			return message == null ? null : message.toString();
+		}
+		return String.valueOf(messageOrSupplier);
+	}
+
+	private static String buildPrefix(String message) {
+		return (StringUtils.isNotBlank(message) ? message + " ==> " : "");
+	}
+
+	private static String formatValues(Object expected, Object actual) {
+		String expectedString = toString(expected);
+		String actualString = toString(actual);
+		if (expectedString.equals(actualString)) {
+			return String.format("expected: %s but was: %s", formatClassAndValue(expected, expectedString),
+				formatClassAndValue(actual, actualString));
+		}
+		return String.format("expected: <%s> but was: <%s>", expectedString, actualString);
+	}
+
+	private static String formatClassAndValue(Object value, String valueString) {
+		// If the value is null, return <null> instead of null<null>.
+		if (value == null) {
+			return "<null>";
+		}
+		String classAndHash = getClassName(value) + toHash(value);
+		// if it's a class, there's no need to repeat the class name contained in the valueString.
+		return (value instanceof Class ? "<" + classAndHash + ">" : classAndHash + "<" + valueString + ">");
+	}
+
+	private static String toString(Object obj) {
+		if (obj instanceof Class) {
+			return getCanonicalName((Class<?>) obj);
+		}
+		return StringUtils.nullSafeToString(obj);
+	}
+
+	private static String toHash(Object obj) {
+		return (obj == null ? "" : "@" + Integer.toHexString(System.identityHashCode(obj)));
+	}
+
+	private static String getClassName(Object obj) {
+		return (obj == null ? "null"
+				: obj instanceof Class ? getCanonicalName((Class<?>) obj) : obj.getClass().getName());
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -15,7 +15,6 @@ import static java.util.stream.Collectors.joining;
 import java.util.Deque;
 import java.util.function.Supplier;
 
-import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
 import org.opentest4j.AssertionFailedError;
 
@@ -51,50 +50,8 @@ class AssertionUtils {
 		throw new AssertionFailedError(nullSafeGet(messageSupplier));
 	}
 
-	static void fail(String message, Object expected, Object actual) {
-		throw new AssertionFailedError(message, expected, actual);
-	}
-
-	/**
-	 * Typically used for {@code assertEquals()}.
-	 */
-	static void failNotEqual(Object expected, Object actual, String message) {
-		fail(format(expected, actual, message), expected, actual);
-	}
-
-	/**
-	 * Typically used for {@code assertEquals()}.
-	 */
-	static void failNotEqual(Object expected, Object actual, Supplier<String> messageSupplier) {
-		fail(format(expected, actual, nullSafeGet(messageSupplier)), expected, actual);
-	}
-
 	static String nullSafeGet(Supplier<String> messageSupplier) {
 		return (messageSupplier != null ? messageSupplier.get() : null);
-	}
-
-	/**
-	 * Alternative to {@link #nullSafeGet(Supplier)} that is used to avoid
-	 * wrapping a String in a lambda expression.
-	 *
-	 * @param messageOrSupplier an object that is either a {@code String} or
-	 * {@code Supplier<String>}
-	 */
-	static String nullSafeGet(Object messageOrSupplier) {
-		if (messageOrSupplier instanceof String) {
-			return (String) messageOrSupplier;
-		}
-		if (messageOrSupplier instanceof Supplier) {
-			Object message = ((Supplier<?>) messageOrSupplier).get();
-			if (message != null) {
-				return message.toString();
-			}
-		}
-		return null;
-	}
-
-	static String buildPrefix(String message) {
-		return (StringUtils.isNotBlank(message) ? message + " ==> " : "");
 	}
 
 	static String getCanonicalName(Class<?> clazz) {
@@ -106,46 +63,6 @@ class AssertionUtils {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
 			return clazz.getName();
 		}
-	}
-
-	static String format(Object expected, Object actual, String message) {
-		return buildPrefix(message) + formatValues(expected, actual);
-	}
-
-	static String formatValues(Object expected, Object actual) {
-		String expectedString = toString(expected);
-		String actualString = toString(actual);
-		if (expectedString.equals(actualString)) {
-			return String.format("expected: %s but was: %s", formatClassAndValue(expected, expectedString),
-				formatClassAndValue(actual, actualString));
-		}
-		return String.format("expected: <%s> but was: <%s>", expectedString, actualString);
-	}
-
-	private static String formatClassAndValue(Object value, String valueString) {
-		// If the value is null, return <null> instead of null<null>.
-		if (value == null) {
-			return "<null>";
-		}
-		String classAndHash = getClassName(value) + toHash(value);
-		// if it's a class, there's no need to repeat the class name contained in the valueString.
-		return (value instanceof Class ? "<" + classAndHash + ">" : classAndHash + "<" + valueString + ">");
-	}
-
-	private static String toString(Object obj) {
-		if (obj instanceof Class) {
-			return getCanonicalName((Class<?>) obj);
-		}
-		return StringUtils.nullSafeToString(obj);
-	}
-
-	private static String toHash(Object obj) {
-		return (obj == null ? "" : "@" + Integer.toHexString(System.identityHashCode(obj)));
-	}
-
-	private static String getClassName(Object obj) {
-		return (obj == null ? "null"
-				: obj instanceof Class ? getCanonicalName((Class<?>) obj) : obj.getClass().getName());
 	}
 
 	static String formatIndexes(Deque<Integer> indexes) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertInstanceOfAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertInstanceOfAssertionsTests.java
@@ -93,7 +93,7 @@ class AssertInstanceOfAssertionsTests {
 
 	private void assertInstanceOfFails(Class<?> expectedType, Object actualValue, String unexpectedSort) {
 		String valueType = actualValue == null ? "null" : actualValue.getClass().getCanonicalName();
-		String expectedMessage = String.format("Unexpected %s ==> expected: <%s> but was: <%s>", unexpectedSort,
+		String expectedMessage = String.format("Unexpected %s, expected: <%s> but was: <%s>", unexpectedSort,
 			expectedType.getCanonicalName(), valueType);
 
 		assertThrowsWithMessage(expectedMessage, () -> assertInstanceOf(expectedType, actualValue));

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsAssertionsTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.ExecutionException;
@@ -32,6 +34,7 @@ import org.opentest4j.AssertionFailedError;
  *
  * @since 5.0
  */
+@SuppressWarnings("ExcessiveLambdaUsage")
 class AssertThrowsAssertionsTests {
 
 	private static final Executable nix = () -> {
@@ -63,7 +66,7 @@ class AssertThrowsAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsThrowable() {
-		EnigmaThrowable enigmaThrowable = assertThrows(EnigmaThrowable.class, (Executable) () -> {
+		EnigmaThrowable enigmaThrowable = assertThrows(EnigmaThrowable.class, () -> {
 			throw new EnigmaThrowable();
 		});
 		assertNotNull(enigmaThrowable);
@@ -71,7 +74,7 @@ class AssertThrowsAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsThrowableWithMessage() {
-		EnigmaThrowable enigmaThrowable = assertThrows(EnigmaThrowable.class, (Executable) () -> {
+		EnigmaThrowable enigmaThrowable = assertThrows(EnigmaThrowable.class, () -> {
 			throw new EnigmaThrowable();
 		}, "message");
 		assertNotNull(enigmaThrowable);
@@ -79,7 +82,7 @@ class AssertThrowsAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsThrowableWithMessageSupplier() {
-		EnigmaThrowable enigmaThrowable = assertThrows(EnigmaThrowable.class, (Executable) () -> {
+		EnigmaThrowable enigmaThrowable = assertThrows(EnigmaThrowable.class, () -> {
 			throw new EnigmaThrowable();
 		}, () -> "message");
 		assertNotNull(enigmaThrowable);
@@ -87,7 +90,7 @@ class AssertThrowsAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsCheckedException() {
-		IOException exception = assertThrows(IOException.class, (Executable) () -> {
+		IOException exception = assertThrows(IOException.class, () -> {
 			throw new IOException();
 		});
 		assertNotNull(exception);
@@ -95,7 +98,7 @@ class AssertThrowsAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsRuntimeException() {
-		IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, (Executable) () -> {
+		IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, () -> {
 			throw new IllegalStateException();
 		});
 		assertNotNull(illegalStateException);
@@ -104,7 +107,7 @@ class AssertThrowsAssertionsTests {
 	@Test
 	void assertThrowsWithExecutableThatThrowsError() {
 		StackOverflowError stackOverflowError = assertThrows(StackOverflowError.class,
-			(Executable) AssertionTestUtils::recurseIndefinitely);
+			AssertionTestUtils::recurseIndefinitely);
 		assertNotNull(stackOverflowError);
 	}
 
@@ -146,7 +149,7 @@ class AssertThrowsAssertionsTests {
 	@Test
 	void assertThrowsWithExecutableThatThrowsAnUnexpectedException() {
 		try {
-			assertThrows(IllegalStateException.class, (Executable) () -> {
+			assertThrows(IllegalStateException.class, () -> {
 				throw new NumberFormatException();
 			});
 			expectAssertionFailedError();
@@ -155,13 +158,14 @@ class AssertThrowsAssertionsTests {
 			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+			assertThat(ex).hasCauseInstanceOf(NumberFormatException.class);
 		}
 	}
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsAnUnexpectedExceptionWithMessageString() {
 		try {
-			assertThrows(IllegalStateException.class, (Executable) () -> {
+			assertThrows(IllegalStateException.class, () -> {
 				throw new NumberFormatException();
 			}, "Custom message");
 			expectAssertionFailedError();
@@ -173,13 +177,14 @@ class AssertThrowsAssertionsTests {
 			assertMessageContains(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+			assertThat(ex).hasCauseInstanceOf(NumberFormatException.class);
 		}
 	}
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsAnUnexpectedExceptionWithMessageSupplier() {
 		try {
-			assertThrows(IllegalStateException.class, (Executable) () -> {
+			assertThrows(IllegalStateException.class, () -> {
 				throw new NumberFormatException();
 			}, () -> "Custom message");
 			expectAssertionFailedError();
@@ -191,14 +196,14 @@ class AssertThrowsAssertionsTests {
 			assertMessageContains(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+			assertThat(ex).hasCauseInstanceOf(NumberFormatException.class);
 		}
 	}
 
 	@Test
-	@SuppressWarnings("serial")
 	void assertThrowsWithExecutableThatThrowsInstanceOfAnonymousInnerClassAsUnexpectedException() {
 		try {
-			assertThrows(IllegalStateException.class, (Executable) () -> {
+			assertThrows(IllegalStateException.class, () -> {
 				throw new NumberFormatException() {
 				};
 			});
@@ -212,13 +217,14 @@ class AssertThrowsAssertionsTests {
 			// coding "$2" is fragile. So we just check for the presence of the "$"
 			// appended to this class's name.
 			assertMessageContains(ex, "but was: <" + getClass().getName() + "$");
+			assertThat(ex).hasCauseInstanceOf(NumberFormatException.class);
 		}
 	}
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsInstanceOfStaticNestedClassAsUnexpectedException() {
 		try {
-			assertThrows(IllegalStateException.class, (Executable) () -> {
+			assertThrows(IllegalStateException.class, () -> {
 				throw new LocalException();
 			});
 			expectAssertionFailedError();
@@ -228,6 +234,7 @@ class AssertThrowsAssertionsTests {
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			// The following verifies that the canonical name is used (i.e., "." instead of "$").
 			assertMessageContains(ex, "but was: <" + LocalException.class.getName().replace("$", ".") + ">");
+			assertThat(ex).hasCauseInstanceOf(LocalException.class);
 		}
 	}
 
@@ -241,7 +248,7 @@ class AssertThrowsAssertionsTests {
 				EnigmaThrowable.class.getName());
 
 			try {
-				assertThrows(enigmaThrowableClass, (Executable) () -> {
+				assertThrows(enigmaThrowableClass, () -> {
 					throw new EnigmaThrowable();
 				});
 				expectAssertionFailedError();
@@ -258,14 +265,16 @@ class AssertThrowsAssertionsTests {
 				// generated to disambiguate between the two identical class names.
 				assertMessageContains(ex, "expected: <org.junit.jupiter.api.EnigmaThrowable@");
 				assertMessageContains(ex, "but was: <org.junit.jupiter.api.EnigmaThrowable@");
+				assertThat(ex).hasCauseInstanceOf(EnigmaThrowable.class);
 			}
 		}
 	}
 
 	// -------------------------------------------------------------------------
 
-	@SuppressWarnings("serial")
 	private static class LocalException extends RuntimeException {
+		@Serial
+		private static final long serialVersionUID = 1L;
 	}
 
 	private static class EnigmaClassLoader extends URLClassLoader {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsAssertionsTests.java
@@ -152,7 +152,7 @@ class AssertThrowsAssertionsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
 		}
@@ -168,9 +168,9 @@ class AssertThrowsAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			// Should look something like this:
-			// Custom message ==> Unexpected exception type thrown ==> expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
+			// Custom message ==> Unexpected exception type thrown, expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
 			assertMessageStartsWith(ex, "Custom message ==> ");
-			assertMessageContains(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
 		}
@@ -186,9 +186,9 @@ class AssertThrowsAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			// Should look something like this:
-			// Custom message ==> Unexpected exception type thrown ==> expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
+			// Custom message ==> Unexpected exception type thrown, expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
 			assertMessageStartsWith(ex, "Custom message ==> ");
-			assertMessageContains(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
 		}
@@ -205,7 +205,7 @@ class AssertThrowsAssertionsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			// As of the time of this writing, the class name of the above anonymous inner
 			// class is org.junit.jupiter.api.AssertionsAssertThrowsTests$2; however, hard
@@ -224,7 +224,7 @@ class AssertThrowsAssertionsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			// The following verifies that the canonical name is used (i.e., "." instead of "$").
 			assertMessageContains(ex, "but was: <" + LocalException.class.getName().replace("$", ".") + ">");
@@ -249,11 +249,11 @@ class AssertThrowsAssertionsTests {
 			catch (AssertionFailedError ex) {
 				// Example Output:
 				//
-				// Unexpected exception type thrown ==>
+				// Unexpected exception type thrown,
 				// expected: <org.junit.jupiter.api.EnigmaThrowable@5d3411d>
 				// but was: <org.junit.jupiter.api.EnigmaThrowable@2471cca7>
 
-				assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+				assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 				// The presence of the "@" sign is sufficient to indicate that the hash was
 				// generated to disambiguate between the two identical class names.
 				assertMessageContains(ex, "expected: <org.junit.jupiter.api.EnigmaThrowable@");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
@@ -54,7 +54,7 @@ class AssertThrowsExactlyAssertionsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.RuntimeException>");
 			assertMessageContains(ex, "but was: <java.lang.Exception>");
 		}
@@ -69,7 +69,7 @@ class AssertThrowsExactlyAssertionsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.RuntimeException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
 		}
@@ -191,7 +191,7 @@ class AssertThrowsExactlyAssertionsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
 		}
@@ -207,9 +207,9 @@ class AssertThrowsExactlyAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			// Should look something like this:
-			// Custom message ==> Unexpected exception type thrown ==> expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
+			// Custom message ==> Unexpected exception type thrown, expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
 			assertMessageStartsWith(ex, "Custom message ==> ");
-			assertMessageContains(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
 		}
@@ -225,9 +225,9 @@ class AssertThrowsExactlyAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			// Should look something like this:
-			// Custom message ==> Unexpected exception type thrown ==> expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
+			// Custom message ==> Unexpected exception type thrown, expected: <java.lang.IllegalStateException> but was: <java.lang.NumberFormatException>
 			assertMessageStartsWith(ex, "Custom message ==> ");
-			assertMessageContains(ex, "Unexpected exception type thrown ==> ");
+			assertMessageContains(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
 		}
@@ -244,7 +244,7 @@ class AssertThrowsExactlyAssertionsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			// As of the time of this writing, the class name of the above anonymous inner
 			// class is org.junit.jupiter.api.AssertThrowsExactlyAssertionsTests$2; however, hard
@@ -263,7 +263,7 @@ class AssertThrowsExactlyAssertionsTests {
 			expectAssertionFailedError();
 		}
 		catch (AssertionFailedError ex) {
-			assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			// The following verifies that the canonical name is used (i.e., "." instead of "$").
 			assertMessageContains(ex, "but was: <" + LocalException.class.getName().replace("$", ".") + ">");
@@ -288,11 +288,11 @@ class AssertThrowsExactlyAssertionsTests {
 			catch (AssertionFailedError ex) {
 				// Example Output:
 				//
-				// Unexpected exception type thrown ==>
+				// Unexpected exception type thrown,
 				// expected: <org.junit.jupiter.api.EnigmaThrowable@5d3411d>
 				// but was: <org.junit.jupiter.api.EnigmaThrowable@2471cca7>
 
-				assertMessageStartsWith(ex, "Unexpected exception type thrown ==> ");
+				assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 				// The presence of the "@" sign is sufficient to indicate that the hash was
 				// generated to disambiguate between the two identical class names.
 				assertMessageContains(ex, "expected: <org.junit.jupiter.api.EnigmaThrowable@");

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.ExecutionException;
@@ -32,6 +34,7 @@ import org.opentest4j.AssertionFailedError;
  *
  * @since 5.8
  */
+@SuppressWarnings("ExcessiveLambdaUsage")
 class AssertThrowsExactlyAssertionsTests {
 
 	private static final Executable nix = () -> {
@@ -39,7 +42,7 @@ class AssertThrowsExactlyAssertionsTests {
 
 	@Test
 	void assertThrowsExactlyTheSpecifiedExceptionClass() {
-		var actual = assertThrowsExactly(EnigmaThrowable.class, (Executable) () -> {
+		var actual = assertThrowsExactly(EnigmaThrowable.class, () -> {
 			throw new EnigmaThrowable();
 		});
 		assertNotNull(actual);
@@ -48,7 +51,7 @@ class AssertThrowsExactlyAssertionsTests {
 	@Test
 	void assertThrowsExactlyWithTheExpectedChildException() {
 		try {
-			assertThrowsExactly(RuntimeException.class, (Executable) () -> {
+			assertThrowsExactly(RuntimeException.class, () -> {
 				throw new Exception();
 			});
 			expectAssertionFailedError();
@@ -57,13 +60,14 @@ class AssertThrowsExactlyAssertionsTests {
 			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.RuntimeException>");
 			assertMessageContains(ex, "but was: <java.lang.Exception>");
+			assertThat(ex).hasCauseExactlyInstanceOf(Exception.class);
 		}
 	}
 
 	@Test
 	void assertThrowsExactlyWithTheExpectedParentException() {
 		try {
-			assertThrowsExactly(RuntimeException.class, (Executable) () -> {
+			assertThrowsExactly(RuntimeException.class, () -> {
 				throw new NumberFormatException();
 			});
 			expectAssertionFailedError();
@@ -72,6 +76,7 @@ class AssertThrowsExactlyAssertionsTests {
 			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.RuntimeException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+			assertThat(ex).hasCauseExactlyInstanceOf(NumberFormatException.class);
 		}
 	}
 
@@ -101,7 +106,7 @@ class AssertThrowsExactlyAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsThrowable() {
-		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, (Executable) () -> {
+		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, () -> {
 			throw new EnigmaThrowable();
 		});
 		assertNotNull(enigmaThrowable);
@@ -109,7 +114,7 @@ class AssertThrowsExactlyAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsThrowableWithMessage() {
-		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, (Executable) () -> {
+		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, () -> {
 			throw new EnigmaThrowable();
 		}, "message");
 		assertNotNull(enigmaThrowable);
@@ -117,7 +122,7 @@ class AssertThrowsExactlyAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsThrowableWithMessageSupplier() {
-		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, (Executable) () -> {
+		EnigmaThrowable enigmaThrowable = assertThrowsExactly(EnigmaThrowable.class, () -> {
 			throw new EnigmaThrowable();
 		}, () -> "message");
 		assertNotNull(enigmaThrowable);
@@ -125,7 +130,7 @@ class AssertThrowsExactlyAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsCheckedException() {
-		IOException exception = assertThrowsExactly(IOException.class, (Executable) () -> {
+		IOException exception = assertThrowsExactly(IOException.class, () -> {
 			throw new IOException();
 		});
 		assertNotNull(exception);
@@ -133,17 +138,16 @@ class AssertThrowsExactlyAssertionsTests {
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsRuntimeException() {
-		IllegalStateException illegalStateException = assertThrowsExactly(IllegalStateException.class,
-			(Executable) () -> {
-				throw new IllegalStateException();
-			});
+		IllegalStateException illegalStateException = assertThrowsExactly(IllegalStateException.class, () -> {
+			throw new IllegalStateException();
+		});
 		assertNotNull(illegalStateException);
 	}
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsError() {
 		StackOverflowError stackOverflowError = assertThrowsExactly(StackOverflowError.class,
-			(Executable) AssertionTestUtils::recurseIndefinitely);
+			AssertionTestUtils::recurseIndefinitely);
 		assertNotNull(stackOverflowError);
 	}
 
@@ -185,7 +189,7 @@ class AssertThrowsExactlyAssertionsTests {
 	@Test
 	void assertThrowsWithExecutableThatThrowsAnUnexpectedException() {
 		try {
-			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+			assertThrowsExactly(IllegalStateException.class, () -> {
 				throw new NumberFormatException();
 			});
 			expectAssertionFailedError();
@@ -194,13 +198,14 @@ class AssertThrowsExactlyAssertionsTests {
 			assertMessageStartsWith(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+			assertThat(ex).hasCauseExactlyInstanceOf(NumberFormatException.class);
 		}
 	}
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsAnUnexpectedExceptionWithMessageString() {
 		try {
-			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+			assertThrowsExactly(IllegalStateException.class, () -> {
 				throw new NumberFormatException();
 			}, "Custom message");
 			expectAssertionFailedError();
@@ -212,13 +217,14 @@ class AssertThrowsExactlyAssertionsTests {
 			assertMessageContains(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+			assertThat(ex).hasCauseExactlyInstanceOf(NumberFormatException.class);
 		}
 	}
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsAnUnexpectedExceptionWithMessageSupplier() {
 		try {
-			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+			assertThrowsExactly(IllegalStateException.class, () -> {
 				throw new NumberFormatException();
 			}, () -> "Custom message");
 			expectAssertionFailedError();
@@ -230,14 +236,14 @@ class AssertThrowsExactlyAssertionsTests {
 			assertMessageContains(ex, "Unexpected exception type thrown, ");
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			assertMessageContains(ex, "but was: <java.lang.NumberFormatException>");
+			assertThat(ex).hasCauseExactlyInstanceOf(NumberFormatException.class);
 		}
 	}
 
 	@Test
-	@SuppressWarnings("serial")
 	void assertThrowsWithExecutableThatThrowsInstanceOfAnonymousInnerClassAsUnexpectedException() {
 		try {
-			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+			assertThrowsExactly(IllegalStateException.class, () -> {
 				throw new NumberFormatException() {
 				};
 			});
@@ -251,13 +257,14 @@ class AssertThrowsExactlyAssertionsTests {
 			// coding "$2" is fragile. So we just check for the presence of the "$"
 			// appended to this class's name.
 			assertMessageContains(ex, "but was: <" + getClass().getName() + "$");
+			assertThat(ex).hasCauseInstanceOf(NumberFormatException.class);
 		}
 	}
 
 	@Test
 	void assertThrowsWithExecutableThatThrowsInstanceOfStaticNestedClassAsUnexpectedException() {
 		try {
-			assertThrowsExactly(IllegalStateException.class, (Executable) () -> {
+			assertThrowsExactly(IllegalStateException.class, () -> {
 				throw new LocalException();
 			});
 			expectAssertionFailedError();
@@ -267,6 +274,7 @@ class AssertThrowsExactlyAssertionsTests {
 			assertMessageContains(ex, "expected: <java.lang.IllegalStateException>");
 			// The following verifies that the canonical name is used (i.e., "." instead of "$").
 			assertMessageContains(ex, "but was: <" + LocalException.class.getName().replace("$", ".") + ">");
+			assertThat(ex).hasCauseExactlyInstanceOf(LocalException.class);
 		}
 	}
 
@@ -280,7 +288,7 @@ class AssertThrowsExactlyAssertionsTests {
 				EnigmaThrowable.class.getName());
 
 			try {
-				assertThrowsExactly(enigmaThrowableClass, (Executable) () -> {
+				assertThrowsExactly(enigmaThrowableClass, () -> {
 					throw new EnigmaThrowable();
 				});
 				expectAssertionFailedError();
@@ -297,14 +305,16 @@ class AssertThrowsExactlyAssertionsTests {
 				// generated to disambiguate between the two identical class names.
 				assertMessageContains(ex, "expected: <org.junit.jupiter.api.EnigmaThrowable@");
 				assertMessageContains(ex, "but was: <org.junit.jupiter.api.EnigmaThrowable@");
+				assertThat(ex).hasCauseExactlyInstanceOf(EnigmaThrowable.class);
 			}
 		}
 	}
 
 	// -------------------------------------------------------------------------
 
-	@SuppressWarnings("serial")
 	private static class LocalException extends RuntimeException {
+		@Serial
+		private static final long serialVersionUID = 1L;
 	}
 
 	private static class EnigmaClassLoader extends URLClassLoader {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionTestUtils.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertionTestUtils.java
@@ -66,13 +66,6 @@ class AssertionTestUtils {
 		}
 	}
 
-	static void assertMessageDoesNotContain(Throwable ex, String msg) throws AssertionError {
-		if (ex.getMessage().contains(msg)) {
-			throw new AssertionError(
-				"Exception message should contain [" + msg + "], but was [" + ex.getMessage() + "].");
-		}
-	}
-
 	static void assertExpectedAndActualValues(AssertionFailedError ex, Object expected, Object actual)
 			throws AssertionError {
 		if (!wrapsEqualValue(ex.getExpected(), expected)) {


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

Resolves #2967.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
