### PR TITLE
Document minimum requirements for test engines

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/engines.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/engines.adoc
@@ -79,8 +79,15 @@ For example, the `junit-jupiter-engine` module registers its
 `org.junit.platform.engine.TestEngine` within the `/META-INF/services` folder in the
 `junit-jupiter-engine` JAR.
 
-[[test-engines-minimum-requirements]]
-==== Minimum Requirements
+[[test-engines-requirements]]
+==== Requirements
+
+NOTE: The words "must", "must not", "required", "shall", "shall not", "should", "should
+not", "recommended",  "may", and "optional" in this section are to be interpreted as
+described in https://www.ietf.org/rfc/rfc2119.txt[RFC 2119.]
+
+[[test-engines-requirements-mandatory]]
+===== Mandatory requirements
 
 For interoperability with build tools and IDEs, `TestEngine` implementations must adhere
 to the following requirements:
@@ -88,13 +95,9 @@ to the following requirements:
 * The `TestDescriptor` returned from `TestEngine.discover()` _must_ be the root of a tree
   of `TestDescriptor` instances. This implies that there _must not_ be any cycles between
   a node and its descendants.
-* The root node _should_ have children rather than being completely dynamic. This allows
-  tools to display the structure of the tests and to select a subset of tests to execute.
 * A `TestEngine` _must_ be able to discover `UniqueIdSelectors` for any unique ID that it
   previously generated and returned from `TestEngine.discover()`. This enables selecting a
-  subset of tests to execute or rerun. It _should_ only return `TestDescriptor` instances
-  with matching unique IDs including their ancestors but _may_ return additional siblings
-  or other nodes that are required for the execution of the selected tests.
+  subset of tests to execute or rerun.
 * The `executionSkipped`, `executionStarted`, and `executionFinished` methods of the
   `EngineExecutionListener` passed to `TestEngine.execute()` _must_ be called for every
   `TestDescriptor` node in the tree returned from `TestEngine.discover()` at most
@@ -102,6 +105,18 @@ to the following requirements:
   after their children. If a node is reported as skipped, there _must not_ be any events
   reported for its descendants.
 
-NOTE: The words "must", "must not", "required", "shall", "shall not", "should", "should
-not", "recommended",  "may", and "optional" in this section are to be interpreted as
-described in https://www.ietf.org/rfc/rfc2119.txt[RFC 2119.]
+[[test-engines-requirements-enhanced-compatibility]]
+===== Enhanced compatibility
+
+Adhering to the following requirements is optional but recommended for enhanced
+compatibility with build tools and IDEs:
+
+* Unless to indicate an empty discovery result, the `TestDescriptor` returned from
+  `TestEngine.discover()` _should_ have children rather than being completely dynamic.
+  This allows tools to display the structure of the tests and to select a subset of tests
+  to execute.
+* When resolving `UniqueIdSelectors`, a `TestEngine` _should_ only return `TestDescriptor`
+  instances with matching unique IDs including their ancestors but _may_ return additional
+  siblings or other nodes that are required for the execution of the selected tests.
+* `TestEngines` _should_ support <<running-tests-tags, tagging>> tests and containers so
+  that tag filters can be applied when discovering tests.

--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/engines.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/engines.adoc
@@ -78,3 +78,30 @@ For example, the `junit-jupiter-engine` module registers its
 `org.junit.jupiter.engine.JupiterTestEngine` in a file named
 `org.junit.platform.engine.TestEngine` within the `/META-INF/services` folder in the
 `junit-jupiter-engine` JAR.
+
+[[test-engines-minimum-requirements]]
+==== Minimum Requirements
+
+For interoperability with build tools and IDEs, `TestEngine` implementations must adhere
+to the following requirements:
+
+* The `TestDescriptor` returned from `TestEngine.discover()` _must_ be the root of a tree
+  of `TestDescriptor` instances. This implies that there _must not_ be any cycles between
+  a node and its descendants.
+* The root node _should_ have children rather than being completely dynamic. This allows
+  tools to display the structure of the tests and to select a subset of tests to execute.
+* A `TestEngine` _must_ be able to discover `UniqueIdSelectors` for any unique ID that it
+  previously generated and returned from `TestEngine.discover()`. This enables selecting a
+  subset of tests to execute or rerun. It _should_ only return `TestDescriptor` instances
+  with matching unique IDs including their ancestors but _may_ return additional siblings
+  or other nodes that are required for the execution of the selected tests.
+* The `executionSkipped`, `executionStarted`, and `executionFinished` methods of the
+  `EngineExecutionListener` passed to `TestEngine.execute()` _must_ be called for every
+  `TestDescriptor` node in the tree returned from `TestEngine.discover()` at most
+  once. Parent nodes _must_ be reported as started before their children and as finished
+  after their children. If a node is reported as skipped, there _must not_ be any events
+  reported for its descendants.
+
+NOTE: The words "must", "must not", "required", "shall", "shall not", "should", "should
+not", "recommended",  "may", and "optional" in this section are to be interpreted as
+described in https://www.ietf.org/rfc/rfc2119.txt[RFC 2119.]


### PR DESCRIPTION
## Overview

This PR adds a section to the User Guide documenting the requirements for test engines for interoperability with IDEs and build tools.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
