### PR TITLE
Improve debug mode detection in JUnit Jupiter

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2176,8 +2176,8 @@ the result of the test, e.g. mark the test as failed although all assertions wer
 JUnit Jupiter supports the `junit.jupiter.execution.timeout.mode` configuration parameter
 to configure when timeouts are applied. There are three modes: `enabled`, `disabled`,
 and `disabled_on_debug`. The default mode is `enabled`.
-A VM runtime is considered to run in debug mode when one or more of its input parameters
-contains `jdwp`.
+A VM runtime is considered to run in debug mode when one of its input parameters starts
+with `-agentlib:jdwp` or `-Xrunjdwp`.
 This heuristic is queried by the `disabled_on_debug` mode.
 
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2176,8 +2176,8 @@ the result of the test, e.g. mark the test as failed although all assertions wer
 JUnit Jupiter supports the `junit.jupiter.execution.timeout.mode` configuration parameter
 to configure when timeouts are applied. There are three modes: `enabled`, `disabled`,
 and `disabled_on_debug`. The default mode is `enabled`.
-A VM runtime is considered to run in debug mode when one of its input parameters starts
-with `-agentlib:jdwp` or one of its input parameters is `-Xdebug`.
+A VM runtime is considered to run in debug mode when one or more of its input parameters
+contains `jdwp`.
 This heuristic is queried by the `disabled_on_debug` mode.
 
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2177,7 +2177,8 @@ JUnit Jupiter supports the `junit.jupiter.execution.timeout.mode` configuration 
 to configure when timeouts are applied. There are three modes: `enabled`, `disabled`,
 and `disabled_on_debug`. The default mode is `enabled`.
 A VM runtime is considered to run in debug mode when one of its input parameters starts
-with `-agentlib:jdwp`. This heuristic is queried by the `disabled_on_debug` mode.
+with `-agentlib:jdwp` or one of its input parameters is `-Xdebug`.
+This heuristic is queried by the `disabled_on_debug` mode.
 
 
 [[writing-tests-parallel-execution]]

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
@@ -40,9 +40,7 @@ public final class RuntimeUtils {
 	 * Try to determine whether the VM was started in debug mode or not.
 	 */
 	public static boolean isDebugMode() {
-		return getInputArguments().map(
-			args -> args.stream().anyMatch(arg -> "-Xdebug".equals(arg) || arg.startsWith("-agentlib:jdwp"))).orElse(
-				false);
+		return getInputArguments().map(args -> args.stream().anyMatch(arg -> arg.contains("jdwp"))).orElse(false);
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
@@ -40,8 +40,10 @@ public final class RuntimeUtils {
 	 * Try to determine whether the VM was started in debug mode or not.
 	 */
 	public static boolean isDebugMode() {
-		return getInputArguments().map(args -> args.stream().anyMatch(
-			arg -> arg.startsWith("-agentlib:jdwp") || arg.startsWith("-Xrunjdwp"))).orElse(false);
+		return getInputArguments() //
+				.map(args -> args.stream().anyMatch(
+					arg -> arg.startsWith("-agentlib:jdwp") || arg.startsWith("-Xrunjdwp"))) //
+				.orElse(false);
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
@@ -40,16 +40,9 @@ public final class RuntimeUtils {
 	 * Try to determine whether the VM was started in debug mode or not.
 	 */
 	public static boolean isDebugMode() {
-		Optional<List<String>> optionalArguments = getInputArguments();
-		if (!optionalArguments.isPresent()) {
-			return false;
-		}
-		for (String argument : optionalArguments.get()) {
-			if (argument.startsWith("-agentlib:jdwp")) {
-				return true;
-			}
-		}
-		return false;
+		return getInputArguments().map(
+			args -> args.stream().anyMatch(arg -> "-Xdebug".equals(arg) || arg.startsWith("-agentlib:jdwp"))).orElse(
+				false);
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
@@ -40,7 +40,8 @@ public final class RuntimeUtils {
 	 * Try to determine whether the VM was started in debug mode or not.
 	 */
 	public static boolean isDebugMode() {
-		return getInputArguments().map(args -> args.stream().anyMatch(arg -> arg.contains("jdwp"))).orElse(false);
+		return getInputArguments().map(args -> args.stream().anyMatch(
+			arg -> arg.startsWith("-agentlib:jdwp") || arg.startsWith("-Xrunjdwp"))).orElse(false);
 	}
 
 	/**


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

I'm handling an upgrade from JUnit 4 to JUnit 5 and noticed that disabling our timeouts with `-Djunit.jupiter.execution.timeout.mode=disabled_on_debug` is not working as expected.

We use [VSCode](https://code.visualstudio.com/) as our editor/IDE. When using the [Debugger for Java extension](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) to debug tests.

When _ran_ in my project, the following "test" prints `[-ea, -Djunit.jupiter.execution.timeout.mode=disabled_on_debug, -XX:+ShowCodeDetailsInExceptionMessages, -Dfile.encoding=UTF-8]`

When _ran with the debugger_ in my project, the following "test" prints `[-Xdebug, -Xnoagent, -Djava.compiler=NONE, -Xrunjdwp:transport=dt_socket,address=localhost:34399,server=n,suspend=y, -ea, -Djunit.jupiter.execution.timeout.mode=disabled_on_debug, -XX:+ShowCodeDetailsInExceptionMessages, -Dfile.encoding=UTF-8]`

```java
@Test
void test() {
  System.out.println(ManagementFactory.getRuntimeMXBean().getInputArguments());
}
```

Notably, the first 4 argument of the output from the run using the debugger are not present from the run without the debugger.

[JUnit 4 detected `-Xdebug` as a sign of debugging](https://github.com/junit-team/junit4/blob/80838a508b8875080c1b59d04f14ebaf74908af0/src/main/java/org/junit/rules/DisableOnDebug.java#L106), but (prior to this change) JUnit 5 does not, leading to the unexpected timeouts while debugging (and regression, compared to JUnit 4). Since JUnit 4 used it, I figured `-Xdebug` was the best thing to detect.

I'm not really sure how to test this kind of thing, but I'm open to suggestions.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
