### PR TITLE
Fix @ArgumentsSource annotation name

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1851,7 +1851,7 @@ if they exceed the configured maximum length. The limit is configurable via the
 `junit.jupiter.params.displayname.argument.maxlength` configuration parameter and defaults
 to 512 characters.
 
-When using `@MethodSource` or `@ArgumentSource`, you can provide custom names for
+When using `@MethodSource` or `@ArgumentsSource`, you can provide custom names for
 arguments using the `{Named}` API. A custom name will be used if the argument is included
 in the invocation display name, like in the example below.
 


### PR DESCRIPTION
## Overview

A small typo fix in user guide

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).