### PR TITLE
Drop transitive dependency on apiguardian

### DIFF
--- a/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java
+++ b/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java
@@ -12,7 +12,7 @@
  * Defines JUnit Jupiter API for writing tests.
  */
 module org.junit.jupiter.api {
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires transitive org.junit.platform.commons;
 	requires transitive org.opentest4j;
 

--- a/junit-jupiter-migrationsupport/src/module/org.junit.jupiter.migrationsupport/module-info.java
+++ b/junit-jupiter-migrationsupport/src/module/org.junit.jupiter.migrationsupport/module-info.java
@@ -15,7 +15,7 @@
  */
 module org.junit.jupiter.migrationsupport {
 	requires transitive junit; // 4
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires transitive org.junit.jupiter.api;
 	requires org.junit.platform.commons;
 

--- a/junit-jupiter-params/src/module/org.junit.jupiter.params/module-info.java
+++ b/junit-jupiter-params/src/module/org.junit.jupiter.params/module-info.java
@@ -14,7 +14,7 @@
  * @since 5.0
  */
 module org.junit.jupiter.params {
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires transitive org.junit.jupiter.api;
 	requires transitive org.junit.platform.commons;
 

--- a/junit-platform-commons/src/module/org.junit.platform.commons/module-info.java
+++ b/junit-platform-commons/src/module/org.junit.platform.commons/module-info.java
@@ -16,7 +16,7 @@
 module org.junit.platform.commons {
 	requires java.logging;
 	requires java.management; // needed by RuntimeUtils to determine input arguments
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 
 	exports org.junit.platform.commons;
 	exports org.junit.platform.commons.annotation;

--- a/junit-platform-engine/src/module/org.junit.platform.engine/module-info.java
+++ b/junit-platform-engine/src/module/org.junit.platform.engine/module-info.java
@@ -17,7 +17,7 @@
  * @since 1.0
  */
 module org.junit.platform.engine {
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires transitive org.junit.platform.commons;
 	requires transitive org.opentest4j;
 

--- a/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
+++ b/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
@@ -21,7 +21,7 @@
  */
 module org.junit.platform.launcher {
 	requires transitive java.logging;
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires transitive org.junit.platform.commons;
 	requires transitive org.junit.platform.engine;
 

--- a/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
+++ b/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
@@ -15,7 +15,7 @@
  */
 module org.junit.platform.reporting {
 	requires java.xml;
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires org.junit.platform.commons;
 	requires transitive org.junit.platform.engine;
 	requires transitive org.junit.platform.launcher;

--- a/junit-platform-runner/src/module/org.junit.platform.runner/module-info.java
+++ b/junit-platform-runner/src/module/org.junit.platform.runner/module-info.java
@@ -16,7 +16,7 @@
  */
 module org.junit.platform.runner {
 	requires transitive junit; // 4
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires transitive org.junit.platform.launcher;
 	requires transitive org.junit.platform.suite.api;
 	requires org.junit.platform.suite.commons;

--- a/junit-platform-suite-api/src/module/org.junit.platform.suite.api/module-info.java
+++ b/junit-platform-suite-api/src/module/org.junit.platform.suite.api/module-info.java
@@ -14,7 +14,7 @@
  * @since 1.0
  */
 module org.junit.platform.suite.api {
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires transitive org.junit.platform.commons;
 
 	exports org.junit.platform.suite.api;

--- a/junit-platform-suite-commons/src/module/org.junit.platform.suite.commons/module-info.java
+++ b/junit-platform-suite-commons/src/module/org.junit.platform.suite.commons/module-info.java
@@ -14,7 +14,7 @@
  * @since 1.8
  */
 module org.junit.platform.suite.commons {
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires org.junit.platform.suite.api;
 	requires org.junit.platform.commons;
 	requires org.junit.platform.engine;

--- a/junit-platform-testkit/src/module/org.junit.platform.testkit/module-info.java
+++ b/junit-platform-testkit/src/module/org.junit.platform.testkit/module-info.java
@@ -15,7 +15,7 @@
  * @uses org.junit.platform.engine.TestEngine
  */
 module org.junit.platform.testkit {
-	requires static transitive org.apiguardian.api;
+	requires static org.apiguardian.api;
 	requires transitive org.assertj.core;
 	requires org.junit.platform.commons;
 	requires transitive org.junit.platform.engine;


### PR DESCRIPTION
## Overview
Annotations should stay as `static` dependencies and not `transitive` this was explained in https://mail.openjdk.org/pipermail/jigsaw-dev/2021-June/014674.html.

Currently the problem we are facing is that when building `assertj-core`, we need to have `apiguardian` as well because `assertj-core` requires `junit5` which transitively requires `apiguardian` even though `assertj-core` does not use `apiguardian` at all.
<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [ ] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
