### PR TITLE
Add contracts to Kotlin-specific assertions

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -48,8 +48,8 @@ JUnit repository on GitHub.
   - A section containing JUnit-specific metadata about each test/container to the HTML
     report is now written by open-test-reporting when added to the classpath/module path
   - Information about published files is now included as attachments.
+* Introduced contracts for Kotlin-specific assertion methods.
 
-* Introduced kotlin contracts for kotlin assertion methods.
 
 [[release-notes-5.12.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -49,6 +49,7 @@ JUnit repository on GitHub.
     report is now written by open-test-reporting when added to the classpath/module path
   - Information about published files is now included as attachments.
 
+* Introduced kotlin contracts for kotlin assertion methods.
 
 [[release-notes-5.12.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/test/kotlin/example/KotlinAssertionsDemo.kt
+++ b/documentation/src/test/kotlin/example/KotlinAssertionsDemo.kt
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.assertTimeout
 import org.junit.jupiter.api.assertTimeoutPreemptively
@@ -106,6 +108,30 @@ class KotlinAssertionsDemo {
             // Simulate task that takes more than 10 ms.
             Thread.sleep(100)
         }
+    }
+
+    @Test
+    fun `assertNotNull with a smart cast`() {
+        val nullablePerson: Person? = person
+
+        assertNotNull(nullablePerson)
+
+        // The compiler smart casts nullablePerson to a non-nullable object.
+        // The safe call operator (?.) isn't required.
+        assertEquals(person.firstName, nullablePerson.firstName)
+        assertEquals(person.lastName, nullablePerson.lastName)
+    }
+
+    @Test
+    fun `assertInstanceOf with a smart cast`() {
+        val maybePerson: Any = person
+
+        assertInstanceOf<Person>(maybePerson)
+
+        // The compiler smart casts maybePerson to a Person object,
+        // allowing to access the Person properties.
+        assertEquals(person.firstName, maybePerson.firstName)
+        assertEquals(person.lastName, maybePerson.lastName)
     }
 }
 // end::user_guide[]

--- a/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
+++ b/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
@@ -155,6 +155,41 @@ internal class KotlinAssertTimeoutAssertionsTests {
         assertMessageStartsWith(error, "Tempus Fugit ==> execution exceeded timeout of 10 ms by")
     }
 
+    @Test
+    fun `assertTimeout with value initialization in lambda`() {
+        val value: Int
+
+        assertTimeout(ofMillis(500)) { value = 10 }
+
+        assertEquals(10, value)
+    }
+
+    @Test
+    fun `assertTimeout with message and value initialization in lambda`() {
+        val value: Int
+
+        assertTimeout(ofMillis(500), "message") { value = 10 }
+
+        assertEquals(10, value)
+    }
+
+    @Test
+    fun `assertTimeout with message supplier and value initialization in lambda`() {
+        val value: Int
+        val valueInMessageSupplier: Int
+
+        assertTimeout(
+            timeout = ofMillis(500),
+            message = {
+                valueInMessageSupplier = 20 // Val can be assigned in the message supplier lambda.
+                "message"
+            },
+            executable = { value = 10 }
+        )
+
+        assertEquals(10, value)
+    }
+
     // -- executable - preemptively ---
 
     @Test
@@ -285,6 +320,20 @@ internal class KotlinAssertTimeoutAssertionsTests {
                 }
             }
         assertMessageEquals(error, "Tempus Fugit ==> execution timed out after 10 ms")
+    }
+
+    @Test
+    fun `assertTimeoutPreemptively with message supplier and value initialization in lambda`() {
+        val valueInMessageSupplier: Int
+
+        assertTimeoutPreemptively(
+            timeout = ofMillis(500),
+            message = {
+                valueInMessageSupplier = 20 // Val can be assigned in the message supplier lambda.
+                "message"
+            },
+            executable = {}
+        )
     }
 
     /**

--- a/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinAssertionsTests.kt
+++ b/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinAssertionsTests.kt
@@ -247,6 +247,89 @@ class KotlinAssertionsTests {
         assertMessageStartsWith(result, "Should be a String")
     }
 
+    @Test
+    fun `assertInstanceOf with compiler smart cast`() {
+        val maybeString: Any = "string"
+
+        assertInstanceOf<String>(maybeString)
+        assertFalse(maybeString.isEmpty()) // A smart cast to a String object.
+    }
+
+    @Test
+    fun `assertInstanceOf with compiler nullable smart cast`() {
+        val maybeString: Any? = "string"
+
+        assertInstanceOf<String>(maybeString)
+        assertFalse(maybeString.isEmpty()) // A smart cast to a non-nullable String object.
+    }
+
+    @Test
+    fun `assertInstanceOf with a null value`() {
+        val error =
+            assertThrows<AssertionFailedError> {
+                assertInstanceOf<String>(null)
+            }
+
+        assertMessageStartsWith(error, "Unexpected null value")
+    }
+
+    @Test
+    fun `assertInstanceOf with message and compiler smart cast`() {
+        val maybeString: Any = "string"
+
+        assertInstanceOf<String>(maybeString, "maybeString is not an instance of String")
+        assertFalse(maybeString.isEmpty()) // A smart cast to a String object.
+    }
+
+    @Test
+    fun `assertInstanceOf with message supplier and compiler smart cast`() {
+        val maybeString: Any = "string"
+
+        val valueInMessageSupplier: Int
+
+        assertInstanceOf<String>(maybeString) {
+            valueInMessageSupplier = 20 // Val can be assigned in the message supplier lambda.
+
+            "maybeString is not an instance of String"
+        }
+
+        assertFalse(maybeString.isEmpty()) // A smart cast to a String object.
+    }
+
+    @Test
+    fun `assertNull with compiler smart cast`() {
+        val nullableString: String? = null
+
+        assertNull(nullableString)
+        // Even safe call is not allowed because compiler knows that nullableString is always null.
+        // nullableString?.isEmpty()
+    }
+
+    @Test
+    fun `assertNull with message and compiler smart cast`() {
+        val nullableString: String? = null
+
+        assertNull(nullableString, "nullableString is not null")
+        // Even safe call is not allowed because compiler knows that nullableString is always null.
+        // nullableString?.isEmpty()
+    }
+
+    @Test
+    fun `assertNull with message supplier and compiler smart cast`() {
+        val nullableString: String? = null
+
+        val valueInMessageSupplier: Int
+
+        assertNull(nullableString) {
+            valueInMessageSupplier = 20 // Val can be assigned in the message supplier lambda.
+
+            "nullableString is not null"
+        }
+
+        // Even safe call is not allowed because compiler knows that nullableString is always null.
+        // nullableString?.isEmpty()
+    }
+
     companion object {
         fun assertExpectedExceptionTypes(
             multipleFailuresError: MultipleFailuresError,


### PR DESCRIPTION
## Overview

Resolves #1866. 
Introduced `assertNull`, `assertNotNull` methods. 
Introduced contracts for `assertNull`, `assertNotNull`, `assertThrows` and `assertDoesNotThrow` methods.

Added smart casting tests for `assertInstanceOf` methods.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
