### PR TITLE
Allow DisplayNameGenerator to return null to fall back to the default one

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -74,21 +74,27 @@ public interface DisplayNameGenerator {
 	/**
 	 * Generate a display name for the given top-level or {@code static} nested test class.
 	 *
+	 * If {@code null} is generated, the default generator will be used to generate the display name.
+	 *
 	 * @param testClass the class to generate a name for; never {@code null}
-	 * @return the display name for the class; never {@code null} or blank
+	 * @return the display name for the class; never blank
 	 */
 	String generateDisplayNameForClass(Class<?> testClass);
 
 	/**
 	 * Generate a display name for the given {@link Nested @Nested} inner test class.
 	 *
+	 * If {@code null} is generated, the default generator will be used to generate the display name.
+	 *
 	 * @param nestedClass the class to generate a name for; never {@code null}
-	 * @return the display name for the nested class; never {@code null} or blank
+	 * @return the display name for the nested class; never blank
 	 */
 	String generateDisplayNameForNestedClass(Class<?> nestedClass);
 
 	/**
 	 * Generate a display name for the given method.
+	 *
+	 * If {@code null} is generated, the default generator will be used to generate the display name.
 	 *
 	 * @implNote The class instance supplied as {@code testClass} may differ from
 	 * the class returned by {@code testMethod.getDeclaringClass()} &mdash; for
@@ -96,7 +102,7 @@ public interface DisplayNameGenerator {
 	 *
 	 * @param testClass the class the test method is invoked on; never {@code null}
 	 * @param testMethod method to generate a display name for; never {@code null}
-	 * @return the display name for the test; never {@code null} or blank
+	 * @return the display name for the test; never blank
 	 */
 	String generateDisplayNameForMethod(Class<?> testClass, Method testMethod);
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.DisplayName;
@@ -90,21 +91,36 @@ final class DisplayNameUtils {
 
 	static String determineDisplayNameForMethod(Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
-		DisplayNameGenerator generator = getDisplayNameGenerator(testClass, configuration);
-		return determineDisplayName(testMethod, () -> generator.generateDisplayNameForMethod(testClass, testMethod));
+		return determineDisplayName(testMethod,
+			createDisplayNameSupplierForMethod(testClass, testMethod, configuration));
 	}
 
 	static Supplier<String> createDisplayNameSupplierForClass(Class<?> testClass, JupiterConfiguration configuration) {
-		return () -> getDisplayNameGenerator(testClass, configuration).generateDisplayNameForClass(testClass);
+		return createDisplayNameSupplier(testClass, configuration,
+			generator -> generator.generateDisplayNameForClass(testClass));
 	}
 
 	static Supplier<String> createDisplayNameSupplierForNestedClass(Class<?> testClass,
 			JupiterConfiguration configuration) {
-		return () -> getDisplayNameGenerator(testClass, configuration).generateDisplayNameForNestedClass(testClass);
+		return createDisplayNameSupplier(testClass, configuration,
+			generator -> generator.generateDisplayNameForNestedClass(testClass));
 	}
 
-	private static DisplayNameGenerator getDisplayNameGenerator(Class<?> testClass,
+	static Supplier<String> createDisplayNameSupplierForMethod(Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
+		return createDisplayNameSupplier(testClass, configuration,
+			generator -> generator.generateDisplayNameForMethod(testClass, testMethod));
+	}
+
+	private static Supplier<String> createDisplayNameSupplier(Class<?> testClass, JupiterConfiguration configuration,
+			Function<DisplayNameGenerator, String> generatorFunction) {
+		Preconditions.notNull(generatorFunction, "DisplayNameGenerator function must not be null");
+		return () -> getOptionalDisplayNameGenerator(testClass) //
+				.map(generatorFunction) //
+				.orElseGet(() -> generatorFunction.apply(configuration.getDefaultDisplayNameGenerator()));
+	}
+
+	private static Optional<DisplayNameGenerator> getOptionalDisplayNameGenerator(Class<?> testClass) {
 		Preconditions.notNull(testClass, "Test class must not be null");
 
 		return AnnotationUtils.findAnnotation(testClass, DisplayNameGeneration.class, true) //
@@ -123,8 +139,7 @@ final class DisplayNameUtils {
 						return indicativeSentencesGenerator;
 					}
 					return ReflectionUtils.newInstance(displayNameGeneratorClass);
-				}) //
-				.orElseGet(configuration::getDefaultDisplayNameGenerator);
+				});
 	}
 
 }


### PR DESCRIPTION
## Overview

Resolves https://github.com/junit-team/junit5/issues/2969

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
