### PR TITLE
Use suite events for more accurate reporting

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.0.adoc
@@ -56,4 +56,5 @@ GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* More accurate reporting of intermediate start/finish events, e.g. iterations of the
+  `Parameterized` runner and classes executed indirectly via the `Suite` runner.

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/JUnit4VersionCheck.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/JUnit4VersionCheck.java
@@ -51,7 +51,7 @@ class JUnit4VersionCheck {
 		}
 	}
 
-	private static BigDecimal parseVersion(String versionString) {
+	static BigDecimal parseVersion(String versionString) {
 		try {
 			Matcher matcher = versionPattern.matcher(versionString);
 			if (matcher.matches()) {

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -91,6 +91,10 @@ class TestRun {
 		return runnerDescendants.contains(testDescriptor);
 	}
 
+	boolean hasSyntheticStartEvent(TestDescriptor testDescriptor) {
+		return inProgressDescriptors.get(testDescriptor) == EventType.SYNTHETIC;
+	}
+
 	Optional<VintageTestDescriptor> lookupNextTestDescriptor(Description description) {
 		return lookupUnambiguouslyOrApplyFallback(description, VintageDescriptors::getNextUnstarted);
 	}

--- a/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ParameterizedTimingTestCase.java
+++ b/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ParameterizedTimingTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.AfterParam;
+import org.junit.runners.Parameterized.BeforeParam;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * @since 5.9
+ */
+@RunWith(Parameterized.class)
+public class ParameterizedTimingTestCase {
+
+	public static Map<String, Instant> EVENTS = new LinkedHashMap<>();
+
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		EVENTS.clear();
+	}
+
+	@BeforeParam
+	public static void beforeParam(String param) throws Exception {
+		EVENTS.put("beforeParam(" + param + ")", Instant.now());
+		Thread.sleep(100);
+	}
+
+	@AfterParam
+	public static void afterParam(String param) throws Exception {
+		Thread.sleep(100);
+		System.out.println("ParameterizedTimingTestCase.afterParam");
+		EVENTS.put("afterParam(" + param + ")", Instant.now());
+	}
+
+	@Parameters(name = "{0}")
+	public static Iterable<String> parameters() {
+		return List.of("foo", "bar");
+	}
+
+	@Parameter
+	public String value;
+
+	@Test
+	public void test() {
+		assertEquals("foo", value);
+	}
+
+}

--- a/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ParameterizedWithAfterParamFailureTestCase.java
+++ b/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ParameterizedWithAfterParamFailureTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.AfterParam;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * @since 5.9
+ */
+@RunWith(Parameterized.class)
+public class ParameterizedWithAfterParamFailureTestCase {
+
+	@AfterParam
+	public static void afterParam() {
+		fail();
+	}
+
+	@Parameters(name = "{0}")
+	public static Iterable<String> parameters() {
+		return List.of("foo", "bar");
+	}
+
+	@Parameter
+	public String value;
+
+	@Test
+	public void test() {
+		assertEquals("foo", value);
+	}
+
+}

--- a/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ParameterizedWithBeforeParamFailureTestCase.java
+++ b/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit4/ParameterizedWithBeforeParamFailureTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.vintage.engine.samples.junit4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.BeforeParam;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * @since 5.9
+ */
+@RunWith(Parameterized.class)
+public class ParameterizedWithBeforeParamFailureTestCase {
+
+	@BeforeParam
+	public static void beforeParam() {
+		fail();
+	}
+
+	@Parameters(name = "{0}")
+	public static Iterable<String> parameters() {
+		return List.of("foo", "bar");
+	}
+
+	@Parameter
+	public String value;
+
+	@Test
+	public void test() {
+		assertEquals("foo", value);
+	}
+
+}


### PR DESCRIPTION
In 4.13 testSuiteStarted/Finished were introduced. While top-level test
class events were already reported at the appropriate time, events for
intermediate levels such as iterations of the `Parameterized` runner or
classes executed by the `Suite` runner were created synthetically when
the first test was started and the last test was finished, respectively.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
