### PR TITLE
Document `@MethodSource` as use case for `@TestInstance` per-class lifecycle

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -751,8 +751,8 @@ NOTE: Beginning with Java 16, `@BeforeAll` and `@AfterAll` methods can be declar
 `static` in `@Nested` test classes.
 
 If you are authoring tests using the Kotlin programming language, you may also find it
-easier to implement `@BeforeAll` and `@AfterAll` methods by switching to the "per-class"
-test instance lifecycle mode.
+easier to implement `@BeforeAll` and `@AfterAll` methods and also factory methods for
+`@MethodSource` by switching to the "per-class" test instance lifecycle mode.
 
 [[writing-tests-test-instance-lifecycle-changing-default]]
 ==== Changing the Default Test Instance Lifecycle

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
@@ -51,7 +51,8 @@ import org.apiguardian.api.API;
  * <li>Declaration of {@code @BeforeAll} and {@code @AfterAll} on interface
  * {@code default} methods.</li>
  * <li>Simplified declaration of non-static {@code @BeforeAll} and {@code @AfterAll}
- * methods in test classes implemented with the Kotlin programming language.</li>
+ * methods and also factory methods for {@code @MethodSource} in test classes
+ * implemented with the Kotlin programming language.</li>
  * </ul>
  *
  * <p>{@code @TestInstance} may also be used as a meta-annotation in order to


### PR DESCRIPTION
## Overview

Related Stack Overflow post: [What use is @TestInstance annotation in JUnit 5?](https://stackoverflow.com/a/66185596/8583692)

Add another use case for `TestInstace.PER_CLASS` in Kotlin, which is, using regular simple class methods as the method factory for `@MethodSource` (which is used for parameterized tests):

```kotlin
@ParameterizedTest
@MethodSource("generateStrings")
fun `Test strings`(argument: String) {
    check(argument.isNotEmpty())
}

private fun generateStrings() = listOf(
    "java",
    "kotlin"
)
```

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---
