### PR TITLE
Consistently use "wrap semantics" for started/finished and opened/closed listener methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -25,6 +25,11 @@ repository on GitHub.
 
 * All utility methods from `ReflectionSupport` now have counterparts returning `Stream`
   instead of `List`.
+* For consistency with Jupiter lifecycle callbacks, listener method pairs for started/
+  finished and opened/closed events are now called using "wrap" semantics, i.e. the latter
+  methods are called in reverse order compared to the former when multiple listeners are
+  registered. This affects the following listener interfaces: `TestExecutionListener`,
+  `EngineExecutionListener`, `LauncherDiscoveryListener`, and `LauncherSessionListener`.
 
 [[release-notes-5.10.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findBefor
 import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findBeforeEachMethods;
 import static org.junit.jupiter.engine.descriptor.TestInstanceLifecycleUtils.getTestInstanceLifecycle;
 import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.createThrowableCollector;
+import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -457,15 +458,15 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 		ExtensionContext extensionContext = context.getExtensionContext();
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 
-		registry.getReversedExtensions(AfterAllCallback.class)//
-				.forEach(extension -> throwableCollector.execute(() -> extension.afterAll(extensionContext)));
+		forEachInReverseOrder(registry.getExtensions(AfterAllCallback.class), //
+			extension -> throwableCollector.execute(() -> extension.afterAll(extensionContext)));
 	}
 
 	private void invokeTestInstancePreDestroyCallbacks(JupiterEngineExecutionContext context) {
 		ExtensionContext extensionContext = context.getExtensionContext();
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 
-		context.getExtensionRegistry().getReversedExtensions(TestInstancePreDestroyCallback.class).forEach(
+		forEachInReverseOrder(context.getExtensionRegistry().getExtensions(TestInstancePreDestroyCallback.class), //
 			extension -> throwableCollector.execute(() -> extension.preDestroyTestInstance(extensionContext)));
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -107,7 +107,9 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 	<E extends Extension> void invokeExecutionExceptionHandlers(Class<E> handlerType, ExtensionRegistry registry,
 			Throwable throwable, ExceptionHandlerInvoker<E> handlerInvoker) {
 
-		invokeExecutionExceptionHandlers(registry.getReversedExtensions(handlerType), throwable, handlerInvoker);
+		List<E> extensions = registry.getExtensions(handlerType);
+		Collections.reverse(extensions);
+		invokeExecutionExceptionHandlers(extensions, throwable, handlerInvoker);
 	}
 
 	private <E extends Extension> void invokeExecutionExceptionHandlers(List<E> exceptionHandlers, Throwable throwable,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.ExtensionUtils.populateNewExtensionRegistryFromExtendWithAnnotation;
 import static org.junit.jupiter.engine.descriptor.ExtensionUtils.registerExtensionsFromExecutableParameters;
 import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.createThrowableCollector;
+import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
 
 import java.lang.reflect.Method;
 
@@ -272,7 +273,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 		ExtensionContext extensionContext = context.getExtensionContext();
 		ThrowableCollector throwableCollector = context.getThrowableCollector();
 
-		registry.getReversedExtensions(type).forEach(callback -> {
+		forEachInReverseOrder(registry.getExtensions(type), callback -> {
 			throwableCollector.execute(() -> callbackInvoker.invoke(callback, extensionContext));
 		});
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistry.java
@@ -14,7 +14,6 @@ import static java.util.stream.Collectors.toCollection;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -36,7 +35,6 @@ public interface ExtensionRegistry {
 	 * in this registry or one of its ancestors.
 	 *
 	 * @param extensionType the type of {@link Extension} to stream
-	 * @see #getReversedExtensions(Class)
 	 * @see #getExtensions(Class)
 	 */
 	<E extends Extension> Stream<E> stream(Class<E> extensionType);
@@ -46,25 +44,10 @@ public interface ExtensionRegistry {
 	 * in this registry or one of its ancestors.
 	 *
 	 * @param extensionType the type of {@link Extension} to get
-	 * @see #getReversedExtensions(Class)
 	 * @see #stream(Class)
 	 */
 	default <E extends Extension> List<E> getExtensions(Class<E> extensionType) {
 		return stream(extensionType).collect(toCollection(ArrayList::new));
-	}
-
-	/**
-	 * Get all {@code Extensions} of the specified type that are present
-	 * in this registry or one of its ancestors, in reverse order.
-	 *
-	 * @param extensionType the type of {@link Extension} to get
-	 * @see #getExtensions(Class)
-	 * @see #stream(Class)
-	 */
-	default <E extends Extension> List<E> getReversedExtensions(Class<E> extensionType) {
-		List<E> extensions = getExtensions(extensionType);
-		Collections.reverse(extensions);
-		return extensions;
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -130,7 +130,6 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 	 * <p>Extensions in ancestors are ignored.
 	 *
 	 * @param extensionType the type of {@link Extension} to stream
-	 * @see #getReversedExtensions(Class)
 	 */
 	private <E extends Extension> Stream<E> streamLocal(Class<E> extensionType) {
 		// @formatter:off

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
@@ -24,7 +24,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collector;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -201,6 +203,16 @@ public final class CollectionUtils {
 		}
 		throw new PreconditionViolationException(
 			"Cannot convert instance of " + object.getClass().getName() + " into a Stream: " + object);
+	}
+
+	/**
+	 * Call the supplied action on each element of the supplied {@link List} from last to first element.
+	 */
+	@API(status = INTERNAL, since = "1.9.2")
+	public static <T> void forEachInReverseOrder(List<T> list, Consumer<? super T> action) {
+		for (ListIterator<T> iterator = list.listIterator(list.size()); iterator.hasPrevious();) {
+			action.accept(iterator.previous());
+		}
 	}
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
@@ -210,6 +210,13 @@ public final class CollectionUtils {
 	 */
 	@API(status = INTERNAL, since = "1.9.2")
 	public static <T> void forEachInReverseOrder(List<T> list, Consumer<? super T> action) {
+		if (list.isEmpty()) {
+			return;
+		}
+		if (list.size() == 1) {
+			action.accept(list.get(0));
+			return;
+		}
 		for (ListIterator<T> iterator = list.listIterator(list.size()); iterator.hasPrevious();) {
 			action.accept(iterator.previous());
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/CompositeEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/CompositeEngineExecutionListener.java
@@ -35,38 +35,41 @@ class CompositeEngineExecutionListener implements EngineExecutionListener {
 
 	@Override
 	public void dynamicTestRegistered(TestDescriptor testDescriptor) {
-		notifyEach(engineExecutionListeners, listener -> listener.dynamicTestRegistered(testDescriptor),
+		notifyEach(engineExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.dynamicTestRegistered(testDescriptor),
 			() -> "dynamicTestRegistered(" + testDescriptor + ")");
 	}
 
 	@Override
 	public void executionSkipped(TestDescriptor testDescriptor, String reason) {
-		notifyEach(engineExecutionListeners, listener -> listener.executionSkipped(testDescriptor, reason),
+		notifyEach(engineExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.executionSkipped(testDescriptor, reason),
 			() -> "executionSkipped(" + testDescriptor + ", " + reason + ")");
 	}
 
 	@Override
 	public void executionStarted(TestDescriptor testDescriptor) {
-		notifyEach(engineExecutionListeners, listener -> listener.executionStarted(testDescriptor),
-			() -> "executionStarted(" + testDescriptor + ")");
+		notifyEach(engineExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.executionStarted(testDescriptor), () -> "executionStarted(" + testDescriptor + ")");
 	}
 
 	@Override
 	public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
-		notifyEach(engineExecutionListeners,
+		notifyEach(engineExecutionListeners, IterationOrder.REVERSED,
 			listener -> listener.executionFinished(testDescriptor, testExecutionResult),
 			() -> "executionFinished(" + testDescriptor + ", " + testExecutionResult + ")");
 	}
 
 	@Override
 	public void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
-		notifyEach(engineExecutionListeners, listener -> listener.reportingEntryPublished(testDescriptor, entry),
+		notifyEach(engineExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.reportingEntryPublished(testDescriptor, entry),
 			() -> "reportingEntryPublished(" + testDescriptor + ", " + entry + ")");
 	}
 
-	private static <T extends EngineExecutionListener> void notifyEach(List<T> listeners, Consumer<T> consumer,
-			Supplier<String> description) {
-		listeners.forEach(listener -> {
+	private static <T extends EngineExecutionListener> void notifyEach(List<T> listeners, IterationOrder iterationOrder,
+			Consumer<T> consumer, Supplier<String> description) {
+		iterationOrder.forEach(listeners, listener -> {
 			try {
 				consumer.accept(listener);
 			}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/CompositeTestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/CompositeTestExecutionListener.java
@@ -43,54 +43,61 @@ class CompositeTestExecutionListener implements TestExecutionListener {
 
 	@Override
 	public void dynamicTestRegistered(TestIdentifier testIdentifier) {
-		notifyEach(testExecutionListeners, listener -> listener.dynamicTestRegistered(testIdentifier),
+		notifyEach(testExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.dynamicTestRegistered(testIdentifier),
 			() -> "dynamicTestRegistered(" + testIdentifier + ")");
 	}
 
 	@Override
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-		notifyEach(testExecutionListeners, listener -> listener.executionSkipped(testIdentifier, reason),
+		notifyEach(testExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.executionSkipped(testIdentifier, reason),
 			() -> "executionSkipped(" + testIdentifier + ", " + reason + ")");
 	}
 
 	@Override
 	public void executionStarted(TestIdentifier testIdentifier) {
-		notifyEach(eagerTestExecutionListeners, listener -> listener.executionJustStarted(testIdentifier),
+		notifyEach(eagerTestExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.executionJustStarted(testIdentifier),
 			() -> "executionJustStarted(" + testIdentifier + ")");
-		notifyEach(testExecutionListeners, listener -> listener.executionStarted(testIdentifier),
-			() -> "executionStarted(" + testIdentifier + ")");
+		notifyEach(testExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.executionStarted(testIdentifier), () -> "executionStarted(" + testIdentifier + ")");
 	}
 
 	@Override
 	public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-		notifyEach(eagerTestExecutionListeners,
+		notifyEach(eagerTestExecutionListeners, IterationOrder.REVERSED,
 			listener -> listener.executionJustFinished(testIdentifier, testExecutionResult),
 			() -> "executionJustFinished(" + testIdentifier + ", " + testExecutionResult + ")");
-		notifyEach(testExecutionListeners, listener -> listener.executionFinished(testIdentifier, testExecutionResult),
+		notifyEach(testExecutionListeners, IterationOrder.REVERSED,
+			listener -> listener.executionFinished(testIdentifier, testExecutionResult),
 			() -> "executionFinished(" + testIdentifier + ", " + testExecutionResult + ")");
 	}
 
 	@Override
 	public void testPlanExecutionStarted(TestPlan testPlan) {
-		notifyEach(testExecutionListeners, listener -> listener.testPlanExecutionStarted(testPlan),
+		notifyEach(testExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.testPlanExecutionStarted(testPlan),
 			() -> "testPlanExecutionStarted(" + testPlan + ")");
 	}
 
 	@Override
 	public void testPlanExecutionFinished(TestPlan testPlan) {
-		notifyEach(testExecutionListeners, listener -> listener.testPlanExecutionFinished(testPlan),
+		notifyEach(testExecutionListeners, IterationOrder.REVERSED,
+			listener -> listener.testPlanExecutionFinished(testPlan),
 			() -> "testPlanExecutionFinished(" + testPlan + ")");
 	}
 
 	@Override
 	public void reportingEntryPublished(TestIdentifier testIdentifier, ReportEntry entry) {
-		notifyEach(testExecutionListeners, listener -> listener.reportingEntryPublished(testIdentifier, entry),
+		notifyEach(testExecutionListeners, IterationOrder.ORIGINAL,
+			listener -> listener.reportingEntryPublished(testIdentifier, entry),
 			() -> "reportingEntryPublished(" + testIdentifier + ", " + entry + ")");
 	}
 
-	private static <T extends TestExecutionListener> void notifyEach(List<T> listeners, Consumer<T> consumer,
-			Supplier<String> description) {
-		listeners.forEach(listener -> {
+	private static <T extends TestExecutionListener> void notifyEach(List<T> listeners, IterationOrder iterationOrder,
+			Consumer<T> consumer, Supplier<String> description) {
+		iterationOrder.forEach(listeners, listener -> {
 			try {
 				consumer.accept(listener);
 			}
@@ -109,4 +116,5 @@ class CompositeTestExecutionListener implements TestExecutionListener {
 		default void executionJustFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
 		}
 	}
+
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/IterationOrder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/IterationOrder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+enum IterationOrder {
+
+	ORIGINAL {
+		@Override
+		<T> void forEach(List<T> listeners, Consumer<T> action) {
+			listeners.forEach(action);
+		}
+	},
+
+	REVERSED {
+		@Override
+		<T> void forEach(List<T> listeners, Consumer<T> action) {
+			forEachInReverseOrder(listeners, action);
+		}
+	};
+
+	abstract <T> void forEach(List<T> listeners, Consumer<T> action);
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListener.java
@@ -10,6 +10,8 @@
 
 package org.junit.platform.launcher.listeners.discovery;
 
+import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,7 +42,7 @@ class CompositeLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	@Override
 	public void launcherDiscoveryFinished(LauncherDiscoveryRequest request) {
-		listeners.forEach(delegate -> delegate.launcherDiscoveryFinished(request));
+		forEachInReverseOrder(listeners, delegate -> delegate.launcherDiscoveryFinished(request));
 	}
 
 	@Override
@@ -50,7 +52,7 @@ class CompositeLauncherDiscoveryListener implements LauncherDiscoveryListener {
 
 	@Override
 	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
-		listeners.forEach(delegate -> delegate.engineDiscoveryFinished(engineId, result));
+		forEachInReverseOrder(listeners, delegate -> delegate.engineDiscoveryFinished(engineId, result));
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/session/CompositeLauncherSessionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/session/CompositeLauncherSessionListener.java
@@ -10,6 +10,8 @@
 
 package org.junit.platform.launcher.listeners.session;
 
+import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +38,6 @@ class CompositeLauncherSessionListener implements LauncherSessionListener {
 
 	@Override
 	public void launcherSessionClosed(LauncherSession session) {
-		listeners.forEach(delegate -> delegate.launcherSessionClosed(session));
+		forEachInReverseOrder(listeners, delegate -> delegate.launcherSessionClosed(session));
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/CollectionUtilsTests.java
@@ -277,4 +277,13 @@ class CollectionUtilsTests {
 		}
 	}
 
+	@Test
+	void iteratesListElementsInReverseOrder() {
+		var items = List.of("foo", "bar", "baz");
+		var result = new ArrayList<>();
+
+		CollectionUtils.forEachInReverseOrder(items, result::add);
+
+		assertThat(result).containsExactly("baz", "bar", "foo");
+	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/CompositeEngineExecutionListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/CompositeEngineExecutionListenerTests.java
@@ -12,6 +12,7 @@ package org.junit.platform.launcher.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.DemoMethodTestDescriptor;
+import org.mockito.InOrder;
 
 @TrackLogRecords
 class CompositeEngineExecutionListenerTests {
@@ -38,9 +40,7 @@ class CompositeEngineExecutionListenerTests {
 
 	@Test
 	void shouldNotThrowExceptionButLogIfDynamicTestRegisteredListenerMethodFails(LogRecordListener logRecordListener) {
-		var testDescriptor = getSampleMethodTestDescriptor();
-
-		compositeTestExecutionListener().dynamicTestRegistered(testDescriptor);
+		compositeEngineExecutionListener().dynamicTestRegistered(anyTestDescriptor());
 
 		assertThatTestListenerErrorLogged(logRecordListener, ThrowingEngineExecutionListener.class,
 			"dynamicTestRegistered");
@@ -48,27 +48,21 @@ class CompositeEngineExecutionListenerTests {
 
 	@Test
 	void shouldNotThrowExceptionButLogIfExecutionStartedListenerMethodFails(LogRecordListener logRecordListener) {
-		var testDescriptor = getSampleMethodTestDescriptor();
-
-		compositeTestExecutionListener().executionStarted(testDescriptor);
+		compositeEngineExecutionListener().executionStarted(anyTestDescriptor());
 
 		assertThatTestListenerErrorLogged(logRecordListener, ThrowingEngineExecutionListener.class, "executionStarted");
 	}
 
 	@Test
 	void shouldNotThrowExceptionButLogIfExecutionSkippedListenerMethodFails(LogRecordListener logRecordListener) {
-		var testDescriptor = getSampleMethodTestDescriptor();
-
-		compositeTestExecutionListener().executionSkipped(testDescriptor, "deliberately skipped container");
+		compositeEngineExecutionListener().executionSkipped(anyTestDescriptor(), "deliberately skipped container");
 
 		assertThatTestListenerErrorLogged(logRecordListener, ThrowingEngineExecutionListener.class, "executionSkipped");
 	}
 
 	@Test
 	void shouldNotThrowExceptionButLogIfExecutionFinishedListenerMethodFails(LogRecordListener logRecordListener) {
-		var testDescriptor = getSampleMethodTestDescriptor();
-
-		compositeTestExecutionListener().executionFinished(testDescriptor, mock(TestExecutionResult.class));
+		compositeEngineExecutionListener().executionFinished(anyTestDescriptor(), anyTestExecutionResult());
 
 		assertThatTestListenerErrorLogged(logRecordListener, ThrowingEngineExecutionListener.class,
 			"executionFinished");
@@ -77,9 +71,7 @@ class CompositeEngineExecutionListenerTests {
 	@Test
 	void shouldNotThrowExceptionButLogIfReportingEntryPublishedListenerMethodFails(
 			LogRecordListener logRecordListener) {
-		var testDescriptor = getSampleMethodTestDescriptor();
-
-		compositeTestExecutionListener().reportingEntryPublished(testDescriptor, ReportEntry.from("one", "two"));
+		compositeEngineExecutionListener().reportingEntryPublished(anyTestDescriptor(), ReportEntry.from("one", "two"));
 
 		assertThatTestListenerErrorLogged(logRecordListener, ThrowingEngineExecutionListener.class,
 			"reportingEntryPublished");
@@ -94,14 +86,37 @@ class CompositeEngineExecutionListenerTests {
 				throw new OutOfMemoryError();
 			}
 		});
-		var testDescriptor = getSampleMethodTestDescriptor();
-		assertThatThrownBy(() -> compositeTestExecutionListener().executionStarted(testDescriptor)).isInstanceOf(
+		var testDescriptor = anyTestDescriptor();
+
+		assertThatThrownBy(() -> compositeEngineExecutionListener().executionStarted(testDescriptor)).isInstanceOf(
 			OutOfMemoryError.class);
 
 		assertNotLogs(logRecordListener);
 	}
 
-	private EngineExecutionListener compositeTestExecutionListener() {
+	@Test
+	void callsListenersInReverseOrderForFinishedEvents() {
+		listeners.clear();
+		var firstListener = mock(EngineExecutionListener.class, "firstListener");
+		var secondListener = mock(EngineExecutionListener.class, "secondListener");
+		listeners.add(firstListener);
+		listeners.add(secondListener);
+
+		var testDescriptor = anyTestDescriptor();
+		var testExecutionResult = anyTestExecutionResult();
+
+		var composite = compositeEngineExecutionListener();
+		composite.executionStarted(testDescriptor);
+		composite.executionFinished(testDescriptor, testExecutionResult);
+
+		InOrder inOrder = inOrder(firstListener, secondListener);
+		inOrder.verify(firstListener).executionStarted(testDescriptor);
+		inOrder.verify(secondListener).executionStarted(testDescriptor);
+		inOrder.verify(secondListener).executionFinished(testDescriptor, testExecutionResult);
+		inOrder.verify(firstListener).executionFinished(testDescriptor, testExecutionResult);
+	}
+
+	private EngineExecutionListener compositeEngineExecutionListener() {
 		return new CompositeEngineExecutionListener(listeners);
 	}
 
@@ -114,8 +129,8 @@ class CompositeEngineExecutionListenerTests {
 		assertThat(logRecordListener.stream(CompositeEngineExecutionListener.class, Level.WARNING).count()).isZero();
 	}
 
-	private TestDescriptor getSampleMethodTestDescriptor() {
-		return getDemoMethodTestDescriptor();
+	private static TestExecutionResult anyTestExecutionResult() {
+		return mock(TestExecutionResult.class);
 	}
 
 	private void assertThatTestListenerErrorLogged(LogRecordListener logRecordListener, Class<?> listenerClass,
@@ -124,10 +139,10 @@ class CompositeEngineExecutionListenerTests {
 			"EngineExecutionListener [" + listenerClass.getName() + "] threw exception for method: " + methodName);
 	}
 
-	private DemoMethodTestDescriptor getDemoMethodTestDescriptor() {
-		var method = ReflectionUtils.findMethod(this.getClass(), "getDemoMethodTestDescriptor",
-			new Class<?>[0]).orElseThrow();
-		return new DemoMethodTestDescriptor(UniqueId.root("method", "unique_id"), this.getClass(), method);
+	private static TestDescriptor anyTestDescriptor() {
+		var testClass = CompositeEngineExecutionListenerTests.class;
+		var method = ReflectionUtils.findMethod(testClass, "anyTestDescriptor", new Class<?>[0]).orElseThrow();
+		return new DemoMethodTestDescriptor(UniqueId.root("method", "unique_id"), testClass, method);
 	}
 
 	private static class ThrowingEngineExecutionListener implements EngineExecutionListener {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherSessionTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherSessionTests.java
@@ -26,8 +26,8 @@ import org.mockito.ArgumentCaptor;
 
 class LauncherSessionTests {
 
-	LauncherSessionListener firstSessionListener = mock(LauncherSessionListener.class);
-	LauncherSessionListener secondSessionListener = mock(LauncherSessionListener.class);
+	LauncherSessionListener firstSessionListener = mock(LauncherSessionListener.class, "firstSessionListener");
+	LauncherSessionListener secondSessionListener = mock(LauncherSessionListener.class, "secondSessionListener");
 	LauncherConfig launcherConfig = createLauncherConfigBuilderWithDisabledServiceLoading() //
 			.addLauncherSessionListeners(firstSessionListener, secondSessionListener) //
 			.addTestEngines(new TestEngineStub()) //
@@ -44,22 +44,22 @@ class LauncherSessionTests {
 		var launcherSession = ArgumentCaptor.forClass(LauncherSession.class);
 		inOrder.verify(firstSessionListener).launcherSessionOpened(launcherSession.capture());
 		inOrder.verify(secondSessionListener).launcherSessionOpened(launcherSession.getValue());
-		inOrder.verify(firstSessionListener).launcherSessionClosed(launcherSession.getValue());
 		inOrder.verify(secondSessionListener).launcherSessionClosed(launcherSession.getValue());
+		inOrder.verify(firstSessionListener).launcherSessionClosed(launcherSession.getValue());
 
 		launcher.execute(testPlan);
 
 		inOrder.verify(firstSessionListener).launcherSessionOpened(launcherSession.capture());
 		inOrder.verify(secondSessionListener).launcherSessionOpened(launcherSession.getValue());
-		inOrder.verify(firstSessionListener).launcherSessionClosed(launcherSession.getValue());
 		inOrder.verify(secondSessionListener).launcherSessionClosed(launcherSession.getValue());
+		inOrder.verify(firstSessionListener).launcherSessionClosed(launcherSession.getValue());
 
 		launcher.execute(request);
 
 		inOrder.verify(firstSessionListener).launcherSessionOpened(launcherSession.capture());
 		inOrder.verify(secondSessionListener).launcherSessionOpened(launcherSession.getValue());
-		inOrder.verify(firstSessionListener).launcherSessionClosed(launcherSession.getValue());
 		inOrder.verify(secondSessionListener).launcherSessionClosed(launcherSession.getValue());
+		inOrder.verify(firstSessionListener).launcherSessionClosed(launcherSession.getValue());
 	}
 
 	@Test
@@ -87,8 +87,8 @@ class LauncherSessionTests {
 
 		session.close();
 
-		inOrder.verify(firstSessionListener).launcherSessionClosed(session);
 		inOrder.verify(secondSessionListener).launcherSessionClosed(session);
+		inOrder.verify(firstSessionListener).launcherSessionClosed(session);
 		verifyNoMoreInteractions(firstSessionListener, secondSessionListener);
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/CompositeLauncherDiscoveryListenerTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.discovery;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.SelectorResolutionResult;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.launcher.EngineDiscoveryResult;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.mockito.InOrder;
+
+class CompositeLauncherDiscoveryListenerTests {
+
+	@Test
+	void callsListenersInReverseOrderForFinishedEvents() {
+		var firstListener = mock(LauncherDiscoveryListener.class, "firstListener");
+		var secondListener = mock(LauncherDiscoveryListener.class, "secondListener");
+
+		var launcherDiscoveryRequest = mock(LauncherDiscoveryRequest.class);
+		var engineId = UniqueId.forEngine("engine");
+		var engineDiscoveryResult = EngineDiscoveryResult.successful();
+		var selector = selectUniqueId(engineId);
+		var selectorResolutionResult = SelectorResolutionResult.resolved();
+
+		var composite = new CompositeLauncherDiscoveryListener(List.of(firstListener, secondListener));
+		composite.launcherDiscoveryStarted(launcherDiscoveryRequest);
+		composite.engineDiscoveryStarted(engineId);
+		composite.selectorProcessed(engineId, selector, selectorResolutionResult);
+		composite.engineDiscoveryFinished(engineId, engineDiscoveryResult);
+		composite.launcherDiscoveryFinished(launcherDiscoveryRequest);
+
+		InOrder inOrder = inOrder(firstListener, secondListener);
+		inOrder.verify(firstListener).launcherDiscoveryStarted(launcherDiscoveryRequest);
+		inOrder.verify(secondListener).launcherDiscoveryStarted(launcherDiscoveryRequest);
+		inOrder.verify(firstListener).engineDiscoveryStarted(engineId);
+		inOrder.verify(secondListener).engineDiscoveryStarted(engineId);
+		inOrder.verify(secondListener).selectorProcessed(engineId, selector, selectorResolutionResult);
+		inOrder.verify(secondListener).engineDiscoveryFinished(engineId, engineDiscoveryResult);
+		inOrder.verify(firstListener).engineDiscoveryFinished(engineId, engineDiscoveryResult);
+		inOrder.verify(secondListener).launcherDiscoveryFinished(launcherDiscoveryRequest);
+		inOrder.verify(firstListener).launcherDiscoveryFinished(launcherDiscoveryRequest);
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/session/CompositeLauncherSessionListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/session/CompositeLauncherSessionListenerTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.listeners.session;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+import org.mockito.InOrder;
+
+public class CompositeLauncherSessionListenerTests {
+
+	@Test
+	void callsListenersInReverseOrderForClosedEvents() {
+		var firstListener = mock(LauncherSessionListener.class, "firstListener");
+		var secondListener = mock(LauncherSessionListener.class, "secondListener");
+
+		var launcherSession = mock(LauncherSession.class);
+
+		var composite = new CompositeLauncherSessionListener(List.of(firstListener, secondListener));
+		composite.launcherSessionOpened(launcherSession);
+		composite.launcherSessionClosed(launcherSession);
+
+		InOrder inOrder = inOrder(firstListener, secondListener);
+		inOrder.verify(firstListener).launcherSessionOpened(launcherSession);
+		inOrder.verify(secondListener).launcherSessionOpened(launcherSession);
+		inOrder.verify(secondListener).launcherSessionClosed(launcherSession);
+		inOrder.verify(firstListener).launcherSessionClosed(launcherSession);
+	}
+}


### PR DESCRIPTION
- Call TestExecutionListener finish methods in reverse order
- Call EngineExecutionListener.executionFinished method in reverse order
- Call LauncherDiscoveryListener.class finish methods in reverse order
- Call LauncherSessionListener closed method in reverse order
- Reuse CollectionUtils.forEachInReverseOrder
- Optimize common cases

Resolves #3082.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
