### PR TITLE
Fix incorrect timeout failure when assertion fails in separate thread

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.1.adoc
@@ -40,6 +40,8 @@ on GitHub.
   references a factory method whose name is the same as other non-factory methods in the
   same class no longer fails with an exception stating that multiple factory methods with
   the same name were found.
+* Assertion failures thrown from methods with applied timeouts using `ThreadMode.SEPARATE`
+  are now properly reported.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -150,8 +150,8 @@ class AssertTimeout {
 
 			try {
 				Future<T> future = submitTask(supplier, threadReference, executorService);
-				FutureResolverWithExceptionHandling<T> resolver = createFutureResolver(messageOrSupplier,
-					threadReference, throwing);
+				FutureResolverWithExceptionHandling resolver = createFutureResolver(messageOrSupplier, threadReference,
+					throwing);
 				return resolver.resolveFutureAndHandleException(future, timeout.toMillis());
 			}
 			finally {
@@ -172,20 +172,16 @@ class AssertTimeout {
 			});
 		}
 
-		private <T> FutureResolverWithExceptionHandling<T> createFutureResolver(Object messageOrSupplier,
+		private FutureResolverWithExceptionHandling createFutureResolver(Object messageOrSupplier,
 				AtomicReference<Thread> threadReference, Throwing throwing) {
-			FutureResolverWithExceptionHandling<T> resolver;
 			switch (throwing) {
 				case MASKED_TIMEOUT_EXCEPTION:
-					resolver = new TimeoutPropagatingFutureResolver<>();
-					break;
+					return new TimeoutPropagatingFutureResolver<>();
 				case ASSERTION_ERROR:
-					resolver = new AssertiveFutureResolver<>(threadReference, messageOrSupplier);
-					break;
+					return new AssertiveFutureResolver<>(threadReference, messageOrSupplier);
 				default:
 					throw new IllegalStateException("Unexpected value: " + throwing);
 			}
-			return resolver;
 		}
 
 		enum Throwing {
@@ -215,8 +211,8 @@ class AssertTimeout {
 		}
 	}
 
-	private abstract static class FutureResolverWithExceptionHandling<T> {
-		T resolveFutureAndHandleException(Future<T> future, long timeoutInMillis) {
+	private abstract static class FutureResolverWithExceptionHandling {
+		<T> T resolveFutureAndHandleException(Future<T> future, long timeoutInMillis) {
 			try {
 				return future.get(timeoutInMillis, TimeUnit.MILLISECONDS);
 			}
@@ -235,7 +231,7 @@ class AssertTimeout {
 		protected abstract void handleTimeoutAndThrow(TimeoutException ex, long timeoutInMillis);
 	}
 
-	private static class AssertiveFutureResolver<T> extends FutureResolverWithExceptionHandling<T> {
+	private static class AssertiveFutureResolver<T> extends FutureResolverWithExceptionHandling {
 
 		private final AtomicReference<Thread> threadReference;
 		private final Object messageOrSupplier;
@@ -262,7 +258,7 @@ class AssertTimeout {
 		}
 	}
 
-	private static class TimeoutPropagatingFutureResolver<T> extends FutureResolverWithExceptionHandling<T> {
+	private static class TimeoutPropagatingFutureResolver<T> extends FutureResolverWithExceptionHandling {
 		@Override
 		protected void handleTimeoutAndThrow(TimeoutException ex, long timeoutInMillis) {
 			throw throwAsUncheckedException(ex);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -182,7 +182,7 @@ class AssertTimeout {
 					cause = new ExecutionTimeoutException("Execution timed out in thread " + thread.getName());
 					cause.setStackTrace(thread.getStackTrace());
 				}
-				throw failureFactory.handleTimeout(ex, timeout, messageSupplier, cause);
+				throw failureFactory.createTimeoutFailure(timeout, messageSupplier, cause);
 			}
 			catch (ExecutionException ex) {
 				throw throwAsUncheckedException(ex.getCause());
@@ -218,8 +218,8 @@ class AssertTimeout {
 	private static class AssertionTimeoutFailureFactory implements TimeoutFailureFactory<AssertionFailedError> {
 
 		@Override
-		public AssertionFailedError handleTimeout(TimeoutException exception, Duration timeout,
-				Supplier<String> messageSupplier, Throwable cause) {
+		public AssertionFailedError createTimeoutFailure(Duration timeout, Supplier<String> messageSupplier,
+				Throwable cause) {
 			return assertionFailure() //
 					.message(messageSupplier) //
 					.reason("execution timed out after " + timeout.toMillis() + " ms") //

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -14,22 +14,10 @@ import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.platform.commons.util.ExceptionUtils.throwAsUncheckedException;
 
 import java.time.Duration;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import org.junit.jupiter.api.Assertions.TimeoutFailureFactory;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingSupplier;
-import org.junit.platform.commons.JUnitException;
-import org.opentest4j.AssertionFailedError;
 
 /**
  * {@code AssertTimeout} is a collection of utility methods that support asserting
@@ -95,117 +83,4 @@ class AssertTimeout {
 		return result;
 	}
 
-	static void assertTimeoutPreemptively(Duration timeout, Executable executable) {
-		assertTimeoutPreemptively(timeout, executable, (String) null);
-	}
-
-	static void assertTimeoutPreemptively(Duration timeout, Executable executable, String message) {
-		assertTimeoutPreemptively(timeout, () -> {
-			executable.execute();
-			return null;
-		}, message);
-	}
-
-	static void assertTimeoutPreemptively(Duration timeout, Executable executable, Supplier<String> messageSupplier) {
-		assertTimeoutPreemptively(timeout, () -> {
-			executable.execute();
-			return null;
-		}, messageSupplier);
-	}
-
-	static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier) {
-		return assertTimeoutPreemptively(timeout, supplier, null, AssertTimeout::createAssertionFailure);
-	}
-
-	static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier, String message) {
-		return assertTimeoutPreemptively(timeout, supplier, message == null ? null : () -> message,
-			AssertTimeout::createAssertionFailure);
-	}
-
-	static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
-			Supplier<String> messageSupplier) {
-		return assertTimeoutPreemptively(timeout, supplier, messageSupplier, AssertTimeout::createAssertionFailure);
-	}
-
-	static <T, E extends Throwable> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
-			Supplier<String> messageSupplier, TimeoutFailureFactory<E> failureFactory) throws E {
-		AtomicReference<Thread> threadReference = new AtomicReference<>();
-		ExecutorService executorService = Executors.newSingleThreadExecutor(new TimeoutThreadFactory());
-
-		try {
-			Future<T> future = submitTask(supplier, threadReference, executorService);
-			return resolveFutureAndHandleException(future, timeout, messageSupplier, threadReference::get,
-				failureFactory);
-		}
-		finally {
-			executorService.shutdownNow();
-		}
-	}
-
-	private static <T> Future<T> submitTask(ThrowingSupplier<T> supplier, AtomicReference<Thread> threadReference,
-			ExecutorService executorService) {
-		return executorService.submit(() -> {
-			try {
-				threadReference.set(Thread.currentThread());
-				return supplier.get();
-			}
-			catch (Throwable throwable) {
-				throw throwAsUncheckedException(throwable);
-			}
-		});
-	}
-
-	private static <T, E extends Throwable> T resolveFutureAndHandleException(Future<T> future, Duration timeout,
-			Supplier<String> messageSupplier, Supplier<Thread> threadSupplier, TimeoutFailureFactory<E> failureFactory)
-			throws E {
-		try {
-			return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-		}
-		catch (TimeoutException ex) {
-			Thread thread = threadSupplier.get();
-			ExecutionTimeoutException cause = null;
-			if (thread != null) {
-				cause = new ExecutionTimeoutException("Execution timed out in thread " + thread.getName());
-				cause.setStackTrace(thread.getStackTrace());
-			}
-			throw failureFactory.createTimeoutFailure(timeout, messageSupplier, cause);
-		}
-		catch (ExecutionException ex) {
-			throw throwAsUncheckedException(ex.getCause());
-		}
-		catch (Throwable ex) {
-			throw throwAsUncheckedException(ex);
-		}
-	}
-
-	private static AssertionFailedError createAssertionFailure(Duration timeout, Supplier<String> messageSupplier,
-			Throwable cause) {
-		return assertionFailure() //
-				.message(messageSupplier) //
-				.reason("execution timed out after " + timeout.toMillis() + " ms") //
-				.cause(cause) //
-				.build();
-	}
-
-	private static class ExecutionTimeoutException extends JUnitException {
-
-		private static final long serialVersionUID = 1L;
-
-		ExecutionTimeoutException(String message) {
-			super(message);
-		}
-	}
-
-	/**
-	 * The thread factory used for preemptive timeout.
-	 * <p>
-	 * The factory creates threads with meaningful names, helpful for debugging purposes.
-	 */
-	private static class TimeoutThreadFactory implements ThreadFactory {
-		private static final AtomicInteger threadNumber = new AtomicInteger(1);
-
-		public Thread newThread(Runnable r) {
-			return new Thread(r, "junit-timeout-thread-" + threadNumber.getAndIncrement());
-		}
-	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeoutPreemptively.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeoutPreemptively.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
+import static org.junit.platform.commons.util.ExceptionUtils.throwAsUncheckedException;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
+import org.junit.platform.commons.JUnitException;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * {@code AssertTimeout} is a collection of utility methods that support asserting
+ * the execution of the code under test did not take longer than the timeout duration
+ * using a preemptive approach.
+ *
+ * @since 5.9.1
+ */
+class AssertTimeoutPreemptively {
+
+	static void assertTimeoutPreemptively(Duration timeout, Executable executable) {
+		assertTimeoutPreemptively(timeout, executable, (String) null);
+	}
+
+	static void assertTimeoutPreemptively(Duration timeout, Executable executable, String message) {
+		assertTimeoutPreemptively(timeout, () -> {
+			executable.execute();
+			return null;
+		}, message);
+	}
+
+	static void assertTimeoutPreemptively(Duration timeout, Executable executable, Supplier<String> messageSupplier) {
+		assertTimeoutPreemptively(timeout, () -> {
+			executable.execute();
+			return null;
+		}, messageSupplier);
+	}
+
+	static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier) {
+		return assertTimeoutPreemptively(timeout, supplier, null, AssertTimeoutPreemptively::createAssertionFailure);
+	}
+
+	static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier, String message) {
+		return assertTimeoutPreemptively(timeout, supplier, message == null ? null : () -> message,
+			AssertTimeoutPreemptively::createAssertionFailure);
+	}
+
+	static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
+			Supplier<String> messageSupplier) {
+		return assertTimeoutPreemptively(timeout, supplier, messageSupplier,
+			AssertTimeoutPreemptively::createAssertionFailure);
+	}
+
+	static <T, E extends Throwable> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
+			Supplier<String> messageSupplier, Assertions.TimeoutFailureFactory<E> failureFactory) throws E {
+		AtomicReference<Thread> threadReference = new AtomicReference<>();
+		ExecutorService executorService = Executors.newSingleThreadExecutor(new TimeoutThreadFactory());
+
+		try {
+			Future<T> future = submitTask(supplier, threadReference, executorService);
+			return resolveFutureAndHandleException(future, timeout, messageSupplier, threadReference::get,
+				failureFactory);
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	private static <T> Future<T> submitTask(ThrowingSupplier<T> supplier, AtomicReference<Thread> threadReference,
+			ExecutorService executorService) {
+		return executorService.submit(() -> {
+			try {
+				threadReference.set(Thread.currentThread());
+				return supplier.get();
+			}
+			catch (Throwable throwable) {
+				throw throwAsUncheckedException(throwable);
+			}
+		});
+	}
+
+	private static <T, E extends Throwable> T resolveFutureAndHandleException(Future<T> future, Duration timeout,
+			Supplier<String> messageSupplier, Supplier<Thread> threadSupplier,
+			Assertions.TimeoutFailureFactory<E> failureFactory) throws E {
+		try {
+			return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+		}
+		catch (TimeoutException ex) {
+			Thread thread = threadSupplier.get();
+			ExecutionTimeoutException cause = null;
+			if (thread != null) {
+				cause = new ExecutionTimeoutException("Execution timed out in thread " + thread.getName());
+				cause.setStackTrace(thread.getStackTrace());
+			}
+			throw failureFactory.createTimeoutFailure(timeout, messageSupplier, cause);
+		}
+		catch (ExecutionException ex) {
+			throw throwAsUncheckedException(ex.getCause());
+		}
+		catch (Throwable ex) {
+			throw throwAsUncheckedException(ex);
+		}
+	}
+
+	private static AssertionFailedError createAssertionFailure(Duration timeout, Supplier<String> messageSupplier,
+			Throwable cause) {
+		return assertionFailure() //
+				.message(messageSupplier) //
+				.reason("execution timed out after " + timeout.toMillis() + " ms") //
+				.cause(cause) //
+				.build();
+	}
+
+	private static class ExecutionTimeoutException extends JUnitException {
+
+		private static final long serialVersionUID = 1L;
+
+		ExecutionTimeoutException(String message) {
+			super(message);
+		}
+	}
+
+	/**
+	 * The thread factory used for preemptive timeout.
+	 * <p>
+	 * The factory creates threads with meaningful names, helpful for debugging purposes.
+	 */
+	private static class TimeoutThreadFactory implements ThreadFactory {
+		private static final AtomicInteger threadNumber = new AtomicInteger(1);
+
+		public Thread newThread(Runnable r) {
+			return new Thread(r, "junit-timeout-thread-" + threadNumber.getAndIncrement());
+		}
+	}
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -3608,7 +3607,6 @@ public class Assertions {
 
 	@API(status = INTERNAL, since = "5.9.1")
 	public interface TimeoutFailureFactory<T extends Throwable> {
-		T handleTimeout(TimeoutException exception, Duration timeout, Supplier<String> messageSupplier,
-				Throwable cause);
+		T createTimeoutFailure(Duration timeout, Supplier<String> messageSupplier, Throwable cause);
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3605,8 +3605,21 @@ public class Assertions {
 		return AssertInstanceOf.assertInstanceOf(expectedType, actualValue, messageSupplier);
 	}
 
+	/**
+	 * Factory for timeout failures.
+	 *
+	 * @param <T> The type of error or exception created
+	 * @since 5.9.1
+	 * @see Assertions#assertTimeoutPreemptively(Duration, ThrowingSupplier, Supplier, TimeoutFailureFactory)
+	 */
 	@API(status = INTERNAL, since = "5.9.1")
 	public interface TimeoutFailureFactory<T extends Throwable> {
+
+		/**
+		 * Create a failure for the given timeout, message, and cause.
+		 *
+		 * @return timeout failure; never {@code null}
+		 */
 		T createTimeoutFailure(Duration timeout, Supplier<String> messageSupplier, Throwable cause);
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -3551,7 +3552,7 @@ public class Assertions {
 	 */
 	@API(status = INTERNAL)
 	public static <T> T assertTimeoutPreemptivelyThrowingTimeoutException(Duration timeout,
-			ThrowingSupplier<T> supplier, Supplier<String> messageSupplier) {
+			ThrowingSupplier<T> supplier, Supplier<String> messageSupplier) throws TimeoutException {
 		return AssertTimeout.assertTimeoutPreemptivelyThrowingTimeoutException(timeout, supplier, messageSupplier);
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3531,8 +3531,9 @@ public class Assertions {
 	 *
 	 * <p>If the assertion passes then the {@code supplier}'s result is returned.
 	 *
-	 * <p>In the case the assertion does not pass, a {@code TimeoutException} will be
-	 * thrown.
+	 * <p>In the case the assertion does not pass, the supplied
+	 * {@link TimeoutFailureFactory} is invoked to create an exception which is
+	 * then thrown.
 	 *
 	 * <p>Note: the {@code supplier} will be executed in a different thread than
 	 * that of the calling code. Furthermore, execution of the {@code supplier} will
@@ -3550,10 +3551,10 @@ public class Assertions {
 	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, String)
 	 * @see #assertTimeout(Duration, Executable, Supplier)
 	 */
-	@API(status = INTERNAL)
-	public static <T> T assertTimeoutPreemptivelyThrowingTimeoutException(Duration timeout,
-			ThrowingSupplier<T> supplier, Supplier<String> messageSupplier) throws TimeoutException {
-		return AssertTimeout.assertTimeoutPreemptivelyThrowingTimeoutException(timeout, supplier, messageSupplier);
+	@API(status = INTERNAL, since = "5.9.1")
+	public static <T, E extends Throwable> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
+			Supplier<String> messageSupplier, TimeoutFailureFactory<E> failureFactory) throws E {
+		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier, messageSupplier, failureFactory);
 	}
 
 	// --- assertInstanceOf ----------------------------------------------------
@@ -3605,4 +3606,9 @@ public class Assertions {
 		return AssertInstanceOf.assertInstanceOf(expectedType, actualValue, messageSupplier);
 	}
 
+	@API(status = INTERNAL, since = "5.9.1")
+	public interface TimeoutFailureFactory<T extends Throwable> {
+		T handleTimeout(TimeoutException exception, Duration timeout, Supplier<String> messageSupplier,
+				Throwable cause);
+	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.api;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.time.Duration;
@@ -3521,6 +3522,37 @@ public class Assertions {
 	public static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
 			Supplier<String> messageSupplier) {
 		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier, messageSupplier);
+	}
+
+	/**
+	 * <em>Assert</em> that execution of the supplied {@code supplier}
+	 * completes before the given {@code timeout} is exceeded.
+	 *
+	 * <p>If the assertion passes then the {@code supplier}'s result is returned.
+	 *
+	 * <p>In the case the assertion does not pass, a {@code TimeoutException} will be
+	 * thrown.
+	 *
+	 * <p>Note: the {@code supplier} will be executed in a different thread than
+	 * that of the calling code. Furthermore, execution of the {@code supplier} will
+	 * be preemptively aborted if the timeout is exceeded. See the
+	 * {@linkplain Assertions Preemptive Timeouts} section of the class-level
+	 * Javadoc for a discussion of possible undesirable side effects.
+	 *
+	 * <p>If necessary, the failure message will be retrieved lazily from the
+	 * supplied {@code messageSupplier}.
+	 *
+	 * @see #assertTimeoutPreemptively(Duration, Executable)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, String)
+	 * @see #assertTimeoutPreemptively(Duration, Executable, Supplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier)
+	 * @see #assertTimeoutPreemptively(Duration, ThrowingSupplier, String)
+	 * @see #assertTimeout(Duration, Executable, Supplier)
+	 */
+	@API(status = INTERNAL)
+	public static <T> T assertTimeoutPreemptivelyThrowingTimeoutException(Duration timeout,
+			ThrowingSupplier<T> supplier, Supplier<String> messageSupplier) {
+		return AssertTimeout.assertTimeoutPreemptivelyThrowingTimeoutException(timeout, supplier, messageSupplier);
 	}
 
 	// --- assertInstanceOf ----------------------------------------------------

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3396,7 +3396,7 @@ public class Assertions {
 	 * @see #assertTimeout(Duration, Executable)
 	 */
 	public static void assertTimeoutPreemptively(Duration timeout, Executable executable) {
-		AssertTimeout.assertTimeoutPreemptively(timeout, executable);
+		AssertTimeoutPreemptively.assertTimeoutPreemptively(timeout, executable);
 	}
 
 	/**
@@ -3419,7 +3419,7 @@ public class Assertions {
 	 * @see #assertTimeout(Duration, Executable, String)
 	 */
 	public static void assertTimeoutPreemptively(Duration timeout, Executable executable, String message) {
-		AssertTimeout.assertTimeoutPreemptively(timeout, executable, message);
+		AssertTimeoutPreemptively.assertTimeoutPreemptively(timeout, executable, message);
 	}
 
 	/**
@@ -3444,7 +3444,7 @@ public class Assertions {
 	 */
 	public static void assertTimeoutPreemptively(Duration timeout, Executable executable,
 			Supplier<String> messageSupplier) {
-		AssertTimeout.assertTimeoutPreemptively(timeout, executable, messageSupplier);
+		AssertTimeoutPreemptively.assertTimeoutPreemptively(timeout, executable, messageSupplier);
 	}
 
 	// --- supplier - preemptively ---
@@ -3469,7 +3469,7 @@ public class Assertions {
 	 * @see #assertTimeout(Duration, Executable)
 	 */
 	public static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier) {
-		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier);
+		return AssertTimeoutPreemptively.assertTimeoutPreemptively(timeout, supplier);
 	}
 
 	/**
@@ -3494,7 +3494,7 @@ public class Assertions {
 	 * @see #assertTimeout(Duration, Executable, String)
 	 */
 	public static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier, String message) {
-		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier, message);
+		return AssertTimeoutPreemptively.assertTimeoutPreemptively(timeout, supplier, message);
 	}
 
 	/**
@@ -3521,7 +3521,7 @@ public class Assertions {
 	 */
 	public static <T> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
 			Supplier<String> messageSupplier) {
-		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier, messageSupplier);
+		return AssertTimeoutPreemptively.assertTimeoutPreemptively(timeout, supplier, messageSupplier);
 	}
 
 	/**
@@ -3553,7 +3553,7 @@ public class Assertions {
 	@API(status = INTERNAL, since = "5.9.1")
 	public static <T, E extends Throwable> T assertTimeoutPreemptively(Duration timeout, ThrowingSupplier<T> supplier,
 			Supplier<String> messageSupplier, TimeoutFailureFactory<E> failureFactory) throws E {
-		return AssertTimeout.assertTimeoutPreemptively(timeout, supplier, messageSupplier, failureFactory);
+		return AssertTimeoutPreemptively.assertTimeoutPreemptively(timeout, supplier, messageSupplier, failureFactory);
 	}
 
 	// --- assertInstanceOf ----------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
@@ -39,15 +39,10 @@ class SeparateThreadTimeoutInvocation<T> implements Invocation<T> {
 			return assertTimeoutPreemptivelyThrowingTimeoutException(timeout.toDuration(), delegate::proceed,
 				descriptionSupplier);
 		}
-		catch (Throwable failure) {
-			if (failure instanceof TimeoutException) {
-				TimeoutException exception = TimeoutExceptionFactory.create(descriptionSupplier.get(), timeout, null);
-				exception.initCause(failure.getCause());
-				throw exception;
-			}
-			else {
-				throw failure;
-			}
+		catch (TimeoutException failure) {
+			TimeoutException exception = TimeoutExceptionFactory.create(descriptionSupplier.get(), timeout, null);
+			exception.initCause(failure.getCause());
+			throw exception;
 		}
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
@@ -36,7 +36,7 @@ class SeparateThreadTimeoutInvocation<T> implements Invocation<T> {
 	@Override
 	public T proceed() throws Throwable {
 		return assertTimeoutPreemptively(timeout.toDuration(), delegate::proceed, descriptionSupplier,
-			(e, __, messageSupplier, cause) -> {
+			(__, messageSupplier, cause) -> {
 				TimeoutException exception = TimeoutExceptionFactory.create(messageSupplier.get(), timeout, null);
 				exception.initCause(cause);
 				return exception;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocation.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.engine.extension;
 
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptivelyThrowingTimeoutException;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -35,14 +35,11 @@ class SeparateThreadTimeoutInvocation<T> implements Invocation<T> {
 
 	@Override
 	public T proceed() throws Throwable {
-		try {
-			return assertTimeoutPreemptivelyThrowingTimeoutException(timeout.toDuration(), delegate::proceed,
-				descriptionSupplier);
-		}
-		catch (TimeoutException failure) {
-			TimeoutException exception = TimeoutExceptionFactory.create(descriptionSupplier.get(), timeout, null);
-			exception.initCause(failure.getCause());
-			throw exception;
-		}
+		return assertTimeoutPreemptively(timeout.toDuration(), delegate::proceed, descriptionSupplier,
+			(e, __, messageSupplier, cause) -> {
+				TimeoutException exception = TimeoutExceptionFactory.create(messageSupplier.get(), timeout, null);
+				exception.initCause(cause);
+				return exception;
+			});
 	}
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -11,40 +11,28 @@
 package org.junit.jupiter.api;
 
 import static java.time.Duration.ofMillis;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
-import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.function.Executable;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.opentest4j.AssertionFailedError;
 
 /**
- * Unit tests for JUnit Jupiter {@link Assertions}.
+ * Unit tests for {@link AssertTimeout}.
  *
  * @since 5.0
  */
 class AssertTimeoutAssertionsTests {
 
-	private static final Duration PREEMPTIVE_TIMEOUT = ofMillis(WINDOWS.isCurrentOs() ? 1000 : 100);
-	private static final Assertions.TimeoutFailureFactory<TimeoutException> TIMEOUT_EXCEPTION_FACTORY = (__, ___,
-			____) -> new TimeoutException();
-
-	private static ThreadLocal<AtomicBoolean> changed = ThreadLocal.withInitial(() -> new AtomicBoolean(false));
+	private static final ThreadLocal<AtomicBoolean> changed = ThreadLocal.withInitial(() -> new AtomicBoolean(false));
 
 	private final Executable nix = () -> {
 	};
@@ -166,191 +154,6 @@ class AssertTimeoutAssertionsTests {
 		assertMessageStartsWith(error, "Tempus Fugit ==> execution exceeded timeout of 10 ms by");
 	}
 
-	// -- executable - preemptively ---
-
-	@Test
-	void assertTimeoutPreemptivelyForExecutableThatCompletesBeforeTheTimeout() {
-		changed.get().set(false);
-		assertTimeoutPreemptively(ofMillis(500), () -> changed.get().set(true));
-		assertFalse(changed.get().get(), "should have executed in a different thread");
-		assertTimeoutPreemptively(ofMillis(500), nix, "message");
-		assertTimeoutPreemptively(ofMillis(500), nix, () -> "message");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyForExecutableThatThrowsAnException() {
-		RuntimeException exception = assertThrows(RuntimeException.class,
-			() -> assertTimeoutPreemptively(ofMillis(500), () -> {
-				throw new RuntimeException("not this time");
-			}));
-		assertMessageEquals(exception, "not this time");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyForExecutableThatThrowsAnAssertionFailedError() {
-		AssertionFailedError exception = assertThrows(AssertionFailedError.class,
-			() -> assertTimeoutPreemptively(ofMillis(500), () -> fail("enigma")));
-		assertMessageEquals(exception, "enigma");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyForExecutableThatCompletesAfterTheTimeout() {
-		AssertionFailedError error = assertThrows(AssertionFailedError.class,
-			() -> assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, this::waitForInterrupt));
-		assertMessageEquals(error, "execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
-		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
-		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyWithMessageForExecutableThatCompletesAfterTheTimeout() {
-		AssertionFailedError error = assertThrows(AssertionFailedError.class,
-			() -> assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, this::waitForInterrupt, "Tempus Fugit"));
-		assertMessageEquals(error,
-			"Tempus Fugit ==> execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
-		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
-		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyWithMessageSupplierForExecutableThatCompletesAfterTheTimeout() {
-		AssertionFailedError error = assertThrows(AssertionFailedError.class,
-			() -> assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, this::waitForInterrupt,
-				() -> "Tempus" + " " + "Fugit"));
-		assertMessageEquals(error,
-			"Tempus Fugit ==> execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
-		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
-		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyWithMessageSupplierForExecutableThatCompletesBeforeTheTimeout() {
-		assertTimeoutPreemptively(ofMillis(500), nix, () -> "Tempus" + " " + "Fugit");
-	}
-
-	// -- supplier - preemptively ---
-
-	@Test
-	void assertTimeoutPreemptivelyForSupplierThatCompletesBeforeTheTimeout() {
-		changed.get().set(false);
-		String result = assertTimeoutPreemptively(ofMillis(500), () -> {
-			changed.get().set(true);
-			return "Tempus Fugit";
-		});
-		assertFalse(changed.get().get(), "should have executed in a different thread");
-		assertEquals("Tempus Fugit", result);
-		assertEquals("Tempus Fugit", assertTimeoutPreemptively(ofMillis(500), () -> "Tempus Fugit", "message"));
-		assertEquals("Tempus Fugit", assertTimeoutPreemptively(ofMillis(500), () -> "Tempus Fugit", () -> "message"));
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyForSupplierThatThrowsAnException() {
-		RuntimeException exception = assertThrows(RuntimeException.class, () -> {
-			assertTimeoutPreemptively(ofMillis(500), () -> {
-				ExceptionUtils.throwAsUncheckedException(new RuntimeException("not this time"));
-				return "Tempus Fugit";
-			});
-		});
-		assertMessageEquals(exception, "not this time");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyForSupplierThatThrowsAnAssertionFailedError() {
-		AssertionFailedError exception = assertThrows(AssertionFailedError.class, () -> {
-			assertTimeoutPreemptively(ofMillis(500), () -> {
-				fail("enigma");
-				return "Tempus Fugit";
-			});
-		});
-		assertMessageEquals(exception, "enigma");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyForSupplierThatCompletesAfterTheTimeout() {
-		AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> {
-			assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> {
-				waitForInterrupt();
-				return "Tempus Fugit";
-			});
-		});
-
-		assertMessageEquals(error, "execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
-		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
-		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyWithMessageForSupplierThatCompletesAfterTheTimeout() {
-		AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> {
-			assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> {
-				waitForInterrupt();
-				return "Tempus Fugit";
-			}, "Tempus Fugit");
-		});
-
-		assertMessageEquals(error,
-			"Tempus Fugit ==> execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
-		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
-		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyWithMessageSupplierForSupplierThatCompletesAfterTheTimeout() {
-		AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> {
-			assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> {
-				waitForInterrupt();
-				return "Tempus Fugit";
-			}, () -> "Tempus" + " " + "Fugit");
-		});
-
-		assertMessageEquals(error,
-			"Tempus Fugit ==> execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
-		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
-		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyUsesThreadsWithSpecificNamePrefix() {
-		AtomicReference<String> threadName = new AtomicReference<>("");
-		assertTimeoutPreemptively(ofMillis(1000), () -> threadName.set(Thread.currentThread().getName()));
-		assertTrue(threadName.get().startsWith("junit-timeout-thread-"),
-			"Thread name does not match the expected prefix");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatCompletesAfterTheTimeout() {
-		assertThrows(TimeoutException.class, () -> Assertions.assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> {
-			waitForInterrupt();
-			return "Tempus Fugit";
-		}, () -> "Tempus Fugit", TIMEOUT_EXCEPTION_FACTORY));
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatThrowsAnAssertionFailedError() {
-		AssertionFailedError exception = assertThrows(AssertionFailedError.class,
-			() -> Assertions.assertTimeoutPreemptively(ofMillis(500), () -> fail("enigma"), () -> "Tempus Fugit",
-				TIMEOUT_EXCEPTION_FACTORY));
-		assertMessageEquals(exception, "enigma");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatThrowsAnException() {
-		RuntimeException exception = assertThrows(RuntimeException.class,
-			() -> Assertions.assertTimeoutPreemptively(ofMillis(500),
-				() -> ExceptionUtils.throwAsUncheckedException(new RuntimeException(":(")), () -> "Tempus Fugit",
-				TIMEOUT_EXCEPTION_FACTORY));
-		assertMessageEquals(exception, ":(");
-	}
-
-	@Test
-	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatCompletesBeforeTimeout()
-			throws Exception {
-		var result = Assertions.assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> "Tempus Fugit",
-			() -> "Tempus Fugit", TIMEOUT_EXCEPTION_FACTORY);
-
-		assertThat(result).isEqualTo("Tempus Fugit");
-	}
-
 	/**
 	 * Take a nap for 100 milliseconds.
 	 */
@@ -360,26 +163,6 @@ class AssertTimeoutAssertionsTests {
 		do {
 			Thread.sleep(100);
 		} while (System.currentTimeMillis() - start < 100);
-	}
-
-	private void waitForInterrupt() {
-		try {
-			assertFalse(Thread.interrupted(), "Already interrupted");
-			new CountDownLatch(1).await();
-		}
-		catch (InterruptedException ignore) {
-			// ignore
-		}
-	}
-
-	/**
-	 * Assert the given stack trace elements contain an element with the given class name and method name.
-	 */
-	private static void assertStackTraceContains(StackTraceElement[] stackTrace, String className, String methodName) {
-		assertThat(stackTrace).anySatisfy(element -> {
-			assertThat(element.getClassName()).endsWith(className);
-			assertThat(element.getMethodName()).isEqualTo(methodName);
-		});
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -342,7 +342,8 @@ class AssertTimeoutAssertionsTests {
 	}
 
 	@Test
-	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatCompletesBeforeTimeout() {
+	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatCompletesBeforeTimeout()
+			throws Exception {
 		var result = assertTimeoutPreemptivelyThrowingTimeoutException(PREEMPTIVE_TIMEOUT, () -> "Tempus Fugit",
 			() -> "Tempus Fugit");
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -41,8 +41,8 @@ import org.opentest4j.AssertionFailedError;
 class AssertTimeoutAssertionsTests {
 
 	private static final Duration PREEMPTIVE_TIMEOUT = ofMillis(WINDOWS.isCurrentOs() ? 1000 : 100);
-	private static final Assertions.TimeoutFailureFactory<TimeoutException> TIMEOUT_EXCEPTION_FACTORY = (__, ___, ____,
-			_____) -> new TimeoutException();
+	private static final Assertions.TimeoutFailureFactory<TimeoutException> TIMEOUT_EXCEPTION_FACTORY = (__, ___,
+			____) -> new TimeoutException();
 
 	private static ThreadLocal<AtomicBoolean> changed = ThreadLocal.withInitial(() -> new AtomicBoolean(false));
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutPreemptivelyAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutPreemptivelyAssertionsTests.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import static java.time.Duration.ofMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.function.Executable;
+import org.junit.platform.commons.util.ExceptionUtils;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * Unit tests for {@link AssertTimeoutPreemptively}.
+ *
+ * @since 5.0
+ */
+class AssertTimeoutPreemptivelyAssertionsTests {
+
+	private static final Duration PREEMPTIVE_TIMEOUT = ofMillis(WINDOWS.isCurrentOs() ? 1000 : 100);
+	private static final Assertions.TimeoutFailureFactory<TimeoutException> TIMEOUT_EXCEPTION_FACTORY = (__, ___,
+			____) -> new TimeoutException();
+
+	private static final ThreadLocal<AtomicBoolean> changed = ThreadLocal.withInitial(() -> new AtomicBoolean(false));
+
+	private final Executable nix = () -> {
+	};
+
+	// --- executable ----------------------------------------------------------
+
+	@Test
+	void assertTimeoutPreemptivelyForExecutableThatCompletesBeforeTheTimeout() {
+		changed.get().set(false);
+		assertTimeoutPreemptively(ofMillis(500), () -> changed.get().set(true));
+		assertFalse(changed.get().get(), "should have executed in a different thread");
+		assertTimeoutPreemptively(ofMillis(500), nix, "message");
+		assertTimeoutPreemptively(ofMillis(500), nix, () -> "message");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyForExecutableThatThrowsAnException() {
+		RuntimeException exception = assertThrows(RuntimeException.class,
+			() -> assertTimeoutPreemptively(ofMillis(500), () -> {
+				throw new RuntimeException("not this time");
+			}));
+		assertMessageEquals(exception, "not this time");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyForExecutableThatThrowsAnAssertionFailedError() {
+		AssertionFailedError exception = assertThrows(AssertionFailedError.class,
+			() -> assertTimeoutPreemptively(ofMillis(500), () -> fail("enigma")));
+		assertMessageEquals(exception, "enigma");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyForExecutableThatCompletesAfterTheTimeout() {
+		AssertionFailedError error = assertThrows(AssertionFailedError.class,
+			() -> assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, this::waitForInterrupt));
+		assertMessageEquals(error, "execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyWithMessageForExecutableThatCompletesAfterTheTimeout() {
+		AssertionFailedError error = assertThrows(AssertionFailedError.class,
+			() -> assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, this::waitForInterrupt, "Tempus Fugit"));
+		assertMessageEquals(error,
+			"Tempus Fugit ==> execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyWithMessageSupplierForExecutableThatCompletesAfterTheTimeout() {
+		AssertionFailedError error = assertThrows(AssertionFailedError.class,
+			() -> assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, this::waitForInterrupt,
+				() -> "Tempus" + " " + "Fugit"));
+		assertMessageEquals(error,
+			"Tempus Fugit ==> execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyWithMessageSupplierForExecutableThatCompletesBeforeTheTimeout() {
+		assertTimeoutPreemptively(ofMillis(500), nix, () -> "Tempus" + " " + "Fugit");
+	}
+
+	// --- supplier ------------------------------------------------------------
+
+	@Test
+	void assertTimeoutPreemptivelyForSupplierThatCompletesBeforeTheTimeout() {
+		changed.get().set(false);
+		String result = assertTimeoutPreemptively(ofMillis(500), () -> {
+			changed.get().set(true);
+			return "Tempus Fugit";
+		});
+		assertFalse(changed.get().get(), "should have executed in a different thread");
+		assertEquals("Tempus Fugit", result);
+		assertEquals("Tempus Fugit", assertTimeoutPreemptively(ofMillis(500), () -> "Tempus Fugit", "message"));
+		assertEquals("Tempus Fugit", assertTimeoutPreemptively(ofMillis(500), () -> "Tempus Fugit", () -> "message"));
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyForSupplierThatThrowsAnException() {
+		RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+			assertTimeoutPreemptively(ofMillis(500), () -> {
+				ExceptionUtils.throwAsUncheckedException(new RuntimeException("not this time"));
+				return "Tempus Fugit";
+			});
+		});
+		assertMessageEquals(exception, "not this time");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyForSupplierThatThrowsAnAssertionFailedError() {
+		AssertionFailedError exception = assertThrows(AssertionFailedError.class, () -> {
+			assertTimeoutPreemptively(ofMillis(500), () -> {
+				fail("enigma");
+				return "Tempus Fugit";
+			});
+		});
+		assertMessageEquals(exception, "enigma");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyForSupplierThatCompletesAfterTheTimeout() {
+		AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> {
+			assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> {
+				waitForInterrupt();
+				return "Tempus Fugit";
+			});
+		});
+
+		assertMessageEquals(error, "execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyWithMessageForSupplierThatCompletesAfterTheTimeout() {
+		AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> {
+			assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> {
+				waitForInterrupt();
+				return "Tempus Fugit";
+			}, "Tempus Fugit");
+		});
+
+		assertMessageEquals(error,
+			"Tempus Fugit ==> execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyWithMessageSupplierForSupplierThatCompletesAfterTheTimeout() {
+		AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> {
+			assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> {
+				waitForInterrupt();
+				return "Tempus Fugit";
+			}, () -> "Tempus" + " " + "Fugit");
+		});
+
+		assertMessageEquals(error,
+			"Tempus Fugit ==> execution timed out after " + PREEMPTIVE_TIMEOUT.toMillis() + " ms");
+		assertMessageStartsWith(error.getCause(), "Execution timed out in ");
+		assertStackTraceContains(error.getCause().getStackTrace(), "CountDownLatch", "await");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyUsesThreadsWithSpecificNamePrefix() {
+		AtomicReference<String> threadName = new AtomicReference<>("");
+		assertTimeoutPreemptively(ofMillis(1000), () -> threadName.set(Thread.currentThread().getName()));
+		assertTrue(threadName.get().startsWith("junit-timeout-thread-"),
+			"Thread name does not match the expected prefix");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatCompletesAfterTheTimeout() {
+		assertThrows(TimeoutException.class, () -> Assertions.assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> {
+			waitForInterrupt();
+			return "Tempus Fugit";
+		}, () -> "Tempus Fugit", TIMEOUT_EXCEPTION_FACTORY));
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatThrowsAnAssertionFailedError() {
+		AssertionFailedError exception = assertThrows(AssertionFailedError.class,
+			() -> Assertions.assertTimeoutPreemptively(ofMillis(500), () -> fail("enigma"), () -> "Tempus Fugit",
+				TIMEOUT_EXCEPTION_FACTORY));
+		assertMessageEquals(exception, "enigma");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatThrowsAnException() {
+		RuntimeException exception = assertThrows(RuntimeException.class,
+			() -> Assertions.assertTimeoutPreemptively(ofMillis(500),
+				() -> ExceptionUtils.throwAsUncheckedException(new RuntimeException(":(")), () -> "Tempus Fugit",
+				TIMEOUT_EXCEPTION_FACTORY));
+		assertMessageEquals(exception, ":(");
+	}
+
+	@Test
+	void assertTimeoutPreemptivelyThrowingTimeoutExceptionWithMessageForSupplierThatCompletesBeforeTimeout()
+			throws Exception {
+		var result = Assertions.assertTimeoutPreemptively(PREEMPTIVE_TIMEOUT, () -> "Tempus Fugit",
+			() -> "Tempus Fugit", TIMEOUT_EXCEPTION_FACTORY);
+
+		assertThat(result).isEqualTo("Tempus Fugit");
+	}
+
+	private void waitForInterrupt() {
+		try {
+			assertFalse(Thread.interrupted(), "Already interrupted");
+			new CountDownLatch(1).await();
+		}
+		catch (InterruptedException ignore) {
+			// ignore
+		}
+	}
+
+	/**
+	 * Assert the given stack trace elements contain an element with the given class name and method name.
+	 */
+	private static void assertStackTraceContains(StackTraceElement[] stackTrace, String className, String methodName) {
+		assertThat(stackTrace).anySatisfy(element -> {
+			assertThat(element.getClassName()).endsWith(className);
+			assertThat(element.getMethodName()).isEqualTo(methodName);
+		});
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
@@ -47,7 +47,8 @@ class SeparateThreadTimeoutInvocationTest {
 
 		assertThatThrownBy(invocation::proceed) //
 				.hasMessage("method() timed out after " + PREEMPTIVE_TIMEOUT_MILLIS + " milliseconds") //
-				.isInstanceOf(TimeoutException.class);
+				.isInstanceOf(TimeoutException.class) //
+				.hasRootCauseMessage("Execution timed out in thread " + threadName.get());
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTest.java
@@ -47,8 +47,7 @@ class SeparateThreadTimeoutInvocationTest {
 
 		assertThatThrownBy(invocation::proceed) //
 				.hasMessage("method() timed out after " + PREEMPTIVE_TIMEOUT_MILLIS + " milliseconds") //
-				.isInstanceOf(TimeoutException.class) //
-				.hasRootCauseMessage("Execution timed out in thread " + threadName.get());
+				.isInstanceOf(TimeoutException.class);
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
@@ -349,9 +349,13 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 			EngineExecutionResults results = executeTestsForClass(TimeoutExceedingSeparateThreadTestCase.class);
 
 			Execution execution = findExecution(results.testEvents(), "testMethod()");
-			assertThat(execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow()) //
+			Throwable failure = execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow();
+			assertThat(failure) //
 					.isInstanceOf(TimeoutException.class) //
 					.hasMessage("testMethod() timed out after 10 milliseconds");
+			assertThat(failure.getCause()) //
+					.hasMessageStartingWith("Execution timed out in ") //
+					.hasStackTraceContaining(TimeoutExceedingSeparateThreadTestCase.class.getName() + ".testMethod");
 		}
 
 		@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutExtensionTests.java
@@ -352,7 +352,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 			Throwable failure = execution.getTerminationInfo().getExecutionResult().getThrowable().orElseThrow();
 			assertThat(failure) //
 					.isInstanceOf(TimeoutException.class) //
-					.hasMessage("testMethod() timed out after 10 milliseconds");
+					.hasMessage("testMethod() timed out after 100 milliseconds");
 			assertThat(failure.getCause()) //
 					.hasMessageStartingWith("Execution timed out in ") //
 					.hasStackTraceContaining(TimeoutExceedingSeparateThreadTestCase.class.getName() + ".testMethod");
@@ -721,7 +721,7 @@ class TimeoutExtensionTests extends AbstractJupiterTestEngineTests {
 
 	static class TimeoutExceedingSeparateThreadTestCase {
 		@Test
-		@Timeout(value = 10, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
+		@Timeout(value = 100, unit = MILLISECONDS, threadMode = SEPARATE_THREAD)
 		void testMethod() throws InterruptedException {
 			Thread.sleep(1000);
 		}


### PR DESCRIPTION
## Overview

This solves the issue #3000 by allowing to specify which exception should be thrown by the preventive timeout assertion.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
