### PR TITLE
Use proper AssertJ assertions

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/DynamicTestTests.java
@@ -179,9 +179,9 @@ class DynamicTestTests {
 		URI containerSourceUri = URI.create("other://container");
 		DynamicContainer container = dynamicContainer("bar", containerSourceUri, Stream.of(test));
 
-		assertThat(test.getTestSourceUri().get()).isSameAs(testSourceUri);
+		assertThat(test.getTestSourceUri()).containsSame(testSourceUri);
 		assertThat(test.toString()).isEqualTo("DynamicTest [displayName = 'foo', testSourceUri = any://test]");
-		assertThat(container.getTestSourceUri().get()).isSameAs(containerSourceUri);
+		assertThat(container.getTestSourceUri()).containsSame(containerSourceUri);
 		assertThat(container.toString()).isEqualTo(
 			"DynamicContainer [displayName = 'bar', testSourceUri = other://container]");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -450,9 +450,9 @@ class DiscoverySelectorResolverTests {
 		resolve(request().selectors(selectPackage("")));
 
 		// 150 is completely arbitrary. The actual number is likely much higher.
-		assertThat(engineDescriptor.getDescendants().size())//
+		assertThat(engineDescriptor.getDescendants())//
 				.describedAs("Too few test descriptors in classpath")//
-				.isGreaterThan(150);
+				.hasSizeGreaterThan(150);
 
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertThat(uniqueIds)//
@@ -474,9 +474,9 @@ class DiscoverySelectorResolverTests {
 		resolve(request().selectors(selectors));
 
 		// 150 is completely arbitrary. The actual number is likely much higher.
-		assertThat(engineDescriptor.getDescendants().size())//
+		assertThat(engineDescriptor.getDescendants())//
 				.describedAs("Too few test descriptors in classpath")//
-				.isGreaterThan(150);
+				.hasSizeGreaterThan(150);
 
 		List<UniqueId> uniqueIds = uniqueIds();
 		assertThat(uniqueIds)//

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -111,19 +111,19 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 					"instanceField2", "beforeEach1", "beforeEach2", "test1", "test2", "afterEach1", "afterEach2");
 				assertThat(testBTempDirs.values()).hasSize(10).doesNotHaveDuplicates();
 
-				assertThat(testATempDirs.get("staticField1")).isEqualTo(classTempDirs.get("staticField1"));
-				assertThat(testBTempDirs.get("staticField1")).isEqualTo(classTempDirs.get("staticField1"));
-				assertThat(testATempDirs.get("staticField2")).isEqualTo(classTempDirs.get("staticField2"));
-				assertThat(testBTempDirs.get("staticField2")).isEqualTo(classTempDirs.get("staticField2"));
+				assertThat(testATempDirs).containsEntry("staticField1", classTempDirs.get("staticField1"));
+				assertThat(testBTempDirs).containsEntry("staticField1", classTempDirs.get("staticField1"));
+				assertThat(testATempDirs).containsEntry("staticField2", classTempDirs.get("staticField2"));
+				assertThat(testBTempDirs).containsEntry("staticField2", classTempDirs.get("staticField2"));
 
-				assertThat(testATempDirs.get("instanceField1")).isNotEqualTo(testBTempDirs.get("instanceField1"));
-				assertThat(testATempDirs.get("instanceField2")).isNotEqualTo(testBTempDirs.get("instanceField2"));
-				assertThat(testATempDirs.get("beforeEach1")).isNotEqualTo(testBTempDirs.get("beforeEach1"));
-				assertThat(testATempDirs.get("beforeEach2")).isNotEqualTo(testBTempDirs.get("beforeEach2"));
-				assertThat(testATempDirs.get("test1")).isNotEqualTo(testBTempDirs.get("test1"));
-				assertThat(testATempDirs.get("test2")).isNotEqualTo(testBTempDirs.get("test2"));
-				assertThat(testATempDirs.get("afterEach1")).isNotEqualTo(testBTempDirs.get("afterEach1"));
-				assertThat(testATempDirs.get("afterEach2")).isNotEqualTo(testBTempDirs.get("afterEach2"));
+				assertThat(testATempDirs).doesNotContainEntry("instanceField1", testBTempDirs.get("instanceField1"));
+				assertThat(testATempDirs).doesNotContainEntry("instanceField2", testBTempDirs.get("instanceField2"));
+				assertThat(testATempDirs).doesNotContainEntry("beforeEach1", testBTempDirs.get("beforeEach1"));
+				assertThat(testATempDirs).doesNotContainEntry("beforeEach2", testBTempDirs.get("beforeEach2"));
+				assertThat(testATempDirs).doesNotContainEntry("test1", testBTempDirs.get("test1"));
+				assertThat(testATempDirs).doesNotContainEntry("test2", testBTempDirs.get("test2"));
+				assertThat(testATempDirs).doesNotContainEntry("afterEach1", testBTempDirs.get("afterEach1"));
+				assertThat(testATempDirs).doesNotContainEntry("afterEach2", testBTempDirs.get("afterEach2"));
 			}));
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutConfigurationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TimeoutConfigurationTests.java
@@ -139,7 +139,7 @@ class TimeoutConfigurationTests {
 	void specificThreadModeIsUsed() {
 		when(extensionContext.getConfigurationParameter(DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME)).thenReturn(
 			Optional.of("SEPARATE_THREAD"));
-		assertThat(config.getDefaultTimeoutThreadMode()).isEqualTo(Optional.of(SEPARATE_THREAD));
+		assertThat(config.getDefaultTimeoutThreadMode()).contains(SEPARATE_THREAD);
 	}
 
 	@Test
@@ -148,7 +148,7 @@ class TimeoutConfigurationTests {
 		when(extensionContext.getConfigurationParameter(DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME)).thenReturn(
 			Optional.of("invalid"));
 
-		assertThat(config.getDefaultTimeoutThreadMode()).isEqualTo(Optional.empty());
+		assertThat(config.getDefaultTimeoutThreadMode()).isNotPresent();
 		assertThat(logRecordListener.stream(Level.WARNING).map(LogRecord::getMessage)) //
 				.containsExactly(
 					"Invalid timeout thread mode 'invalid' set via the 'junit.jupiter.execution.timeout.thread.mode.default' configuration parameter.");

--- a/platform-tests/src/test/java/org/junit/platform/AbstractEqualsAndHashCodeTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/AbstractEqualsAndHashCodeTests.java
@@ -26,7 +26,7 @@ public abstract class AbstractEqualsAndHashCodeTests {
 		assertThat(different).isNotNull();
 
 		assertThat(equal1).isNotSameAs(equal2);
-		assertThat(equal1).isNotEqualTo(null);
+		assertThat(equal1).isNotNull();
 		assertThat(equal1).isNotEqualTo(new Object());
 		assertThat(equal1).isNotEqualTo(different);
 		assertThat(different).isNotEqualTo(equal1);

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ClasspathScannerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ClasspathScannerTests.java
@@ -123,7 +123,7 @@ class ClasspathScannerTests {
 	private void assertClassesScannedWhenExceptionIsThrown(Predicate<Class<?>> filter) throws Exception {
 		var classFilter = ClassFilter.of(filter);
 		var classes = this.classpathScanner.scanForClassesInClasspathRoot(getTestClasspathRoot(), classFilter);
-		assertThat(classes.size()).isGreaterThanOrEqualTo(150);
+		assertThat(classes).hasSizeGreaterThanOrEqualTo(150);
 	}
 
 	private void assertDebugMessageLogged(LogRecordListener listener, String regex) {
@@ -177,7 +177,7 @@ class ClasspathScannerTests {
 	@Test
 	void scanForClassesInPackage() {
 		var classes = classpathScanner.scanForClassesInPackage("org.junit.platform.commons", allClasses);
-		assertThat(classes.size()).isGreaterThanOrEqualTo(20);
+		assertThat(classes).hasSizeGreaterThanOrEqualTo(20);
 		assertTrue(classes.contains(NestedClassToBeFound.class));
 		assertTrue(classes.contains(MemberClassToBeFound.class));
 	}
@@ -253,7 +253,7 @@ class ClasspathScannerTests {
 		var classFilter = ClassFilter.of(this::inDefaultPackage);
 		var classes = classpathScanner.scanForClassesInPackage("", classFilter);
 
-		assertThat(classes.size()).as("number of classes found in default package").isGreaterThanOrEqualTo(1);
+		assertThat(classes).as("number of classes found in default package").isNotEmpty();
 		assertTrue(classes.stream().allMatch(this::inDefaultPackage));
 		assertTrue(classes.stream().anyMatch(clazz -> "DefaultPackageTestCase".equals(clazz.getName())));
 	}
@@ -345,7 +345,7 @@ class ClasspathScannerTests {
 		var root = getTestClasspathRoot();
 		var classes = classpathScanner.scanForClassesInClasspathRoot(root, allClasses);
 
-		assertThat(classes.size()).isGreaterThanOrEqualTo(20);
+		assertThat(classes).hasSizeGreaterThanOrEqualTo(20);
 		assertTrue(classes.contains(ClasspathScannerTests.class));
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
@@ -269,7 +269,7 @@ class DiscoveryRequestCreatorTests {
 		assertThat(methodSelectors).hasSize(2);
 		assertThat(methodSelectors.get(0).getClassName()).isEqualTo("com.acme.Foo");
 		assertThat(methodSelectors.get(0).getMethodName()).isEqualTo("m");
-		assertThat(methodSelectors.get(0).getMethodParameterTypes()).isEqualTo("");
+		assertThat(methodSelectors.get(0).getMethodParameterTypes()).isEmpty();
 		assertThat(methodSelectors.get(1).getClassName()).isEqualTo("com.example.Bar");
 		assertThat(methodSelectors.get(1).getMethodName()).isEqualTo("method");
 		assertThat(methodSelectors.get(1).getMethodParameterTypes()).isEqualTo("java.lang.Object");

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/TreeNodeTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/TreeNodeTests.java
@@ -51,7 +51,7 @@ class TreeNodeTests {
 			}
 		});
 
-		assertThat(treeNode.children.size()).isEqualTo(NUM_THREADS * ITEMS_PER_THREAD);
+		assertThat(treeNode.children).hasSize(NUM_THREADS * ITEMS_PER_THREAD);
 	}
 
 	@Test
@@ -64,7 +64,7 @@ class TreeNodeTests {
 			}
 		});
 
-		assertThat(treeNode.reports.size()).isEqualTo(NUM_THREADS * ITEMS_PER_THREAD);
+		assertThat(treeNode.reports).hasSize(NUM_THREADS * ITEMS_PER_THREAD);
 	}
 
 	private void runConcurrently(Runnable action) throws InterruptedException {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/CompositeTestSourceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/CompositeTestSourceTests.java
@@ -53,12 +53,12 @@ class CompositeTestSourceTests extends AbstractTestSourceTests {
 		var sources = new ArrayList<>(List.of(fileSource, classSource));
 		var compositeTestSource = CompositeTestSource.from(sources);
 
-		assertThat(compositeTestSource.getSources().size()).isEqualTo(2);
+		assertThat(compositeTestSource.getSources()).hasSize(2);
 		assertThat(compositeTestSource.getSources()).contains(fileSource, classSource);
 
 		// Ensure the supplied sources list was defensively copied.
 		sources.remove(1);
-		assertThat(compositeTestSource.getSources().size()).isEqualTo(2);
+		assertThat(compositeTestSource.getSources()).hasSize(2);
 
 		// Ensure the returned sources list is immutable.
 		assertThrows(UnsupportedOperationException.class, () -> compositeTestSource.getSources().add(fileSource));

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TagFilterTests.java
@@ -172,12 +172,12 @@ class TagFilterTests {
 
 	private void assertIncluded(FilterResult filterResult, String expectedReason) {
 		assertTrue(filterResult.included());
-		assertThat(filterResult.getReason()).isPresent().contains(expectedReason);
+		assertThat(filterResult.getReason()).contains(expectedReason);
 	}
 
 	private void assertExcluded(FilterResult filterResult, String expectedReason) {
 		assertTrue(filterResult.excluded());
-		assertThat(filterResult.getReason()).isPresent().contains(expectedReason);
+		assertThat(filterResult.getReason()).contains(expectedReason);
 	}
 
 	// -------------------------------------------------------------------------

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -403,7 +403,7 @@ class DefaultLauncherTests {
 		launcher.execute(request().build());
 
 		var configurationParameters = engine.requestForExecution.getConfigurationParameters();
-		assertThat(configurationParameters.get("key").isPresent()).isFalse();
+		assertThat(configurationParameters.get("key")).isNotPresent();
 		assertThat(configurationParameters.size()).isEqualTo(0);
 	}
 
@@ -417,8 +417,8 @@ class DefaultLauncherTests {
 
 		var configurationParameters = engine.requestForExecution.getConfigurationParameters();
 		assertThat(configurationParameters.size()).isEqualTo(1);
-		assertThat(configurationParameters.get("key").isPresent()).isTrue();
-		assertThat(configurationParameters.get("key").get()).isEqualTo("value");
+		assertThat(configurationParameters.get("key")).isPresent();
+		assertThat(configurationParameters.get("key")).contains("value");
 	}
 
 	@Test


### PR DESCRIPTION
Slight refactoring of AssertJ assertions into shorter, more descriptive and generating better error messages.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
- [x] All [continuous integration builds](https://github.com/junit-team/junit5#continuous-integration-builds) pass
