### PR TITLE
Enable Gradle's configuration cache by default

### DIFF
--- a/.github/actions/main-build/action.yml
+++ b/.github/actions/main-build/action.yml
@@ -17,3 +17,8 @@ runs:
       with:
         name: Test Distribution trace files (${{ github.job }})
         path: '**/build/test-results/*/trace.json'
+    - uses: actions/upload-artifact@v3
+      if: ${{ always() }}
+      with:
+        name: Configuration Cache reports (${{ github.job }})
+        path: 'build/reports/configuration-cache/**'

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -51,3 +51,8 @@ jobs:
         with:
           name: "Test Distribution trace files (OpenJDK ${{ matrix.jdk }})"
           path: '**/build/test-results/*/trace.json'
+      - uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: "Configuration Cache reports (OpenJDK ${{ matrix.jdk }})"
+          path: 'build/reports/configuration-cache/**'

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.configuration-cache=true
 org.gradle.java.installations.fromEnv=JDK8,JDK18,JDK19,JDK20,JDK21
 
 # Test Distribution


### PR DESCRIPTION
To opt-out, use `--no-configuration-cache`
