### PR TITLE
Fix fallback to ForkJoinPools Java 7 constructor on Java 9 and higher

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/index.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/index.adoc
@@ -16,6 +16,8 @@ authors as well as build tool and IDE vendors.
 
 include::{includedir}/link-attributes.adoc[]
 
+include::{basedir}/release-notes-5.10.0-M1.adoc[]
+
 include::{basedir}/release-notes-5.9.1.adoc[]
 
 include::{basedir}/release-notes-5.9.0.adoc[]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -1,0 +1,58 @@
+[[release-notes-5.10.0-M1️]]
+== 5.10.0-M1️
+
+*Date of Release:* ❓
+
+*Scope:* ❓
+
+For a complete list of all _closed_ issues and pull requests for this release, consult the
+link:{junit5-repo}+/milestone/5.10.0-M1️?closed=1+[5.10.0-M1️] milestone page in the JUnit repository on
+GitHub.
+
+
+[[release-notes-5.10.0-M1️-junit-platform]]
+=== JUnit Platform
+
+==== Bug Fixes
+
+* Fixed fallback to ForkJoinPools Java 7 constructor on Java 9 and higher
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓
+
+
+[[release-notes-5.10.0-M1️-junit-jupiter]]
+=== JUnit Jupiter
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓
+
+
+[[release-notes-5.10.0-M1️-junit-vintage]]
+=== JUnit Vintage
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.hierarchical;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.JUnitException;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ForkJoinPoolHierarchicalTestExecutorServiceTests {
+
+	@Mock
+	ParallelExecutionConfiguration configuration;
+
+	@Test
+	void exceptionsFromInvalidConfigurationAreNotSwallowed() {
+		when(configuration.getParallelism()).thenReturn(2);
+		when(configuration.getMaxPoolSize()).thenReturn(1); // invalid, should be > parallelism
+		when(configuration.getCorePoolSize()).thenReturn(1);
+		when(configuration.getMinimumRunnable()).thenReturn(1);
+		when(configuration.getSaturatePredicate()).thenReturn(__ -> true);
+		when(configuration.getKeepAliveSeconds()).thenReturn(0);
+
+		JUnitException exception = assertThrows(JUnitException.class,
+			() -> new ForkJoinPoolHierarchicalTestExecutorService(configuration));
+		assertThat(exception).hasMessage("Failed to create ForkJoinPool");
+		assertThat(exception).rootCause().isInstanceOf(IllegalArgumentException.class);
+	}
+
+}


### PR DESCRIPTION
## Overview

When an invalid ParallelExecutionConfiguration is provided on Java 9+ the
`ForkJoinPoolHierarchicalTestExecutorService` will fall back to using the
since Java 7 constructor. As a result misconfiguration goes unnoticed. 

Separated the exceptions thrown by finding the Java 9+ constructor from those
thrown by invoking the constructor with an invalid configuration. The former
can be ignored, the latter should not be.

Fixes: #3045

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
