### PR TITLE
Do not parse `{displayName}` placeholder for `@ParameterizedTest` using `MessageFormat`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -58,6 +58,9 @@ repository on GitHub.
   `@MethodSource("myFactory([Ljava.lang.String;)`.
 * Exceptions thrown for undeletable files when cleaning up a temporary directory created
   via `@TempDir` now include the root cause.
+* The `{displayName}` placeholder of `@ParameterizedTest` is no longer parsed during the
+  evaluation of the `MessageFormat`, now `@DisplayName` and Kotlin method names can contain
+  single apostrophes and `MessageFormat` elements, such as `{data}`.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -36,6 +36,7 @@ class ParameterizedTestNameFormatter {
 	private final String displayName;
 	private final ParameterizedTestMethodContext methodContext;
 	private final int argumentMaxLength;
+	private final String DISPLAY_NAME_TEMPORARY_PLACEHOLDER = "__DISPLAY_NAME__";
 
 	ParameterizedTestNameFormatter(String pattern, String displayName, ParameterizedTestMethodContext methodContext,
 			int argumentMaxLength) {
@@ -62,7 +63,7 @@ class ParameterizedTestNameFormatter {
 		MessageFormat format = new MessageFormat(pattern);
 		Object[] humanReadableArguments = makeReadable(format, namedArguments);
 		String formatted = format.format(humanReadableArguments);
-		return formatted.replace("__DISPLAY_NAME__", this.displayName);
+		return formatted.replace(DISPLAY_NAME_TEMPORARY_PLACEHOLDER, this.displayName);
 	}
 
 	private Object[] extractNamedArguments(Object[] arguments) {
@@ -73,7 +74,7 @@ class ParameterizedTestNameFormatter {
 
 	private String prepareMessageFormatPattern(int invocationIndex, Object[] arguments) {
 		String result = pattern//
-				.replace(DISPLAY_NAME_PLACEHOLDER, "__DISPLAY_NAME__")//
+				.replace(DISPLAY_NAME_PLACEHOLDER, DISPLAY_NAME_TEMPORARY_PLACEHOLDER)//
 				.replace(INDEX_PLACEHOLDER, String.valueOf(invocationIndex));
 
 		if (result.contains(ARGUMENTS_WITH_NAMES_PLACEHOLDER)) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -62,7 +62,7 @@ class ParameterizedTestNameFormatter {
 		MessageFormat format = new MessageFormat(pattern);
 		Object[] humanReadableArguments = makeReadable(format, namedArguments);
 		String formatted = format.format(humanReadableArguments);
-		return formatted.replace("__DISPLAY_NAME__",  this.displayName);
+		return formatted.replace("__DISPLAY_NAME__", this.displayName);
 	}
 
 	private Object[] extractNamedArguments(Object[] arguments) {
@@ -72,9 +72,9 @@ class ParameterizedTestNameFormatter {
 	}
 
 	private String prepareMessageFormatPattern(int invocationIndex, Object[] arguments) {
-			String result = pattern//
-					.replace(DISPLAY_NAME_PLACEHOLDER, "__DISPLAY_NAME__")//
-					.replace(INDEX_PLACEHOLDER, String.valueOf(invocationIndex));
+		String result = pattern//
+				.replace(DISPLAY_NAME_PLACEHOLDER, "__DISPLAY_NAME__")//
+				.replace(INDEX_PLACEHOLDER, String.valueOf(invocationIndex));
 
 		if (result.contains(ARGUMENTS_WITH_NAMES_PLACEHOLDER)) {
 			result = result.replace(ARGUMENTS_WITH_NAMES_PLACEHOLDER, argumentsWithNamesPattern(arguments));

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -61,7 +61,8 @@ class ParameterizedTestNameFormatter {
 		String pattern = prepareMessageFormatPattern(invocationIndex, namedArguments);
 		MessageFormat format = new MessageFormat(pattern);
 		Object[] humanReadableArguments = makeReadable(format, namedArguments);
-		return format.format(humanReadableArguments);
+		String formatted = format.format(humanReadableArguments);
+		return formatted.replace("__DISPLAY_NAME__",  this.displayName);
 	}
 
 	private Object[] extractNamedArguments(Object[] arguments) {
@@ -71,9 +72,9 @@ class ParameterizedTestNameFormatter {
 	}
 
 	private String prepareMessageFormatPattern(int invocationIndex, Object[] arguments) {
-		String result = pattern//
-				.replace(DISPLAY_NAME_PLACEHOLDER, this.displayName)//
-				.replace(INDEX_PLACEHOLDER, String.valueOf(invocationIndex));
+			String result = pattern//
+					.replace(DISPLAY_NAME_PLACEHOLDER, "__DISPLAY_NAME__")//
+					.replace(INDEX_PLACEHOLDER, String.valueOf(invocationIndex));
 
 		if (result.contains(ARGUMENTS_WITH_NAMES_PLACEHOLDER)) {
 			result = result.replace(ARGUMENTS_WITH_NAMES_PLACEHOLDER, argumentsWithNamesPattern(arguments));

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestNameFormatter.java
@@ -31,12 +31,12 @@ import org.junit.platform.commons.util.StringUtils;
 class ParameterizedTestNameFormatter {
 
 	private static final char ELLIPSIS = '\u2026';
+	private static final String DISPLAY_NAME_TEMPORARY_PLACEHOLDER = "__DISPLAY_NAME__";
 
 	private final String pattern;
 	private final String displayName;
 	private final ParameterizedTestMethodContext methodContext;
 	private final int argumentMaxLength;
-	private final String DISPLAY_NAME_TEMPORARY_PLACEHOLDER = "__DISPLAY_NAME__";
 
 	ParameterizedTestNameFormatter(String pattern, String displayName, ParameterizedTestMethodContext methodContext,
 			int argumentMaxLength) {

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -61,6 +61,14 @@ class ParameterizedTestNameFormatterTests {
 	}
 
 	@Test
+	void formatsDisplayNameWithApostrophe() {
+		var formatter = formatter(DISPLAY_NAME_PLACEHOLDER, "display'Zero");
+
+		assertEquals("display'Zero", formatter.format(1));
+		assertEquals("display'Zero", formatter.format(2));
+	}
+
+	@Test
 	void formatsInvocationIndex() {
 		var formatter = formatter(INDEX_PLACEHOLDER, "enigma");
 

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -62,10 +62,20 @@ class ParameterizedTestNameFormatterTests {
 
 	@Test
 	void formatsDisplayNameWithApostrophe() {
+		String displayName = "display'Zero";
 		var formatter = formatter(DISPLAY_NAME_PLACEHOLDER, "display'Zero");
 
-		assertEquals("display'Zero", formatter.format(1));
-		assertEquals("display'Zero", formatter.format(2));
+		assertEquals(displayName, formatter.format(1));
+		assertEquals(displayName, formatter.format(2));
+	}
+
+	@Test
+	void formatsDisplayNameContainingFormatElements() {
+		String displayName = "{enigma} {0} '{1}'";
+		var formatter = formatter(DISPLAY_NAME_PLACEHOLDER, displayName);
+
+		assertEquals(displayName, formatter.format(1));
+		assertEquals(displayName, formatter.format(2));
 	}
 
 	@Test

--- a/junit-jupiter-params/src/test/kotlin/ParameterizedTestNameFormatterIntegrationTests.kt
+++ b/junit-jupiter-params/src/test/kotlin/ParameterizedTestNameFormatterIntegrationTests.kt
@@ -1,0 +1,60 @@
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+@TestMethodOrder(MethodOrderer.MethodName::class)
+class ParameterizedTestNameFormatterIntegrationTests {
+    @BeforeEach
+    fun setUp(info: TestInfo) {
+        System.out.printf(
+                "Class: %s, method: %s%nDisplay Name: %s%n%n",
+                info.testClass.orElseThrow(),
+                info.testMethod.orElseThrow(),
+                info.displayName
+        )
+    }
+
+    @MethodSource("methodSource")
+    @ParameterizedTest
+    fun `implicit'Name`(param: String) {
+        Assertions.assertNotNull(param)
+    }
+
+    @MethodSource("methodSource")
+    @ParameterizedTest(name = "{0}")
+    fun `zero'Only`(param: String) {
+        Assertions.assertNotNull(param)
+    }
+
+    @MethodSource("methodSource")
+    @ParameterizedTest(name = "{displayName}")
+    fun `displayName'Only`(param: String) {
+        Assertions.assertNotNull(param)
+    }
+
+    @MethodSource("methodSource")
+    @ParameterizedTest(name = "{displayName} - {0}")
+    fun `displayName'Zero`(param: String) {
+        Assertions.assertNotNull(param)
+    }
+
+    @MethodSource("methodSource")
+    @ParameterizedTest(name = "{0} - {displayName}")
+    fun `zero'DisplayName`(param: String) {
+        Assertions.assertNotNull(param)
+    }
+
+    companion object {
+
+        @JvmStatic
+        private fun methodSource(): Array<String> =
+                arrayOf(
+                        "foo",
+                        "bar"
+                )
+    }
+}

--- a/junit-jupiter-params/src/test/kotlin/ParameterizedTestNameFormatterIntegrationTests.kt
+++ b/junit-jupiter-params/src/test/kotlin/ParameterizedTestNameFormatterIntegrationTests.kt
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2015-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.MethodOrderer
@@ -11,10 +20,10 @@ class ParameterizedTestNameFormatterIntegrationTests {
     @BeforeEach
     fun setUp(info: TestInfo) {
         System.out.printf(
-                "Class: %s, method: %s%nDisplay Name: %s%n%n",
-                info.testClass.orElseThrow(),
-                info.testMethod.orElseThrow(),
-                info.displayName
+            "Class: %s, method: %s%nDisplay Name: %s%n%n",
+            info.testClass.orElseThrow(),
+            info.testMethod.orElseThrow(),
+            info.displayName
         )
     }
 
@@ -52,9 +61,9 @@ class ParameterizedTestNameFormatterIntegrationTests {
 
         @JvmStatic
         private fun methodSource(): Array<String> =
-                arrayOf(
-                        "foo",
-                        "bar"
-                )
+            arrayOf(
+                "foo",
+                "bar"
+            )
     }
 }

--- a/junit-jupiter-params/src/test/kotlin/ParameterizedTestNameFormatterIntegrationTests.kt
+++ b/junit-jupiter-params/src/test/kotlin/ParameterizedTestNameFormatterIntegrationTests.kt
@@ -7,69 +7,56 @@
  *
  * https://www.eclipse.org/legal/epl-v20.html
  */
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.TestInfo
-import org.junit.jupiter.api.TestMethodOrder
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 
-@TestMethodOrder(MethodOrderer.MethodName::class)
 class ParameterizedTestNameFormatterIntegrationTests {
 
-    @MethodSource("methodSource")
+    @ValueSource(strings = ["foo", "bar"])
     @ParameterizedTest
     fun `implicit'Name`(param: String, info: TestInfo) {
         if (param.equals("foo")) {
-            Assertions.assertEquals("[1] foo", info.displayName)
+            assertEquals("[1] foo", info.displayName)
         } else {
-            Assertions.assertEquals("[2] bar", info.displayName)
+            assertEquals("[2] bar", info.displayName)
         }
     }
 
-    @MethodSource("methodSource")
+    @ValueSource(strings = ["foo", "bar"])
     @ParameterizedTest(name = "{0}")
     fun `zero'Only`(param: String, info: TestInfo) {
         if (param.equals("foo")) {
-            Assertions.assertEquals("foo", info.displayName)
+            assertEquals("foo", info.displayName)
         } else {
-            Assertions.assertEquals("bar", info.displayName)
+            assertEquals("bar", info.displayName)
         }
     }
 
-    @MethodSource("methodSource")
+    @ValueSource(strings = ["foo", "bar"])
     @ParameterizedTest(name = "{displayName}")
     fun `displayName'Only`(param: String, info: TestInfo) {
-        Assertions.assertEquals("displayName'Only(String, TestInfo)", info.displayName)
+        assertEquals("displayName'Only(String, TestInfo)", info.displayName)
     }
 
-    @MethodSource("methodSource")
+    @ValueSource(strings = ["foo", "bar"])
     @ParameterizedTest(name = "{displayName} - {0}")
     fun `displayName'Zero`(param: String, info: TestInfo) {
         if (param.equals("foo")) {
-            Assertions.assertEquals("displayName'Zero(String, TestInfo) - foo", info.displayName)
+            assertEquals("displayName'Zero(String, TestInfo) - foo", info.displayName)
         } else {
-            Assertions.assertEquals("displayName'Zero(String, TestInfo) - bar", info.displayName)
+            assertEquals("displayName'Zero(String, TestInfo) - bar", info.displayName)
         }
     }
 
-    @MethodSource("methodSource")
+    @ValueSource(strings = ["foo", "bar"])
     @ParameterizedTest(name = "{0} - {displayName}")
     fun `zero'DisplayName`(param: String, info: TestInfo) {
         if (param.equals("foo")) {
-            Assertions.assertEquals("foo - zero'DisplayName(String, TestInfo)", info.displayName)
+            assertEquals("foo - zero'DisplayName(String, TestInfo)", info.displayName)
         } else {
-            Assertions.assertEquals("bar - zero'DisplayName(String, TestInfo)", info.displayName)
+            assertEquals("bar - zero'DisplayName(String, TestInfo)", info.displayName)
         }
-    }
-
-    companion object {
-
-        @JvmStatic
-        private fun methodSource(): Array<String> =
-            arrayOf(
-                "foo",
-                "bar"
-            )
     }
 }

--- a/junit-jupiter-params/src/test/kotlin/ParameterizedTestNameFormatterIntegrationTests.kt
+++ b/junit-jupiter-params/src/test/kotlin/ParameterizedTestNameFormatterIntegrationTests.kt
@@ -8,7 +8,6 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.TestMethodOrder
@@ -17,44 +16,51 @@ import org.junit.jupiter.params.provider.MethodSource
 
 @TestMethodOrder(MethodOrderer.MethodName::class)
 class ParameterizedTestNameFormatterIntegrationTests {
-    @BeforeEach
-    fun setUp(info: TestInfo) {
-        System.out.printf(
-            "Class: %s, method: %s%nDisplay Name: %s%n%n",
-            info.testClass.orElseThrow(),
-            info.testMethod.orElseThrow(),
-            info.displayName
-        )
-    }
 
     @MethodSource("methodSource")
     @ParameterizedTest
-    fun `implicit'Name`(param: String) {
-        Assertions.assertNotNull(param)
+    fun `implicit'Name`(param: String, info: TestInfo) {
+        if (param.equals("foo")) {
+            Assertions.assertEquals("[1] foo", info.displayName)
+        } else {
+            Assertions.assertEquals("[2] bar", info.displayName)
+        }
     }
 
     @MethodSource("methodSource")
     @ParameterizedTest(name = "{0}")
-    fun `zero'Only`(param: String) {
-        Assertions.assertNotNull(param)
+    fun `zero'Only`(param: String, info: TestInfo) {
+        if (param.equals("foo")) {
+            Assertions.assertEquals("foo", info.displayName)
+        } else {
+            Assertions.assertEquals("bar", info.displayName)
+        }
     }
 
     @MethodSource("methodSource")
     @ParameterizedTest(name = "{displayName}")
-    fun `displayName'Only`(param: String) {
-        Assertions.assertNotNull(param)
+    fun `displayName'Only`(param: String, info: TestInfo) {
+        Assertions.assertEquals("displayName'Only(String, TestInfo)", info.displayName)
     }
 
     @MethodSource("methodSource")
     @ParameterizedTest(name = "{displayName} - {0}")
-    fun `displayName'Zero`(param: String) {
-        Assertions.assertNotNull(param)
+    fun `displayName'Zero`(param: String, info: TestInfo) {
+        if (param.equals("foo")) {
+            Assertions.assertEquals("displayName'Zero(String, TestInfo) - foo", info.displayName)
+        } else {
+            Assertions.assertEquals("displayName'Zero(String, TestInfo) - bar", info.displayName)
+        }
     }
 
     @MethodSource("methodSource")
     @ParameterizedTest(name = "{0} - {displayName}")
-    fun `zero'DisplayName`(param: String) {
-        Assertions.assertNotNull(param)
+    fun `zero'DisplayName`(param: String, info: TestInfo) {
+        if (param.equals("foo")) {
+            Assertions.assertEquals("foo - zero'DisplayName(String, TestInfo)", info.displayName)
+        } else {
+            Assertions.assertEquals("bar - zero'DisplayName(String, TestInfo)", info.displayName)
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Overview

The `@ParameterizedTest` annotation was breaking name generation by not allowing `'` in the method names for Kotlin-based tests or in custom display names in geneeral. It also made it so that placeholders were not being replaced correctly.

To solve it, instead of replacing the `DISPLAY_NAME_PLACEHOLDER` before the `MessageFormat` was being evaluated, the `DISPLAY_NAME_PLACEHOLDER` is now replaced with another temporary placeholder, which is then replaced after the `MessageFormat` is evaluated.

Solves: #3235 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Change is documented in the [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
