### PR TITLE
#3010 Fix CsvArgumentsProvider handling of headers

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -95,6 +95,7 @@ class CsvArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<CsvS
 				// Lazily retrieve headers if necessary.
 				if (useHeadersInDisplayName && headers == null) {
 					headers = getHeaders(this.csvParser);
+					continue;
 				}
 				Preconditions.notNull(csvRecord,
 					() -> "Record at index " + index + " contains invalid CSV: \"" + input + "\"");

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -354,6 +354,24 @@ class CsvArgumentsProviderTests {
 	}
 
 	@Test
+	void supportsCsvHeadersWhenUsingValueAttribute() {
+		var annotation = csvSource().useHeadersInDisplayName(true).lines("FRUIT, RANK", "apple, 1",
+			"banana, 2").build();
+
+		var arguments = provideArguments(annotation);
+		Stream<String[]> argumentsAsStrings = arguments.map(array -> {
+			String[] strings = new String[array.length];
+			for (int i = 0; i < array.length; i++) {
+				strings[i] = String.valueOf(array[i]);
+			}
+			return strings;
+		});
+
+		assertThat(argumentsAsStrings).containsExactly(array("FRUIT = apple", "RANK = 1"),
+			array("FRUIT = banana", "RANK = 2"));
+	}
+
+	@Test
 	void throwsExceptionIfColumnCountExceedsHeaderCount() {
 		var annotation = csvSource().useHeadersInDisplayName(true).textBlock("""
 				FRUIT, RANK


### PR DESCRIPTION
## Overview

This addresses issue #3010.

Previously, when parsing `value` attribute of the `@CsvSource` annotation with `useHeadersInDisplayName` set to true, CsvArgumentsProvider didn't handle headers correctly. After parsing the first line with headers, instead of moving to the next line, it tried to validate a not-yet-parsed CSV record which lead to an exception being thrown. This was due to the missing `continue` statement in the `for` loop.
Now, with `continue` added, as soon as headers are parsed, `for` loop is advanced to the next iteration and to the next line of CSV input, containing the expected CSV record.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
