### PR TITLE
Update settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -89,8 +89,8 @@ buildCache {
 }
 
 val javaVersion = JavaVersion.current()
-require(javaVersion == JavaVersion.VERSION_17) {
-	"The JUnit 5 build must be executed with Java 17. Currently executing with Java ${javaVersion.majorVersion}."
+require(javaVersion == JavaVersion.VERSION_18) {
+	"The JUnit 5 build must be executed with Java 18. Currently executing with Java ${javaVersion.majorVersion}."
 }
 
 rootProject.name = "junit5"


### PR DESCRIPTION
provided it works I am testing now I will let you know if it fails.

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
there's no reason that this change cannot be made. We are Java 18. Just holding up everyone up for nothing and it works plus it will make it easier if there are bugs to be reported on Java 18 builds but I don't think so.

very simple change just one number 7 becomes 8 ie. Java 17 check in gradlew becomes Java 18. I should have write access to change this but whatever until you build me up with enough credential I guess...
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass

REsults are as follows: someone following the advice of Oracle for Java, and everyone else will no longer be put in a situation where they cannot use Junit test cases as the build will be successful:


PS E:\can\junit5> ./gradlew clean assemble
Type-safe project accessors is an incubating feature.
Project accessors enabled, but root project name not explicitly set for 'buildSrc'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching.

BUILD SUCCESSFUL in 4m 42s
179 actionable tasks: 133 executed, 46 from cache

A build scan was not published as you have not authenticated with server 'ge.junit.org'.
For more information, please see https://gradle.com/help/gradle-authenticating-with-gradle-enterprise.
PS E:\can\junit5>
