### PR TITLE
Introduce extension API for resolving additional tags

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -949,3 +949,39 @@ most one of each type of _lifecycle method_ (see <<writing-tests-classes-and-met
 per test class or test interface unless there are no dependencies between such lifecycle
 methods.
 ====
+
+==== Adding additional tags
+
+When a simple `@Tag` is not sufficient for your test, you can extend the tagging
+mechanism by implementing the `TagResolver` SPI.
+
+A `TagResolver` is not registered like the other extension points using `@ExtendWith()`.
+Instead this uses the java `ServiceLoader` mechanism to search for classes implementing
+the `TagResolver` interface. To register such a `TagResolver` you have to create a file
+called `org.junit.jupiter.api.extension.TagResolver` in the directory `META-INF/services`.
+This file will contain a line separated list of your implementations of `TagResolver`.
+
+_META-INF/services/org.junit.jupiter.api.extension.TagResolver_
+----
+org.example.YourTagResolver
+----
+
+__
+----
+package org.example;
+
+import org.junit.jupiter.api.extension.TagResolver;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+
+class YourTagResolver implements TagResolver {
+
+    @Override
+    public List<String> resolveAdditionalTags(AnnotatedElement element) {
+        return List.of("tag1", "tag2");
+    }
+}
+----
+
+The `AnnotatedElement` is always not null and will either be a `Class` or `Method`

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TagResolver.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TagResolver.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+
+/**
+ * {@code TagResolver} defines the SPI for adding additional tags to a test.
+ *
+ * <p>Extensions that implement {@code TagResolver} must be registered in the
+ * <em>META-INF/services</em> directory in a plain text file called
+ * <em>org.junit.jupiter.api.extension.TagResolver</em>
+ *
+ * @see java.util.ServiceLoader
+ */
+@FunctionalInterface
+public interface TagResolver {
+
+	/**
+	 * Resolve additional tags by inspecting the {@link AnnotatedElement} for
+	 * this descriptor, this can either be a Class or a method.
+	 *
+	 * @param element the current annotated element; never {@code null}
+	 * @return all found tags
+	 */
+	List<String> resolveAdditionalTags(AnnotatedElement element);
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
@@ -133,18 +133,18 @@ public class ExtensionContextTests {
 		ClassExtensionContext outerExtensionContext = new ClassExtensionContext(null, null, outerClassDescriptor,
 			configuration, null, null);
 
-		assertThat(outerExtensionContext.getTags()).containsExactly("outer-tag");
+		assertThat(outerExtensionContext.getTags()).containsExactly("outer-tag", "resolved-tag1", "resolved-tag2");
 		assertThat(outerExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 
 		ClassExtensionContext nestedExtensionContext = new ClassExtensionContext(outerExtensionContext, null,
 			nestedClassDescriptor, configuration, null, null);
-		assertThat(nestedExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "nested-tag");
+		assertThat(nestedExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "nested-tag", "resolved-tag1", "resolved-tag2");
 		assertThat(nestedExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 
 		MethodExtensionContext methodExtensionContext = new MethodExtensionContext(outerExtensionContext, null,
 			methodTestDescriptor, configuration, new OpenTest4JAwareThrowableCollector(), null);
 		methodExtensionContext.setTestInstances(DefaultTestInstances.of(new OuterClass()));
-		assertThat(methodExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "method-tag");
+		assertThat(methodExtensionContext.getTags()).containsExactlyInAnyOrder("outer-tag", "method-tag", "resolved-tag1", "resolved-tag2");
 		assertThat(methodExtensionContext.getRoot()).isSameAs(outerExtensionContext);
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
@@ -67,7 +67,8 @@ class JupiterTestDescriptorTests {
 
 		assertEquals(TestCase.class, descriptor.getTestClass());
 		assertThat(descriptor.getTags()).containsExactly(TestTag.create("inherited-class-level-tag"),
-			TestTag.create("classTag1"), TestTag.create("classTag2"));
+			TestTag.create("classTag1"), TestTag.create("classTag2"), TestTag.create("resolved-tag1"),
+			TestTag.create("resolved-tag2"));
 	}
 
 	@Test
@@ -137,7 +138,7 @@ class JupiterTestDescriptorTests {
 
 		List<String> tags = methodDescriptor.getTags().stream().map(TestTag::getName).collect(toList());
 		assertThat(tags).containsExactlyInAnyOrder("inherited-class-level-tag", "classTag1", "classTag2", "methodTag1",
-			"methodTag2");
+			"methodTag2", "resolved-tag1", "resolved-tag2");
 	}
 
 	@Test
@@ -149,7 +150,8 @@ class JupiterTestDescriptorTests {
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("custom name", descriptor.getDisplayName(), "display name:");
 		assertEquals("customTestAnnotation()", descriptor.getLegacyReportingName(), "legacy name:");
-		assertThat(descriptor.getTags()).containsExactly(TestTag.create("custom-tag"));
+		assertThat(descriptor.getTags()).containsExactly(TestTag.create("custom-tag"), TestTag.create("resolved-tag1"),
+			TestTag.create("resolved-tag2"));
 	}
 
 	@Test
@@ -277,6 +279,12 @@ class JupiterTestDescriptorTests {
 		parentDescriptor.addChild(nestedDescriptor);
 		assertThat(parentDescriptor.getEnclosingTestClasses()).isEmpty();
 		assertThat(nestedDescriptor.getEnclosingTestClasses()).containsExactly(StaticTestCase.class);
+	}
+
+	@Test
+	void resolvesAdditionalTags() {
+		ClassBasedTestDescriptor descriptor = new ClassTestDescriptor(uniqueId, getClass(), configuration);
+		assertThat(descriptor.getTags()).contains(TestTag.create("resolved-tag1"), TestTag.create("resolved-tag2"));
 	}
 
 	// -------------------------------------------------------------------------

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
@@ -49,7 +49,7 @@ class TestTemplateTestDescriptorTests {
 		parent.addChild(testDescriptor);
 
 		assertThat(testDescriptor.getTags()).containsExactlyInAnyOrder(TestTag.create("foo"), TestTag.create("bar"),
-			TestTag.create("baz"));
+			TestTag.create("baz"), TestTag.create("resolved-tag1"), TestTag.create("resolved-tag2"));
 	}
 
 	@Test

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/subpackage/SomeTagResolver.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/descriptor/subpackage/SomeTagResolver.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.descriptor.subpackage;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.TagResolver;
+
+public class SomeTagResolver implements TagResolver {
+	@Override
+	public List<String> resolveAdditionalTags(AnnotatedElement element) {
+		return List.of("resolved-tag1", "resolved-tag2");
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestInfoParameterResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TestInfoParameterResolverTests.java
@@ -59,7 +59,7 @@ class TestInfoParameterResolverTests {
 	@Test
 	@Tag("method-tag")
 	void getTags(TestInfo testInfo) {
-		assertEquals(2, testInfo.getTags().size());
+		assertEquals(4, testInfo.getTags().size());
 		assertTrue(testInfo.getTags().contains("method-tag"));
 		assertTrue(testInfo.getTags().contains("class-tag"));
 	}
@@ -73,7 +73,7 @@ class TestInfoParameterResolverTests {
 	@BeforeAll
 	static void beforeAll(TestInfo testInfo) {
 		Set<String> tags = testInfo.getTags();
-		assertEquals(1, tags.size());
+		assertEquals(3, tags.size());
 		assertTrue(tags.contains("class-tag"));
 	}
 

--- a/junit-jupiter-engine/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.TagResolver
+++ b/junit-jupiter-engine/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.TagResolver
@@ -1,0 +1,1 @@
+org.junit.jupiter.engine.descriptor.subpackage.SomeTagResolver


### PR DESCRIPTION
## Overview

This PR adds the ability to add additional tags, next to the `@Tag` mechanism, by providing an SPI to resolve additional tags from the  `AnnotatedElement` (the test class or test method)

The idea came from [sociable unit-tests](https://medium.com/clarityai-engineering/sociable-or-solitary-unit-tests-choose-your-tradeoffs-7ced14d4baef). With those changes a developer could for example add additional metadata to a test class or method A to declare that another class B is also tested here. When the developer now wants to execute all tests for class B he could for example execute the tests with tag `org.example.B`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
