### PR TITLE
Document shadowJar cache miss

### DIFF
--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -194,6 +194,10 @@ tasks.jar {
 	}
 }
 
+tasks.withType<ShadowJar>().configureEach {
+	outputs.doNotCacheIf("Shadow jar contains a Manifest with Build-Time") { true }
+}
+
 tasks.withType<JavaCompile>().configureEach {
 	options.encoding = "UTF-8"
 }


### PR DESCRIPTION
## Overview

Document build cache miss to ease detection of (new) performance regression.

## Details

The `shadowJar` task is getting build cache misses due to one of its input changing between builds (`Manifest` file containing _build time_)
https://ge.junit.org/c/tz35q4eso3ktg/we4fflr3ipauu/task-inputs?cacheability=cacheable&expanded=WyJpcGFwaG1zcmhwdDVlLXJvb3RzcGVjJDIkMSJd&task-text=shad#change-ipaphmsrhpt5e-rootSpec$2$1-0-0

Marking the task as non cacheable will prevent from analyzing the same cache miss in the future.

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).