### PR TITLE
Force using 'true' or 'false' for boolean args

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -146,7 +146,11 @@ public class DefaultArgumentConverter extends SimpleArgumentConverter {
 		private static final Map<Class<?>, Function<String, ?>> CONVERTERS;
 		static {
 			Map<Class<?>, Function<String, ?>> converters = new HashMap<>();
-			converters.put(Boolean.class, Boolean::valueOf);
+			converters.put(Boolean.class, source -> {
+				Preconditions.condition("true".equalsIgnoreCase(source) || "false".equalsIgnoreCase(source),
+					() -> "String must be (ignoring case) 'true' or 'false': " + source);
+				return Boolean.valueOf(source);
+			});
 			converters.put(Character.class, source -> {
 				Preconditions.condition(source.length() == 1, () -> "String must have length of 1: " + source);
 				return source.charAt(0);

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.params.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.lang.Thread.State;
@@ -97,6 +98,19 @@ class DefaultArgumentConverterTests {
 		assertConverts("42.2_3", float.class, 42.23f);
 		assertConverts("42.23", double.class, 42.23);
 		assertConverts("42.2_3", double.class, 42.23);
+	}
+
+	@Test
+	void throwsExceptionOnInvalidStringForPrimitiveTypes() {
+		var invalidCharException = assertThrows(ArgumentConversionException.class, () -> convert("ab", char.class));
+		assertThat(invalidCharException).hasMessage("Failed to convert String \"ab\" to type java.lang.Character");
+		assertThat(invalidCharException.getCause()).hasMessage("String must have length of 1: ab");
+
+		var invalidBooleanException = assertThrows(ArgumentConversionException.class,
+			() -> convert("tru", boolean.class));
+		assertThat(invalidBooleanException).hasMessage("Failed to convert String \"tru\" to type java.lang.Boolean");
+		assertThat(invalidBooleanException.getCause()).hasMessage(
+			"String must be (ignoring case) 'true' or 'false': tru");
 	}
 
 	/**
@@ -232,11 +246,14 @@ class DefaultArgumentConverterTests {
 	// -------------------------------------------------------------------------
 
 	private void assertConverts(Object input, Class<?> targetClass, Object expectedOutput) {
-		var result = DefaultArgumentConverter.INSTANCE.convert(input, targetClass);
+		var result = convert(input, targetClass);
 
 		assertThat(result) //
 				.describedAs(input + " --(" + targetClass.getName() + ")--> " + expectedOutput) //
 				.isEqualTo(expectedOutput);
 	}
 
+	private Object convert(Object input, Class<?> targetClass) {
+		return DefaultArgumentConverter.INSTANCE.convert(input, targetClass);
+	}
 }


### PR DESCRIPTION
Cause use of anything other than 'true' or 'false' (case-insensitive) fail in conversion, to make potential typos explicitly visible (instead of implicitly just treating all else as 'false')

Includes a few tests for failures on invalid values, for conversions handled by `StringToBooleanAndCharPrimitiveConverter`.

Issue: #3177

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
