### PR TITLE
Supply invocation index for @ParameterizedTest to test author 

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -42,7 +42,7 @@ repository on GitHub.
 
 ==== New Features and Improvements
 
-* ❓
+* Adding the possibility to get the invocation index : `ArgumentsAccessor.getInvocationIndex`
 
 
 [[release-notes-5.10.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -42,7 +42,7 @@ repository on GitHub.
 
 ==== New Features and Improvements
 
-* Adding the possibility to get the invocation index : `ArgumentsAccessor.getInvocationIndex`
+* New `ArgumentsAccessor.getInvocationIndex` method to supply index of a `@ParameterizedTest` invocation.
 
 
 [[release-notes-5.10.0-M1-junit-vintage]]

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -92,7 +92,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 				.map(arguments -> consumedArguments(arguments, methodContext))
 				.map(arguments -> {
 					invocationCount.incrementAndGet();
-					return createInvocationContext(formatter, methodContext, arguments);
+					return createInvocationContext(formatter, methodContext, arguments, invocationCount.intValue());
 				})
 				.onClose(() ->
 						Preconditions.condition(invocationCount.get() > 0,
@@ -122,8 +122,8 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 	}
 
 	private TestTemplateInvocationContext createInvocationContext(ParameterizedTestNameFormatter formatter,
-			ParameterizedTestMethodContext methodContext, Object[] arguments) {
-		return new ParameterizedTestInvocationContext(formatter, methodContext, arguments);
+			ParameterizedTestMethodContext methodContext, Object[] arguments, Integer invocationIndex) {
+		return new ParameterizedTestInvocationContext(formatter, methodContext, arguments, invocationIndex);
 	}
 
 	private ParameterizedTestNameFormatter createNameFormatter(ExtensionContext extensionContext, Method templateMethod,

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -122,7 +122,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 	}
 
 	private TestTemplateInvocationContext createInvocationContext(ParameterizedTestNameFormatter formatter,
-			ParameterizedTestMethodContext methodContext, Object[] arguments, Integer invocationIndex) {
+			ParameterizedTestMethodContext methodContext, Object[] arguments, int invocationIndex) {
 		return new ParameterizedTestInvocationContext(formatter, methodContext, arguments, invocationIndex);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
@@ -27,7 +27,7 @@ class ParameterizedTestInvocationContext implements TestTemplateInvocationContex
 	private final Object[] arguments;
 	private final Integer invocationIndex;
 
-	public ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter,
+	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter,
 			ParameterizedTestMethodContext methodContext, Object[] arguments, Integer invocationIndex) {
 		this.formatter = formatter;
 		this.methodContext = methodContext;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
@@ -25,10 +25,10 @@ class ParameterizedTestInvocationContext implements TestTemplateInvocationContex
 	private final ParameterizedTestNameFormatter formatter;
 	private final ParameterizedTestMethodContext methodContext;
 	private final Object[] arguments;
-	private final Integer invocationIndex;
+	private final int invocationIndex;
 
 	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter,
-			ParameterizedTestMethodContext methodContext, Object[] arguments, Integer invocationIndex) {
+			ParameterizedTestMethodContext methodContext, Object[] arguments, int invocationIndex) {
 		this.formatter = formatter;
 		this.methodContext = methodContext;
 		this.arguments = arguments;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestInvocationContext.java
@@ -25,12 +25,14 @@ class ParameterizedTestInvocationContext implements TestTemplateInvocationContex
 	private final ParameterizedTestNameFormatter formatter;
 	private final ParameterizedTestMethodContext methodContext;
 	private final Object[] arguments;
+	private final Integer invocationIndex;
 
-	ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter,
-			ParameterizedTestMethodContext methodContext, Object[] arguments) {
+	public ParameterizedTestInvocationContext(ParameterizedTestNameFormatter formatter,
+			ParameterizedTestMethodContext methodContext, Object[] arguments, Integer invocationIndex) {
 		this.formatter = formatter;
 		this.methodContext = methodContext;
 		this.arguments = arguments;
+		this.invocationIndex = invocationIndex;
 	}
 
 	@Override
@@ -40,7 +42,8 @@ class ParameterizedTestInvocationContext implements TestTemplateInvocationContex
 
 	@Override
 	public List<Extension> getAdditionalExtensions() {
-		return singletonList(new ParameterizedTestParameterResolver(this.methodContext, this.arguments));
+		return singletonList(
+			new ParameterizedTestParameterResolver(this.methodContext, this.arguments, this.invocationIndex));
 	}
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestMethodContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestMethodContext.java
@@ -161,7 +161,7 @@ class ParameterizedTestMethodContext {
 	 * Resolve the parameter for the supplied context using the supplied
 	 * arguments.
 	 */
-	Object resolve(ParameterContext parameterContext, Object[] arguments, Integer invocationIndex) {
+	Object resolve(ParameterContext parameterContext, Object[] arguments, int invocationIndex) {
 		return getResolver(parameterContext).resolve(parameterContext, arguments, invocationIndex);
 	}
 
@@ -213,7 +213,7 @@ class ParameterizedTestMethodContext {
 	}
 
 	interface Resolver {
-		Object resolve(ParameterContext parameterContext, Object[] arguments, Integer invocationIndex);
+		Object resolve(ParameterContext parameterContext, Object[] arguments, int invocationIndex);
 	}
 
 	static class Converter implements Resolver {
@@ -227,7 +227,7 @@ class ParameterizedTestMethodContext {
 		}
 
 		@Override
-		public Object resolve(ParameterContext parameterContext, Object[] arguments, Integer invocationIndex) {
+		public Object resolve(ParameterContext parameterContext, Object[] arguments, int invocationIndex) {
 			Object argument = arguments[parameterContext.getIndex()];
 			try {
 				return this.argumentConverter.convert(argument, parameterContext);
@@ -250,7 +250,7 @@ class ParameterizedTestMethodContext {
 		}
 
 		@Override
-		public Object resolve(ParameterContext parameterContext, Object[] arguments, Integer invocationIndex) {
+		public Object resolve(ParameterContext parameterContext, Object[] arguments, int invocationIndex) {
 			ArgumentsAccessor accessor = new DefaultArgumentsAccessor(invocationIndex, arguments);
 			try {
 				return this.argumentsAggregator.aggregateArguments(accessor, parameterContext);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestMethodContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestMethodContext.java
@@ -161,8 +161,8 @@ class ParameterizedTestMethodContext {
 	 * Resolve the parameter for the supplied context using the supplied
 	 * arguments.
 	 */
-	Object resolve(ParameterContext parameterContext, Object[] arguments) {
-		return getResolver(parameterContext).resolve(parameterContext, arguments);
+	Object resolve(ParameterContext parameterContext, Object[] arguments, Integer invocationIndex) {
+		return getResolver(parameterContext).resolve(parameterContext, arguments, invocationIndex);
 	}
 
 	private Resolver getResolver(ParameterContext parameterContext) {
@@ -213,9 +213,7 @@ class ParameterizedTestMethodContext {
 	}
 
 	interface Resolver {
-
-		Object resolve(ParameterContext parameterContext, Object[] arguments);
-
+		Object resolve(ParameterContext parameterContext, Object[] arguments, Integer invocationIndex);
 	}
 
 	static class Converter implements Resolver {
@@ -229,7 +227,7 @@ class ParameterizedTestMethodContext {
 		}
 
 		@Override
-		public Object resolve(ParameterContext parameterContext, Object[] arguments) {
+		public Object resolve(ParameterContext parameterContext, Object[] arguments, Integer invocationIndex) {
 			Object argument = arguments[parameterContext.getIndex()];
 			try {
 				return this.argumentConverter.convert(argument, parameterContext);
@@ -252,8 +250,8 @@ class ParameterizedTestMethodContext {
 		}
 
 		@Override
-		public Object resolve(ParameterContext parameterContext, Object[] arguments) {
-			ArgumentsAccessor accessor = new DefaultArgumentsAccessor(arguments);
+		public Object resolve(ParameterContext parameterContext, Object[] arguments, Integer invocationIndex) {
+			ArgumentsAccessor accessor = new DefaultArgumentsAccessor(invocationIndex, arguments);
 			try {
 				return this.argumentsAggregator.aggregateArguments(accessor, parameterContext);
 			}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
@@ -34,10 +34,13 @@ class ParameterizedTestParameterResolver implements ParameterResolver, AfterTest
 
 	private final ParameterizedTestMethodContext methodContext;
 	private final Object[] arguments;
+	private final Integer invocationIndex;
 
-	ParameterizedTestParameterResolver(ParameterizedTestMethodContext methodContext, Object[] arguments) {
+	ParameterizedTestParameterResolver(ParameterizedTestMethodContext methodContext, Object[] arguments,
+			Integer invocationIndex) {
 		this.methodContext = methodContext;
 		this.arguments = arguments;
+		this.invocationIndex = invocationIndex;
 	}
 
 	@Override
@@ -69,7 +72,7 @@ class ParameterizedTestParameterResolver implements ParameterResolver, AfterTest
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
 			throws ParameterResolutionException {
-		return this.methodContext.resolve(parameterContext, extractPayloads(this.arguments));
+		return this.methodContext.resolve(parameterContext, extractPayloads(this.arguments), this.invocationIndex);
 	}
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
@@ -34,10 +34,10 @@ class ParameterizedTestParameterResolver implements ParameterResolver, AfterTest
 
 	private final ParameterizedTestMethodContext methodContext;
 	private final Object[] arguments;
-	private final Integer invocationIndex;
+	private final int invocationIndex;
 
 	ParameterizedTestParameterResolver(ParameterizedTestMethodContext methodContext, Object[] arguments,
-			Integer invocationIndex) {
+			int invocationIndex) {
 		this.methodContext = methodContext;
 		this.arguments = arguments;
 		this.invocationIndex = invocationIndex;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessor.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessor.java
@@ -189,7 +189,7 @@ public interface ArgumentsAccessor {
 	List<Object> toList();
 
 	/**
-	 * Get invocation index of the current test
+	 * Get the index of the current test invocation.
 	 */
 	int getInvocationIndex();
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessor.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAccessor.java
@@ -188,4 +188,8 @@ public interface ArgumentsAccessor {
 	 */
 	List<Object> toList();
 
+	/**
+	 * Get invocation index of the current test
+	 */
+	int getInvocationIndex();
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessor.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessor.java
@@ -36,10 +36,12 @@ import org.junit.platform.commons.util.Preconditions;
 public class DefaultArgumentsAccessor implements ArgumentsAccessor {
 
 	private final Object[] arguments;
+	private final int invocationIndex;
 
-	public DefaultArgumentsAccessor(Object... arguments) {
+	public DefaultArgumentsAccessor(int invocationIndex, Object... arguments) {
 		Preconditions.notNull(arguments, "Arguments array must not be null");
 		this.arguments = arguments;
+		this.invocationIndex = invocationIndex;
 	}
 
 	@Override
@@ -124,6 +126,11 @@ public class DefaultArgumentsAccessor implements ArgumentsAccessor {
 	@Override
 	public List<Object> toList() {
 		return Collections.unmodifiableList(Arrays.asList(this.arguments));
+	}
+
+	@Override
+	public int getInvocationIndex() {
+		return this.invocationIndex;
 	}
 
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/AggregatorIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/AggregatorIntegrationTests.java
@@ -207,6 +207,16 @@ public class AggregatorIntegrationTests {
 	private EngineExecutionResults execute(DiscoverySelector... selectors) {
 		return EngineTestKit.execute("junit-jupiter", request().selectors(selectors).build());
 	}
+	@ParameterizedTest
+	@CsvSource({ "first", "second"})
+	void argumentsAccessorInvocationIndex(ArgumentsAccessor arguments) {
+		if("first".equals(arguments.getString(0))){
+			assertEquals(1, arguments.getInvocationIndex());
+		}
+		if("second".equals(arguments.getString(0))){
+			assertEquals(2, arguments.getInvocationIndex());
+		}
+	}
 
 	// -------------------------------------------------------------------------
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/AggregatorIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/AggregatorIntegrationTests.java
@@ -207,13 +207,14 @@ public class AggregatorIntegrationTests {
 	private EngineExecutionResults execute(DiscoverySelector... selectors) {
 		return EngineTestKit.execute("junit-jupiter", request().selectors(selectors).build());
 	}
+
 	@ParameterizedTest
-	@CsvSource({ "first", "second"})
+	@CsvSource({ "first", "second" })
 	void argumentsAccessorInvocationIndex(ArgumentsAccessor arguments) {
-		if("first".equals(arguments.getString(0))){
+		if ("first".equals(arguments.getString(0))) {
 			assertEquals(1, arguments.getInvocationIndex());
 		}
-		if("second".equals(arguments.getString(0))){
+		if ("second".equals(arguments.getString(0))) {
 			assertEquals(2, arguments.getInvocationIndex());
 		}
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
@@ -31,7 +31,7 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void argumentsMustNotBeNull() {
-		assertThrows(PreconditionViolationException.class, () -> new DefaultArgumentsAccessor((Object[]) null));
+		assertThrows(PreconditionViolationException.class, () -> new DefaultArgumentsAccessor(1,(Object[]) null));
 	}
 
 	@Test
@@ -50,34 +50,34 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void getNull() {
-		assertNull(new DefaultArgumentsAccessor(new Object[] { null }).get(0));
+		assertNull(new DefaultArgumentsAccessor(1,new Object[] { null }).get(0));
 	}
 
 	@Test
 	void getWithNullCastToWrapperType() {
-		assertNull(new DefaultArgumentsAccessor((Object[]) new Integer[] { null }).get(0, Integer.class));
+		assertNull(new DefaultArgumentsAccessor(1,(Object[]) new Integer[] { null }).get(0, Integer.class));
 	}
 
 	@Test
 	void get() {
-		assertEquals(1, new DefaultArgumentsAccessor(1).get(0));
+		assertEquals(1, new DefaultArgumentsAccessor(1,1).get(0));
 	}
 
 	@Test
 	void getWithCast() {
-		assertEquals(Integer.valueOf(1), new DefaultArgumentsAccessor(1).get(0, Integer.class));
-		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor('A').get(0, Character.class));
+		assertEquals(Integer.valueOf(1), new DefaultArgumentsAccessor(1,1).get(0, Integer.class));
+		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1,'A').get(0, Character.class));
 	}
 
 	@Test
 	void getWithCastToPrimitiveType() {
 		Exception exception = assertThrows(ArgumentAccessException.class,
-			() -> new DefaultArgumentsAccessor(1).get(0, int.class));
+			() -> new DefaultArgumentsAccessor(1,1).get(0, int.class));
 		assertThat(exception.getMessage()).isEqualTo(
 			"Argument at index [0] with value [1] and type [java.lang.Integer] could not be converted or cast to type [int].");
 
 		exception = assertThrows(ArgumentAccessException.class,
-			() -> new DefaultArgumentsAccessor(new Object[] { null }).get(0, int.class));
+			() -> new DefaultArgumentsAccessor(1, new Object[] { null }).get(0, int.class));
 		assertThat(exception.getMessage()).isEqualTo(
 			"Argument at index [0] with value [null] and type [null] could not be converted or cast to type [int].");
 	}
@@ -85,59 +85,59 @@ class DefaultArgumentsAccessorTests {
 	@Test
 	void getWithCastToIncompatibleType() {
 		Exception exception = assertThrows(ArgumentAccessException.class,
-			() -> new DefaultArgumentsAccessor(1).get(0, Character.class));
+			() -> new DefaultArgumentsAccessor(1,1).get(0, Character.class));
 		assertThat(exception.getMessage()).isEqualTo(
 			"Argument at index [0] with value [1] and type [java.lang.Integer] could not be converted or cast to type [java.lang.Character].");
 	}
 
 	@Test
 	void getCharacter() {
-		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor('A', 'B').getCharacter(0));
+		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1,'A', 'B').getCharacter(0));
 	}
 
 	@Test
 	void getBoolean() {
-		assertEquals(Boolean.TRUE, new DefaultArgumentsAccessor(true, false).getBoolean(0));
+		assertEquals(Boolean.TRUE, new DefaultArgumentsAccessor(1,true, false).getBoolean(0));
 	}
 
 	@Test
 	void getByte() {
-		assertEquals(Byte.valueOf((byte) 42), new DefaultArgumentsAccessor((byte) 42).getByte(0));
+		assertEquals(Byte.valueOf((byte) 42), new DefaultArgumentsAccessor(1,(byte) 42).getByte(0));
 	}
 
 	@Test
 	void getShort() {
-		assertEquals(Short.valueOf((short) 42), new DefaultArgumentsAccessor((short) 42).getShort(0));
+		assertEquals(Short.valueOf((short) 42), new DefaultArgumentsAccessor(1,(short) 42).getShort(0));
 	}
 
 	@Test
 	void getInteger() {
-		assertEquals(Integer.valueOf(42), new DefaultArgumentsAccessor(42).getInteger(0));
+		assertEquals(Integer.valueOf(42), new DefaultArgumentsAccessor(1,42).getInteger(0));
 	}
 
 	@Test
 	void getLong() {
-		assertEquals(Long.valueOf(42L), new DefaultArgumentsAccessor(42L).getLong(0));
+		assertEquals(Long.valueOf(42L), new DefaultArgumentsAccessor(1,42L).getLong(0));
 	}
 
 	@Test
 	void getFloat() {
-		assertEquals(Float.valueOf(42.0f), new DefaultArgumentsAccessor(42.0f).getFloat(0));
+		assertEquals(Float.valueOf(42.0f), new DefaultArgumentsAccessor(1,42.0f).getFloat(0));
 	}
 
 	@Test
 	void getDouble() {
-		assertEquals(Double.valueOf(42.0), new DefaultArgumentsAccessor(42.0).getDouble(0));
+		assertEquals(Double.valueOf(42.0), new DefaultArgumentsAccessor(1,42.0).getDouble(0));
 	}
 
 	@Test
 	void getString() {
-		assertEquals("foo", new DefaultArgumentsAccessor("foo", "bar").getString(0));
+		assertEquals("foo", new DefaultArgumentsAccessor(1,"foo", "bar").getString(0));
 	}
 
 	@Test
 	void toArray() {
-		var arguments = new DefaultArgumentsAccessor("foo", "bar");
+		var arguments = new DefaultArgumentsAccessor(1,"foo", "bar");
 		var copy = arguments.toArray();
 		assertArrayEquals(new String[] { "foo", "bar" }, copy);
 
@@ -148,7 +148,7 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void toList() {
-		var arguments = new DefaultArgumentsAccessor("foo", "bar");
+		var arguments = new DefaultArgumentsAccessor(1,"foo", "bar");
 		var copy = arguments.toList();
 		assertIterableEquals(Arrays.asList("foo", "bar"), copy);
 
@@ -158,9 +158,9 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void size() {
-		assertEquals(0, new DefaultArgumentsAccessor().size());
-		assertEquals(1, new DefaultArgumentsAccessor(42).size());
-		assertEquals(5, new DefaultArgumentsAccessor('a', 'b', 'c', 'd', 'e').size());
+		assertEquals(0, new DefaultArgumentsAccessor(1).size());
+		assertEquals(1, new DefaultArgumentsAccessor(1,42).size());
+		assertEquals(5, new DefaultArgumentsAccessor(1,'a', 'b', 'c', 'd', 'e').size());
 	}
 
 }

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
@@ -36,14 +36,14 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void indexMustNotBeNegative() {
-		ArgumentsAccessor arguments = new DefaultArgumentsAccessor(1, 2);
+		ArgumentsAccessor arguments = new DefaultArgumentsAccessor(1, 1, 2);
 		Exception exception = assertThrows(PreconditionViolationException.class, () -> arguments.get(-1));
 		assertThat(exception.getMessage()).containsSubsequence("index must be", ">= 0");
 	}
 
 	@Test
 	void indexMustBeSmallerThanLength() {
-		ArgumentsAccessor arguments = new DefaultArgumentsAccessor(1, 2);
+		ArgumentsAccessor arguments = new DefaultArgumentsAccessor(1, 1, 2);
 		Exception exception = assertThrows(PreconditionViolationException.class, () -> arguments.get(2));
 		assertThat(exception.getMessage()).containsSubsequence("index must be", "< 2");
 	}

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
@@ -31,7 +31,7 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void argumentsMustNotBeNull() {
-		assertThrows(PreconditionViolationException.class, () -> new DefaultArgumentsAccessor(1,(Object[]) null));
+		assertThrows(PreconditionViolationException.class, () -> new DefaultArgumentsAccessor(1, (Object[]) null));
 	}
 
 	@Test
@@ -50,29 +50,29 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void getNull() {
-		assertNull(new DefaultArgumentsAccessor(1,new Object[] { null }).get(0));
+		assertNull(new DefaultArgumentsAccessor(1, new Object[] { null }).get(0));
 	}
 
 	@Test
 	void getWithNullCastToWrapperType() {
-		assertNull(new DefaultArgumentsAccessor(1,(Object[]) new Integer[] { null }).get(0, Integer.class));
+		assertNull(new DefaultArgumentsAccessor(1, (Object[]) new Integer[] { null }).get(0, Integer.class));
 	}
 
 	@Test
 	void get() {
-		assertEquals(1, new DefaultArgumentsAccessor(1,1).get(0));
+		assertEquals(1, new DefaultArgumentsAccessor(1, 1).get(0));
 	}
 
 	@Test
 	void getWithCast() {
-		assertEquals(Integer.valueOf(1), new DefaultArgumentsAccessor(1,1).get(0, Integer.class));
-		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1,'A').get(0, Character.class));
+		assertEquals(Integer.valueOf(1), new DefaultArgumentsAccessor(1, 1).get(0, Integer.class));
+		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1, 'A').get(0, Character.class));
 	}
 
 	@Test
 	void getWithCastToPrimitiveType() {
 		Exception exception = assertThrows(ArgumentAccessException.class,
-			() -> new DefaultArgumentsAccessor(1,1).get(0, int.class));
+			() -> new DefaultArgumentsAccessor(1, 1).get(0, int.class));
 		assertThat(exception.getMessage()).isEqualTo(
 			"Argument at index [0] with value [1] and type [java.lang.Integer] could not be converted or cast to type [int].");
 
@@ -85,59 +85,59 @@ class DefaultArgumentsAccessorTests {
 	@Test
 	void getWithCastToIncompatibleType() {
 		Exception exception = assertThrows(ArgumentAccessException.class,
-			() -> new DefaultArgumentsAccessor(1,1).get(0, Character.class));
+			() -> new DefaultArgumentsAccessor(1, 1).get(0, Character.class));
 		assertThat(exception.getMessage()).isEqualTo(
 			"Argument at index [0] with value [1] and type [java.lang.Integer] could not be converted or cast to type [java.lang.Character].");
 	}
 
 	@Test
 	void getCharacter() {
-		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1,'A', 'B').getCharacter(0));
+		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1, 'A', 'B').getCharacter(0));
 	}
 
 	@Test
 	void getBoolean() {
-		assertEquals(Boolean.TRUE, new DefaultArgumentsAccessor(1,true, false).getBoolean(0));
+		assertEquals(Boolean.TRUE, new DefaultArgumentsAccessor(1, true, false).getBoolean(0));
 	}
 
 	@Test
 	void getByte() {
-		assertEquals(Byte.valueOf((byte) 42), new DefaultArgumentsAccessor(1,(byte) 42).getByte(0));
+		assertEquals(Byte.valueOf((byte) 42), new DefaultArgumentsAccessor(1, (byte) 42).getByte(0));
 	}
 
 	@Test
 	void getShort() {
-		assertEquals(Short.valueOf((short) 42), new DefaultArgumentsAccessor(1,(short) 42).getShort(0));
+		assertEquals(Short.valueOf((short) 42), new DefaultArgumentsAccessor(1, (short) 42).getShort(0));
 	}
 
 	@Test
 	void getInteger() {
-		assertEquals(Integer.valueOf(42), new DefaultArgumentsAccessor(1,42).getInteger(0));
+		assertEquals(Integer.valueOf(42), new DefaultArgumentsAccessor(1, 42).getInteger(0));
 	}
 
 	@Test
 	void getLong() {
-		assertEquals(Long.valueOf(42L), new DefaultArgumentsAccessor(1,42L).getLong(0));
+		assertEquals(Long.valueOf(42L), new DefaultArgumentsAccessor(1, 42L).getLong(0));
 	}
 
 	@Test
 	void getFloat() {
-		assertEquals(Float.valueOf(42.0f), new DefaultArgumentsAccessor(1,42.0f).getFloat(0));
+		assertEquals(Float.valueOf(42.0f), new DefaultArgumentsAccessor(1, 42.0f).getFloat(0));
 	}
 
 	@Test
 	void getDouble() {
-		assertEquals(Double.valueOf(42.0), new DefaultArgumentsAccessor(1,42.0).getDouble(0));
+		assertEquals(Double.valueOf(42.0), new DefaultArgumentsAccessor(1, 42.0).getDouble(0));
 	}
 
 	@Test
 	void getString() {
-		assertEquals("foo", new DefaultArgumentsAccessor(1,"foo", "bar").getString(0));
+		assertEquals("foo", new DefaultArgumentsAccessor(1, "foo", "bar").getString(0));
 	}
 
 	@Test
 	void toArray() {
-		var arguments = new DefaultArgumentsAccessor(1,"foo", "bar");
+		var arguments = new DefaultArgumentsAccessor(1, "foo", "bar");
 		var copy = arguments.toArray();
 		assertArrayEquals(new String[] { "foo", "bar" }, copy);
 
@@ -148,7 +148,7 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void toList() {
-		var arguments = new DefaultArgumentsAccessor(1,"foo", "bar");
+		var arguments = new DefaultArgumentsAccessor(1, "foo", "bar");
 		var copy = arguments.toList();
 		assertIterableEquals(Arrays.asList("foo", "bar"), copy);
 
@@ -159,8 +159,8 @@ class DefaultArgumentsAccessorTests {
 	@Test
 	void size() {
 		assertEquals(0, new DefaultArgumentsAccessor(1).size());
-		assertEquals(1, new DefaultArgumentsAccessor(1,42).size());
-		assertEquals(5, new DefaultArgumentsAccessor(1,'a', 'b', 'c', 'd', 'e').size());
+		assertEquals(1, new DefaultArgumentsAccessor(1, 42).size());
+		assertEquals(5, new DefaultArgumentsAccessor(1, 'a', 'b', 'c', 'd', 'e').size());
 	}
 
 }

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/aggregator/ArgumentsAccessorKotlinTests.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/aggregator/ArgumentsAccessorKotlinTests.kt
@@ -21,14 +21,14 @@ class ArgumentsAccessorKotlinTests {
 
     @Test
     fun `get() with reified type and index`() {
-        assertEquals(1, DefaultArgumentsAccessor(1).get<Int>(0))
-        assertEquals('A', DefaultArgumentsAccessor('A').get<Char>(0))
+        assertEquals(1, DefaultArgumentsAccessor(0, 1).get<Int>(0))
+        assertEquals('A', DefaultArgumentsAccessor(0, 'A').get<Char>(0))
     }
 
     @Test
     fun `get() with reified type and index for incompatible type`() {
         val exception = assertThrows<ArgumentAccessException> {
-            DefaultArgumentsAccessor(Integer.valueOf(1)).get<Char>(0)
+            DefaultArgumentsAccessor(0, Integer.valueOf(1)).get<Char>(0)
         }
 
         assertThat(exception).hasMessage(
@@ -38,13 +38,13 @@ class ArgumentsAccessorKotlinTests {
 
     @Test
     fun `get() with index`() {
-        assertEquals(1, DefaultArgumentsAccessor(1).get(0))
-        assertEquals('A', DefaultArgumentsAccessor('A').get(0))
+        assertEquals(1, DefaultArgumentsAccessor(0, 1).get(0))
+        assertEquals('A', DefaultArgumentsAccessor(0, 'A').get(0))
     }
 
     @Test
     fun `get() with index and class reference`() {
-        assertEquals(1, DefaultArgumentsAccessor(1).get(0, Integer::class.java))
-        assertEquals('A', DefaultArgumentsAccessor('A').get(0, Character::class.java))
+        assertEquals(1, DefaultArgumentsAccessor(0, 1).get(0, Integer::class.java))
+        assertEquals('A', DefaultArgumentsAccessor(0, 'A').get(0, Character::class.java))
     }
 }


### PR DESCRIPTION
## Overview

Adding the possibility to get the invocation index of any ArgumentsAccessor 
Fixes #1668

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
