### PR TITLE
Replace warning emoji in release notes template with VERSION

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-TEMPLATE.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-TEMPLATE.adoc
@@ -1,18 +1,18 @@
-// TODO: replace all occurrences of ⚠️ with appropriate values, delete this comment, and
+// TODO: replace all occurrences of VERSION with appropriate values, delete this comment, and
 // 'include:' this new file in index.adoc.
-[[release-notes-⚠️]]
-== ⚠️
+[[release-notes-VERSION]]
+== VERSION
 
 *Date of Release:* ❓
 
 *Scope:* ❓
 
 For a complete list of all _closed_ issues and pull requests for this release, consult the
-link:{junit5-repo}+/milestone/⚠️?closed=1+[⚠️] milestone page in the JUnit repository on
+link:{junit5-repo}+/milestone/VERSION?closed=1+[VERSION] milestone page in the JUnit repository on
 GitHub.
 
 
-[[release-notes-⚠️-junit-platform]]
+[[release-notes-VERSION-junit-platform]]
 === JUnit Platform
 
 ==== Bug Fixes
@@ -28,7 +28,7 @@ GitHub.
 * ❓
 
 
-[[release-notes-⚠️-junit-jupiter]]
+[[release-notes-VERSION-junit-jupiter]]
 === JUnit Jupiter
 
 ==== Bug Fixes
@@ -44,7 +44,7 @@ GitHub.
 * ❓
 
 
-[[release-notes-⚠️-junit-vintage]]
+= [[release-notes-VERSION-junit-vintage]]
 === JUnit Vintage
 
 ==== Bug Fixes


### PR DESCRIPTION
## Overview

The release notes use ⚠️ as a version placeholder. This symbol consists of `U+26A0` (the triangle `⚠`) and `U+FE0F` (an invisible emojii indicator).

Depending on your IDE, this may be rendered as ⚠️ or in my case `⚠` followed by an invisible character. So [it is relatively easy](https://github.com/junit-team/junit5/commit/21018062818ff2dc765fb1f06339509fa2bf51a8#r87940423) to search and replace only `U+26A0`, leaving in place `U+FE0F`.

By replacing ⚠️ with `VERSION` we can avoid this problem altogether.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
