### PR TITLE
[params] Use test class' classloader to load parameters

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestMethodContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestMethodContext.java
@@ -253,7 +253,7 @@ class ParameterizedTestMethodContext {
 
 		@Override
 		public Object resolve(ParameterContext parameterContext, Object[] arguments, int invocationIndex) {
-			ArgumentsAccessor accessor = new DefaultArgumentsAccessor(invocationIndex, arguments);
+			ArgumentsAccessor accessor = new DefaultArgumentsAccessor(invocationIndex, parameterContext, arguments);
 			try {
 				return this.argumentsAggregator.aggregateArguments(accessor, parameterContext);
 			}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessor.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessor.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.converter.DefaultArgumentConverter;
 import org.junit.platform.commons.util.ClassUtils;
 import org.junit.platform.commons.util.Preconditions;
@@ -37,12 +38,14 @@ public class DefaultArgumentsAccessor implements ArgumentsAccessor {
 
 	private final int invocationIndex;
 	private final Object[] arguments;
+	private final DefaultArgumentConverter converter;
 
-	public DefaultArgumentsAccessor(int invocationIndex, Object... arguments) {
+	public DefaultArgumentsAccessor(int invocationIndex, ParameterContext context, Object... arguments) {
 		Preconditions.condition(invocationIndex >= 1, () -> "invocation index must be >= 1");
 		Preconditions.notNull(arguments, "Arguments array must not be null");
 		this.invocationIndex = invocationIndex;
 		this.arguments = arguments;
+		this.converter = new DefaultArgumentConverter(context);
 	}
 
 	@Override
@@ -57,7 +60,7 @@ public class DefaultArgumentsAccessor implements ArgumentsAccessor {
 		Preconditions.notNull(requiredType, "requiredType must not be null");
 		Object value = get(index);
 		try {
-			Object convertedValue = DefaultArgumentConverter.INSTANCE.convert(value, requiredType);
+			Object convertedValue = converter.convert(value, requiredType);
 			return requiredType.cast(convertedValue);
 		}
 		catch (Exception ex) {

--- a/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
+++ b/junit-jupiter-params/src/test/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessorTests.java
@@ -31,53 +31,54 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void argumentsMustNotBeNull() {
-		assertThrows(PreconditionViolationException.class, () -> new DefaultArgumentsAccessor(1, (Object[]) null));
+		assertThrows(PreconditionViolationException.class,
+			() -> new DefaultArgumentsAccessor(1, null, (Object[]) null));
 	}
 
 	@Test
 	void indexMustNotBeNegative() {
-		ArgumentsAccessor arguments = new DefaultArgumentsAccessor(1, 1, 2);
+		ArgumentsAccessor arguments = new DefaultArgumentsAccessor(1, null, 1, 2);
 		Exception exception = assertThrows(PreconditionViolationException.class, () -> arguments.get(-1));
 		assertThat(exception.getMessage()).containsSubsequence("index must be", ">= 0");
 	}
 
 	@Test
 	void indexMustBeSmallerThanLength() {
-		ArgumentsAccessor arguments = new DefaultArgumentsAccessor(1, 1, 2);
+		ArgumentsAccessor arguments = new DefaultArgumentsAccessor(1, null, 1, 2);
 		Exception exception = assertThrows(PreconditionViolationException.class, () -> arguments.get(2));
 		assertThat(exception.getMessage()).containsSubsequence("index must be", "< 2");
 	}
 
 	@Test
 	void getNull() {
-		assertNull(new DefaultArgumentsAccessor(1, new Object[] { null }).get(0));
+		assertNull(new DefaultArgumentsAccessor(1, null, new Object[] { null }).get(0));
 	}
 
 	@Test
 	void getWithNullCastToWrapperType() {
-		assertNull(new DefaultArgumentsAccessor(1, (Object[]) new Integer[] { null }).get(0, Integer.class));
+		assertNull(new DefaultArgumentsAccessor(1, null, (Object[]) new Integer[] { null }).get(0, Integer.class));
 	}
 
 	@Test
 	void get() {
-		assertEquals(1, new DefaultArgumentsAccessor(1, 1).get(0));
+		assertEquals(1, new DefaultArgumentsAccessor(1, null, 1).get(0));
 	}
 
 	@Test
 	void getWithCast() {
-		assertEquals(Integer.valueOf(1), new DefaultArgumentsAccessor(1, 1).get(0, Integer.class));
-		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1, 'A').get(0, Character.class));
+		assertEquals(Integer.valueOf(1), new DefaultArgumentsAccessor(1, null, 1).get(0, Integer.class));
+		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1, null, 'A').get(0, Character.class));
 	}
 
 	@Test
 	void getWithCastToPrimitiveType() {
 		Exception exception = assertThrows(ArgumentAccessException.class,
-			() -> new DefaultArgumentsAccessor(1, 1).get(0, int.class));
+			() -> new DefaultArgumentsAccessor(1, null, 1).get(0, int.class));
 		assertThat(exception.getMessage()).isEqualTo(
 			"Argument at index [0] with value [1] and type [java.lang.Integer] could not be converted or cast to type [int].");
 
 		exception = assertThrows(ArgumentAccessException.class,
-			() -> new DefaultArgumentsAccessor(1, new Object[] { null }).get(0, int.class));
+			() -> new DefaultArgumentsAccessor(1, null, new Object[] { null }).get(0, int.class));
 		assertThat(exception.getMessage()).isEqualTo(
 			"Argument at index [0] with value [null] and type [null] could not be converted or cast to type [int].");
 	}
