### PR TITLE
Support saturating the ForkJoinPool via a property

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.1.adoc
@@ -23,8 +23,7 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
-
+* Support saturating the ForkJoinPool via a property.
 
 [[release-notes-5.9.1-junit-jupiter]]
 === JUnit Jupiter
@@ -47,8 +46,9 @@ on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
-
+* Added `junit.jupiter.execution.parallel.config.dynamic.saturate` and
+  `junit.jupiter.execution.parallel.config.fixed.saturate` to limit the concurrently
+  executing tests to the maximum desired parallelism.
 
 [[release-notes-5.9.1-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2332,12 +2332,14 @@ strategy with a factor of `1`. Consequently, the desired parallelism will be equ
 number of available processors/cores.
 
 .Parallelism does not imply maximum number of concurrent threads
-NOTE: JUnit Jupiter does not guarantee that the number of concurrently executing tests
+NOTE: By default JUnit Jupiter does not guarantee that the number of concurrently executing tests
 will not exceed the configured parallelism. For example, when using one of the
 synchronization mechanisms described in the next section, the `ForkJoinPool` that is used
 behind the scenes may spawn additional threads to ensure execution continues with
-sufficient parallelism. Thus, if you require such guarantees in a test class, please use
-your own means of controlling concurrency.
+sufficient parallelism.
+By setting the optional configuration parameters `junit.jupiter.execution.parallel.config.dynamic.saturate`
+or `junit.jupiter.execution.parallel.config.fixed.saturate` to `true` the number of
+concurrently executing tests will not exceed the configured parallelism.
 
 [[writing-tests-parallel-execution-config-properties]]
 ===== Relevant properties
@@ -2384,10 +2386,27 @@ The following table lists relevant properties for configuring parallel execution
 | a positive decimal number
 | ```1.0```
 
+| ```junit.jupiter.execution.parallel.config.dynamic.saturate```
+| Limit the concurrently executing tests to the maximum parallelism desired parallelism
+  for the  ```dynamic``` configuration strategy.
+|
+  * `true`
+  * `false`
+| ```false```
+
 | ```junit.jupiter.execution.parallel.config.fixed.parallelism```
 | Desired parallelism for the ```fixed``` configuration strategy
 | a positive integer
 | no default value
+
+
+| ```junit.jupiter.execution.parallel.config.fixed.saturate```
+| Limit the concurrently executing tests to the maximum parallelism desired parallelism
+  for the  ```fixed``` configuration strategy.
+|
+  * `true`
+  * `false`
+| ```false```
 
 | ```junit.jupiter.execution.parallel.config.custom.class```
 | Fully qualified class name of the _ParallelExecutionConfigurationStrategy_ to be

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -15,7 +15,9 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_CUSTOM_CLASS_PROPERTY_NAME;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME;
+import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_DYNAMIC_SATURATE_PROPERTY_NAME;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_FIXED_PARALLELISM_PROPERTY_NAME;
+import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_FIXED_SATURATE_PROPERTY_NAME;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_STRATEGY_PROPERTY_NAME;
 
 import org.apiguardian.api.API;
@@ -167,6 +169,19 @@ public final class Constants {
 			+ CONFIG_FIXED_PARALLELISM_PROPERTY_NAME;
 
 	/**
+	 * Property name used to limit the concurrently executing tests to the
+	 * maximum parallelism desired parallelism for the {@code fixed}
+	 * configuration strategy: {@value}
+	 *
+	 * <p>Value must either {@code true} or {@code false}; defaults to {@code false}.
+	 *
+	 * @since 5.9.1
+	 */
+	@API(status = EXPERIMENTAL, since = "5.9.1")
+	public static final String PARALLEL_CONFIG_FIXED_SATURATE_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
+			+ CONFIG_FIXED_SATURATE_PROPERTY_NAME;
+
+	/**
 	 * Property name used to set the factor to be multiplied with the number of
 	 * available processors/cores to determine the desired parallelism for the
 	 * {@code dynamic} configuration strategy: {@value}
@@ -178,6 +193,19 @@ public final class Constants {
 	@API(status = EXPERIMENTAL, since = "5.3")
 	public static final String PARALLEL_CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
 			+ CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME;
+
+	/**
+	 * Property name used to limit the concurrently executing tests to the
+	 * maximum parallelism desired parallelism for the {@code dynamic}
+	 * configuration strategy: {@value}
+	 *
+	 * <p>Value must either {@code true} or {@code false}; defaults to {@code false}.
+	 *
+	 * @since 5.9.1
+	 */
+	@API(status = EXPERIMENTAL, since = "5.9.1")
+	public static final String PARALLEL_CONFIG_DYNAMIC_SATURATE_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
+			+ CONFIG_DYNAMIC_SATURATE_PROPERTY_NAME;
 
 	/**
 	 * Property name used to specify the fully qualified class name of the

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfiguration.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfiguration.java
@@ -10,6 +10,9 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.Predicate;
+
 /**
  * @since 1.3
  */
@@ -20,14 +23,16 @@ class DefaultParallelExecutionConfiguration implements ParallelExecutionConfigur
 	private final int maxPoolSize;
 	private final int corePoolSize;
 	private final int keepAliveSeconds;
+	private final Predicate<? super ForkJoinPool> saturate;
 
 	DefaultParallelExecutionConfiguration(int parallelism, int minimumRunnable, int maxPoolSize, int corePoolSize,
-			int keepAliveSeconds) {
+			int keepAliveSeconds, boolean saturate) {
 		this.parallelism = parallelism;
 		this.minimumRunnable = minimumRunnable;
 		this.maxPoolSize = maxPoolSize;
 		this.corePoolSize = corePoolSize;
 		this.keepAliveSeconds = keepAliveSeconds;
+		this.saturate = saturate ? __ -> true : null;
 	}
 
 	@Override
@@ -55,4 +60,8 @@ class DefaultParallelExecutionConfiguration implements ParallelExecutionConfigur
 		return keepAliveSeconds;
 	}
 
+	@Override
+	public Predicate<? super ForkJoinPool> getSaturatePredicate() {
+		return saturate;
+	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
@@ -42,8 +42,11 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 					() -> new JUnitException(String.format("Configuration parameter '%s' must be set",
 						CONFIG_FIXED_PARALLELISM_PROPERTY_NAME)));
 
+			boolean saturate = configurationParameters.get(CONFIG_FIXED_SATURATE_PROPERTY_NAME,
+				Boolean::valueOf).orElse(false);
+
 			return new DefaultParallelExecutionConfiguration(parallelism, parallelism, 256 + parallelism, parallelism,
-				KEEP_ALIVE_SECONDS);
+				KEEP_ALIVE_SECONDS, saturate);
 		}
 	},
 
