### PR TITLE
Add ConsoleLauncher option to print discovery result

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -75,6 +75,10 @@ public class ConsoleLauncher {
 			if (!options.isBannerDisabled()) {
 				displayBanner(out);
 			}
+			if (options.isListTests()) {
+				listTests(options, out);
+				return ConsoleLauncherExecutionResult.success();
+			}
 			if (options.isDisplayHelp()) {
 				commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
 				return ConsoleLauncherExecutionResult.success();
@@ -113,6 +117,21 @@ public class ConsoleLauncher {
 		engine.getArtifactId().ifPresent(details::add);
 		engine.getVersion().ifPresent(details::add);
 		out.println(engine.getId() + details);
+	}
+
+	private void listTests(CommandLineOptions options, PrintWriter out) {
+		try {
+			// Should tests always be printed like a tree?
+			// options.setDetails(Details.TREE);
+			// scan all directories
+			options.setScanClasspath(true);
+			new ConsoleTestExecutor(options).list(out);
+		}
+		catch (Exception exception) {
+			exception.printStackTrace(err);
+			err.println();
+			commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
+		}
 	}
 
 	private ConsoleLauncherExecutionResult executeTests(CommandLineOptions options, PrintWriter out) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -120,7 +120,7 @@ public class ConsoleLauncher {
 
 	private ConsoleLauncherExecutionResult listTests(CommandLineOptions options, PrintWriter out) {
 		try {
-			new ConsoleTestExecutor(options).list(out);
+			new ConsoleTestExecutor(options).discover(out);
 			return ConsoleLauncherExecutionResult.success();
 		}
 		catch (Exception exception) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -76,8 +76,7 @@ public class ConsoleLauncher {
 				displayBanner(out);
 			}
 			if (options.isListTests()) {
-				listTests(options, out);
-				return ConsoleLauncherExecutionResult.success();
+				return listTests(options, out);
 			}
 			if (options.isDisplayHelp()) {
 				commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
@@ -119,18 +118,13 @@ public class ConsoleLauncher {
 		out.println(engine.getId() + details);
 	}
 
-	private void listTests(CommandLineOptions options, PrintWriter out) {
+	private ConsoleLauncherExecutionResult listTests(CommandLineOptions options, PrintWriter out) {
 		try {
-			// Should tests always be printed like a tree?
-			// options.setDetails(Details.TREE);
-			// scan all directories
-			options.setScanClasspath(true);
 			new ConsoleTestExecutor(options).list(out);
+			return ConsoleLauncherExecutionResult.success();
 		}
 		catch (Exception exception) {
-			exception.printStackTrace(err);
-			err.println();
-			commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
+			return handleTestExecutorException(exception, options);
 		}
 	}
 
@@ -140,11 +134,16 @@ public class ConsoleLauncher {
 			return ConsoleLauncherExecutionResult.forSummary(testExecutionSummary, options);
 		}
 		catch (Exception exception) {
-			exception.printStackTrace(err);
-			err.println();
-			commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
-			return ConsoleLauncherExecutionResult.failed();
+			return handleTestExecutorException(exception, options);
 		}
+	}
+
+	private ConsoleLauncherExecutionResult handleTestExecutorException(Exception exception,
+			CommandLineOptions options) {
+		exception.printStackTrace(err);
+		err.println();
+		commandLineOptionsParser.printHelp(out, options.isAnsiColorOutputDisabled());
+		return ConsoleLauncherExecutionResult.failed();
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AvailableOptions.java
@@ -85,11 +85,15 @@ class AvailableOptions {
 		@Option(names = { "--h", "-help" }, help = true, hidden = true)
 		private boolean helpRequested2;
 
+		@Option(names = { "--list-tests" }, description = "List all observable tests.")
+		private boolean listTestsRequested;
+
 		@Option(names = { "--list-engines" }, description = "List all observable test engines.")
 		private boolean listEnginesRequested;
 
 		private void applyTo(CommandLineOptions result) {
 			result.setDisplayHelp(this.helpRequested || this.helpRequested2);
+			result.setListTests(this.listTestsRequested);
 			result.setListEngines(this.listEnginesRequested);
 		}
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandLineOptions.java
@@ -49,6 +49,7 @@ public class CommandLineOptions {
 
 	private boolean displayHelp;
 	private boolean listEngines;
+	private boolean listTests;
 	private boolean ansiColorOutputDisabled;
 	private Path colorPalettePath;
 	private boolean isSingleColorPalette;
@@ -100,6 +101,14 @@ public class CommandLineOptions {
 
 	public void setListEngines(boolean listEngines) {
 		this.listEngines = listEngines;
+	}
+
+	public boolean isListTests() {
+		return listTests;
+	}
+
+	public void setListTests(boolean listTests) {
+		this.listTests = listTests;
 	}
 
 	public boolean isAnsiColorOutputDisabled() {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -74,7 +74,9 @@ public class ConsoleTestExecutor {
 		TestPlan testPlan = launcher.discover(discoveryRequest);
 
 		commandLineTestPrinter.ifPresent(printer -> printer.listTests(testPlan));
-		printFoundTestsSummary(out, testPlan);
+		if (options.getDetails() != Details.NONE) {
+			printFoundTestsSummary(out, testPlan);
+		}
 	}
 
 	private static void printFoundTestsSummary(PrintWriter out, TestPlan testPlan) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -16,7 +16,6 @@ import java.io.PrintWriter;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -31,7 +30,6 @@ import org.junit.platform.console.options.Theme;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
@@ -57,8 +55,8 @@ public class ConsoleTestExecutor {
 		this.launcherSupplier = launcherSupplier;
 	}
 
-	public void list(PrintWriter out) throws Exception {
-		new CustomContextClassLoaderExecutor(createCustomClassLoader()).invoke(() -> listTests(out));
+	public Void list(PrintWriter out) throws Exception {
+		return new CustomContextClassLoaderExecutor(createCustomClassLoader()).invoke(() -> listTests(out));
 	}
 
 	public TestExecutionSummary execute(PrintWriter out) throws Exception {
@@ -67,22 +65,13 @@ public class ConsoleTestExecutor {
 
 	private Void listTests(PrintWriter out) {
 		Launcher launcher = launcherSupplier.get();
-		TestExecutionListener testExecutionListener = createDetailsPrintingListener(out).get();
-		launcher.registerTestExecutionListeners(testExecutionListener);
+		Optional<DetailsPrintingListener> commandLineTestPrinter = createDetailsPrintingListener(out);
 
 		LauncherDiscoveryRequest discoveryRequest = new DiscoveryRequestCreator().toDiscoveryRequest(options);
 		TestPlan testPlan = launcher.discover(discoveryRequest);
 
-		testExecutionListener.testPlanExecutionStarted(testPlan);
-		skipTests(testPlan.getAllIdentifiers().values(), testExecutionListener);
-		testExecutionListener.testPlanExecutionFinished(testPlan);
+		commandLineTestPrinter.ifPresent(printer -> printer.listTests(testPlan));
 		return null;
-	}
-
-	private void skipTests(Collection<TestIdentifier> tests, TestExecutionListener testExecutionListener) {
-		for (TestIdentifier testIdentifier : tests) {
-			testExecutionListener.executionSkipped(testIdentifier, "");
-		}
 	}
 
 	private TestExecutionSummary executeTests(PrintWriter out) {
@@ -131,7 +120,7 @@ public class ConsoleTestExecutor {
 		return summaryListener;
 	}
 
-	private Optional<TestExecutionListener> createDetailsPrintingListener(PrintWriter out) {
+	private Optional<DetailsPrintingListener> createDetailsPrintingListener(PrintWriter out) {
 		ColorPalette colorPalette = getColorPalette();
 		Theme theme = options.getTheme();
 		switch (options.getDetails()) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DetailsPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DetailsPrintingListener.java
@@ -15,6 +15,6 @@ import org.junit.platform.launcher.TestPlan;
 
 public interface DetailsPrintingListener extends TestExecutionListener {
 
-    void listTests(TestPlan testPlan);
+	void listTests(TestPlan testPlan);
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DetailsPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DetailsPrintingListener.java
@@ -10,9 +10,16 @@
 
 package org.junit.platform.console.tasks;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
 
+/**
+ * @since 1.9
+ */
+@API(status = EXPERIMENTAL, since = "1.9")
 public interface DetailsPrintingListener extends TestExecutionListener {
 
 	void listTests(TestPlan testPlan);

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DetailsPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DetailsPrintingListener.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console.tasks;
+
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+
+public interface DetailsPrintingListener extends TestExecutionListener {
+
+    void listTests(TestPlan testPlan);
+
+}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
@@ -107,8 +107,9 @@ class FlatPrintingListener implements DetailsPrintingListener {
 
 	@Override
 	public void listTests(TestPlan testPlan) {
-		for (TestIdentifier testIdentifier : testPlan.getAllIdentifiers().values()) {
-			println(Style.SUCCESSFUL, "%s (%s)", testIdentifier.getDisplayName(), testIdentifier.getUniqueId());
+		for (TestIdentifier testIdentifier : testPlan) {
+			println(Style.valueOf(testIdentifier), "%s (%s)", testIdentifier.getDisplayName(),
+				testIdentifier.getUniqueId());
 		}
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
@@ -107,9 +107,12 @@ class FlatPrintingListener implements DetailsPrintingListener {
 
 	@Override
 	public void listTests(TestPlan testPlan) {
-		for (TestIdentifier testIdentifier : testPlan) {
-			println(Style.valueOf(testIdentifier), "%s (%s)", testIdentifier.getDisplayName(),
-				testIdentifier.getUniqueId());
-		}
+		testPlan.accept(new TestPlan.Visitor() {
+			@Override
+			public void visit(TestIdentifier testIdentifier) {
+				println(Style.valueOf(testIdentifier), "%s (%s)", testIdentifier.getDisplayName(),
+					testIdentifier.getUniqueId());
+			}
+		});
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
@@ -16,14 +16,13 @@ import java.util.regex.Pattern;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
-import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
  * @since 1.0
  */
-class FlatPrintingListener implements TestExecutionListener {
+class FlatPrintingListener implements DetailsPrintingListener {
 
 	private static final Pattern LINE_START_PATTERN = Pattern.compile("(?m)^");
 
@@ -106,4 +105,10 @@ class FlatPrintingListener implements TestExecutionListener {
 		return LINE_START_PATTERN.matcher(message).replaceAll(INDENTATION).trim();
 	}
 
+	@Override
+	public void listTests(TestPlan testPlan) {
+		for (TestIdentifier testIdentifier : testPlan.getAllIdentifiers().values()) {
+			println(Style.SUCCESSFUL, "%s (%s)", testIdentifier.getDisplayName(), testIdentifier.getUniqueId());
+		}
+	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrinter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrinter.java
@@ -67,6 +67,10 @@ class TreePrinter {
 		String caption = colorCaption(node);
 		String duration = color(Style.CONTAINER, node.duration + " ms");
 		String icon = color(Style.SKIPPED, theme.skipped());
+		boolean nodeIsBeingListed = node.duration == 0 && !node.result().isPresent() && !node.reason().isPresent();
+		if (nodeIsBeingListed) {
+			icon = color(Style.SKIPPED, theme.blank());
+		}
 		if (node.result().isPresent()) {
 			TestExecutionResult result = node.result().get();
 			Style resultStyle = Style.valueOf(result);

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrinter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrinter.java
@@ -67,10 +67,6 @@ class TreePrinter {
 		String caption = colorCaption(node);
 		String duration = color(Style.CONTAINER, node.duration + " ms");
 		String icon = color(Style.SKIPPED, theme.skipped());
-		boolean nodeIsBeingListed = node.duration == 0 && !node.result().isPresent() && !node.reason().isPresent();
-		if (nodeIsBeingListed) {
-			icon = color(Style.SKIPPED, theme.blank());
-		}
 		if (node.result().isPresent()) {
 			TestExecutionResult result = node.result().get();
 			Style resultStyle = Style.valueOf(result);
@@ -83,8 +79,11 @@ class TreePrinter {
 			out.print(" ");
 			out.print(duration);
 		}
-		out.print(" ");
-		out.print(icon);
+		boolean nodeIsBeingListed = node.duration == 0 && !node.result().isPresent() && !node.reason().isPresent();
+		if (!nodeIsBeingListed) {
+			out.print(" ");
+			out.print(icon);
+		}
 		node.result().ifPresent(result -> printThrowable(tabbed, result));
 		node.reason().ifPresent(reason -> printMessage(Style.SKIPPED, tabbed, reason));
 		node.reports.forEach(e -> printReportEntry(tabbed, e));

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
@@ -78,13 +78,13 @@ class TreePrintingListener implements DetailsPrintingListener {
 	@Override
 	public void listTests(TestPlan testPlan) {
 		root = new TreeNode(testPlan.toString());
-		listTests(testPlan.getAllIdentifiers());
+		testPlan.getRoots().forEach(testIdentifier -> addRecursively(testPlan, testIdentifier));
 		treePrinter.print(root);
 	}
 
-	private void listTests(Map<UniqueId, TestIdentifier> testIdentifiers) {
-		for (TestIdentifier testIdentifier : testIdentifiers.values()) {
-			addNode(testIdentifier, () -> new TreeNode(testIdentifier));
-		}
+	private void addRecursively(TestPlan testPlan, TestIdentifier testIdentifier) {
+		addNode(testIdentifier, () -> new TreeNode(testIdentifier));
+		testPlan.getChildren(testIdentifier.getUniqueIdObject()) //
+				.forEach(child -> addRecursively(testPlan, child));
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
@@ -76,7 +76,12 @@ class TreePrintingListener implements DetailsPrintingListener {
 	@Override
 	public void listTests(TestPlan testPlan) {
 		root = new TreeNode(testPlan.toString());
-		testPlan.forEach(testIdentifier -> addNode(testIdentifier, new TreeNode(testIdentifier)));
+		testPlan.accept(new TestPlan.Visitor() {
+			@Override
+			public void visit(TestIdentifier testIdentifier) {
+				addNode(testIdentifier, new TreeNode(testIdentifier));
+			}
+		});
 		treePrinter.print(root);
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
@@ -78,13 +78,7 @@ class TreePrintingListener implements DetailsPrintingListener {
 	@Override
 	public void listTests(TestPlan testPlan) {
 		root = new TreeNode(testPlan.toString());
-		testPlan.getRoots().forEach(testIdentifier -> addRecursively(testPlan, testIdentifier));
+		testPlan.forEach(testIdentifier -> addNode(testIdentifier, () -> new TreeNode(testIdentifier)));
 		treePrinter.print(root);
-	}
-
-	private void addRecursively(TestPlan testPlan, TestIdentifier testIdentifier) {
-		addNode(testIdentifier, () -> new TreeNode(testIdentifier));
-		testPlan.getChildren(testIdentifier.getUniqueIdObject()) //
-				.forEach(child -> addRecursively(testPlan, child));
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
@@ -13,7 +13,6 @@ package org.junit.platform.console.tasks;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
@@ -35,8 +34,7 @@ class TreePrintingListener implements DetailsPrintingListener {
 		this.treePrinter = new TreePrinter(out, theme, colorPalette);
 	}
 
-	private void addNode(TestIdentifier testIdentifier, Supplier<TreeNode> nodeSupplier) {
-		TreeNode node = nodeSupplier.get();
+	private void addNode(TestIdentifier testIdentifier, TreeNode node) {
 		nodesByUniqueId.put(testIdentifier.getUniqueIdObject(), node);
 		testIdentifier.getParentIdObject().map(nodesByUniqueId::get).orElse(root).addChild(node);
 	}
@@ -57,7 +55,7 @@ class TreePrintingListener implements DetailsPrintingListener {
 
 	@Override
 	public void executionStarted(TestIdentifier testIdentifier) {
-		addNode(testIdentifier, () -> new TreeNode(testIdentifier));
+		addNode(testIdentifier, new TreeNode(testIdentifier));
 	}
 
 	@Override
@@ -67,7 +65,7 @@ class TreePrintingListener implements DetailsPrintingListener {
 
 	@Override
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-		addNode(testIdentifier, () -> new TreeNode(testIdentifier, reason));
+		addNode(testIdentifier, new TreeNode(testIdentifier, reason));
 	}
 
 	@Override
@@ -78,7 +76,7 @@ class TreePrintingListener implements DetailsPrintingListener {
 	@Override
 	public void listTests(TestPlan testPlan) {
 		root = new TreeNode(testPlan.toString());
-		testPlan.forEach(testIdentifier -> addNode(testIdentifier, () -> new TreeNode(testIdentifier)));
+		testPlan.forEach(testIdentifier -> addNode(testIdentifier, new TreeNode(testIdentifier)));
 		treePrinter.print(root);
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrintingListener.java
@@ -19,14 +19,13 @@ import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
-import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
  * @since 1.0
  */
-class TreePrintingListener implements TestExecutionListener {
+class TreePrintingListener implements DetailsPrintingListener {
 
 	private final Map<UniqueId, TreeNode> nodesByUniqueId = new ConcurrentHashMap<>();
 	private TreeNode root;
@@ -76,4 +75,16 @@ class TreePrintingListener implements TestExecutionListener {
 		getNode(testIdentifier).addReportEntry(entry);
 	}
 
+	@Override
+	public void listTests(TestPlan testPlan) {
+		root = new TreeNode(testPlan.toString());
+		listTests(testPlan.getAllIdentifiers());
+		treePrinter.print(root);
+	}
+
+	private void listTests(Map<UniqueId, TestIdentifier> testIdentifiers) {
+		for (TestIdentifier testIdentifier : testIdentifiers.values()) {
+			addNode(testIdentifier, () -> new TreeNode(testIdentifier));
+		}
+	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/VerboseTreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/VerboseTreePrintingListener.java
@@ -71,6 +71,12 @@ class VerboseTreePrintingListener implements DetailsPrintingListener {
 		printNumberOfTests(testPlan, "Test plan execution finished. Number of all tests: ");
 	}
 
+	private void printNumberOfTests(TestPlan testPlan, String prefix) {
+		long tests = testPlan.countTestIdentifiers(TestIdentifier::isTest);
+		printf(NONE, "%s", prefix);
+		printf(Style.TEST, "%d%n", tests);
+	}
+
 	@Override
 	public void executionStarted(TestIdentifier testIdentifier) {
 		this.executionStartedMillis = System.currentTimeMillis();
@@ -215,13 +221,5 @@ class VerboseTreePrintingListener implements DetailsPrintingListener {
 			}
 		});
 		frames.pop();
-
-		printNumberOfTests(testPlan, "Number of static tests: ");
-	}
-
-	private void printNumberOfTests(TestPlan testPlan, String prefix) {
-		long tests = testPlan.countTestIdentifiers(TestIdentifier::isTest);
-		printf(NONE, "%s", prefix);
-		printf(Style.TEST, "%d%n", tests);
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/VerboseTreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/VerboseTreePrintingListener.java
@@ -20,14 +20,13 @@ import java.util.Deque;
 import org.junit.platform.console.options.Theme;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
-import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 /**
  * @since 1.0
  */
-class VerboseTreePrintingListener implements TestExecutionListener {
+class VerboseTreePrintingListener implements DetailsPrintingListener {
 
 	private final PrintWriter out;
 	private final Theme theme;
@@ -186,4 +185,12 @@ class VerboseTreePrintingListener implements TestExecutionListener {
 		printf(NONE, "%n");
 	}
 
+	@Override
+	public void listTests(TestPlan testPlan) {
+		for (TestIdentifier testIdentifier : testPlan.getAllIdentifiers().values()) {
+			printVerticals(theme.entry());
+			printf(Style.valueOf(testIdentifier), " %s%n", testIdentifier.getDisplayName());
+			printDetails(testIdentifier);
+		}
+	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -266,6 +266,10 @@ public class TestPlan {
 		return unmodifiableSet(result);
 	}
 
+	public Map<UniqueId, TestIdentifier> getAllIdentifiers() {
+		return this.allIdentifiers;
+	}
+
 	/**
 	 * Return whether this test plan contains any tests.
 	 *

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -19,14 +19,8 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -65,7 +59,7 @@ import org.junit.platform.engine.UniqueId;
  * @see TestExecutionListener
  */
 @API(status = STABLE, since = "1.0")
-public class TestPlan implements Iterable<TestIdentifier> {
+public class TestPlan {
 
 	private final Set<TestIdentifier> roots = synchronizedSet(new LinkedHashSet<>(4));
 
@@ -301,11 +295,6 @@ public class TestPlan implements Iterable<TestIdentifier> {
 		return this.configurationParameters;
 	}
 
-	@Override
-	public Iterator<TestIdentifier> iterator() {
-		return new DepthFirstIterator(getRoots());
-	}
-
 	/**
 	 * Accept the supplied {@link Visitor} for a depth-first traversal of the
 	 * test plan.
@@ -324,29 +313,6 @@ public class TestPlan implements Iterable<TestIdentifier> {
 		getChildren(testIdentifier).forEach(it -> accept(visitor, it));
 		if (testIdentifier.isContainer()) {
 			visitor.postVisitContainer(testIdentifier);
-		}
-	}
-
-	private class DepthFirstIterator implements Iterator<TestIdentifier> {
-
-		private final Deque<TestIdentifier> deque = new ArrayDeque<>();
-
-		public DepthFirstIterator(Set<TestIdentifier> roots) {
-			roots.forEach(deque::addLast);
-		}
-
-		@Override
-		public boolean hasNext() {
-			return !deque.isEmpty();
-		}
-
-		@Override
-		public TestIdentifier next() {
-			TestIdentifier result = deque.removeFirst();
-			List<TestIdentifier> children = new ArrayList<>(getChildren(result));
-			Collections.reverse(children);
-			children.forEach(deque::addFirst);
-			return result;
 		}
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -266,10 +266,6 @@ public class TestPlan {
 		return unmodifiableSet(result);
 	}
 
-	public Map<UniqueId, TestIdentifier> getAllIdentifiers() {
-		return this.allIdentifiers;
-	}
-
 	/**
 	 * Return whether this test plan contains any tests.
 	 *

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -296,7 +296,9 @@ public class TestPlan {
 	 * test plan.
 	 *
 	 * @param visitor the visitor to accept; never {@code null}
+	 * @since 1.10
 	 */
+	@API(status = EXPERIMENTAL, since = "1.10")
 	public void accept(Visitor visitor) {
 		getRoots().forEach(it -> accept(visitor, it));
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.launcher.core;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -112,11 +111,6 @@ class InternalTestPlan extends TestPlan {
 	@Override
 	public Set<TestIdentifier> getDescendants(TestIdentifier parent) {
 		return delegate.getDescendants(parent);
-	}
-
-	@Override
-	public Map<UniqueId, TestIdentifier> getAllIdentifiers() {
-		return delegate.getAllIdentifiers();
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/InternalTestPlan.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.launcher.core;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -111,6 +112,11 @@ class InternalTestPlan extends TestPlan {
 	@Override
 	public Set<TestIdentifier> getDescendants(TestIdentifier parent) {
 		return delegate.getDescendants(parent);
+	}
+
+	@Override
+	public Map<UniqueId, TestIdentifier> getAllIdentifiers() {
+		return delegate.getAllIdentifiers();
 	}
 
 	@Override

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
@@ -13,19 +13,22 @@ package org.junit.platform.launcher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+import org.junit.platform.fakes.TestDescriptorStub;
 
 class TestPlanTests {
 
 	private final ConfigurationParameters configParams = mock();
 
-	private EngineDescriptor engineDescriptor = new EngineDescriptor(UniqueId.forEngine("foo"), "Foo");
+	private final EngineDescriptor engineDescriptor = new EngineDescriptor(UniqueId.forEngine("foo"), "Foo");
 
 	@Test
 	void doesNotContainTestsForEmptyContainers() {
@@ -75,6 +78,27 @@ class TestPlanTests {
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		assertThat(testPlan.containsTests()).as("contains tests").isTrue();
+	}
+
+	@Test
+	void iteratesInDepthFirstOrder() {
+		var container = new TestDescriptorStub(engineDescriptor.getUniqueId().append("container", "bar"), "Bar");
+		var test1 = new TestDescriptorStub(container.getUniqueId().append("test", "bar"), "Bar");
+		container.addChild(test1);
+		engineDescriptor.addChild(container);
+
+		var engineDescriptor2 = new EngineDescriptor(UniqueId.forEngine("baz"), "Baz");
+		var test2 = new TestDescriptorStub(engineDescriptor2.getUniqueId().append("test", "baz1"), "Baz");
+		var test3 = new TestDescriptorStub(engineDescriptor2.getUniqueId().append("test", "baz2"), "Baz");
+		engineDescriptor2.addChild(test2);
+		engineDescriptor2.addChild(test3);
+
+		var testPlan = TestPlan.from(List.of(engineDescriptor, engineDescriptor2), configParams);
+
+		var testIdentifiers = StreamSupport.stream(testPlan.spliterator(), false).toList();
+		assertThat(testIdentifiers).extracting(TestIdentifier::getUniqueIdObject) //
+				.containsExactly(engineDescriptor.getUniqueId(), container.getUniqueId(), test1.getUniqueId(),
+					engineDescriptor2.getUniqueId(), test2.getUniqueId(), test3.getUniqueId());
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.ConfigurationParameters;
@@ -79,27 +78,6 @@ class TestPlanTests {
 		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams);
 
 		assertThat(testPlan.containsTests()).as("contains tests").isTrue();
-	}
-
-	@Test
-	void iteratesInDepthFirstOrder() {
-		var container = new TestDescriptorStub(engineDescriptor.getUniqueId().append("container", "bar"), "Bar");
-		var test1 = new TestDescriptorStub(container.getUniqueId().append("test", "bar"), "Bar");
-		container.addChild(test1);
-		engineDescriptor.addChild(container);
-
-		var engineDescriptor2 = new EngineDescriptor(UniqueId.forEngine("baz"), "Baz");
-		var test2 = new TestDescriptorStub(engineDescriptor2.getUniqueId().append("test", "baz1"), "Baz");
-		var test3 = new TestDescriptorStub(engineDescriptor2.getUniqueId().append("test", "baz2"), "Baz");
-		engineDescriptor2.addChild(test2);
-		engineDescriptor2.addChild(test3);
-
-		var testPlan = TestPlan.from(List.of(engineDescriptor, engineDescriptor2), configParams);
-
-		var testIdentifiers = StreamSupport.stream(testPlan.spliterator(), false).toList();
-		assertThat(testIdentifiers).extracting(TestIdentifier::getUniqueIdObject) //
-				.containsExactly(engineDescriptor.getUniqueId(), container.getUniqueId(), test1.getUniqueId(),
-					engineDescriptor2.getUniqueId(), test2.getUniqueId(), test3.getUniqueId());
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestPlanTests.java
@@ -11,6 +11,7 @@
 package org.junit.platform.launcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
@@ -99,6 +100,41 @@ class TestPlanTests {
 		assertThat(testIdentifiers).extracting(TestIdentifier::getUniqueIdObject) //
 				.containsExactly(engineDescriptor.getUniqueId(), container.getUniqueId(), test1.getUniqueId(),
 					engineDescriptor2.getUniqueId(), test2.getUniqueId(), test3.getUniqueId());
+	}
+
+	@Test
+	void acceptsVisitorsInDepthFirstOrder() {
+		var container = new TestDescriptorStub(engineDescriptor.getUniqueId().append("container", "bar"), "Bar");
+		var test1 = new TestDescriptorStub(container.getUniqueId().append("test", "bar"), "Bar");
+		container.addChild(test1);
+		engineDescriptor.addChild(container);
+
+		var engineDescriptor2 = new EngineDescriptor(UniqueId.forEngine("baz"), "Baz");
+		var test2 = new TestDescriptorStub(engineDescriptor2.getUniqueId().append("test", "baz1"), "Baz");
+		var test3 = new TestDescriptorStub(engineDescriptor2.getUniqueId().append("test", "baz2"), "Baz");
+		engineDescriptor2.addChild(test2);
+		engineDescriptor2.addChild(test3);
+
+		var testPlan = TestPlan.from(List.of(engineDescriptor, engineDescriptor2), configParams);
+		var visitor = mock(TestPlan.Visitor.class);
+
+		testPlan.accept(visitor);
+
+		var inOrder = inOrder(visitor);
+
+		inOrder.verify(visitor).preVisitContainer(TestIdentifier.from(engineDescriptor));
+		inOrder.verify(visitor).visit(TestIdentifier.from(engineDescriptor));
+		inOrder.verify(visitor).preVisitContainer(TestIdentifier.from(container));
+		inOrder.verify(visitor).visit(TestIdentifier.from(container));
+		inOrder.verify(visitor).visit(TestIdentifier.from(test1));
+		inOrder.verify(visitor).postVisitContainer(TestIdentifier.from(container));
+		inOrder.verify(visitor).postVisitContainer(TestIdentifier.from(engineDescriptor));
+
+		inOrder.verify(visitor).preVisitContainer(TestIdentifier.from(engineDescriptor2));
+		inOrder.verify(visitor).visit(TestIdentifier.from(engineDescriptor2));
+		inOrder.verify(visitor).visit(TestIdentifier.from(test2));
+		inOrder.verify(visitor).visit(TestIdentifier.from(test3));
+		inOrder.verify(visitor).postVisitContainer(TestIdentifier.from(engineDescriptor2));
 	}
 
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -113,7 +113,50 @@ class StandaloneTests {
 
 	@Test
 	@Order(2)
-	void test() throws IOException {
+	void discoverTree() {
+		var result = Request.builder() //
+				.setTool(new Java()) //
+				.setProject("standalone") //
+				.addArguments("-jar", MavenRepo.jar("junit-platform-console-standalone")) //
+				.addArguments("--list-tests") //
+				.addArguments("--scan-class-path") //
+				.addArguments("--disable-banner") //
+				.addArguments("--disable-ansi-colors") //
+				.addArguments("--include-classname", "standalone.*") //
+				.addArguments("--classpath", "bin").build() //
+				.run(false);
+
+		assertEquals(0, result.getExitCode(), String.join("\n", result.getOutputLines("out")));
+
+		var expected = """
+				╷
+				├─ JUnit Jupiter
+				│  ├─ JupiterIntegration
+				│  │  ├─ successful()
+				│  │  ├─ fail()
+				│  │  ├─ abort()
+				│  │  └─ disabled()
+				│  ├─ SuiteIntegration$SingleTestContainer
+				│  │  └─ successful()
+				│  └─ JupiterParamsIntegration
+				│     └─ parameterizedTest(String)
+				├─ JUnit Vintage
+				│  └─ VintageIntegration
+				│     ├─ f4il
+				│     ├─ ignored
+				│     └─ succ3ssful
+				└─ JUnit Platform Suite
+				   └─ SuiteIntegration
+				      └─ JUnit Jupiter
+				         └─ SuiteIntegration$SingleTestContainer
+				            └─ successful()
+				""".stripIndent();
+		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
+	}
+
+	@Test
+	@Order(3)
+	void execute() throws IOException {
 		var result = Request.builder() //
 				.setTool(new Java()) //
 				.setProject("standalone") //
@@ -145,8 +188,8 @@ class StandaloneTests {
 	}
 
 	@Test
-	@Order(3)
-	void testOnJava8() throws IOException {
+	@Order(4)
+	void executeOnJava8() throws IOException {
 		var result = Request.builder() //
 				.setTool(new Java()) //
 				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
@@ -179,9 +222,9 @@ class StandaloneTests {
 	}
 
 	@Test
-	@Order(3)
+	@Order(5)
 	// https://github.com/junit-team/junit5/issues/2600
-	void testOnJava8SelectPackage() throws IOException {
+	void executeOnJava8SelectPackage() throws IOException {
 		var result = Request.builder() //
 				.setTool(new Java()) //
 				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
@@ -214,9 +257,9 @@ class StandaloneTests {
 	}
 
 	@Test
-	@Order(5)
+	@Order(6)
 	@Disabled("https://github.com/junit-team/junit5/issues/1724")
-	void testWithJarredTestClasses() {
+	void executeWithJarredTestClasses() {
 		var jar = MavenRepo.jar("junit-platform-console-standalone");
 		var path = new ArrayList<String>();
 		// path.add("bin"); // "exploded" test classes are found, see also test() above

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -173,6 +173,87 @@ class StandaloneTests {
 		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
 	}
 
+	@Test
+	@Order(2)
+	void discoverVerbose() {
+		Result result = listTests("--details=verbose");
+
+		var expected = """
+				├─ JUnit Jupiter
+				│  ├─ JupiterIntegration
+				│  │  ├─ successful()
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:successful()]
+				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
+				│  │  │     source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'successful', methodParameterTypes = '']
+				│  │  ├─ fail()
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:fail()]
+				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
+				│  │  │     source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'fail', methodParameterTypes = '']
+				│  │  ├─ abort()
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:abort()]
+				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
+				│  │  │     source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'abort', methodParameterTypes = '']
+				│  │  ├─ disabled()
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:disabled()]
+				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
+				│  │  │     source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'disabled', methodParameterTypes = '']
+				│  └─ JupiterIntegration
+				│  ├─ SuiteIntegration$SingleTestContainer
+				│  │  ├─ successful()
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]/[method:successful()]
+				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]
+				│  │  │     source: MethodSource [className = 'standalone.SuiteIntegration$SingleTestContainer', methodName = 'successful', methodParameterTypes = '']
+				│  └─ SuiteIntegration$SingleTestContainer
+				│  ├─ JupiterParamsIntegration
+				│  │  ├─ parameterizedTest(String)
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterParamsIntegration]/[test-template:parameterizedTest(java.lang.String)]
+				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterParamsIntegration]
+				│  │  │     source: MethodSource [className = 'standalone.JupiterParamsIntegration', methodName = 'parameterizedTest', methodParameterTypes = 'java.lang.String']
+				│  └─ JupiterParamsIntegration
+				└─ JUnit Jupiter
+				├─ JUnit Vintage
+				│  ├─ VintageIntegration
+				│  │  ├─ f4il
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:f4il(standalone.VintageIntegration)]
+				│  │  │     parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
+				│  │  │     source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'f4il', methodParameterTypes = '']
+				│  │  ├─ ignored
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:ignored(standalone.VintageIntegration)]
+				│  │  │     parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
+				│  │  │     source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'ignored', methodParameterTypes = '']
+				│  │  ├─ succ3ssful
+				│  │  │       tags: []
+				│  │  │   uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:succ3ssful(standalone.VintageIntegration)]
+				│  │  │     parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
+				│  │  │     source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'succ3ssful', methodParameterTypes = '']
+				│  └─ VintageIntegration
+				└─ JUnit Vintage
+				├─ JUnit Platform Suite
+				│  ├─ SuiteIntegration
+				│  │  ├─ JUnit Jupiter
+				│  │  │  ├─ SuiteIntegration$SingleTestContainer
+				│  │  │  │  ├─ successful()
+				│  │  │  │  │       tags: []
+				│  │  │  │  │   uniqueId: [engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]/[method:successful()]
+				│  │  │  │  │     parent: [engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]
+				│  │  │  │  │     source: MethodSource [className = 'standalone.SuiteIntegration$SingleTestContainer', methodName = 'successful', methodParameterTypes = '']
+				│  │  │  └─ SuiteIntegration$SingleTestContainer
+				│  │  └─ JUnit Jupiter
+				│  └─ SuiteIntegration
+				└─ JUnit Platform Suite
+				Number of static tests: 9
+				""".stripIndent();
+		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
+	}
+
 	private static Result listTests(String... args) {
 		var result = Request.builder() //
 				.setTool(new Java()) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -115,30 +115,30 @@ class StandaloneTests {
 	@Test
 	@Order(2)
 	void discoverTree() {
-		Result result = listTests();
+		Result result = listTests("--details-theme=ascii");
 
 		var expected = """
-				╷
-				├─ JUnit Jupiter
-				│  ├─ JupiterIntegration
-				│  │  ├─ successful()
-				│  │  ├─ fail()
-				│  │  ├─ abort()
-				│  │  └─ disabled()
-				│  ├─ SuiteIntegration$SingleTestContainer
-				│  │  └─ successful()
-				│  └─ JupiterParamsIntegration
-				│     └─ parameterizedTest(String)
-				├─ JUnit Vintage
-				│  └─ VintageIntegration
-				│     ├─ f4il
-				│     ├─ ignored
-				│     └─ succ3ssful
-				└─ JUnit Platform Suite
-				   └─ SuiteIntegration
-				      └─ JUnit Jupiter
-				         └─ SuiteIntegration$SingleTestContainer
-				            └─ successful()
+				.
+				+-- JUnit Jupiter
+				| +-- JupiterIntegration
+				| | +-- successful()
+				| | +-- fail()
+				| | +-- abort()
+				| | '-- disabled()
+				| +-- SuiteIntegration$SingleTestContainer
+				| | '-- successful()
+				| '-- JupiterParamsIntegration
+				|   '-- parameterizedTest(String)
+				+-- JUnit Vintage
+				| '-- VintageIntegration
+				|   +-- f4il
+				|   +-- ignored
+				|   '-- succ3ssful
+				'-- JUnit Platform Suite
+				  '-- SuiteIntegration
+				    '-- JUnit Jupiter
+				      '-- SuiteIntegration$SingleTestContainer
+				        '-- successful()
 
 				[        11 containers found ]
 				[         9 tests found      ]
@@ -184,79 +184,79 @@ class StandaloneTests {
 	@Test
 	@Order(2)
 	void discoverVerbose() {
-		Result result = listTests("--details=verbose");
+		Result result = listTests("--details=verbose", "--details-theme=ascii");
 
 		var expected = """
-				├─ JUnit Jupiter
-				│  ├─ JupiterIntegration
-				│  │  ├─ successful()
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:successful()]
-				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
-				│  │  │     source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'successful', methodParameterTypes = '']
-				│  │  ├─ fail()
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:fail()]
-				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
-				│  │  │     source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'fail', methodParameterTypes = '']
-				│  │  ├─ abort()
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:abort()]
-				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
-				│  │  │     source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'abort', methodParameterTypes = '']
-				│  │  ├─ disabled()
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:disabled()]
-				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
-				│  │  │     source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'disabled', methodParameterTypes = '']
-				│  └─ JupiterIntegration
-				│  ├─ SuiteIntegration$SingleTestContainer
-				│  │  ├─ successful()
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]/[method:successful()]
-				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]
-				│  │  │     source: MethodSource [className = 'standalone.SuiteIntegration$SingleTestContainer', methodName = 'successful', methodParameterTypes = '']
-				│  └─ SuiteIntegration$SingleTestContainer
-				│  ├─ JupiterParamsIntegration
-				│  │  ├─ parameterizedTest(String)
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterParamsIntegration]/[test-template:parameterizedTest(java.lang.String)]
-				│  │  │     parent: [engine:junit-jupiter]/[class:standalone.JupiterParamsIntegration]
-				│  │  │     source: MethodSource [className = 'standalone.JupiterParamsIntegration', methodName = 'parameterizedTest', methodParameterTypes = 'java.lang.String']
-				│  └─ JupiterParamsIntegration
-				└─ JUnit Jupiter
-				├─ JUnit Vintage
-				│  ├─ VintageIntegration
-				│  │  ├─ f4il
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:f4il(standalone.VintageIntegration)]
-				│  │  │     parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
-				│  │  │     source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'f4il', methodParameterTypes = '']
-				│  │  ├─ ignored
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:ignored(standalone.VintageIntegration)]
-				│  │  │     parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
-				│  │  │     source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'ignored', methodParameterTypes = '']
-				│  │  ├─ succ3ssful
-				│  │  │       tags: []
-				│  │  │   uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:succ3ssful(standalone.VintageIntegration)]
-				│  │  │     parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
-				│  │  │     source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'succ3ssful', methodParameterTypes = '']
-				│  └─ VintageIntegration
-				└─ JUnit Vintage
-				├─ JUnit Platform Suite
-				│  ├─ SuiteIntegration
-				│  │  ├─ JUnit Jupiter
-				│  │  │  ├─ SuiteIntegration$SingleTestContainer
-				│  │  │  │  ├─ successful()
-				│  │  │  │  │       tags: []
-				│  │  │  │  │   uniqueId: [engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]/[method:successful()]
-				│  │  │  │  │     parent: [engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]
-				│  │  │  │  │     source: MethodSource [className = 'standalone.SuiteIntegration$SingleTestContainer', methodName = 'successful', methodParameterTypes = '']
-				│  │  │  └─ SuiteIntegration$SingleTestContainer
-				│  │  └─ JUnit Jupiter
-				│  └─ SuiteIntegration
-				└─ JUnit Platform Suite
+				+-- JUnit Jupiter
+				| +-- JupiterIntegration
+				| | +-- successful()
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:successful()]
+				| | |    parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
+				| | |    source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'successful', methodParameterTypes = '']
+				| | +-- fail()
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:fail()]
+				| | |    parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
+				| | |    source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'fail', methodParameterTypes = '']
+				| | +-- abort()
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:abort()]
+				| | |    parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
+				| | |    source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'abort', methodParameterTypes = '']
+				| | +-- disabled()
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]/[method:disabled()]
+				| | |    parent: [engine:junit-jupiter]/[class:standalone.JupiterIntegration]
+				| | |    source: MethodSource [className = 'standalone.JupiterIntegration', methodName = 'disabled', methodParameterTypes = '']
+				| '-- JupiterIntegration
+				| +-- SuiteIntegration$SingleTestContainer
+				| | +-- successful()
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]/[method:successful()]
+				| | |    parent: [engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]
+				| | |    source: MethodSource [className = 'standalone.SuiteIntegration$SingleTestContainer', methodName = 'successful', methodParameterTypes = '']
+				| '-- SuiteIntegration$SingleTestContainer
+				| +-- JupiterParamsIntegration
+				| | +-- parameterizedTest(String)
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-jupiter]/[class:standalone.JupiterParamsIntegration]/[test-template:parameterizedTest(java.lang.String)]
+				| | |    parent: [engine:junit-jupiter]/[class:standalone.JupiterParamsIntegration]
+				| | |    source: MethodSource [className = 'standalone.JupiterParamsIntegration', methodName = 'parameterizedTest', methodParameterTypes = 'java.lang.String']
+				| '-- JupiterParamsIntegration
+				'-- JUnit Jupiter
+				+-- JUnit Vintage
+				| +-- VintageIntegration
+				| | +-- f4il
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:f4il(standalone.VintageIntegration)]
+				| | |    parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
+				| | |    source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'f4il', methodParameterTypes = '']
+				| | +-- ignored
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:ignored(standalone.VintageIntegration)]
+				| | |    parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
+				| | |    source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'ignored', methodParameterTypes = '']
+				| | +-- succ3ssful
+				| | |      tags: []
+				| | |  uniqueId: [engine:junit-vintage]/[runner:standalone.VintageIntegration]/[test:succ3ssful(standalone.VintageIntegration)]
+				| | |    parent: [engine:junit-vintage]/[runner:standalone.VintageIntegration]
+				| | |    source: MethodSource [className = 'standalone.VintageIntegration', methodName = 'succ3ssful', methodParameterTypes = '']
+				| '-- VintageIntegration
+				'-- JUnit Vintage
+				+-- JUnit Platform Suite
+				| +-- SuiteIntegration
+				| | +-- JUnit Jupiter
+				| | | +-- SuiteIntegration$SingleTestContainer
+				| | | | +-- successful()
+				| | | | |      tags: []
+				| | | | |  uniqueId: [engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]/[method:successful()]
+				| | | | |    parent: [engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]
+				| | | | |    source: MethodSource [className = 'standalone.SuiteIntegration$SingleTestContainer', methodName = 'successful', methodParameterTypes = '']
+				| | | '-- SuiteIntegration$SingleTestContainer
+				| | '-- JUnit Jupiter
+				| '-- SuiteIntegration
+				'-- JUnit Platform Suite
 
 				[        11 containers found ]
 				[         9 tests found      ]

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -139,6 +139,10 @@ class StandaloneTests {
 				      └─ JUnit Jupiter
 				         └─ SuiteIntegration$SingleTestContainer
 				            └─ successful()
+
+				[        11 containers found ]
+				[         9 tests found      ]
+
 				""".stripIndent();
 		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
 	}
@@ -169,6 +173,10 @@ class StandaloneTests {
 				JUnit Jupiter ([engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter])
 				SuiteIntegration$SingleTestContainer ([engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer])
 				successful() ([engine:junit-platform-suite]/[suite:standalone.SuiteIntegration]/[engine:junit-jupiter]/[class:standalone.SuiteIntegration$SingleTestContainer]/[method:successful()])
+
+				[        11 containers found ]
+				[         9 tests found      ]
+
 				""".stripIndent();
 		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
 	}
@@ -249,7 +257,10 @@ class StandaloneTests {
 				│  │  └─ JUnit Jupiter
 				│  └─ SuiteIntegration
 				└─ JUnit Platform Suite
-				Number of static tests: 9
+
+				[        11 containers found ]
+				[         9 tests found      ]
+
 				""".stripIndent();
 		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
 	}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -265,6 +265,34 @@ class StandaloneTests {
 		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
 	}
 
+	@Test
+	@Order(2)
+	void discoverNone() {
+		Result result = listTests("--details=none");
+
+		var expected = """
+
+				[        11 containers found ]
+				[         9 tests found      ]
+
+				""".stripIndent();
+		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
+	}
+
+	@Test
+	@Order(2)
+	void discoverSummary() {
+		Result result = listTests("--details=summary");
+
+		var expected = """
+
+				[        11 containers found ]
+				[         9 tests found      ]
+
+				""".stripIndent();
+		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
+	}
+
 	private static Result listTests(String... args) {
 		var result = Request.builder() //
 				.setTool(new Java()) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -10,6 +10,7 @@
 
 package platform.tooling.support.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -270,13 +271,7 @@ class StandaloneTests {
 	void discoverNone() {
 		Result result = listTests("--details=none");
 
-		var expected = """
-
-				[        11 containers found ]
-				[         9 tests found      ]
-
-				""".stripIndent();
-		assertLinesMatch(expected.lines(), result.getOutputLines("out").stream());
+		assertThat(result.getOutputLines("out")).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

- Add command line option for listing all tests
- Add getter for test identifiers in test plan
- List all tests by skipping them
- Add & implement details printing listener interface
- Omit the arrow symbol when listing tests
- List all tests
- Fix indentation
- Add API annotation
- Fix hierarchy when listing tests in tree mode
- Omit icon when blank
- Add integration test
- Make TestPlan iterable
- Remove unnecessary Supplier
- Add test and fix flat mode
- Add test and fix verbose mode
- Use Visitor instead of Iterator
- Add summary of found containers/tests
- Add tests for summary and none detail modes
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] ~Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~ will be done in #3243
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