@@ -85,59 +86,59 @@ class DefaultArgumentsAccessorTests {
 	@Test
 	void getWithCastToIncompatibleType() {
 		Exception exception = assertThrows(ArgumentAccessException.class,
-			() -> new DefaultArgumentsAccessor(1, 1).get(0, Character.class));
+			() -> new DefaultArgumentsAccessor(1, null, 1).get(0, Character.class));
 		assertThat(exception.getMessage()).isEqualTo(
 			"Argument at index [0] with value [1] and type [java.lang.Integer] could not be converted or cast to type [java.lang.Character].");
 	}
 
 	@Test
 	void getCharacter() {
-		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1, 'A', 'B').getCharacter(0));
+		assertEquals(Character.valueOf('A'), new DefaultArgumentsAccessor(1, null, 'A', 'B').getCharacter(0));
 	}
 
 	@Test
 	void getBoolean() {
-		assertEquals(Boolean.TRUE, new DefaultArgumentsAccessor(1, true, false).getBoolean(0));
+		assertEquals(Boolean.TRUE, new DefaultArgumentsAccessor(1, null, true, false).getBoolean(0));
 	}
 
 	@Test
 	void getByte() {
-		assertEquals(Byte.valueOf((byte) 42), new DefaultArgumentsAccessor(1, (byte) 42).getByte(0));
+		assertEquals(Byte.valueOf((byte) 42), new DefaultArgumentsAccessor(1, null, (byte) 42).getByte(0));
 	}
 
 	@Test
 	void getShort() {
-		assertEquals(Short.valueOf((short) 42), new DefaultArgumentsAccessor(1, (short) 42).getShort(0));
+		assertEquals(Short.valueOf((short) 42), new DefaultArgumentsAccessor(1, null, (short) 42).getShort(0));
 	}
 
 	@Test
 	void getInteger() {
-		assertEquals(Integer.valueOf(42), new DefaultArgumentsAccessor(1, 42).getInteger(0));
+		assertEquals(Integer.valueOf(42), new DefaultArgumentsAccessor(1, null, 42).getInteger(0));
 	}
 
 	@Test
 	void getLong() {
-		assertEquals(Long.valueOf(42L), new DefaultArgumentsAccessor(1, 42L).getLong(0));
+		assertEquals(Long.valueOf(42L), new DefaultArgumentsAccessor(1, null, 42L).getLong(0));
 	}
 
 	@Test
 	void getFloat() {
-		assertEquals(Float.valueOf(42.0f), new DefaultArgumentsAccessor(1, 42.0f).getFloat(0));
+		assertEquals(Float.valueOf(42.0f), new DefaultArgumentsAccessor(1, null, 42.0f).getFloat(0));
 	}
 
 	@Test
 	void getDouble() {
-		assertEquals(Double.valueOf(42.0), new DefaultArgumentsAccessor(1, 42.0).getDouble(0));
+		assertEquals(Double.valueOf(42.0), new DefaultArgumentsAccessor(1, null, 42.0).getDouble(0));
 	}
 
 	@Test
 	void getString() {
-		assertEquals("foo", new DefaultArgumentsAccessor(1, "foo", "bar").getString(0));
+		assertEquals("foo", new DefaultArgumentsAccessor(1, null, "foo", "bar").getString(0));
 	}
 
 	@Test
 	void toArray() {
-		var arguments = new DefaultArgumentsAccessor(1, "foo", "bar");
+		var arguments = new DefaultArgumentsAccessor(1, null, "foo", "bar");
 		var copy = arguments.toArray();
 		assertArrayEquals(new String[] { "foo", "bar" }, copy);
 
@@ -148,7 +149,7 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void toList() {
-		var arguments = new DefaultArgumentsAccessor(1, "foo", "bar");
+		var arguments = new DefaultArgumentsAccessor(1, null, "foo", "bar");
 		var copy = arguments.toList();
 		assertIterableEquals(Arrays.asList("foo", "bar"), copy);
 
@@ -158,9 +159,9 @@ class DefaultArgumentsAccessorTests {
 
 	@Test
 	void size() {
-		assertEquals(0, new DefaultArgumentsAccessor(1).size());
-		assertEquals(1, new DefaultArgumentsAccessor(1, 42).size());
-		assertEquals(5, new DefaultArgumentsAccessor(1, 'a', 'b', 'c', 'd', 'e').size());
+		assertEquals(0, new DefaultArgumentsAccessor(1, null).size());
+		assertEquals(1, new DefaultArgumentsAccessor(1, null, 42).size());
+		assertEquals(5, new DefaultArgumentsAccessor(1, null, 'a', 'b', 'c', 'd', 'e').size());
 	}
 
 }

--- a/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/aggregator/ArgumentsAccessorKotlinTests.kt
+++ b/junit-jupiter-params/src/test/kotlin/org/junit/jupiter/params/aggregator/ArgumentsAccessorKotlinTests.kt
@@ -21,14 +21,14 @@ class ArgumentsAccessorKotlinTests {
 
     @Test
     fun `get() with reified type and index`() {
-        assertEquals(1, DefaultArgumentsAccessor(1, 1).get<Int>(0))
-        assertEquals('A', DefaultArgumentsAccessor(1, 'A').get<Char>(0))
+        assertEquals(1, DefaultArgumentsAccessor(1, null, 1).get<Int>(0))
+        assertEquals('A', DefaultArgumentsAccessor(1, null, 'A').get<Char>(0))
     }
 
     @Test
     fun `get() with reified type and index for incompatible type`() {
         val exception = assertThrows<ArgumentAccessException> {
-            DefaultArgumentsAccessor(1, Integer.valueOf(1)).get<Char>(0)
+            DefaultArgumentsAccessor(1, null, Integer.valueOf(1)).get<Char>(0)
         }
 
         assertThat(exception).hasMessage(
@@ -38,13 +38,13 @@ class ArgumentsAccessorKotlinTests {
 
     @Test
     fun `get() with index`() {
-        assertEquals(1, DefaultArgumentsAccessor(1, 1).get(0))
-        assertEquals('A', DefaultArgumentsAccessor(1, 'A').get(0))
+        assertEquals(1, DefaultArgumentsAccessor(1, null, 1).get(0))
+        assertEquals('A', DefaultArgumentsAccessor(1, null, 'A').get(0))
     }
 
     @Test
     fun `get() with index and class reference`() {
-        assertEquals(1, DefaultArgumentsAccessor(1, 1).get(0, Integer::class.java))
-        assertEquals('A', DefaultArgumentsAccessor(1, 'A').get(0, Character::class.java))
+        assertEquals(1, DefaultArgumentsAccessor(1, null, 1).get(0, Integer::class.java))
+        assertEquals('A', DefaultArgumentsAccessor(1, null, 'A').get(0, Character::class.java))
     }
 }


### PR DESCRIPTION
Fixes #3291.

## Overview

As noted in #3291, to support varied classloader environments, the argument converter/loader logic should ideally be classloader aware. The best thing to do is to use the test class' classloader to load any classes. This PR attempts to do this.

The declaring class (and hence its classloader) is available through the `ParameterContext` (`getParameter().getDeclaringExecutable().getDeclaringClass()`). However, the reference to the `ParameterContext` is lost in the `SimpleArgumentConverter` abstraction, from which `DefaultArgumentConverter` currently inherits. Hence I have changed `DefaultArgumentConverter` to implement `ArgumentConverter` directly. This technical represents a major (breaking) change to the package `org.junit.jupiter.params.converter`, because `DefaultArgumentConverter` is a public class in that package. However, because it's been annotated `INTERNAL` I don't think that that matters (any downstream users that have inherited from it probably deserve what they get... :smile:).

I have tried to implement it as best as I can so that if (for whatever reason) the `DefaultArgumentConverter` doesn't have access to the parameter context, then it will fall back to its current behaviour. If one is present, then it will use the test class' classloader.

The implementation was complicated by the fact that `DefaultArgumentsAccessor` invokes `DefaultArgumentsConverter.convert()` directly, and  `DefaultArgumentsAccessor` (and the `ArgumentsAccessor` API provides no `ParameterContext`. So there was no way to pass the necessary information in to `convert()`. I have added the `ParameterContext` as a constructor parameter to `DefaultArgumentsAccessor` to work around this. It might have been cleaner (less changes to the tests) to add a second constructor instead and have the original delegate to the new one, 

The current implementation passes all current tests (at least, it did on my machine!) but I haven't added new tests for the enhanced class-loader-sensitive functionality as yet. I want to make sure that we're happy with this direction before I invest that time. There are a couple of different ways that this cat could be skinned (no offence to cats intended) and the interaction between the various default implementations is a bit complicated.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
