### PR TITLE
Avoid unnecessarily parsing unique IDs

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/index.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/index.adoc
@@ -18,6 +18,8 @@ include::{includedir}/link-attributes.adoc[]
 
 include::{basedir}/release-notes-5.10.0-M1.adoc[]
 
+include::{basedir}/release-notes-5.9.2.adoc[]
+
 include::{basedir}/release-notes-5.9.1.adoc[]
 
 include::{basedir}/release-notes-5.9.0.adoc[]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.2.adoc
@@ -23,7 +23,8 @@ JUnit repository on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* Introduce `TestPlan.getTestIdentifier(UniqueId)` and `TestPlan.getChildren(UniqueId)` to
+  avoid parsing unique IDs unnecessarily during test execution.
 
 
 [[release-notes-5.9.2-junit-jupiter]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.2.adoc
@@ -1,0 +1,58 @@
+[[release-notes-5.9.2]]
+== 5.9.2
+
+*Date of Release:* ❓
+
+*Scope:* Bug fixes and enhancements since 5.9.1
+
+For a complete list of all _closed_ issues and pull requests for this release, consult the
+link:{junit5-repo}+/milestones/5.9.2+[5.9.2] milestone page in the
+JUnit repository on GitHub.
+
+
+[[release-notes-5.9.2-junit-platform]]
+=== JUnit Platform
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓
+
+
+[[release-notes-5.9.2-junit-jupiter]]
+=== JUnit Jupiter
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓
+
+
+= [[release-notes-5.9.2-junit-vintage]]
+=== JUnit Vintage
+
+==== Bug Fixes
+
+* ❓
+
+==== Deprecations and Breaking Changes
+
+* ❓
+
+==== New Features and Improvements
+
+* ❓

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/OverloadedTestMethodTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/OverloadedTestMethodTests.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.testkit.engine.Event;
 import org.junit.platform.testkit.engine.Events;
@@ -40,7 +41,7 @@ class OverloadedTestMethodTests extends AbstractJupiterTestEngineTests {
 			event -> event.getTestDescriptor().getUniqueId().toString().contains(TestInfo.class.getName())).findFirst();
 		assertTrue(first.isPresent());
 		TestIdentifier testIdentifier = TestIdentifier.from(first.get().getTestDescriptor());
-		String uniqueId = testIdentifier.getUniqueId();
+		UniqueId uniqueId = testIdentifier.getUniqueIdObject();
 
 		tests = executeTests(selectUniqueId(uniqueId)).testEvents();
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 
 import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
@@ -27,7 +28,7 @@ import org.junit.platform.launcher.TestPlan;
  */
 class TreePrintingListener implements TestExecutionListener {
 
-	private final Map<String, TreeNode> nodesByUniqueId = new ConcurrentHashMap<>();
+	private final Map<UniqueId, TreeNode> nodesByUniqueId = new ConcurrentHashMap<>();
 	private TreeNode root;
 	private final TreePrinter treePrinter;
 
@@ -35,15 +36,14 @@ class TreePrintingListener implements TestExecutionListener {
 		this.treePrinter = new TreePrinter(out, theme, colorPalette);
 	}
 
-	private TreeNode addNode(TestIdentifier testIdentifier, Supplier<TreeNode> nodeSupplier) {
+	private void addNode(TestIdentifier testIdentifier, Supplier<TreeNode> nodeSupplier) {
 		TreeNode node = nodeSupplier.get();
-		nodesByUniqueId.put(testIdentifier.getUniqueId(), node);
-		testIdentifier.getParentId().map(nodesByUniqueId::get).orElse(root).addChild(node);
-		return node;
+		nodesByUniqueId.put(testIdentifier.getUniqueIdObject(), node);
+		testIdentifier.getParentIdObject().map(nodesByUniqueId::get).orElse(root).addChild(node);
 	}
 
 	private TreeNode getNode(TestIdentifier testIdentifier) {
-		return nodesByUniqueId.get(testIdentifier.getUniqueId());
+		return nodesByUniqueId.get(testIdentifier.getUniqueIdObject());
 	}
 
 	@Override

--- a/junit-platform-jfr/src/main/java/org/junit/platform/jfr/FlightRecordingExecutionListener.java
+++ b/junit-platform-jfr/src/main/java/org/junit/platform/jfr/FlightRecordingExecutionListener.java
@@ -42,7 +42,7 @@ import org.junit.platform.launcher.TestPlan;
 public class FlightRecordingExecutionListener implements TestExecutionListener {
 
 	private final AtomicReference<TestPlanExecutionEvent> testPlanExecutionEvent = new AtomicReference<>();
-	private final Map<String, TestExecutionEvent> testExecutionEvents = new ConcurrentHashMap<>();
+	private final Map<org.junit.platform.engine.UniqueId, TestExecutionEvent> testExecutionEvents = new ConcurrentHashMap<>();
 
 	@Override
 	public void testPlanExecutionStarted(TestPlan plan) {
@@ -70,7 +70,7 @@ public class FlightRecordingExecutionListener implements TestExecutionListener {
 	@Override
 	public void executionStarted(TestIdentifier test) {
 		TestExecutionEvent event = new TestExecutionEvent();
-		testExecutionEvents.put(test.getUniqueId(), event);
+		testExecutionEvents.put(test.getUniqueIdObject(), event);
 		event.initialize(test);
 		event.begin();
 	}
@@ -78,7 +78,7 @@ public class FlightRecordingExecutionListener implements TestExecutionListener {
 	@Override
 	public void executionFinished(TestIdentifier test, TestExecutionResult result) {
 		Optional<Throwable> throwable = result.getThrowable();
-		TestExecutionEvent event = testExecutionEvents.remove(test.getUniqueId());
+		TestExecutionEvent event = testExecutionEvents.remove(test.getUniqueIdObject());
 		event.end();
 		event.result = result.getStatus().toString();
 		event.exceptionClass = throwable.map(Throwable::getClass).orElse(null);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -158,7 +158,7 @@ public class TestPlan {
 	 */
 	public Optional<TestIdentifier> getParent(TestIdentifier child) {
 		Preconditions.notNull(child, "child must not be null");
-		return child.getParentId().map(this::getTestIdentifier);
+		return child.getParentIdObject().map(this::getTestIdentifier);
 	}
 
 	/**
@@ -166,11 +166,11 @@ public class TestPlan {
 	 *
 	 * @param parent the identifier to look up the children for; never {@code null}
 	 * @return an unmodifiable set of the parent's children, potentially empty
-	 * @see #getChildren(String)
+	 * @see #getChildren(UniqueId)
 	 */
 	public Set<TestIdentifier> getChildren(TestIdentifier parent) {
 		Preconditions.notNull(parent, "parent must not be null");
-		return getChildren(parent.getUniqueId());
+		return getChildren(parent.getUniqueIdObject());
 	}
 
 	/**
@@ -180,11 +180,26 @@ public class TestPlan {
 	 * {@code null} or blank
 	 * @return an unmodifiable set of the parent's children, potentially empty
 	 * @see #getChildren(TestIdentifier)
+	 * @deprecated Use {@link #getChildren(UniqueId)}
 	 */
+	@API(status = DEPRECATED, since = "1.10")
+	@Deprecated
 	public Set<TestIdentifier> getChildren(String parentId) {
 		Preconditions.notBlank(parentId, "parent ID must not be null or blank");
-		UniqueId uniqueId = UniqueId.parse(parentId);
-		return children.containsKey(uniqueId) ? unmodifiableSet(children.get(uniqueId)) : emptySet();
+		return getChildren(UniqueId.parse(parentId));
+	}
+
+	/**
+	 * Get the children of the supplied unique ID.
+	 *
+	 * @param parentId the unique ID to look up the children for; never
+	 * {@code null}
+	 * @return an unmodifiable set of the parent's children, potentially empty
+	 * @see #getChildren(TestIdentifier)
+	 */
+	@API(status = MAINTAINED, since = "1.10")
+	public Set<TestIdentifier> getChildren(UniqueId parentId) {
+		return children.containsKey(parentId) ? unmodifiableSet(children.get(parentId)) : emptySet();
 	}
 
 	/**
@@ -195,13 +210,29 @@ public class TestPlan {
 	 * @return the identifier with the supplied unique ID; never {@code null}
 	 * @throws PreconditionViolationException if no {@code TestIdentifier}
 	 * with the supplied unique ID is present in this test plan
+	 * @deprecated Use {@link #getTestIdentifier(UniqueId)}
 	 */
+	@API(status = DEPRECATED, since = "1.10")
+	@Deprecated
 	public TestIdentifier getTestIdentifier(String uniqueId) throws PreconditionViolationException {
 		Preconditions.notBlank(uniqueId, "unique ID must not be null or blank");
-		UniqueId uniqueIdObject = UniqueId.parse(uniqueId);
-		Preconditions.condition(allIdentifiers.containsKey(uniqueIdObject),
+		return getTestIdentifier(UniqueId.parse(uniqueId));
+	}
+
+	/**
+	 * Get the {@link TestIdentifier} with the supplied unique ID.
+	 *
+	 * @param uniqueId the unique ID to look up the identifier for; never
+	 * {@code null}
+	 * @return the identifier with the supplied unique ID; never {@code null}
+	 * @throws PreconditionViolationException if no {@code TestIdentifier}
+	 * with the supplied unique ID is present in this test plan
+	 */
+	@API(status = MAINTAINED, since = "1.10")
+	public TestIdentifier getTestIdentifier(UniqueId uniqueId) {
+		Preconditions.notNull(uniqueId, () -> "uniqueId must not be null");
+		return Preconditions.notNull(allIdentifiers.get(uniqueId),
 			() -> "No TestIdentifier with unique ID [" + uniqueId + "] has been added to this TestPlan.");
-		return allIdentifiers.get(uniqueIdObject);
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ExecutionListenerAdapter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ExecutionListenerAdapter.java
@@ -62,7 +62,7 @@ class ExecutionListenerAdapter implements EngineExecutionListener {
 	}
 
 	private TestIdentifier getTestIdentifier(TestDescriptor testDescriptor) {
-		return this.testPlan.getTestIdentifier(testDescriptor.getUniqueId().toString());
+		return this.testPlan.getTestIdentifier(testDescriptor.getUniqueId());
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
@@ -80,13 +81,25 @@ class InternalTestPlan extends TestPlan {
 		return delegate.getChildren(parent);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public Set<TestIdentifier> getChildren(String parentId) {
 		return delegate.getChildren(parentId);
 	}
 
 	@Override
+	public Set<TestIdentifier> getChildren(UniqueId parentId) {
+		return delegate.getChildren(parentId);
+	}
+
+	@SuppressWarnings("deprecation")
+	@Override
 	public TestIdentifier getTestIdentifier(String uniqueId) throws PreconditionViolationException {
+		return delegate.getTestIdentifier(uniqueId);
+	}
+
+	@Override
+	public TestIdentifier getTestIdentifier(UniqueId uniqueId) {
 		return delegate.getTestIdentifier(uniqueId);
 	}
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -24,7 +24,6 @@ import javax.xml.stream.XMLStreamException;
 
 import org.apiguardian.api.API;
 import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
@@ -107,7 +106,7 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 
 	private void writeXmlReportInCaseOfRoot(TestIdentifier testIdentifier) {
 		if (isRoot(testIdentifier)) {
-			String rootName = UniqueId.parse(testIdentifier.getUniqueId()).getSegments().get(0).getValue();
+			String rootName = testIdentifier.getUniqueIdObject().getSegments().get(0).getValue();
 			writeXmlReportSafely(testIdentifier, rootName);
 		}
 	}
@@ -123,7 +122,7 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 	}
 
 	private boolean isRoot(TestIdentifier testIdentifier) {
-		return !testIdentifier.getParentId().isPresent();
+		return !testIdentifier.getParentIdObject().isPresent();
 	}
 
 	private void printException(String message, Exception exception) {

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatform.java
@@ -191,7 +191,7 @@ public class JUnitPlatform extends Runner implements Filterable {
 	private LauncherDiscoveryRequest createDiscoveryRequestForUniqueIds(Set<TestIdentifier> testIdentifiers) {
 		// @formatter:off
 		List<DiscoverySelector> selectors = testIdentifiers.stream()
-				.map(TestIdentifier::getUniqueId)
+				.map(TestIdentifier::getUniqueIdObject)
 				.map(DiscoverySelectors::selectUniqueId)
 				.collect(toList());
 		// @formatter:on

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatformRunnerListener.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatformRunnerListener.java
@@ -15,6 +15,7 @@ import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
 
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
@@ -37,7 +38,7 @@ class JUnitPlatformRunnerListener implements TestExecutionListener {
 
 	@Override
 	public void dynamicTestRegistered(TestIdentifier testIdentifier) {
-		String parentId = testIdentifier.getParentId().get();
+		UniqueId parentId = testIdentifier.getParentIdObject().get();
 		testTree.addDynamicDescription(testIdentifier, parentId);
 	}
 

--- a/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatformTestTree.java
+++ b/junit-platform-runner/src/main/java/org/junit/platform/runner/JUnitPlatformTestTree.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestIdentifier;
@@ -86,7 +87,7 @@ class JUnitPlatformTestTree {
 		testPlan.getRoots().forEach(testIdentifier -> buildDescription(testIdentifier, suiteDescription, testPlan));
 	}
 
-	void addDynamicDescription(TestIdentifier newIdentifier, String parentId) {
+	void addDynamicDescription(TestIdentifier newIdentifier, UniqueId parentId) {
 		Description parent = getDescription(this.testPlan.getTestIdentifier(parentId));
 		buildDescription(newIdentifier, parent, this.testPlan);
 	}
@@ -103,9 +104,9 @@ class JUnitPlatformTestTree {
 		String name = nameExtractor.apply(identifier);
 		if (identifier.isTest()) {
 			String containerName = testPlan.getParent(identifier).map(nameExtractor).orElse("<unrooted>");
-			return Description.createTestDescription(containerName, name, identifier.getUniqueId());
+			return Description.createTestDescription(containerName, name, identifier.getUniqueIdObject());
 		}
-		return Description.createSuiteDescription(name, identifier.getUniqueId());
+		return Description.createSuiteDescription(name, identifier.getUniqueIdObject());
 	}
 
 	private String getTechnicalName(TestIdentifier testIdentifier) {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherEngineFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherEngineFilterTests.java
@@ -55,8 +55,8 @@ class DefaultLauncherEngineFilterTests {
 
 		assertThat(testPlan.getRoots()).hasSize(1);
 		var rootIdentifier = testPlan.getRoots().iterator().next();
-		assertThat(testPlan.getChildren(rootIdentifier.getUniqueId())).hasSize(1);
-		assertThat(testPlan.getChildren(UniqueId.forEngine("first").toString())).hasSize(1);
+		assertThat(testPlan.getChildren(rootIdentifier.getUniqueIdObject())).hasSize(1);
+		assertThat(testPlan.getChildren(UniqueId.forEngine("first"))).hasSize(1);
 	}
 
 	@Test
@@ -118,8 +118,8 @@ class DefaultLauncherEngineFilterTests {
 
 		assertThat(testPlan.getRoots()).hasSize(1);
 		var rootIdentifier = testPlan.getRoots().iterator().next();
-		assertThat(testPlan.getChildren(rootIdentifier.getUniqueId())).hasSize(1);
-		assertThat(testPlan.getChildren(UniqueId.forEngine("first").toString())).hasSize(1);
+		assertThat(testPlan.getChildren(rootIdentifier.getUniqueIdObject())).hasSize(1);
+		assertThat(testPlan.getChildren(UniqueId.forEngine("first"))).hasSize(1);
 	}
 
 	@Test
@@ -143,8 +143,8 @@ class DefaultLauncherEngineFilterTests {
 
 		assertThat(testPlan.getRoots()).hasSize(1);
 		var rootIdentifier = testPlan.getRoots().iterator().next();
-		assertThat(testPlan.getChildren(rootIdentifier.getUniqueId())).hasSize(1);
-		assertThat(testPlan.getChildren(UniqueId.forEngine("first").toString())).hasSize(1);
+		assertThat(testPlan.getChildren(rootIdentifier.getUniqueIdObject())).hasSize(1);
+		assertThat(testPlan.getChildren(UniqueId.forEngine("first"))).hasSize(1);
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -346,8 +346,8 @@ class DefaultLauncherTests {
 
 		assertThat(testPlan.getRoots()).hasSize(1);
 		var rootIdentifier = testPlan.getRoots().iterator().next();
-		assertThat(testPlan.getChildren(rootIdentifier.getUniqueId())).hasSize(2);
-		assertThat(testPlan.getChildren("[engine:myEngine]")).hasSize(2);
+		assertThat(testPlan.getChildren(rootIdentifier.getUniqueIdObject())).hasSize(2);
+		assertThat(testPlan.getChildren(UniqueId.parse("[engine:myEngine]"))).hasSize(2);
 	}
 
 	@Test
@@ -363,8 +363,8 @@ class DefaultLauncherTests {
 			request().selectors(selectUniqueId(test1.getUniqueId()), selectUniqueId(test2.getUniqueId())).build());
 
 		assertThat(testPlan.getRoots()).hasSize(2);
-		assertThat(testPlan.getChildren(UniqueId.forEngine("engine1").toString())).hasSize(1);
-		assertThat(testPlan.getChildren(UniqueId.forEngine("engine2").toString())).hasSize(1);
+		assertThat(testPlan.getChildren(UniqueId.forEngine("engine1"))).hasSize(1);
+		assertThat(testPlan.getChildren(UniqueId.forEngine("engine2"))).hasSize(1);
 	}
 
 	@Test
@@ -387,8 +387,8 @@ class DefaultLauncherTests {
 					.filters(includeWithUniqueIdContainsTest, includeWithUniqueIdContains1) //
 					.build());
 
-		assertThat(testPlan.getChildren(UniqueId.forEngine("myEngine").toString())).hasSize(1);
-		assertThat(testPlan.getTestIdentifier(test1.getUniqueId().toString())).isNotNull();
+		assertThat(testPlan.getChildren(UniqueId.forEngine("myEngine"))).hasSize(1);
+		assertThat(testPlan.getTestIdentifier(test1.getUniqueId())).isNotNull();
 	}
 
 	@Test
@@ -535,12 +535,12 @@ class DefaultLauncherTests {
 		inOrder.verify(listener).testPlanExecutionStarted(testPlanArgumentCaptor.capture());
 
 		var testPlan = testPlanArgumentCaptor.getValue();
-		var engineTestIdentifier = testPlan.getTestIdentifier(engineId.toString());
-		var containerAndTestIdentifier = testPlan.getTestIdentifier(containerAndTestId.toString());
-		var dynamicTestIdentifier = testPlan.getTestIdentifier(dynamicTestId.toString());
-		assertThat(engineTestIdentifier.getParentId()).isEmpty();
-		assertThat(containerAndTestIdentifier.getParentId()).contains(engineId.toString());
-		assertThat(dynamicTestIdentifier.getParentId()).contains(containerAndTestId.toString());
+		var engineTestIdentifier = testPlan.getTestIdentifier(engineId);
+		var containerAndTestIdentifier = testPlan.getTestIdentifier(containerAndTestId);
+		var dynamicTestIdentifier = testPlan.getTestIdentifier(dynamicTestId);
+		assertThat(engineTestIdentifier.getParentIdObject()).isEmpty();
+		assertThat(containerAndTestIdentifier.getParentIdObject()).contains(engineId);
+		assertThat(dynamicTestIdentifier.getParentIdObject()).contains(containerAndTestId);
 
 		inOrder.verify(listener).executionStarted(engineTestIdentifier);
 		inOrder.verify(listener).executionStarted(containerAndTestIdentifier);
@@ -579,7 +579,7 @@ class DefaultLauncherTests {
 		var launcher = createLauncher(engine);
 		var testPlan = launcher.discover(request().build());
 		var engineIdentifier = getOnlyElement(testPlan.getRoots());
-		var engineUniqueId = UniqueId.parse(engineIdentifier.getUniqueId());
+		var engineUniqueId = engineIdentifier.getUniqueIdObject();
 		assertThat(testPlan.getChildren(engineIdentifier)).hasSize(1);
 
 		var addedIdentifier = TestIdentifier.from(

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/ExecutionListenerAdapterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/ExecutionListenerAdapterTests.java
@@ -39,7 +39,7 @@ class ExecutionListenerAdapterTests {
 		var discoveryResult = new LauncherDiscoveryResult(Map.of(mock(TestEngine.class), testDescriptor),
 			mock(ConfigurationParameters.class));
 		var testPlan = InternalTestPlan.from(discoveryResult);
-		var testIdentifier = testPlan.getTestIdentifier(testDescriptor.getUniqueId().toString());
+		var testIdentifier = testPlan.getTestIdentifier(testDescriptor.getUniqueId());
 
 		//not yet spyable with mockito? -> https://github.com/mockito/mockito/issues/146
 		var testExecutionListener = new MockTestExecutionListener();

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.JupiterTestEngine;
 import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.LauncherSessionListener;
@@ -114,10 +115,10 @@ class LauncherFactoryTests {
 				.addPostDiscoveryFilters(TagFilter.includeTags("test-post-discovery")).build();
 
 		var testPlan = LauncherFactory.create(config).discover(discoveryRequest);
-		final var vintage = testPlan.getChildren("[engine:junit-vintage]");
+		final var vintage = testPlan.getChildren(UniqueId.parse("[engine:junit-vintage]"));
 		assertThat(vintage).isEmpty();
 
-		final var jupiter = testPlan.getChildren("[engine:junit-jupiter]");
+		final var jupiter = testPlan.getChildren(UniqueId.parse("[engine:junit-jupiter]"));
 		assertThat(jupiter).hasSize(1);
 	}
 
@@ -135,10 +136,10 @@ class LauncherFactoryTests {
 					.build();
 
 			var testPlan = LauncherFactory.create(config).discover(discoveryRequest);
-			final var vintage = testPlan.getChildren("[engine:junit-vintage]");
+			final var vintage = testPlan.getChildren(UniqueId.parse("[engine:junit-vintage]"));
 			assertThat(vintage).isEmpty();
 
-			final var jupiter = testPlan.getChildren("[engine:junit-jupiter]");
+			final var jupiter = testPlan.getChildren(UniqueId.parse("[engine:junit-jupiter]"));
 			assertThat(jupiter).hasSize(1);
 		}
 		finally {
@@ -160,10 +161,10 @@ class LauncherFactoryTests {
 					.enablePostDiscoveryFilterAutoRegistration(false).build();
 
 			var testPlan = LauncherFactory.create(config).discover(discoveryRequest);
-			final var vintage = testPlan.getChildren("[engine:junit-vintage]");
+			final var vintage = testPlan.getChildren(UniqueId.parse("[engine:junit-vintage]"));
 			assertThat(vintage).hasSize(1);
 
-			final var jupiter = testPlan.getChildren("[engine:junit-jupiter]");
+			final var jupiter = testPlan.getChildren(UniqueId.parse("[engine:junit-jupiter]"));
 			assertThat(jupiter).hasSize(1);
 		}
 		finally {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
@@ -65,7 +65,7 @@ class StreamInterceptingTestExecutionListenerIntegrationTests {
 		var listener = mock(TestExecutionListener.class);
 		doAnswer(invocation -> {
 			TestIdentifier testIdentifier = invocation.getArgument(0);
-			if (testIdentifier.getUniqueId().equals(test.getUniqueId().toString())) {
+			if (testIdentifier.getUniqueIdObject().equals(test.getUniqueId())) {
 				printStreamSupplier.get().print("123");
 			}
 			return null;
@@ -83,7 +83,7 @@ class StreamInterceptingTestExecutionListenerIntegrationTests {
 		var inOrder = inOrder(listener);
 		inOrder.verify(listener).testPlanExecutionStarted(testPlanArgumentCaptor.capture());
 		var testPlan = testPlanArgumentCaptor.getValue();
-		var testIdentifier = testPlan.getTestIdentifier(test.getUniqueId().toString());
+		var testIdentifier = testPlan.getTestIdentifier(test.getUniqueId());
 
 		var reportEntryArgumentCaptor = ArgumentCaptor.forClass(ReportEntry.class);
 		inOrder.verify(listener).reportingEntryPublished(same(testIdentifier), reportEntryArgumentCaptor.capture());

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/LegacyReportingUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/LegacyReportingUtilsTests.java
@@ -73,14 +73,14 @@ class LegacyReportingUtilsTests {
 
 	private String getClassName(UniqueId uniqueId) {
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), mock(ConfigurationParameters.class));
-		return LegacyReportingUtils.getClassName(testPlan, testPlan.getTestIdentifier(uniqueId.toString()));
+		return LegacyReportingUtils.getClassName(testPlan, testPlan.getTestIdentifier(uniqueId));
 	}
 
 	@SuppressWarnings("deprecation")
 	private String getClassNameFromOldLocation(UniqueId uniqueId) {
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), mock(ConfigurationParameters.class));
 		return org.junit.platform.launcher.listeners.LegacyReportingUtils.getClassName(testPlan,
-			testPlan.getTestIdentifier(uniqueId.toString()));
+			testPlan.getTestIdentifier(uniqueId));
 	}
 
 	private TestDescriptor createTestDescriptor(UniqueId uniqueId, String displayName, TestSource source) {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
@@ -395,14 +395,15 @@ class LegacyXmlReportGeneratingListenerTests {
 	@Test
 	void writesReportEntriesToSystemOutElement() throws Exception {
 		var engineDescriptor = new EngineDescriptor(UniqueId.forEngine("engine"), "Engine");
-		engineDescriptor.addChild(new TestDescriptorStub(UniqueId.root("child", "test"), "test"));
+		var childUniqueId = UniqueId.root("child", "test");
+		engineDescriptor.addChild(new TestDescriptorStub(childUniqueId, "test"));
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), mock(ConfigurationParameters.class));
 
 		var out = new StringWriter();
 		var listener = new LegacyXmlReportGeneratingListener(tempDirectory, new PrintWriter(out));
 
 		listener.testPlanExecutionStarted(testPlan);
-		var testIdentifier = testPlan.getTestIdentifier("[child:test]");
+		var testIdentifier = testPlan.getTestIdentifier(childUniqueId);
 		listener.executionStarted(testIdentifier);
 		listener.reportingEntryPublished(testIdentifier, ReportEntry.from("foo", "bar"));
 		Map<String, String> map = new LinkedHashMap<>();
@@ -410,7 +411,7 @@ class LegacyXmlReportGeneratingListenerTests {
 		map.put("qux", "foo");
 		listener.reportingEntryPublished(testIdentifier, ReportEntry.from(map));
 		listener.executionFinished(testIdentifier, successful());
-		listener.executionFinished(testPlan.getTestIdentifier("[engine:engine]"), successful());
+		listener.executionFinished(testPlan.getTestIdentifier(engineDescriptor.getUniqueId()), successful());
 
 		var testsuite = readValidXmlFile(tempDirectory.resolve("TEST-engine.xml"));
 

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportDataTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportDataTests.java
@@ -35,11 +35,12 @@ class XmlReportDataTests {
 	@Test
 	void resultsOfTestIdentifierWithoutAnyReportedEventsAreEmpty() {
 		var engineDescriptor = new EngineDescriptor(UniqueId.forEngine("engine"), "Engine");
-		engineDescriptor.addChild(new TestDescriptorStub(UniqueId.root("child", "test"), "test"));
+		var childUniqueId = UniqueId.root("child", "test");
+		engineDescriptor.addChild(new TestDescriptorStub(childUniqueId, "test"));
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
-		var results = reportData.getResults(testPlan.getTestIdentifier("[child:test]"));
+		var results = reportData.getResults(testPlan.getTestIdentifier(childUniqueId));
 
 		assertThat(results).isEmpty();
 	}
@@ -47,14 +48,15 @@ class XmlReportDataTests {
 	@Test
 	void resultsOfTestIdentifierWithoutReportedEventsContainsOnlyFailureOfAncestor() {
 		var engineDescriptor = new EngineDescriptor(UniqueId.forEngine("engine"), "Engine");
-		engineDescriptor.addChild(new TestDescriptorStub(UniqueId.root("child", "test"), "test"));
+		var childUniqueId = UniqueId.root("child", "test");
+		engineDescriptor.addChild(new TestDescriptorStub(childUniqueId, "test"));
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		var failureOfAncestor = failed(new RuntimeException("failed!"));
-		reportData.markFinished(testPlan.getTestIdentifier("[engine:engine]"), failureOfAncestor);
+		reportData.markFinished(testPlan.getTestIdentifier(engineDescriptor.getUniqueId()), failureOfAncestor);
 
-		var results = reportData.getResults(testPlan.getTestIdentifier("[child:test]"));
+		var results = reportData.getResults(testPlan.getTestIdentifier(childUniqueId));
 
 		assertThat(results).containsExactly(failureOfAncestor);
 	}
@@ -62,13 +64,14 @@ class XmlReportDataTests {
 	@Test
 	void resultsOfTestIdentifierWithoutReportedEventsContainsOnlySuccessOfAncestor() {
 		var engineDescriptor = new EngineDescriptor(UniqueId.forEngine("engine"), "Engine");
-		engineDescriptor.addChild(new TestDescriptorStub(UniqueId.root("child", "test"), "test"));
+		var childUniqueId = UniqueId.root("child", "test");
+		engineDescriptor.addChild(new TestDescriptorStub(childUniqueId, "test"));
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
-		reportData.markFinished(testPlan.getTestIdentifier("[engine:engine]"), successful());
+		reportData.markFinished(testPlan.getTestIdentifier(engineDescriptor.getUniqueId()), successful());
 
-		var results = reportData.getResults(testPlan.getTestIdentifier("[child:test]"));
+		var results = reportData.getResults(testPlan.getTestIdentifier(childUniqueId));
 
 		assertThat(results).containsExactly(successful());
 	}

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
@@ -76,7 +76,7 @@ class XmlReportWriterTests {
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		reportData.addReportEntry(TestIdentifier.from(testDescriptor), ReportEntry.from("myKey", "myValue"));
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId.toString()), successful());
+		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), successful());
 
 		var testsuite = writeXmlReport(testPlan, reportData);
 
@@ -99,7 +99,7 @@ class XmlReportWriterTests {
 			"foo", "bar"));
 		reportData.addReportEntry(TestIdentifier.from(testDescriptor), reportEntry);
 		reportData.addReportEntry(TestIdentifier.from(testDescriptor), ReportEntry.from(Map.of("baz", "qux")));
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId.toString()), successful());
+		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), successful());
 
 		var testsuite = writeXmlReport(testPlan, reportData);
 
@@ -122,7 +122,7 @@ class XmlReportWriterTests {
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
-		reportData.markSkipped(testPlan.getTestIdentifier(uniqueId.toString()), null);
+		reportData.markSkipped(testPlan.getTestIdentifier(uniqueId), null);
 
 		var testsuite = writeXmlReport(testPlan, reportData);
 
@@ -152,7 +152,7 @@ class XmlReportWriterTests {
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId.toString()), failed(null));
+		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), failed(null));
 
 		var testsuite = writeXmlReport(testPlan, reportData);
 
@@ -172,7 +172,7 @@ class XmlReportWriterTests {
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId.toString()), failed(new NullPointerException()));
+		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), failed(new NullPointerException()));
 
 		var testsuite = writeXmlReport(testPlan, reportData);
 
@@ -190,7 +190,7 @@ class XmlReportWriterTests {
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		var assertionError = new AssertionError("<foo><![CDATA[bar]]></foo>");
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId.toString()), failed(assertionError));
+		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), failed(assertionError));
 
 		var testsuite = writeXmlReport(testPlan, reportData);
 
@@ -206,7 +206,7 @@ class XmlReportWriterTests {
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		var assertionError = new AssertionError("expected: <A> but was: <B\0>");
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId.toString()), failed(assertionError));
+		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), failed(assertionError));
 
 		System.setProperty("foo.bar", "\1");
 		Match testsuite;
@@ -235,7 +235,7 @@ class XmlReportWriterTests {
 
 		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
 		var assertionError = new AssertionError("<foo><![CDATA[bar]]></foo>");
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId.toString()), failed(assertionError));
+		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), failed(assertionError));
 		Writer assertingWriter = new StringWriter() {
 
 			@SuppressWarnings("NullableProblems")

--- a/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/runner/JUnitPlatformRunnerTests.java
@@ -760,11 +760,11 @@ class JUnitPlatformRunnerTests {
 	// -------------------------------------------------------------------------
 
 	private static Description suiteDescription(String uniqueId) {
-		return createSuiteDescription(uniqueId, uniqueId);
+		return createSuiteDescription(uniqueId, UniqueId.parse(uniqueId));
 	}
 
 	private static Description testDescription(String uniqueId) {
-		return createTestDescription(uniqueId, uniqueId, uniqueId);
+		return createTestDescription(uniqueId, uniqueId, UniqueId.parse(uniqueId));
 	}
 
 	private TestDescriptor testDescriptorWithTags(String... tag) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -64,7 +64,6 @@ gradleEnterprise {
 		}
 
 		val enableTestDistribution = providers.gradleProperty("enableTestDistribution")
-			.forUseAtConfigurationTime()
 			.map(String::toBoolean)
 			.getOrElse(false)
 		if (enableTestDistribution) {


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
