### PR TITLE
[2854] - List all tests found by Console Launcher

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -75,6 +75,9 @@ public class ConsoleLauncher {
 			if (!options.isBannerDisabled()) {
 				displayBanner(out);
 			}
+			if (options.isListTests()) {
+				return listTests(options, out);
+			}
 			if (options.isDisplayHelp()) {
 				commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
 				return ConsoleLauncherExecutionResult.success();
@@ -99,6 +102,16 @@ public class ConsoleLauncher {
 		out.println();
 	}
 
+	private ConsoleLauncherExecutionResult listTests(CommandLineOptions options, PrintWriter out) {
+		try {
+			new ConsoleTestExecutor(options).list(out);
+			return ConsoleLauncherExecutionResult.success();
+		}
+		catch (Exception exception) {
+			return handleTestExecutorException(exception, options);
+		}
+	}
+
 	void displayEngines(PrintWriter out) {
 		ServiceLoaderTestEngineRegistry registry = new ServiceLoaderTestEngineRegistry();
 		Iterable<TestEngine> engines = registry.loadTestEngines();
@@ -121,11 +134,16 @@ public class ConsoleLauncher {
 			return ConsoleLauncherExecutionResult.forSummary(testExecutionSummary, options);
 		}
 		catch (Exception exception) {
-			exception.printStackTrace(err);
-			err.println();
-			commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
-			return ConsoleLauncherExecutionResult.failed();
+			return handleTestExecutorException(exception, options);
 		}
+	}
+
+	private ConsoleLauncherExecutionResult handleTestExecutorException(Exception exception,
+			CommandLineOptions options) {
+		exception.printStackTrace(err);
+		err.println();
+		commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
+		return ConsoleLauncherExecutionResult.failed();
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
@@ -48,6 +48,7 @@ public class CommandLineOptions {
 	static final Theme DEFAULT_THEME = Theme.valueOf(ConsoleUtils.charset());
 
 	private boolean displayHelp;
+	private boolean listTests;
 	private boolean listEngines;
 	private boolean ansiColorOutputDisabled;
 	private Path colorPalettePath;
@@ -92,6 +93,14 @@ public class CommandLineOptions {
 
 	public void setDisplayHelp(boolean displayHelp) {
 		this.displayHelp = displayHelp;
+	}
+
+	public boolean isListTests() {
+		return listTests;
+	}
+
+	public void setListTests(boolean listTests) {
+		this.listTests = listTests;
 	}
 
 	public boolean isListEngines() {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DetailsPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DetailsPrintingListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console.tasks;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+
+/**
+ * @since 1.9
+ */
+@API(status = EXPERIMENTAL, since = "1.9")
+public interface DetailsPrintingListener extends TestExecutionListener {
+
+	void listTests(TestPlan testPlan);
+
+}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
@@ -16,14 +16,13 @@ import java.util.regex.Pattern;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
-import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
  * @since 1.0
  */
-class FlatPrintingListener implements TestExecutionListener {
+class FlatPrintingListener implements DetailsPrintingListener {
 
 	private static final Pattern LINE_START_PATTERN = Pattern.compile("(?m)^");
 
@@ -106,4 +105,10 @@ class FlatPrintingListener implements TestExecutionListener {
 		return LINE_START_PATTERN.matcher(message).replaceAll(INDENTATION).trim();
 	}
 
+	@Override
+	public void listTests(TestPlan testPlan) {
+		for (TestIdentifier testIdentifier : testPlan.getAllIdentifiers().values()) {
+			println(Style.SUCCESSFUL, "%s (%s)", testIdentifier.getDisplayName(), testIdentifier.getUniqueId());
+		}
+	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrinter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrinter.java
@@ -67,6 +67,10 @@ class TreePrinter {
 		String caption = colorCaption(node);
 		String duration = color(Style.CONTAINER, node.duration + " ms");
 		String icon = color(Style.SKIPPED, theme.skipped());
+		boolean nodeIsBeingListed = node.duration == 0 && !node.result().isPresent() && !node.reason().isPresent();
+		if (nodeIsBeingListed) {
+			icon = color(Style.SKIPPED, theme.blank());
+		}
 		if (node.result().isPresent()) {
 			TestExecutionResult result = node.result().get();
 			Style resultStyle = Style.valueOf(result);

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
@@ -17,15 +17,15 @@ import java.util.function.Supplier;
 
 import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
-import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
  * @since 1.0
  */
-class TreePrintingListener implements TestExecutionListener {
+class TreePrintingListener implements DetailsPrintingListener {
 
 	private final Map<String, TreeNode> nodesByUniqueId = new ConcurrentHashMap<>();
 	private TreeNode root;
@@ -76,4 +76,16 @@ class TreePrintingListener implements TestExecutionListener {
 		getNode(testIdentifier).addReportEntry(entry);
 	}
 
+	@Override
+	public void listTests(TestPlan testPlan) {
+		root = new TreeNode(testPlan.toString());
+		listTests(testPlan.getAllIdentifiers());
+		treePrinter.print(root);
+	}
+
+	private void listTests(Map<UniqueId, TestIdentifier> testIdentifiers) {
+		for (TestIdentifier testIdentifier : testIdentifiers.values()) {
+			addNode(testIdentifier, () -> new TreeNode(testIdentifier));
+		}
+	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/VerboseTreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/VerboseTreePrintingListener.java
@@ -20,14 +20,13 @@ import java.util.Deque;
 import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
-import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
  * @since 1.0
  */
-class VerboseTreePrintingListener implements TestExecutionListener {
+class VerboseTreePrintingListener implements DetailsPrintingListener {
 
 	private final PrintWriter out;
 	private final Theme theme;
@@ -186,4 +185,12 @@ class VerboseTreePrintingListener implements TestExecutionListener {
 		printf(NONE, "%n");
 	}
 
+	@Override
+	public void listTests(TestPlan testPlan) {
+		for (TestIdentifier testIdentifier : testPlan.getAllIdentifiers().values()) {
+			printVerticals(theme.entry());
+			printf(Style.SKIPPED, " %s%n", testIdentifier.getDisplayName());
+			printDetails(testIdentifier);
+		}
+	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -235,6 +235,10 @@ public class TestPlan {
 		return unmodifiableSet(result);
 	}
 
+	public Map<UniqueId, TestIdentifier> getAllIdentifiers() {
+		return this.allIdentifiers;
+	}
+
 	/**
 	 * Return whether this test plan contains any tests.
 	 *

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
@@ -10,12 +10,14 @@
 
 package org.junit.platform.launcher.core;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
@@ -98,6 +100,11 @@ class InternalTestPlan extends TestPlan {
 	@Override
 	public Set<TestIdentifier> getDescendants(TestIdentifier parent) {
 		return delegate.getDescendants(parent);
+	}
+
+	@Override
+	public Map<UniqueId, TestIdentifier> getAllIdentifiers() {
+		return delegate.getAllIdentifiers();
 	}
 
 	@Override


### PR DESCRIPTION
# Overview
Addresses [2854](https://github.com/junit-team/junit5/issues/2854)
Lists all `TestIdentifiers` from a `TestPlan`, result of a test discovery. Essentially same output as if one is executing the tests, but without the execution.

## Option
`--list-tests`

## Examples
### Command
`java -jar junit-platform-console-standalone-1.9.0-SNAPSHOT.jar --list-tests -cp test/ --scan-classpath`

## Tree
command +` --details tree` yields

```
╷
├─ JUnit Vintage    
├─ CarTest    
│   ├─ testModel()    
│   └─ testMake()    
└─ JUnit Jupiter 
```

## Verbose
command + `--details` verbose yields

```
─ JUnit Vintage
     tags: []
 uniqueId: [engine:junit-vintage]
   parent: []
├─ CarTest
     tags: []
 uniqueId: [engine:junit-jupiter]/[class:CarTest]
   parent: [engine:junit-jupiter]
   source: ClassSource [className = 'CarTest', filePosition = null]
├─ testModel()
     tags: []
 uniqueId: [engine:junit-jupiter]/[class:CarTest]/[method:testModel()]
   parent: [engine:junit-jupiter]/[class:CarTest]
   source: MethodSource [className = 'CarTest', methodName = 'testModel', methodParameterTypes = '']
├─ testMake()
     tags: []
 uniqueId: [engine:junit-jupiter]/[class:CarTest]/[method:testMake()]
   parent: [engine:junit-jupiter]/[class:CarTest]
   source: MethodSource [className = 'CarTest', methodName = 'testMake', methodParameterTypes = '']
├─ JUnit Jupiter
     tags: []
 uniqueId: [engine:junit-jupiter]
   parent: []
```
## Flat
command + `--details` flat yields

```
JUnit Vintage ([engine:junit-vintage])
CarTest ([engine:junit-jupiter]/[class:CarTest])
testModel() ([engine:junit-jupiter]/[class:CarTest]/[method:testModel()])
testMake() ([engine:junit-jupiter]/[class:CarTest]/[method:testMake()])
JUnit Jupiter ([engine:junit-jupiter])
```

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
