### PR TITLE
Fix temp dir error reporting for undeletable files

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -54,6 +54,8 @@ repository on GitHub.
   `@MethodSource("myFactory([I)"` (which was already supported) and
   `@MethodSource("myFactory(java.lang.String[])` instead of
   `@MethodSource("myFactory([Ljava.lang.String;)`.
+* Exceptions thrown for undeletable files when cleaning up a temporary directory created
+  via `@TempDir` now include the root cause.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -30,6 +30,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
@@ -341,13 +342,12 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		}
 
 		private IOException createIOExceptionWithAttachedFailures(SortedMap<Path, IOException> failures) {
-			// @formatter:off
-			String joinedPaths = failures.keySet().stream()
-					.map(this::tryToDeleteOnExit)
-					.map(this::relativizeSafely)
-					.map(String::valueOf)
+			Path emptyPath = Paths.get("");
+			String joinedPaths = failures.keySet().stream() //
+					.map(this::tryToDeleteOnExit) //
+					.map(this::relativizeSafely) //
+					.map(path -> emptyPath.equals(path) ? "<root>" : path.toString()) //
 					.collect(joining(", "));
-			// @formatter:on
 			IOException exception = new IOException("Failed to delete temp directory " + dir.toAbsolutePath()
 					+ ". The following paths could not be deleted (see suppressed exceptions for details): "
 					+ joinedPaths);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -319,6 +319,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 						}
 						catch (Exception suppressed) {
 							exception.addSuppressed(suppressed);
+							failures.put(path, exception);
 						}
 					}
 					else {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -200,6 +200,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 		assertSingleFailedTest(results, //
 			instanceOf(IOException.class), //
 			message(it -> it.startsWith("Failed to delete temp directory")), //
+			message(it -> it.endsWith(
+				"The following paths could not be deleted (see suppressed exceptions for details): <root>, undeletable")), //
 			suppressed(0, instanceOf(DirectoryNotEmptyException.class)), //
 			suppressed(1, instanceOf(IOException.class), message("Simulated failure")));
 	}
@@ -212,6 +214,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 		assertSingleFailedTest(results, //
 			instanceOf(IOException.class), //
 			message(it -> it.startsWith("Failed to delete temp directory")), //
+			message(it -> it.endsWith(
+				"The following paths could not be deleted (see suppressed exceptions for details): <root>, undeletable")), //
 			suppressed(0, instanceOf(DirectoryNotEmptyException.class)), //
 			suppressed(1, instanceOf(IOException.class), message("Simulated failure")));
 	}


### PR DESCRIPTION
## Overview

- Include root cause when failing to delete file
- Improve error message when root could not be deleted

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
