### PR TITLE
Prevent Combine PRs workflow execution on forks

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   combine-prs:
+    if: github.repository == 'junit-team/junit5'
     runs-on: ubuntu-latest
     steps:
       - name: combine-prs


### PR DESCRIPTION
## Overview

The [Combine PRs](https://github.com/junit-team/junit5/blob/main/.github/workflows/combine-prs.yml) workflow is triggered every day also on forks and [it fails](https://github.com/scordio/junit5/actions/workflows/combine-prs.yml) due to the absence of the `github_token` value.

Since dependency management on forks probably makes little sense, I suggest disabling the job execution based on the repository name.