### PR TITLE
Load classes using the test's own `ClassLoader`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -15,7 +15,8 @@ repository on GitHub.
 
 ==== Bug Fixes
 
-* ❓
+* Use a test class's own classloader to search for `@MethodSource` and `MethodBasedCondition` methods.
+  This allows these features to work correctly inside an OSGi framework.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
@@ -57,13 +57,14 @@ abstract class MethodBasedCondition<A extends Annotation> implements ExecutionCo
 	}
 
 	private Method getConditionMethod(String fullyQualifiedMethodName, ExtensionContext context) {
+		final Class<?> testClass = context.getRequiredTestClass();
 		if (!fullyQualifiedMethodName.contains("#")) {
-			return findMethod(context.getRequiredTestClass(), fullyQualifiedMethodName);
+			return findMethod(testClass, fullyQualifiedMethodName);
 		}
 		String[] methodParts = ReflectionUtils.parseFullyQualifiedMethodName(fullyQualifiedMethodName);
 		String className = methodParts[0];
 		String methodName = methodParts[1];
-		Class<?> clazz = ReflectionUtils.tryToLoadClass(className).getOrThrow(
+		Class<?> clazz = ReflectionUtils.tryToLoadClass(className, testClass.getClassLoader()).getOrThrow(
 			cause -> new JUnitException(format("Could not load class [%s]", className), cause));
 		return findMethod(clazz, methodName);
 	}


### PR DESCRIPTION
Load classes using a `ClassLoader` obtained from the test class or fall back to the default class loader.

This allows JUnit to find the classes while running inside an OSGi framework.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).