### PR TITLE
Stop further suite discovery when encountering a cycle

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.9.2.adoc
@@ -25,6 +25,7 @@ JUnit repository on GitHub.
 
 * Introduce `TestPlan.getTestIdentifier(UniqueId)` and `TestPlan.getChildren(UniqueId)` to
   avoid parsing unique IDs unnecessarily during test execution.
+* Quietly stop further suite discovery when encountering a cycle in a test suite
 
 
 [[release-notes-5.9.2-junit-jupiter]]

--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/junit-platform-suite-engine.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/junit-platform-suite-engine.adoc
@@ -20,7 +20,7 @@ you need _at least one_ other test engine and its dependencies on the classpath.
   `TestEngine` API for declarative test suites
 
 NOTE: Both of the required dependencies are aggregated in the `junit-platform-suite`
-artifact which can be declard in _test_ scope instead of declaring explicit dependencies
+artifact which can be declared in _test_ scope instead of declaring explicit dependencies
 on `junit-platform-suite-api` and `junit-platform-suite-engine`.
 
 [[junit-platform-suite-engine-setup-transitive-dependencies]]

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
@@ -10,13 +10,8 @@
 
 package org.junit.platform.suite.engine;
 
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.groupingBy;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
 import static org.junit.platform.suite.commons.SuiteLauncherDiscoveryRequestBuilder.request;
