### PR TITLE
Document concurrency considerations for TestExecutionListener implementations

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestExecutionListener.java
@@ -46,6 +46,12 @@ import org.junit.platform.engine.reporting.ReportEntry;
  * {@link #testPlanExecutionStarted(TestPlan)} and
  * {@link #testPlanExecutionFinished(TestPlan)}.
  *
+ * <p>Note on concurrency: {@link #testPlanExecutionStarted(TestPlan)} and
+ * {@link #testPlanExecutionFinished(TestPlan)} are always called from the same
+ * thread. It is safe to assume that there is at most one {@code TestPlan}
+ * instance at a time. All other methods could be called from different threads
+ * concurrently in case one or multiple test engines execute tests in parallel.
+ *
  * @since 1.0
  * @see Launcher
  * @see TestPlan
@@ -58,6 +64,8 @@ public interface TestExecutionListener {
 	 * Called when the execution of the {@link TestPlan} has started,
 	 * <em>before</em> any test has been executed.
 	 *
+	 * <p>Called from the same thread as {@link #testPlanExecutionFinished(TestPlan)}.
+	 *
 	 * @param testPlan describes the tree of tests about to be executed
 	 */
 	default void testPlanExecutionStarted(TestPlan testPlan) {
@@ -66,6 +74,8 @@ public interface TestExecutionListener {
 	/**
 	 * Called when the execution of the {@link TestPlan} has finished,
 	 * <em>after</em> all tests have been executed.
+	 *
+	 * <p>Called from the same thread as {@link #testPlanExecutionStarted(TestPlan)}.
 	 *
 	 * @param testPlan describes the tree of tests that have been executed
 	 */


### PR DESCRIPTION
## Overview
This PR integrates [@marcphilipp 's comment](https://github.com/junit-team/junit5/issues/2539#issuecomment-766325555) as a note in `TestExecutionListener`'s Javadoc. There are no code changes.

Are there other documents to update as well (guide)?

Fixes: #2539

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