@@ -65,8 +68,11 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 			int parallelism = Math.max(1,
 				factor.multiply(BigDecimal.valueOf(Runtime.getRuntime().availableProcessors())).intValue());
 
+			boolean saturate = configurationParameters.get(CONFIG_DYNAMIC_SATURATE_PROPERTY_NAME,
+				Boolean::valueOf).orElse(false);
+
 			return new DefaultParallelExecutionConfiguration(parallelism, parallelism, 256 + parallelism, parallelism,
-				KEEP_ALIVE_SECONDS);
+				KEEP_ALIVE_SECONDS, saturate);
 		}
 	},
 
@@ -115,6 +121,20 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 	public static final String CONFIG_FIXED_PARALLELISM_PROPERTY_NAME = "fixed.parallelism";
 
 	/**
+	 * Property name used to enable saturation of the underlying fork join pool
+	 * for the {@link #FIXED} configuration strategy.
+	 *
+	 * <p>When set to {@code true} the maximum number of concurrent threads will
+	 * not exceed the desired parallelism, even when some threads are blocked.
+	 *
+	 * <p>Value must either {@code true} or {@code false}; defaults to {@code false}.
+	 *
+	 * @see #FIXED
+	 */
+	@API(status = EXPERIMENTAL, since = "1.9.1")
+	public static final String CONFIG_FIXED_SATURATE_PROPERTY_NAME = "fixed.saturate";
+
+	/**
 	 * Property name of the factor used to determine the desired parallelism for the
 	 * {@link #DYNAMIC} configuration strategy.
 	 *
@@ -123,6 +143,20 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 	 * @see #DYNAMIC
 	 */
 	public static final String CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME = "dynamic.factor";
+
+	/**
+	 * Property name used to enable saturation of the underlying fork join pool
+	 * for the {@link #DYNAMIC} configuration strategy.
+	 *
+	 * <p>When set to {@code true} the maximum number of concurrent threads will
+	 * not exceed the desired parallelism, even when some threads are blocked.
+	 *
+	 * <p>Value must either {@code true} or {@code false}; defaults to {@code false}.
+	 *
+	 * @see #DYNAMIC
+	 */
+	@API(status = EXPERIMENTAL, since = "1.9.1")
+	public static final String CONFIG_DYNAMIC_SATURATE_PROPERTY_NAME = "dynamic.saturate";
 
 	/**
 	 * Property name used to specify the fully qualified class name of the


### PR DESCRIPTION
## Overview

The JUnit Platform now supports saturating the ForkJoinPool via a property.
Enabling this property will limit the number of concurrently executing tests
will to the configured parallelism even when some are blocked.

For JUnit Jupiter this can be enabled by through the
`junit.jupiter.execution.parallel.config.dynamic.saturate` and
`junit.jupiter.execution.parallel.config.fixed.saturate` configuration
properties.

Fixes: #2545 
Fixes: #1858
Fixes: #3026 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