-
-import java.util.function.Supplier;
 
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.Preconditions;
@@ -26,7 +21,6 @@ import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.UniqueId.Segment;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
@@ -60,26 +54,10 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 	private SuiteLauncher launcher;
 
 	SuiteTestDescriptor(UniqueId id, Class<?> suiteClass, ConfigurationParameters configurationParameters) {
-		super(requireNoCycles(id), getSuiteDisplayName(suiteClass), ClassSource.from(suiteClass));
+		super(id, getSuiteDisplayName(suiteClass), ClassSource.from(suiteClass));
 		this.configurationParameters = configurationParameters;
 		this.failIfNoTests = getFailIfNoTests(suiteClass);
 		this.suiteClass = suiteClass;
-	}
-
-	private static UniqueId requireNoCycles(UniqueId id) {
-		// @formatter:off
-		boolean containsCycle = id.getSegments().stream()
-				.filter(segment -> SuiteTestDescriptor.SEGMENT_TYPE.equals(segment.getType()))
-				.map(Segment::getValue)
-				.collect(groupingBy(identity(), counting()))
-				.values()
-				.stream()
-				.anyMatch(count -> count > 1);
-		// @formatter:on
-		Supplier<String> message = () -> String.format(
-			"Configuration error: The suite configuration may not contain a cycle [%s]", id);
-		Preconditions.condition(!containsCycle, message);
-		return id;
 	}
 
 	private static Boolean getFailIfNoTests(Class<?> suiteClass) {

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteEngineTests.java
@@ -22,6 +22,7 @@ import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessf
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
 import static org.junit.platform.testkit.engine.EventConditions.test;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
@@ -39,7 +40,9 @@ import org.junit.platform.suite.engine.testcases.MultipleTestsTestCase;
 import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
 import org.junit.platform.suite.engine.testcases.TaggedTestTestCase;
 import org.junit.platform.suite.engine.testsuites.AbstractSuite;
+import org.junit.platform.suite.engine.testsuites.CyclicSuite;
 import org.junit.platform.suite.engine.testsuites.DynamicSuite;
+import org.junit.platform.suite.engine.testsuites.EmptyCyclicSuite;
 import org.junit.platform.suite.engine.testsuites.EmptyDynamicTestSuite;
 import org.junit.platform.suite.engine.testsuites.EmptyDynamicTestWithFailIfNoTestFalseSuite;
 import org.junit.platform.suite.engine.testsuites.EmptyTestCaseSuite;
@@ -50,6 +53,7 @@ import org.junit.platform.suite.engine.testsuites.NestedSuite;
 import org.junit.platform.suite.engine.testsuites.SelectClassesSuite;
 import org.junit.platform.suite.engine.testsuites.SuiteDisplayNameSuite;
 import org.junit.platform.suite.engine.testsuites.SuiteSuite;
+import org.junit.platform.suite.engine.testsuites.ThreePartCyclicSuite;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
 /**
@@ -347,6 +351,44 @@ class SuiteEngineTests {
 				.haveExactly(1, event(test(JUnit4TestsTestCase.class.getName()), finishedSuccessfully()))
 				.doNotHave(test(TaggedTestTestCase.class.getName()))
 				.doNotHave(container("junit-jupiter"));
+		// @formatter:on
+	}
+
+	@Test
+	void cyclicSuite() {
+		// @formatter:off
+		EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(CyclicSuite.class))
+				.execute()
+				.allEvents()
+				.assertThatEvents()
+				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
+		// @formatter:on
+	}
+
+	@Test
+	void emptyCyclicSuite() {
+		// @formatter:off
+		EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(EmptyCyclicSuite.class))
+				.execute()
+				.allEvents()
+				.assertThatEvents()
+				.haveExactly(1, event(container(EmptyCyclicSuite.class), finishedWithFailure(message(
+						"Suite [org.junit.platform.suite.engine.testsuites.EmptyCyclicSuite] did not discover any tests"
+				))));
+		// @formatter:on
+	}
+
+	@Test
+	void threePartCyclicSuite() {
+		// @formatter:off
+		EngineTestKit.engine(ENGINE_ID)
+				.selectors(selectClass(ThreePartCyclicSuite.PartA.class))
+				.execute()
+				.allEvents()
+				.assertThatEvents()
+				.haveExactly(1, event(test(SingleTestTestCase.class.getName()), finishedSuccessfully()));
 		// @formatter:on
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/SuiteTestDescriptorTests.java
@@ -25,14 +25,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
-import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
-import org.junit.platform.suite.engine.testsuites.CyclicSuite;
 import org.junit.platform.suite.engine.testsuites.SelectClassesSuite;
 
 /**
@@ -88,21 +86,6 @@ class SuiteTestDescriptorTests {
 				() -> suite.addDiscoveryRequestFrom(methodId));
 			assertEquals("discovery request can not be modified after discovery", exception.getMessage());
 		});
-	}
-
-	@Test
-	void suitesMayNotContainACycle() {
-		// @formatter:off
-		UniqueId expectedCycle = suiteId
-				.append("engine", SuiteEngineDescriptor.ENGINE_ID)
-				.append(SuiteTestDescriptor.SEGMENT_TYPE, CyclicSuite.class.getName())
-				.append("engine", SuiteEngineDescriptor.ENGINE_ID)
-				.append(SuiteTestDescriptor.SEGMENT_TYPE, CyclicSuite.class.getName());
-		// @formatter:on
-		suite.addDiscoveryRequestFrom(CyclicSuite.class);
-		JUnitException exception = assertThrows(JUnitException.class, suite::discover);
-		assertEquals("Configuration error: The suite configuration may not contain a cycle [" + expectedCycle + "]",
-			exception.getCause().getCause().getCause().getMessage());
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/EmptyCyclicSuite.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/EmptyCyclicSuite.java
@@ -13,13 +13,12 @@ package org.junit.platform.suite.engine.testsuites;
 import org.junit.platform.suite.api.IncludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
 
 /**
- * @since 1.8
+ * @since 1.9.2
  */
 @Suite
 @IncludeClassNamePatterns(".*")
-@SelectClasses({ CyclicSuite.class, SingleTestTestCase.class })
-public class CyclicSuite {
+@SelectClasses(EmptyCyclicSuite.class)
+public class EmptyCyclicSuite {
 }

--- a/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/ThreePartCyclicSuite.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/engine/testsuites/ThreePartCyclicSuite.java
@@ -16,10 +16,28 @@ import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.engine.testcases.SingleTestTestCase;
 
 /**
- * @since 1.8
+ * @since 1.9.2
  */
-@Suite
-@IncludeClassNamePatterns(".*")
-@SelectClasses({ CyclicSuite.class, SingleTestTestCase.class })
-public class CyclicSuite {
+public class ThreePartCyclicSuite {
+
+	@Suite
+	@IncludeClassNamePatterns(".*")
+	@SelectClasses({ PartB.class })
+	public static class PartA {
+
+	}
+
+	@Suite
+	@IncludeClassNamePatterns(".*")
+	@SelectClasses({ PartC.class })
+	public static class PartB {
+
+	}
+
+	@Suite
+	@IncludeClassNamePatterns(".*")
+	@SelectClasses({ PartB.class, SingleTestTestCase.class })
+	public static class PartC {
+
+	}
 }


### PR DESCRIPTION
## Overview

It is relatively easy to create a test suite that contains itself by accident. E.g:

```java
package org.example.tag;

@Tag("fast")
public class FastTest {
    @Test
    public void test() {
        System.out.println("I am fast test");
    }
}
```
```java
package org.example.tag;

@Tag("slow")
public class SlowTest {
    @Test
    public void test() {
        System.out.println("I am slow test");
    }
}
```
```java
package org.example.tag;

@SelectPackages("org.example.tag")
@IncludeTags("fast")
@Suite
public class TestSuite {
}
```

This configuration will result in a a long stack trace with a message explaining that the suite contained a cycle.

```
Configuration error: The suite configuration may not contain a cycle [[engine:junit-platform-suite]/[suite:org.example.tag.TestSuite]/[engine:junit-platform-suite]/[suite:org.example.tag.TestSuite]]
```

And it is is not immediately apparent how a user should resolve this problem. This example could be resolved by explicitly excluding the suite engine by adding `@ExcludeEngine("junit-platform-suite")`. This prevents further discovery.  But when multiple suites are involved this may not be right action.

Fortunately the suite itself is aware of the cycle and as stopping further discovery is the only reasonable action. This means that this can be done without any sort of explicit configuration.

Fixes: #3115


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
