### PR TITLE
Combined PRs

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: combine-prs
-        uses: github/combine-prs@v3.1.0
+        uses: github/combine-prs@v3.1.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ archunit = { module = "com.tngtech.archunit:archunit-junit5", version = "1.0.1" 
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 bartholdy = { module = "de.sormuras:bartholdy", version = "0.2.3" }
 bnd = { module = "biz.aQute.bnd:biz.aQute.bndlib", version = "6.4.0" }
-classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.153" }
+classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.157" }
 commons-io = { module = "commons-io:commons-io", version = "2.11.0" }
 groovy4 = { module = "org.apache.groovy:groovy", version = "4.0.10" }
 groovy2-bom = { module = "org.codehaus.groovy:groovy-bom", version = "2.5.21" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ bartholdy = { module = "de.sormuras:bartholdy", version = "0.2.3" }
 bnd = { module = "biz.aQute.bnd:biz.aQute.bndlib", version = "6.4.0" }
 classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.157" }
 commons-io = { module = "commons-io:commons-io", version = "2.11.0" }
-groovy4 = { module = "org.apache.groovy:groovy", version = "4.0.10" }
+groovy4 = { module = "org.apache.groovy:groovy", version = "4.0.11" }
 groovy2-bom = { module = "org.codehaus.groovy:groovy-bom", version = "2.5.21" }
 hamcrest = { module = "org.hamcrest:hamcrest", version = "2.2" }
 jfrunit = { module = "org.moditect.jfrunit:jfrunit-core", version = "1.0.0.Alpha2" }

--- a/gradle/plugins/common/build.gradle.kts
+++ b/gradle/plugins/common/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 	implementation("com.diffplug.spotless:spotless-plugin-gradle:6.17.0")
 	implementation("com.github.ben-manes:gradle-versions-plugin:0.46.0")
 	implementation("gradle.plugin.com.github.johnrengelman:shadow:8.0.0")
-	compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.12.6") // keep in sync with root settings.gradle.kts
+	compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.13") // keep in sync with root settings.gradle.kts
 }
 
 tasks {

--- a/gradle/plugins/common/build.gradle.kts
+++ b/gradle/plugins/common/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 	implementation(project(":build-parameters"))
 	implementation(kotlin("gradle-plugin"))
 	implementation("biz.aQute.bnd:biz.aQute.bnd.gradle:6.4.0")
-	implementation("com.diffplug.spotless:spotless-plugin-gradle:6.17.0")
+	implementation("com.diffplug.spotless:spotless-plugin-gradle:6.18.0")
 	implementation("com.github.ben-manes:gradle-versions-plugin:0.46.0")
 	implementation("gradle.plugin.com.github.johnrengelman:shadow:8.0.0")
 	compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.13") // keep in sync with root settings.gradle.kts

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 		gradlePluginPortal()
 	}
 	plugins {
-		id("com.gradle.enterprise") version "3.12.6" // keep in sync with gradle/plugins/build.gradle.kts
+		id("com.gradle.enterprise") version "3.13" // keep in sync with gradle/plugins/build.gradle.kts
 		id("com.gradle.common-custom-user-data-gradle-plugin") version "1.10"
 		id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
 		id("org.ajoberstar.git-publish") version "4.1.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ pluginManagement {
 		id("org.asciidoctor.jvm.pdf") version "4.0.0-alpha.1"
 		id("me.champeau.jmh") version "0.7.0"
 		id("io.spring.nohttp") version "0.0.11"
-		id("io.github.gradle-nexus.publish-plugin") version "1.2.0"
+		id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 	}
 }
 


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- #3257 Bump github/combine-prs from 3.1.0 to 3.1.1
- #3256 Bump com.gradle:gradle-enterprise-gradle-plugin from 3.12.6 to 3.13
- #3255 Bump io.github.classgraph:classgraph from 4.8.153 to 4.8.157
- #3254 Bump com.gradle.enterprise from 3.12.6 to 3.13
- #3253 Bump io.github.gradle-nexus.publish-plugin from 1.2.0 to 1.3.0
- #3252 Bump com.diffplug.spotless:spotless-plugin-gradle from 6.17.0 to 6.18.0
- #3251 Bump org.apache.groovy:groovy from 4.0.10 to 4.0.11

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action