### PR TITLE
Introduce new `@MethodSource` syntax to differentiate overloaded local factory methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.2.adoc
@@ -32,7 +32,8 @@ JUnit repository on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Introduce new `@MethodSource` syntax to add the possibility to explicitly select
+  an overloaded local factory method without specifying its fully qualified name
 
 ==== Deprecations and Breaking Changes
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1406,9 +1406,11 @@ include::{testDir}/example/ExternalMethodSourceDemo.java[tags=external_MethodSou
 Factory methods can declare parameters, which will be provided by registered
 implementations of the `ParameterResolver` extension API. In the following example, the
 factory method is referenced by its name since there is only one such method in the test
-class. If there are several methods with the same name, the factory method must be
-referenced by its fully qualified method name – for example,
-`@MethodSource("example.MyTests#factoryMethodWithArguments(java.lang.String)")`.
+class. If there are several local methods with the same name, parameters can also be
+provided to differentiate them – for example, `@MethodSource("factoryMethod()")` or
+`@MethodSource("factoryMethod(java.lang.String)")`. Alternatively, the factory method
+can be referenced by its fully qualified method name, e.g.
+`@MethodSource("example.MyTests#factoryMethod(java.lang.String)")`.
 
 [source,java,indent=0]
 ----

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/provider/MethodArgumentsProviderTests.java
@@ -395,6 +395,20 @@ class MethodArgumentsProviderTests {
 		}
 
 		@Test
+		void providesArgumentsUsingSimpleNameWithoutParameter() {
+			var arguments = provideArguments("stringStreamProviderWithOrWithoutParameter()");
+
+			assertThat(arguments).containsExactly(array("foo"), array("bar"));
+		}
+
+		@Test
+		void providesArgumentsUsingSimpleNameWithParameter() {
+			var arguments = provideArguments("stringStreamProviderWithOrWithoutParameter(java.lang.String)");
+
+			assertThat(arguments).containsExactly(array("foo!"), array("bar!"));
+		}
+
+		@Test
 		void throwsExceptionWhenSeveralFactoryMethodsWithSameNameAreAvailable() {
 			var exception = assertThrows(PreconditionViolationException.class,
 				() -> provideArguments("stringStreamProviderWithOrWithoutParameter").toArray());

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -910,20 +910,42 @@ public final class ReflectionUtils {
 
 		String className = fullyQualifiedMethodName.substring(0, indexOfFirstHashtag);
 		String methodPart = fullyQualifiedMethodName.substring(indexOfFirstHashtag + 1);
-		String methodName = methodPart;
+		String[] parsedMethodPart = parseSimpleMethodName(methodPart);
+
+		return new String[] { className, parsedMethodPart[0], parsedMethodPart[1] };
+	}
+
+	/**
+	 * Parse the supplied method name into a 2-element {@code String[]} with
+	 * the following content.
+	 *
+	 * <ul>
+	 *   <li>index {@code 0}: the name of the method</li>
+	 *   <li>index {@code 1}: a comma-separated list of parameter types, or a
+	 *       blank string if the method does not declare any formal parameters</li>
+	 * </ul>
+	 *
+	 * @param simpleMethodName a simple method name, never {@code null} or blank
+	 * @return a 2-element array of strings containing the parsed values
+	 */
+	public static String[] parseSimpleMethodName(String simpleMethodName) {
+		String methodName = simpleMethodName;
 		String methodParameters = "";
 
-		if (methodPart.endsWith("()")) {
-			methodName = methodPart.substring(0, methodPart.length() - 2);
+		if (simpleMethodName.endsWith("()")) {
+			methodName = simpleMethodName.substring(0, simpleMethodName.length() - 2);
 		}
-		else if (methodPart.endsWith(")")) {
-			int indexOfLastOpeningParenthesis = methodPart.lastIndexOf('(');
-			if ((indexOfLastOpeningParenthesis > 0) && (indexOfLastOpeningParenthesis < methodPart.length() - 1)) {
-				methodName = methodPart.substring(0, indexOfLastOpeningParenthesis);
-				methodParameters = methodPart.substring(indexOfLastOpeningParenthesis + 1, methodPart.length() - 1);
+		else if (simpleMethodName.endsWith(")")) {
+			int indexOfLastOpeningParenthesis = simpleMethodName.lastIndexOf('(');
+			if ((indexOfLastOpeningParenthesis > 0)
+					&& (indexOfLastOpeningParenthesis < simpleMethodName.length() - 1)) {
+				methodName = simpleMethodName.substring(0, indexOfLastOpeningParenthesis);
+				methodParameters = simpleMethodName.substring(indexOfLastOpeningParenthesis + 1,
+					simpleMethodName.length() - 1);
 			}
 		}
-		return new String[] { className, methodName, methodParameters };
+
+		return new String[] { methodName, methodParameters };
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -928,6 +928,7 @@ public final class ReflectionUtils {
 	 * @param simpleMethodName a simple method name, never {@code null} or blank
 	 * @return a 2-element array of strings containing the parsed values
 	 */
+	@API(status = INTERNAL, since = "1.9")
 	public static String[] parseSimpleMethodName(String simpleMethodName) {
 		String methodName = simpleMethodName;
 		String methodParameters = "";

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -909,10 +909,10 @@ public final class ReflectionUtils {
 					+ "and then the method name, optionally followed by a parameter list enclosed in parentheses.");
 
 		String className = fullyQualifiedMethodName.substring(0, indexOfFirstHashtag);
-		String methodPart = fullyQualifiedMethodName.substring(indexOfFirstHashtag + 1);
-		String[] parsedMethodPart = parseSimpleMethodName(methodPart);
+		String qualifiedMethodName = fullyQualifiedMethodName.substring(indexOfFirstHashtag + 1);
+		String[] methodPart = parseQualifiedMethodName(qualifiedMethodName);
 
-		return new String[] { className, parsedMethodPart[0], parsedMethodPart[1] };
+		return new String[] { className, methodPart[0], methodPart[1] };
 	}
 
 	/**
@@ -925,24 +925,24 @@ public final class ReflectionUtils {
 	 *       blank string if the method does not declare any formal parameters</li>
 	 * </ul>
 	 *
-	 * @param simpleMethodName a simple method name, never {@code null} or blank
+	 * @param qualifiedMethodName a qualified method name, never {@code null} or blank
 	 * @return a 2-element array of strings containing the parsed values
 	 */
 	@API(status = INTERNAL, since = "1.9")
-	public static String[] parseSimpleMethodName(String simpleMethodName) {
-		String methodName = simpleMethodName;
+	public static String[] parseQualifiedMethodName(String qualifiedMethodName) {
+		String methodName = qualifiedMethodName;
 		String methodParameters = "";
 
-		if (simpleMethodName.endsWith("()")) {
-			methodName = simpleMethodName.substring(0, simpleMethodName.length() - 2);
+		if (qualifiedMethodName.endsWith("()")) {
+			methodName = qualifiedMethodName.substring(0, qualifiedMethodName.length() - 2);
 		}
-		else if (simpleMethodName.endsWith(")")) {
-			int indexOfLastOpeningParenthesis = simpleMethodName.lastIndexOf('(');
+		else if (qualifiedMethodName.endsWith(")")) {
+			int indexOfLastOpeningParenthesis = qualifiedMethodName.lastIndexOf('(');
 			if ((indexOfLastOpeningParenthesis > 0)
-					&& (indexOfLastOpeningParenthesis < simpleMethodName.length() - 1)) {
-				methodName = simpleMethodName.substring(0, indexOfLastOpeningParenthesis);
-				methodParameters = simpleMethodName.substring(indexOfLastOpeningParenthesis + 1,
-					simpleMethodName.length() - 1);
+					&& (indexOfLastOpeningParenthesis < qualifiedMethodName.length() - 1)) {
+				methodName = qualifiedMethodName.substring(0, indexOfLastOpeningParenthesis);
+				methodParameters = qualifiedMethodName.substring(indexOfLastOpeningParenthesis + 1,
+					qualifiedMethodName.length() - 1);
 			}
 		}
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -705,19 +705,19 @@ class ReflectionUtilsTests {
 	@ParameterizedTest
 	@ValueSource(strings = { "method", "method()" })
 	void parseSimpleMethodNameForMethodWithoutParameters(String methodName) {
-		assertThat(ReflectionUtils.parseSimpleMethodName(methodName))//
+		assertThat(ReflectionUtils.parseQualifiedMethodName(methodName))//
 				.containsExactly("method", "");
 	}
 
 	@Test
 	void parseSimpleMethodNameForMethodWithSingleParameter() {
-		assertThat(ReflectionUtils.parseSimpleMethodName("method(java.lang.Object)"))//
+		assertThat(ReflectionUtils.parseQualifiedMethodName("method(java.lang.Object)"))//
 				.containsExactly("method", "java.lang.Object");
 	}
 
 	@Test
 	void parseSimpleMethodNameForMethodWithMultipleParameters() {
-		assertThat(ReflectionUtils.parseSimpleMethodName("method(int, java.lang.Object)"))//
+		assertThat(ReflectionUtils.parseQualifiedMethodName("method(int, java.lang.Object)"))//
 				.containsExactly("method", "int, java.lang.Object");
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -55,6 +55,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.logging.LogRecordListener;
@@ -698,6 +700,25 @@ class ReflectionUtilsTests {
 	void parseFullyQualifiedMethodNameForMethodWithMultipleParameters() {
 		assertThat(ReflectionUtils.parseFullyQualifiedMethodName("com.example.Test#method(int, java.lang.Object)"))//
 				.containsExactly("com.example.Test", "method", "int, java.lang.Object");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "method", "method()" })
+	void parseSimpleMethodNameForMethodWithoutParameters(String methodName) {
+		assertThat(ReflectionUtils.parseSimpleMethodName(methodName))//
+				.containsExactly("method", "");
+	}
+
+	@Test
+	void parseSimpleMethodNameForMethodWithSingleParameter() {
+		assertThat(ReflectionUtils.parseSimpleMethodName("method(java.lang.Object)"))//
+				.containsExactly("method", "java.lang.Object");
+	}
+
+	@Test
+	void parseSimpleMethodNameForMethodWithMultipleParameters() {
+		assertThat(ReflectionUtils.parseSimpleMethodName("method(int, java.lang.Object)"))//
+				.containsExactly("method", "int, java.lang.Object");
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

Resolves #3080 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
