### PR TITLE
Add support for concrete Collection/Map types to EmptySource

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -62,6 +62,8 @@ repository on GitHub.
   `@ParameterizedTest` invocation.
 * `DisplayNameGenerator` methods are now allowed to return `null`, in order to signal
   to fall back to the default display name generator.
+* `@EmptySource` now supports additional types, including `Collection` and `Map` subtypes
+  with a public no-arg constructor.
 
 
 [[release-notes-5.10.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1257,10 +1257,12 @@ for parameterized tests that accept a single argument.
   method.
    - `@NullSource` cannot be used for a parameter that has a primitive type.
 * `{EmptySource}`: provides a single _empty_ argument to the annotated `@ParameterizedTest`
-  method for parameters of the following types: `java.lang.String`, `java.util.List`,
-  `java.util.Set`, `java.util.Map`, primitive arrays (e.g., `int[]`, `char[][]`, etc.),
-  object arrays (e.g.,`String[]`, `Integer[][]`, etc.).
-   - Subtypes of the supported types are not supported.
+  method for parameters of the following types: `java.lang.String`, `java.util.Collection`
+  and subtypes with a public no-arg constructor, `java.util.List`, `java.util.Set`,
+  `java.util.SortedSet`, `java.util.NavigableSet`, `java.util.Map` and subtypes with a
+  public no-arg constructor, `java.util.SortedMap`, `java.util.NavigableMap`, primitive
+  arrays (e.g., `int[]`, `char[][]`, etc.), object arrays (e.g.,`String[]`, `Integer[][]`,
+  etc.).
 * `{NullAndEmptySource}`: a _composed annotation_ that combines the functionality of
   `@NullSource` and `@EmptySource`.
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyArgumentsProvider.java
@@ -11,13 +11,21 @@
 package org.junit.jupiter.params.provider;
 
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.junit.platform.commons.util.ReflectionUtils.newInstance;
 
 import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -44,14 +52,35 @@ class EmptyArgumentsProvider implements ArgumentsProvider {
 		if (String.class.equals(parameterType)) {
 			return Stream.of(arguments(""));
 		}
+		if (Collection.class.equals(parameterType)) {
+			return Stream.of(arguments(Collections.emptySet()));
+		}
 		if (List.class.equals(parameterType)) {
 			return Stream.of(arguments(Collections.emptyList()));
 		}
 		if (Set.class.equals(parameterType)) {
 			return Stream.of(arguments(Collections.emptySet()));
 		}
+		if (SortedSet.class.equals(parameterType)) {
+			return Stream.of(arguments(Collections.emptySortedSet()));
+		}
+		if (NavigableSet.class.equals(parameterType)) {
+			return Stream.of(arguments(Collections.emptyNavigableSet()));
+		}
 		if (Map.class.equals(parameterType)) {
 			return Stream.of(arguments(Collections.emptyMap()));
+		}
+		if (SortedMap.class.equals(parameterType)) {
+			return Stream.of(arguments(Collections.emptySortedMap()));
+		}
+		if (NavigableMap.class.equals(parameterType)) {
+			return Stream.of(arguments(Collections.emptyNavigableMap()));
+		}
+		if (Collection.class.isAssignableFrom(parameterType) || Map.class.isAssignableFrom(parameterType)) {
+			Optional<Constructor<?>> defaultConstructor = getDefaultConstructor(parameterType);
+			if (defaultConstructor.isPresent()) {
+				return Stream.of(arguments(newInstance(defaultConstructor.get())));
+			}
 		}
 		if (parameterType.isArray()) {
 			Object array = Array.newInstance(parameterType.getComponentType(), 0);
@@ -61,6 +90,15 @@ class EmptyArgumentsProvider implements ArgumentsProvider {
 		throw new PreconditionViolationException(
 			String.format("@EmptySource cannot provide an empty argument to method [%s]: [%s] is not a supported type.",
 				testMethod.toGenericString(), parameterType.getName()));
+	}
+
+	private static Optional<Constructor<?>> getDefaultConstructor(Class<?> clazz) {
+		try {
+			return Optional.of(clazz.getConstructor());
+		}
+		catch (NoSuchMethodException e) {
+			return Optional.empty();
+		}
 	}
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptySource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptySource.java
@@ -27,13 +27,18 @@ import org.apiguardian.api.API;
  * <h2>Supported Parameter Types</h2>
  *
  * <p>This argument source will only provide an empty argument for the following
- * method parameter types. Subtypes of the supported types are not supported.
+ * method parameter types.
  *
  * <ul>
  * <li>{@link java.lang.String}</li>
+ * <li>{@link java.util.Collection} and subtypes with a public no-arg constructor</li>
  * <li>{@link java.util.List}</li>
  * <li>{@link java.util.Set}</li>
- * <li>{@link java.util.Map}</li>
+ * <li>{@link java.util.SortedSet}</li>
+ * <li>{@link java.util.NavigableSet}</li>
+ * <li>{@link java.util.Map} and subtypes with a public no-arg constructor</li>
+ * <li>{@link java.util.SortedMap}</li>
+ * <li>{@link java.util.NavigableMap}</li>
  * <li>primitive arrays &mdash; for example {@code int[]}, {@code char[][]}, etc.</li>
  * <li>object arrays &mdash; for example {@code String[]}, {@code Integer[][]}, etc.</li>
  * </ul>

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -43,12 +43,21 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
@@ -459,9 +468,31 @@ class ParameterizedTestIntegrationTests {
 			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=")));
 		}
 
+		/**
+		 * @since 5.10
+		 */
+		@Test
+		void executesWithEmptySourceForCollection() {
+			var results = execute("testWithEmptySourceForCollection", Collection.class);
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
+		}
+
 		@Test
 		void executesWithEmptySourceForList() {
 			var results = execute("testWithEmptySourceForList", List.class);
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
+		}
+
+		/**
+		 * @since 5.10
+		 */
+		@ParameterizedTest(name = "{1}")
+		@CsvSource({ //
+				"testWithEmptySourceForArrayList, java.util.ArrayList", //
+				"testWithEmptySourceForLinkedList, java.util.LinkedList"//
+		})
+		void executesWithEmptySourceForListSubtype(String methodName, Class<?> parameterType) {
+			var results = execute(methodName, parameterType);
 			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
 		}
 
@@ -471,9 +502,41 @@ class ParameterizedTestIntegrationTests {
 			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
 		}
 
+		/**
+		 * @since 5.10
+		 */
+		@ParameterizedTest(name = "{1}")
+		@CsvSource({ //
+				"testWithEmptySourceForSortedSet, java.util.SortedSet", //
+				"testWithEmptySourceForNavigableSet, java.util.NavigableSet", //
+				"testWithEmptySourceForHashSet, java.util.HashSet", //
+				"testWithEmptySourceForTreeSet, java.util.TreeSet", //
+				"testWithEmptySourceForLinkedHashSet, java.util.LinkedHashSet"//
+		})
+		void executesWithEmptySourceForSetSubtype(String methodName, Class<?> parameterType) {
+			var results = execute(methodName, parameterType);
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument=[]")));
+		}
+
 		@Test
 		void executesWithEmptySourceForMap() {
 			var results = execute("testWithEmptySourceForMap", Map.class);
+			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument={}")));
+		}
+
+		/**
+		 * @since 5.10
+		 */
+		@ParameterizedTest(name = "{1}")
+		@CsvSource({ //
+				"testWithEmptySourceForSortedMap, java.util.SortedMap", //
+				"testWithEmptySourceForNavigableMap, java.util.NavigableMap", //
+				"testWithEmptySourceForHashMap, java.util.HashMap", //
+				"testWithEmptySourceForTreeMap, java.util.TreeMap", //
+				"testWithEmptySourceForLinkedHashMap, java.util.LinkedHashMap"//
+		})
+		void executesWithEmptySourceForMapSubtype(String methodName, Class<?> parameterType) {
+			var results = execute(methodName, parameterType);
 			results.testEvents().succeeded().assertEventsMatchExactly(event(test(), displayName("[1] argument={}")));
 		}
 
@@ -515,10 +578,7 @@ class ParameterizedTestIntegrationTests {
 		@ParameterizedTest(name = "{1}")
 		@CsvSource({ //
 				"testWithEmptySourceForPrimitive, int", //
-				"testWithEmptySourceForUnsupportedReferenceType, java.lang.Integer", //
-				"testWithEmptySourceForUnsupportedListSubtype, java.util.ArrayList", //
-				"testWithEmptySourceForUnsupportedSetSubtype, java.util.HashSet", //
-				"testWithEmptySourceForUnsupportedMapSubtype, java.util.HashMap"//
+				"testWithEmptySourceForUnsupportedReferenceType, java.lang.Integer"//
 		})
 		void failsWithEmptySourceForUnsupportedType(String methodName, Class<?> parameterType) {
 			execute(methodName, parameterType).containerEvents().failed().assertEventsMatchExactly(//
@@ -558,6 +618,12 @@ class ParameterizedTestIntegrationTests {
 		@Test
 		void executesWithNullAndEmptySourceForList() {
 			var results = execute("testWithNullAndEmptySourceForList", List.class);
+			assertNullAndEmpty(results);
+		}
+
+		@Test
+		void executesWithNullAndEmptySourceForArrayList() {
+			var results = execute("testWithNullAndEmptySourceForArrayList", ArrayList.class);
 			assertNullAndEmpty(results);
 		}
 
@@ -984,7 +1050,25 @@ class ParameterizedTestIntegrationTests {
 
 		@ParameterizedTest
 		@EmptySource
+		void testWithEmptySourceForCollection(Collection<?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
 		void testWithEmptySourceForList(List<?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForArrayList(ArrayList<?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForLinkedList(LinkedList<?> argument) {
 			assertThat(argument).isEmpty();
 		}
 
@@ -996,7 +1080,67 @@ class ParameterizedTestIntegrationTests {
 
 		@ParameterizedTest
 		@EmptySource
+		void testWithEmptySourceForSortedSet(SortedSet<?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForNavigableSet(NavigableSet<?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForHashSet(HashSet<?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForTreeSet(TreeSet<?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForLinkedHashSet(LinkedHashSet<?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
 		void testWithEmptySourceForMap(Map<?, ?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForSortedMap(SortedMap<?, ?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForNavigableMap(NavigableMap<?, ?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForHashMap(HashMap<?, ?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForTreeMap(TreeMap<?, ?> argument) {
+			assertThat(argument).isEmpty();
+		}
+
+		@ParameterizedTest
+		@EmptySource
+		void testWithEmptySourceForLinkedHashMap(LinkedHashMap<?, ?> argument) {
 			assertThat(argument).isEmpty();
 		}
 
@@ -1042,24 +1186,6 @@ class ParameterizedTestIntegrationTests {
 			fail("should not have been executed");
 		}
 
-		@ParameterizedTest
-		@EmptySource
-		void testWithEmptySourceForUnsupportedListSubtype(ArrayList<?> argument) {
-			fail("should not have been executed");
-		}
-
-		@ParameterizedTest
-		@EmptySource
-		void testWithEmptySourceForUnsupportedSetSubtype(HashSet<?> argument) {
-			fail("should not have been executed");
-		}
-
-		@ParameterizedTest
-		@EmptySource
-		void testWithEmptySourceForUnsupportedMapSubtype(HashMap<?, ?> argument) {
-			fail("should not have been executed");
-		}
-
 	}
 
 	static class NullAndEmptySourceTestCase {
@@ -1080,6 +1206,12 @@ class ParameterizedTestIntegrationTests {
 		@ParameterizedTest
 		@NullAndEmptySource
 		void testWithNullAndEmptySourceForList(List<?> argument) {
+			assertTrue(argument == null || argument.isEmpty());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		void testWithNullAndEmptySourceForArrayList(ArrayList<?> argument) {
 			assertTrue(argument == null || argument.isEmpty());
 		}
 


### PR DESCRIPTION
## Overview

Fixes #2791.

This adds support for:
* `Collection` and subtypes with a public no-arg constructor
* `SortedSet`
* `NavigableSet`
* `Map` subtypes with a public no-arg constructor
* `SortedMap`
* `NavigableMap`

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
