### PR TITLE
Build changes towards configuration cache compatibility

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,1 +1,1 @@
-// intentionally left blank
+rootProject.name = "buildSrc"

--- a/buildSrc/src/main/kotlin/build-metadata.gradle.kts
+++ b/buildSrc/src/main/kotlin/build-metadata.gradle.kts
@@ -4,15 +4,13 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
-val buildTimeAndDate: OffsetDateTime by extra {
-
-	// SOURCE_DATE_EPOCH is a UNIX timestamp for pinning build metadata against
-	// in order to achieve reproducible builds
-	//
-	// More details - https://reproducible-builds.org/docs/source-date-epoch/
-
+val buildTimeAndDate =
 	if (System.getenv().containsKey("SOURCE_DATE_EPOCH")) {
 
+		// SOURCE_DATE_EPOCH is a UNIX timestamp for pinning build metadata against
+		// in order to achieve reproducible builds
+		//
+		// More details - https://reproducible-builds.org/docs/source-date-epoch/
 		val sourceDateEpoch = System.getenv("SOURCE_DATE_EPOCH").toLong()
 
 		Instant.ofEpochSecond(sourceDateEpoch).atOffset(ZoneOffset.UTC)
@@ -20,7 +18,6 @@ val buildTimeAndDate: OffsetDateTime by extra {
 	} else {
 		OffsetDateTime.now()
 	}
-}
 
 val buildDate: String by extra { DateTimeFormatter.ISO_LOCAL_DATE.format(buildTimeAndDate) }
 val buildTime: String by extra { DateTimeFormatter.ofPattern("HH:mm:ss.SSSZ").format(buildTimeAndDate) }

--- a/buildSrc/src/main/kotlin/java-toolchain-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-toolchain-conventions.gradle.kts
@@ -1,8 +1,8 @@
-val javaToolchainVersion: String? by project
-val defaultLanguageVersion = JavaLanguageVersion.of(17)
-val javaLanguageVersion = javaToolchainVersion?.let { JavaLanguageVersion.of(it) } ?: defaultLanguageVersion
-
 project.pluginManager.withPlugin("java") {
+	val javaToolchainVersion: String? by project
+	val defaultLanguageVersion = JavaLanguageVersion.of(17)
+	val javaLanguageVersion = javaToolchainVersion?.let { JavaLanguageVersion.of(it) } ?: defaultLanguageVersion
+
 	val extension = the<JavaPluginExtension>()
 	val javaToolchainService = the<JavaToolchainService>()
 	extension.toolchain.languageVersion.set(javaLanguageVersion)

--- a/buildSrc/src/main/kotlin/org/junit/gradle/java/ExecJarAction.kt
+++ b/buildSrc/src/main/kotlin/org/junit/gradle/java/ExecJarAction.kt
@@ -1,0 +1,27 @@
+package org.junit.gradle.java
+
+import org.gradle.api.Action
+import org.gradle.api.Task
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.jvm.tasks.Jar
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.jvm.toolchain.JavaToolchainSpec
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class ExecJarAction @Inject constructor(private val operations: ExecOperations): Action<Task> {
+
+    abstract val javaLauncher: Property<JavaLauncher>
+
+    abstract val args: ListProperty<String>
+
+    override fun execute(t: Task) {
+        operations.exec {
+            executable = javaLauncher.get()
+                .metadata.installationPath.file("bin/jar").asFile.absolutePath
+            args = this@ExecJarAction.args.get()
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/org/junit/gradle/java/ModulePathArgumentProvider.kt
+++ b/buildSrc/src/main/kotlin/org/junit/gradle/java/ModulePathArgumentProvider.kt
@@ -1,0 +1,31 @@
+package org.junit.gradle.java
+
+import org.gradle.api.Named
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
+import org.gradle.kotlin.dsl.get
+import org.gradle.process.CommandLineArgumentProvider
+
+class ModulePathArgumentProvider(project: Project, modularProjects: List<Project>) : CommandLineArgumentProvider,
+    Named {
+
+    @get:CompileClasspath
+    val modulePath: Provider<Configuration> = project.configurations.named("compileClasspath")
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val moduleSourceDirs: FileCollection = project.files(modularProjects.map { "${it.projectDir}/src/module" })
+
+    override fun asArguments() = listOf(
+        "--module-path",
+        modulePath.get().asPath,
+        "--module-source-path",
+        moduleSourceDirs.asPath
+    )
+
+    @Internal
+    override fun getName() = "module-path"
+}

--- a/buildSrc/src/main/kotlin/org/junit/gradle/java/PatchModuleArgumentProvider.kt
+++ b/buildSrc/src/main/kotlin/org/junit/gradle/java/PatchModuleArgumentProvider.kt
@@ -1,0 +1,38 @@
+package org.junit.gradle.java
+
+import javaModuleName
+import org.gradle.api.Named
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.the
+import org.gradle.process.CommandLineArgumentProvider
+
+class PatchModuleArgumentProvider(compiledProject: Project, patchModuleProject: Project) : CommandLineArgumentProvider,
+	Named {
+
+	@get:Input
+	val module: String = patchModuleProject.javaModuleName
+
+	@get:InputFiles
+	@get:PathSensitive(PathSensitivity.RELATIVE)
+	val patch: Provider<FileCollection> = compiledProject.provider {
+		if (patchModuleProject == compiledProject)
+			compiledProject.files(compiledProject.the<SourceSetContainer>().matching { it.name.startsWith("main") }.map { it.output })
+		else
+			patchModuleProject.files(patchModuleProject.the<SourceSetContainer>()["main"].java.srcDirs)
+	}
+
+	override fun asArguments(): List<String> {
+		val path = patch.get().filter { it.exists() }.asPath
+		if (path.isEmpty()) {
+			return emptyList()
+		}
+		return listOf("--patch-module", "$module=$path")
+	}
+
+	@Internal
+	override fun getName() = "patch-module($module)"
+}

--- a/buildSrc/src/main/kotlin/org/junit/gradle/java/WriteArtifactsFile.kt
+++ b/buildSrc/src/main/kotlin/org/junit/gradle/java/WriteArtifactsFile.kt
@@ -1,0 +1,36 @@
+package org.junit.gradle.java
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.*
+
+abstract class WriteArtifactsFile : DefaultTask() {
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @get:Input
+    abstract val moduleVersions: SetProperty<ModuleVersionIdentifier>
+
+    fun from(configuration: Provider<Configuration>) {
+        moduleVersions.addAll(configuration.map {
+            it.resolvedConfiguration.resolvedArtifacts.map { it.moduleVersion.id }
+        })
+    }
+
+    @TaskAction
+    fun writeFile() {
+        outputFile.get().asFile.printWriter().use { out ->
+            moduleVersions.get()
+                .map { "${it.group}:${it.name}:${it.version}" }
+                .sorted()
+                .forEach(out::println)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/osgi-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/osgi-conventions.gradle.kts
@@ -10,60 +10,65 @@ val importAPIGuardian = "org.apiguardian.*;resolution:=\"optional\""
 // This task enhances `jar` and `shadowJar` tasks with the bnd
 // `BundleTaskExtension` extension which allows for generating OSGi
 // metadata into the jar
-tasks.withType<Jar>().matching {
-	task: Jar -> task.name == "jar" || task.name == "shadowJar"
+tasks.withType<Jar>().matching { task: Jar ->
+	task.name == "jar" || task.name == "shadowJar"
 }.configureEach {
-	val bte = extensions.create<BundleTaskExtension>(BundleTaskExtension.NAME, this)
-
 	extra["importAPIGuardian"] = importAPIGuardian
 
-	// These are bnd instructions necessary for generating OSGi metadata.
-	// We've generalized these so that they are widely applicable limiting
-	// module configurations to special cases.
-	bte.setBnd("""
-			# Set the Bundle-SymbolicName to the archiveBaseName.
-			# We don't use the archiveClassifier which Bnd will use
-			# in the default Bundle-SymbolicName value.
-			Bundle-SymbolicName: ${'$'}{task.archiveBaseName}
+	extensions.create<BundleTaskExtension>(BundleTaskExtension.NAME, this).apply {
+		properties.set(provider {
+			mapOf("project.description" to project.description)
+		})
+		// These are bnd instructions necessary for generating OSGi metadata.
+		// We've generalized these so that they are widely applicable limiting
+		// module configurations to special cases.
+		setBnd(
+			"""
+				# Set the Bundle-SymbolicName to the archiveBaseName.
+				# We don't use the archiveClassifier which Bnd will use
+				# in the default Bundle-SymbolicName value.
+				Bundle-SymbolicName: ${'$'}{task.archiveBaseName}
 
-			# Set the Bundle-Name from the project description
-			Bundle-Name: ${'$'}{project.description}
+				# Set the Bundle-Name from the project description
+				Bundle-Name: ${'$'}{project.description}
 
-			# These are the general rules for package imports.
-			Import-Package: \
-				${importAPIGuardian},\
-				org.junit.platform.commons.logging;status=INTERNAL,\
-				kotlin.*;resolution:="optional",\
-				*
+				# These are the general rules for package imports.
+				Import-Package: \
+					${importAPIGuardian},\
+					org.junit.platform.commons.logging;status=INTERNAL,\
+					kotlin.*;resolution:="optional",\
+					*
 
-			# This tells bnd not to complain if a module doesn't actually import
-			# the kotlin and apiguardian packages, but enough modules do to make it a default.
-			-fixupmessages.kotlin.import: "Unused Import-Package instructions: \\[kotlin.*\\]";is:=ignore
-			-fixupmessages.apiguardian.import: "Unused Import-Package instructions: \\[org.apiguardian.*\\]";is:=ignore
+				# This tells bnd not to complain if a module doesn't actually import
+				# the kotlin and apiguardian packages, but enough modules do to make it a default.
+				-fixupmessages.kotlin.import: "Unused Import-Package instructions: \\[kotlin.*\\]";is:=ignore
+				-fixupmessages.apiguardian.import: "Unused Import-Package instructions: \\[org.apiguardian.*\\]";is:=ignore
 
-			# This tells bnd to ignore classes it finds in `META-INF/versions/`
-			# because bnd doesn't yet support multi-release jars.
-			-fixupmessages.wrong.dir: "Classes found in the wrong directory: \\{META-INF/versions/...";is:=ignore
+				# This tells bnd to ignore classes it finds in `META-INF/versions/`
+				# because bnd doesn't yet support multi-release jars.
+				-fixupmessages.wrong.dir: "Classes found in the wrong directory: \\{META-INF/versions/...";is:=ignore
 
-			# Don't scan for Class.forName package imports.
-			# See https://bnd.bndtools.org/instructions/noclassforname.html
-			-noclassforname: true
+				# Don't scan for Class.forName package imports.
+				# See https://bnd.bndtools.org/instructions/noclassforname.html
+				-noclassforname: true
 
-			# Don't add all the extra headers bnd normally adds.
-			# See https://bnd.bndtools.org/instructions/noextraheaders.html
-			-noextraheaders: true
+				# Don't add all the extra headers bnd normally adds.
+				# See https://bnd.bndtools.org/instructions/noextraheaders.html
+				-noextraheaders: true
 
-			# Don't add the Private-Package header.
-			# See https://bnd.bndtools.org/instructions/removeheaders.html
-			-removeheaders: Private-Package
+				# Don't add the Private-Package header.
+				# See https://bnd.bndtools.org/instructions/removeheaders.html
+				-removeheaders: Private-Package
 
-			# Instruct the APIGuardianAnnotations how to operate.
-			# See https://bnd.bndtools.org/instructions/export-apiguardian.html
-			-export-apiguardian: *;version=${'$'}{versionmask;===;${'$'}{version_cleanup;${'$'}{task.archiveVersion}}}
-		""")
+				# Instruct the APIGuardianAnnotations how to operate.
+				# See https://bnd.bndtools.org/instructions/export-apiguardian.html
+				-export-apiguardian: *;version=${'$'}{versionmask;===;${'$'}{version_cleanup;${'$'}{task.archiveVersion}}}
+			"""
+		)
 
-	// Do the actual work putting OSGi stuff in the jar.
-	doLast(bte.buildAction())
+		// Do the actual work putting OSGi stuff in the jar.
+		doLast(buildAction())
+	}
 }
 
 // Bnd's Resolve task uses a properties file for its configuration. This
@@ -90,7 +95,7 @@ val osgiVerification by configurations.creating {
 // that its metadata is valid. If the metadata is invalid this task will
 // fail.
 val verifyOSGi by tasks.registering(Resolve::class) {
-	bndrun.fileProvider(osgiProperties.map{ it.outputFile })
+	bndrun.fileProvider(osgiProperties.map { it.outputFile })
 	outputBndrun.set(layout.buildDirectory.file("resolvedOSGiProperties.bndrun"))
 	isReportOptional = false
 	// By default bnd will use jars found in:

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -1,3 +1,5 @@
+import org.junit.gradle.java.ExecJarAction
+
 plugins {
 	`java-library-conventions`
 	`java-multi-release-sources`
@@ -16,18 +18,15 @@ dependencies {
 tasks.jar {
 	val release9ClassesDir = sourceSets.mainRelease9.get().output.classesDirs.singleFile
 	inputs.dir(release9ClassesDir).withPathSensitivity(PathSensitivity.RELATIVE)
-	doLast {
-		exec {
-			executable = project.the<JavaToolchainService>().launcherFor(java.toolchain).get()
-				.metadata.installationPath.file("bin/jar").asFile.absolutePath
-			args(
-				"--update",
-				"--file", archiveFile.get().asFile.absolutePath,
-				"--release", "9",
-				"-C", release9ClassesDir.absolutePath, "."
-			)
-		}
-	}
+	doLast(objects.newInstance(ExecJarAction::class).apply {
+		javaLauncher.set(project.the<JavaToolchainService>().launcherFor(java.toolchain))
+		args.addAll(
+			"--update",
+			"--file", archiveFile.get().asFile.absolutePath,
+			"--release", "9",
+			"-C", release9ClassesDir.absolutePath, "."
+		)
+	})
 }
 
 eclipse {

--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
@@ -1,3 +1,5 @@
+import org.junit.gradle.java.WriteArtifactsFile
+
 plugins {
 	`java-library-conventions`
 	`shadow-conventions`
@@ -26,19 +28,9 @@ tasks {
 			attributes("Main-Class" to "org.junit.platform.console.ConsoleLauncher")
 		}
 	}
-	val shadowedArtifactsFile by registering {
-		inputs.files(configurations.shadowed).withNormalizer(ClasspathNormalizer::class)
-		val outputFile = layout.buildDirectory.file("shadowed-artifacts")
-		outputs.file(outputFile)
-		doFirst {
-			outputFile.get().asFile.printWriter().use { out ->
-				configurations.shadowed.get().resolvedConfiguration.resolvedArtifacts
-					.map { it.moduleVersion.id }
-					.map { "${it.group}:${it.name}:${it.version}" }
-					.sorted()
-					.forEach(out::println)
-			}
-		}
+	val shadowedArtifactsFile by registering(WriteArtifactsFile::class) {
+		from(configurations.shadowed)
+		outputFile.set(layout.buildDirectory.file("shadowed-artifacts"))
 	}
 	shadowJar {
 		// https://github.com/junit-team/junit5/issues/2557

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -38,19 +38,16 @@ tasks {
 			into("META-INF")
 		}
 		from(sourceSets.mainRelease9.get().output.classesDirs)
-		doLast {
-			exec {
-				executable = project.the<JavaToolchainService>().launcherFor(java.toolchain).get()
-					.metadata.installationPath.file("bin/jar").asFile.absolutePath
-				args(
-					"--update",
-					"--file", archiveFile.get().asFile.absolutePath,
-					"--main-class", "org.junit.platform.console.ConsoleLauncher",
-					"--release", "17",
-					"-C", release17ClassesDir.absolutePath, "."
-				)
-			}
-		}
+		doLast(objects.newInstance(org.junit.gradle.java.ExecJarAction::class).apply {
+			javaLauncher.set(project.the<JavaToolchainService>().launcherFor(java.toolchain))
+			args.addAll(
+				"--update",
+				"--file", archiveFile.get().asFile.absolutePath,
+				"--main-class", "org.junit.platform.console.ConsoleLauncher",
+				"--release", "17",
+				"-C", release17ClassesDir.absolutePath, "."
+			)
+		})
 	}
 	jar {
 		manifest {


### PR DESCRIPTION
- Extract ExecJarAction
- Extract CommandLineArgumentProviders to top-level classes
- Configure BND to be compatible with configuration cache
- Move local variables into Action for configuration cache compatibility
- Use local variable instead of project's extra properties
- Extract top-level task class
