### PR TITLE
Model parameters using org.gradlex.build-parameters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma = false
 ij_kotlin_allow_trailing_comma_on_call_site = false
+indent_style = tab

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -10,9 +10,9 @@ on:
       - '*'
 
 env:
-  ORG_GRADLE_PROJECT_enableTestDistribution: true
-  ORG_GRADLE_PROJECT_junitBuildCacheUsername: ${{ secrets.BUILD_CACHE_USERNAME }}
-  ORG_GRADLE_PROJECT_junitBuildCachePassword: ${{ secrets.BUILD_CACHE_PASSWORD }}
+  ENTERPRISE_ENABLETESTDISTRIBUTION: true
+  BUILDCACHE_USERNAME: ${{ secrets.BUILD_CACHE_USERNAME }}
+  BUILDCACHE_PASSWORD: ${{ secrets.BUILD_CACHE_PASSWORD }}
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ on:
       - '*'
 
 env:
-  ORG_GRADLE_PROJECT_enableTestDistribution: true
-  ORG_GRADLE_PROJECT_junitBuildCacheUsername: ${{ secrets.BUILD_CACHE_USERNAME }}
-  ORG_GRADLE_PROJECT_junitBuildCachePassword: ${{ secrets.BUILD_CACHE_PASSWORD }}
+  ENTERPRISE_ENABLETESTDISTRIBUTION: true
+  BUILDCACHE_USERNAME: ${{ secrets.BUILD_CACHE_USERNAME }}
+  BUILDCACHE_PASSWORD: ${{ secrets.BUILD_CACHE_PASSWORD }}
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Gradle
 .gradle
 /build/
-/*/build/
+/**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/build-logic/build-parameters/build.gradle.kts
+++ b/build-logic/build-parameters/build.gradle.kts
@@ -1,11 +1,10 @@
 plugins {
-	id("org.gradlex.build-parameters") version "1.4"
+	id("org.gradlex.build-parameters") version "1.4.1"
 }
 
 group = "org.junit.gradle"
 
 buildParameters {
-	enableValidation.set(false) // see https://github.com/gradlex-org/build-parameters/issues/80
 	bool("ci") {
 		description.set("Whether or not this build is running a CI environment")
 		defaultValue.set(false)

--- a/build-logic/build-parameters/build.gradle.kts
+++ b/build-logic/build-parameters/build.gradle.kts
@@ -15,7 +15,7 @@ buildParameters {
 			description.set("Username to authenticate with the remote build cache")
 			fromEnvironment()
 		}
-		string("Password") {
+		string("password") {
 			description.set("Password to authenticate with the remote build cache")
 			fromEnvironment()
 		}

--- a/build-logic/build-parameters/build.gradle.kts
+++ b/build-logic/build-parameters/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+	id("org.gradlex.build-parameters") version "1.4"
+}
+
+group = "org.junit.gradle"
+
+buildParameters {
+	enableValidation.set(false) // see https://github.com/gradlex-org/build-parameters/issues/80
+	bool("ci") {
+		description.set("Whether or not this build is running a CI environment")
+		defaultValue.set(false)
+		fromEnvironment()
+	}
+	group("buildCache") {
+		string("username") {
+			description.set("Username to authenticate with the remote build cache")
+			fromEnvironment()
+		}
+		string("Password") {
+			description.set("Password to authenticate with the remote build cache")
+			fromEnvironment()
+		}
+		string("url") {
+			description.set("URL to the remote build cache")
+			fromEnvironment()
+		}
+	}
+	group("enterprise") {
+		description.set("Parameters controlling Gradle Enterprise features")
+		bool("enableTestDistribution") {
+			description.set("Whether or not to use Test Distribution for executing tests")
+			defaultValue.set(false)
+			fromEnvironment()
+		}
+	}
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,1 @@
+include("build-parameters")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,8 @@
+import buildparameters.BuildParametersExtension
 import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
 
 pluginManagement {
+	includeBuild("build-logic")
 	repositories {
 		gradlePluginPortal()
 	}
@@ -23,6 +25,7 @@ plugins {
 	id("com.gradle.enterprise")
 	id("com.gradle.common-custom-user-data-gradle-plugin")
 	id("org.gradle.toolchains.foojay-resolver-convention")
+	id("build-parameters")
 }
 
 dependencyResolutionManagement {
@@ -37,15 +40,11 @@ dependencyResolutionManagement {
 }
 
 val gradleEnterpriseServer = "https://ge.junit.org"
-val isCiServer = System.getenv("CI") != null
-val junitBuildCacheUrl: String? by extra
-val junitBuildCacheUsername: String? by extra
-val junitBuildCachePassword: String? by extra
 
 gradleEnterprise {
 	buildScan {
 		capture.isTaskInputFiles = true
-		isUploadInBackground = !isCiServer
+		isUploadInBackground = !buildParameters.ci
 
 		publishAlways()
 
@@ -57,7 +56,7 @@ gradleEnterprise {
 		}
 
 		obfuscation {
-			if (isCiServer) {
+			if (buildParameters.ci) {
 				username { "github" }
 			} else {
 				hostname { null }
@@ -65,10 +64,7 @@ gradleEnterprise {
 			}
 		}
 
-		val enableTestDistribution = providers.gradleProperty("enableTestDistribution")
-			.map(String::toBoolean)
-			.getOrElse(false)
-		if (enableTestDistribution) {
+		if (buildParameters.enterprise.enableTestDistribution) {
 			tag("test-distribution")
 		}
 	}
@@ -76,14 +72,14 @@ gradleEnterprise {
 
 buildCache {
 	local {
-		isEnabled = !isCiServer
+		isEnabled = !buildParameters.ci
 	}
 	remote<HttpBuildCache> {
-		url = uri(junitBuildCacheUrl ?: "$gradleEnterpriseServer/cache/")
-		isPush = isCiServer && !junitBuildCacheUsername.isNullOrEmpty() && !junitBuildCachePassword.isNullOrEmpty()
+		url = uri(buildParameters.buildCache.url.getOrElse("$gradleEnterpriseServer/cache/"))
+		isPush = buildParameters.ci && buildParameters.buildCache.username.isPresent && buildParameters.buildCache.password.isPresent
 		credentials {
-			username = junitBuildCacheUsername?.ifEmpty { null }
-			password = junitBuildCachePassword?.ifEmpty { null }
+			username = buildParameters.buildCache.username.orNull
+			password = buildParameters.buildCache.password.orNull
 		}
 	}
 }
@@ -130,5 +126,8 @@ rootProject.children.forEach { project ->
 		"${project.buildFile} must exist"
 	}
 }
+
+val buildParameters: BuildParametersExtension
+	get() = the()
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Introduces the org.gradlex.build-parameters plugin to model parameters
that can be supplied to this build. For that an included build is added
that contains the parameter configurations. It's necessary to put this
into an included build instead of buildSrc because buildSrc can not
build plugins that can be applied to the settings script.

The details on how to conncet to the remote build cache as well as the
enablement of test distribution are then read from the
BuildParametersExtension in settings.gradle.kts. Injection of the
parameters on CI now uses auto-generated environment variable look up
provided by the build parameters plugin.

The next step would be to also model parameters used in other parts of
the build logic using the build parameters plugin. This however requires
a larger refactoring of buildSrc because buildSrc can only depend on
included build modules that are included via Settings.includeBuild, but
we need to include the build-logic build via
pluginManagement.includeBuild due to the reasons stated in the
beginning.
