### PR TITLE
Add explicit ClassLoader support for NestedClass/MethodSelectors

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -37,9 +37,10 @@ repository on GitHub.
   `ClassLoader`. This allows parameter types to be resolved with custom `ClassLoader`
   arrangements (such as OSGi). Consequently, `DiscoverySelectors.selectMethod(Class<?>,
   String, String)` also now works properly with custom `ClassLoader` arrangements.
-* New overloaded constructors for `ClassSelector`, `NestedClassSelector`, and
-  `MethodSelector` that take an explicit `ClassLoader` as a parameter, allowing selectors
-  to select classes in custom `ClassLoader` arrangements like in OSGi.
+* New overloaded constructors for `ClassSelector`, `NestedClassSelector`,
+  `MethodSelector`, and `NestedMethodSelector` that take an explicit `ClassLoader` as a
+  parameter, allowing selectors to select classes in custom `ClassLoader` arrangements
+  like in OSGi.
 * For consistency with JUnit Jupiter lifecycle callbacks, listener method pairs for
   started/finished and opened/closed events are now invoked using "wrapping" semantics.
   This means that finished/closed event methods are invoked in reverse order compared to

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-M1.adoc
@@ -37,9 +37,9 @@ repository on GitHub.
   `ClassLoader`. This allows parameter types to be resolved with custom `ClassLoader`
   arrangements (such as OSGi). Consequently, `DiscoverySelectors.selectMethod(Class<?>,
   String, String)` also now works properly with custom `ClassLoader` arrangements.
-* New overloaded constructors for `ClassSelector` and `MethodSelector` that take an
-  explicit `ClassLoader` as a parameter, allowing selectors to select classes in custom
-  `ClassLoader` arrangements like in OSGi.
+* New overloaded constructors for `ClassSelector`, `NestedClassSelector`, and
+  `MethodSelector` that take an explicit `ClassLoader` as a parameter, allowing selectors
+  to select classes in custom `ClassLoader` arrangements like in OSGi.
 * For consistency with JUnit Jupiter lifecycle callbacks, listener method pairs for
   started/finished and opened/closed events are now invoked using "wrapping" semantics.
   This means that finished/closed event methods are invoked in reverse order compared to

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassSelector.java
@@ -49,10 +49,6 @@ public class ClassSelector implements DiscoverySelector {
 
 	private Class<?> javaClass;
 
-	ClassSelector(String className) {
-		this(className, null);
-	}
-
 	ClassSelector(String className, ClassLoader classLoader) {
 		this.className = className;
 		this.classLoader = classLoader;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -635,9 +635,26 @@ public final class DiscoverySelectors {
 	 */
 	@API(status = STABLE, since = "1.6")
 	public static NestedClassSelector selectNestedClass(List<String> enclosingClassNames, String nestedClassName) {
+		return selectNestedClass(enclosingClassNames, nestedClassName, null);
+	}
+
+	/**
+	 * Create a {@code NestedClassSelector} for the supplied class name, its enclosing
+	 * classes' names, and class loader.
+	 *
+	 * @param enclosingClassNames the names of the enclosing classes; never {@code null} or empty
+	 * @param nestedClassName the name of the nested class to select; never {@code null} or blank
+	 * @param classLoader the class loader to use to load the enclosing and nested classes, or
+	 * {@code null} to signal that the default {@code ClassLoader} should be used
+	 * @since 1.10
+	 * @see NestedClassSelector
+	 */
+	@API(status = EXPERIMENTAL, since = "1.10")
+	public static NestedClassSelector selectNestedClass(List<String> enclosingClassNames, String nestedClassName,
+			ClassLoader classLoader) {
 		Preconditions.notEmpty(enclosingClassNames, "Enclosing class names must not be null or empty");
 		Preconditions.notBlank(nestedClassName, "Nested class name must not be null or blank");
-		return new NestedClassSelector(enclosingClassNames, nestedClassName);
+		return new NestedClassSelector(enclosingClassNames, nestedClassName, classLoader);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -669,11 +669,29 @@ public final class DiscoverySelectors {
 	@API(status = STABLE, since = "1.6")
 	public static NestedMethodSelector selectNestedMethod(List<String> enclosingClassNames, String nestedClassName,
 			String methodName) {
+		return selectNestedMethod(enclosingClassNames, nestedClassName, methodName, (ClassLoader) null);
+	}
 
+	/**
+	 * Create a {@code NestedMethodSelector} for the supplied nested class name, method name,
+	 * and class loader.
+	 *
+	 * @param enclosingClassNames the names of the enclosing classes; never {@code null} or empty
+	 * @param nestedClassName the name of the nested class to select; never {@code null} or blank
+	 * @param methodName the name of the method to select; never {@code null} or blank
+	 * @param classLoader the class loader to use to load the method's declaring
+	 * class, or {@code null} to signal that the default {@code ClassLoader}
+	 * should be used
+	 * @since 1.10
+	 * @see NestedMethodSelector
+	 */
+	@API(status = EXPERIMENTAL, since = "1.10")
+	public static NestedMethodSelector selectNestedMethod(List<String> enclosingClassNames, String nestedClassName,
+			String methodName, ClassLoader classLoader) throws PreconditionViolationException {
 		Preconditions.notEmpty(enclosingClassNames, "Enclosing class names must not be null or empty");
 		Preconditions.notBlank(nestedClassName, "Nested class name must not be null or blank");
 		Preconditions.notBlank(methodName, "Method name must not be null or blank");
-		return new NestedMethodSelector(enclosingClassNames, nestedClassName, methodName);
+		return new NestedMethodSelector(enclosingClassNames, nestedClassName, methodName, classLoader);
 	}
 
 	/**
@@ -696,12 +714,35 @@ public final class DiscoverySelectors {
 	@API(status = STABLE, since = "1.6")
 	public static NestedMethodSelector selectNestedMethod(List<String> enclosingClassNames, String nestedClassName,
 			String methodName, String methodParameterTypes) {
+		return selectNestedMethod(enclosingClassNames, nestedClassName, methodName, methodParameterTypes, null);
+	}
+
+	/**
+	 * Create a {@code NestedMethodSelector} for the supplied nested class name, method name,
+	 * method parameter types, and class loader.
+	 *
+	 * @param enclosingClassNames the names of the enclosing classes; never {@code null} or empty
+	 * @param nestedClassName the name of the nested class to select; never {@code null} or blank
+	 * @param methodName the name of the method to select; never {@code null} or blank
+	 * @param methodParameterTypes the method parameter types as a single string; never
+	 * {@code null} though potentially an empty string if the method does not accept
+	 * arguments
+	 * @param classLoader the class loader to use to load the method's declaring
+	 * class, or {@code null} to signal that the default {@code ClassLoader}
+	 * should be used
+	 * @since 1.10
+	 * @see #selectNestedMethod(List, String, String, String)
+	 */
+	@API(status = EXPERIMENTAL, since = "1.10")
+	public static NestedMethodSelector selectNestedMethod(List<String> enclosingClassNames, String nestedClassName,
+			String methodName, String methodParameterTypes, ClassLoader classLoader) {
 
 		Preconditions.notEmpty(enclosingClassNames, "Enclosing class names must not be null or empty");
 		Preconditions.notBlank(nestedClassName, "Nested class name must not be null or blank");
 		Preconditions.notBlank(methodName, "Method name must not be null or blank");
 		Preconditions.notNull(methodParameterTypes, "Parameter types must not be null");
-		return new NestedMethodSelector(enclosingClassNames, nestedClassName, methodName, methodParameterTypes);
+		return new NestedMethodSelector(enclosingClassNames, nestedClassName, methodName, methodParameterTypes,
+			classLoader);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
@@ -63,16 +63,8 @@ public class MethodSelector implements DiscoverySelector {
 	private Class<?> javaClass;
 	private Method javaMethod;
 
-	MethodSelector(String className, String methodName) {
-		this(className, methodName, (ClassLoader) null);
-	}
-
 	MethodSelector(String className, String methodName, ClassLoader classLoader) {
 		this(className, methodName, "", classLoader);
-	}
-
-	MethodSelector(String className, String methodName, String methodParameterTypes) {
-		this(className, methodName, methodParameterTypes, null);
 	}
 
 	MethodSelector(String className, String methodName, String methodParameterTypes, ClassLoader classLoader) {
@@ -236,10 +228,10 @@ public class MethodSelector implements DiscoverySelector {
 	public String toString() {
 		// @formatter:off
 		return new ToStringBuilder(this)
-				.append("className", this.className)
-				.append("methodName", this.methodName)
-				.append("methodParameterTypes", this.methodParameterTypes)
-				.append("classLoader", this.classLoader)
+				.append("className", getClassName())
+				.append("methodName", getMethodName())
+				.append("methodParameterTypes", getMethodParameterTypes())
+				.append("classLoader", getClassLoader())
 				.toString();
 		// @formatter:on
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedMethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/NestedMethodSelector.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine.discovery;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.Method;
@@ -55,15 +56,15 @@ public class NestedMethodSelector implements DiscoverySelector {
 	private final NestedClassSelector nestedClassSelector;
 	private final MethodSelector methodSelector;
 
-	NestedMethodSelector(List<String> enclosingClassNames, String nestedClassName, String methodName) {
-		this.nestedClassSelector = new NestedClassSelector(enclosingClassNames, nestedClassName);
-		this.methodSelector = new MethodSelector(nestedClassName, methodName);
+	NestedMethodSelector(List<String> enclosingClassNames, String nestedClassName, String methodName,
+			ClassLoader classLoader) {
+		this(enclosingClassNames, nestedClassName, methodName, "", classLoader);
 	}
 
 	NestedMethodSelector(List<String> enclosingClassNames, String nestedClassName, String methodName,
-			String methodParameterTypes) {
-		this.nestedClassSelector = new NestedClassSelector(enclosingClassNames, nestedClassName);
-		this.methodSelector = new MethodSelector(nestedClassName, methodName, methodParameterTypes);
+			String methodParameterTypes, ClassLoader classLoader) {
+		this.nestedClassSelector = new NestedClassSelector(enclosingClassNames, nestedClassName, classLoader);
+		this.methodSelector = new MethodSelector(nestedClassName, methodName, methodParameterTypes, classLoader);
 	}
 
 	NestedMethodSelector(List<Class<?>> enclosingClasses, Class<?> nestedClass, String methodName) {
@@ -80,6 +81,16 @@ public class NestedMethodSelector implements DiscoverySelector {
 	NestedMethodSelector(List<Class<?>> enclosingClasses, Class<?> nestedClass, Method method) {
 		this.nestedClassSelector = new NestedClassSelector(enclosingClasses, nestedClass);
 		this.methodSelector = new MethodSelector(nestedClass, method);
+	}
+
+	/**
+	 * Get the {@link ClassLoader} used to load the nested class.
+	 *
+	 * @since 1.10
+	 */
+	@API(status = EXPERIMENTAL, since = "1.10")
+	public ClassLoader getClassLoader() {
+		return this.nestedClassSelector.getClassLoader();
 	}
 
 	/**
@@ -182,6 +193,7 @@ public class NestedMethodSelector implements DiscoverySelector {
 				.append("nestedClassName", getNestedClassName()) //
 				.append("methodName", getMethodName()) //
 				.append("methodParameterTypes", getMethodParameterTypes()) //
+				.append("classLoader", getClassLoader()) //
 				.toString();
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/ClassSelectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/ClassSelectorTests.java
@@ -27,16 +27,16 @@ class ClassSelectorTests extends AbstractEqualsAndHashCodeTests {
 
 	@Test
 	void equalsAndHashCode() {
-		var selector1 = new ClassSelector("org.example.TestClass");
-		var selector2 = new ClassSelector("org.example.TestClass");
-		var selector3 = new ClassSelector("org.example.X");
+		var selector1 = new ClassSelector("org.example.TestClass", null);
+		var selector2 = new ClassSelector("org.example.TestClass", null);
+		var selector3 = new ClassSelector("org.example.X", null);
 
 		assertEqualsAndHashCode(selector1, selector2, selector3);
 	}
 
 	@Test
 	void preservesOriginalExceptionWhenTryingToLoadClass() {
-		var selector = new ClassSelector("org.example.TestClass");
+		var selector = new ClassSelector("org.example.TestClass", null);
 
 		var e = assertThrows(PreconditionViolationException.class, selector::getJavaClass);
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
@@ -692,6 +692,27 @@ class DiscoverySelectorsTests {
 		}
 
 		@Test
+		void selectNestedClassByClassNamesAndClassLoader() throws Exception {
+			var testClasses = List.of(AbstractClassWithNestedInnerClass.class, ClassWithNestedInnerClass.class,
+				AbstractClassWithNestedInnerClass.NestedClass.class);
+			try (var testClassLoader = TestClassLoader.forClasses(testClasses.toArray(Class[]::new))) {
+
+				var selector = selectNestedClass(List.of(enclosingClassName), nestedClassName, testClassLoader);
+
+				assertThat(selector.getEnclosingClasses()).doesNotContain(ClassWithNestedInnerClass.class);
+				assertThat(selector.getEnclosingClasses()).extracting(Class::getName).containsOnly(enclosingClassName);
+				assertThat(selector.getNestedClass()).isNotEqualTo(AbstractClassWithNestedInnerClass.NestedClass.class);
+				assertThat(selector.getNestedClass().getName()).isEqualTo(nestedClassName);
+
+				assertThat(selector.getClassLoader()).isSameAs(testClassLoader);
+				assertThat(selector.getEnclosingClasses()).extracting(Class::getClassLoader).containsOnly(
+					testClassLoader);
+				assertThat(selector.getNestedClass().getClassLoader()).isSameAs(testClassLoader);
+				assertSame(testClassLoader, selector.getNestedClass().getClassLoader());
+			}
+		}
+
+		@Test
 		void selectDoubleNestedClassByClassNames() {
 			var selector = selectNestedClass(List.of(enclosingClassName, nestedClassName), doubleNestedClassName);
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
@@ -748,6 +748,30 @@ class DiscoverySelectorsTests {
 		}
 
 		@Test
+		void selectNestedMethodByEnclosingClassNamesAndMethodNameAndClassLoader() throws Exception {
+			var testClasses = List.of(AbstractClassWithNestedInnerClass.class, ClassWithNestedInnerClass.class,
+				AbstractClassWithNestedInnerClass.NestedClass.class);
+			try (var testClassLoader = TestClassLoader.forClasses(testClasses.toArray(Class[]::new))) {
+
+				var selector = selectNestedMethod(List.of(enclosingClassName), nestedClassName, methodName,
+					testClassLoader);
+
+				assertThat(selector.getEnclosingClasses()).doesNotContain(ClassWithNestedInnerClass.class);
+				assertThat(selector.getEnclosingClasses()).extracting(Class::getName).containsOnly(enclosingClassName);
+				assertThat(selector.getNestedClass()).isNotEqualTo(AbstractClassWithNestedInnerClass.NestedClass.class);
+				assertThat(selector.getNestedClass().getName()).isEqualTo(nestedClassName);
+
+				assertThat(selector.getClassLoader()).isSameAs(testClassLoader);
+				assertThat(selector.getEnclosingClasses()).extracting(Class::getClassLoader).containsOnly(
+					testClassLoader);
+				assertThat(selector.getNestedClass().getClassLoader()).isSameAs(testClassLoader);
+				assertSame(testClassLoader, selector.getNestedClass().getClassLoader());
+
+				assertThat(selector.getMethodName()).isEqualTo(methodName);
+			}
+		}
+
+		@Test
 		void selectNestedMethodByEnclosingClassesAndMethodName() throws Exception {
 			var selector = selectNestedMethod(List.of(ClassWithNestedInnerClass.class),
 				AbstractClassWithNestedInnerClass.NestedClass.class, methodName);
@@ -774,6 +798,31 @@ class DiscoverySelectorsTests {
 			assertThat(selector.getEnclosingClassNames()).containsOnly(enclosingClassName);
 			assertThat(selector.getNestedClassName()).isEqualTo(nestedClassName);
 			assertThat(selector.getMethodName()).isEqualTo(methodName);
+		}
+
+		@Test
+		void selectNestedMethodByEnclosingClassNamesAndMethodNameWithParameterTypesAndClassLoader() throws Exception {
+			var testClasses = List.of(AbstractClassWithNestedInnerClass.class, ClassWithNestedInnerClass.class,
+				AbstractClassWithNestedInnerClass.NestedClass.class);
+			try (var testClassLoader = TestClassLoader.forClasses(testClasses.toArray(Class[]::new))) {
+
+				var selector = selectNestedMethod(List.of(enclosingClassName), nestedClassName, methodName,
+					String.class.getName(), testClassLoader);
+
+				assertThat(selector.getEnclosingClasses()).doesNotContain(ClassWithNestedInnerClass.class);
+				assertThat(selector.getEnclosingClasses()).extracting(Class::getName).containsOnly(enclosingClassName);
+				assertThat(selector.getNestedClass()).isNotEqualTo(AbstractClassWithNestedInnerClass.NestedClass.class);
+				assertThat(selector.getNestedClass().getName()).isEqualTo(nestedClassName);
+
+				assertThat(selector.getClassLoader()).isSameAs(testClassLoader);
+				assertThat(selector.getEnclosingClasses()).extracting(Class::getClassLoader).containsOnly(
+					testClassLoader);
+				assertThat(selector.getNestedClass().getClassLoader()).isSameAs(testClassLoader);
+				assertSame(testClassLoader, selector.getNestedClass().getClassLoader());
+
+				assertThat(selector.getMethodName()).isEqualTo(methodName);
+				assertThat(selector.getMethodParameterTypes()).isEqualTo(String.class.getName());
+			}
 		}
 
 		@Test
@@ -808,7 +857,8 @@ class DiscoverySelectorsTests {
 			assertViolatesPrecondition(() -> selectNestedMethod(List.of("ClassName"), "ClassName", null, "int"));
 			assertViolatesPrecondition(() -> selectNestedMethod(List.of("ClassName"), "ClassName", " "));
 			assertViolatesPrecondition(() -> selectNestedMethod(List.of("ClassName"), "ClassName", " ", "int"));
-			assertViolatesPrecondition(() -> selectNestedMethod(List.of("ClassName"), "ClassName", "methodName", null));
+			assertViolatesPrecondition(
+				() -> selectNestedMethod(List.of("ClassName"), "ClassName", "methodName", (String) null));
 		}
 
 		abstract class AbstractClassWithNestedInnerClass {

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/MethodSelectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/MethodSelectorTests.java
@@ -30,7 +30,7 @@ class MethodSelectorTests extends AbstractEqualsAndHashCodeTests {
 		var selector1 = new MethodSelector("TestClass", "method", "int, boolean", null);
 		var selector2 = new MethodSelector("TestClass", "method", "int, boolean", null);
 
-		assertEqualsAndHashCode(selector1, selector2, new MethodSelector("TestClass", "method", "int"));
+		assertEqualsAndHashCode(selector1, selector2, new MethodSelector("TestClass", "method", "int", null));
 		assertEqualsAndHashCode(selector1, selector2, new MethodSelector("TestClass", "method", (ClassLoader) null));
 		assertEqualsAndHashCode(selector1, selector2, new MethodSelector("TestClass", "X", "int, boolean", null));
 		assertEqualsAndHashCode(selector1, selector2, new MethodSelector("TestClass", "X", (ClassLoader) null));

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/NestedClassSelectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/NestedClassSelectorTests.java
@@ -30,18 +30,18 @@ class NestedClassSelectorTests extends AbstractEqualsAndHashCodeTests {
 	@Test
 	void equalsAndHashCode() {
 		var selector1 = new NestedClassSelector(List.of("org.example.EnclosingTestClass"),
-			"org.example.NestedTestClass");
+			"org.example.NestedTestClass", null);
 		var selector2 = new NestedClassSelector(List.of("org.example.EnclosingTestClass"),
-			"org.example.NestedTestClass");
-		var selector3 = new NestedClassSelector(List.of("org.example.X"), "org.example.Y");
+			"org.example.NestedTestClass", null);
+		var selector3 = new NestedClassSelector(List.of("org.example.X"), "org.example.Y", null);
 
 		assertEqualsAndHashCode(selector1, selector2, selector3);
 	}
 
 	@Test
 	void preservesOriginalExceptionWhenTryingToLoadEnclosingClasses() {
-		var selector = new NestedClassSelector(List.of("org.example.EnclosingTestClass"),
-			"org.example.NestedTestClass");
+		var selector = new NestedClassSelector(List.of("org.example.EnclosingTestClass"), "org.example.NestedTestClass",
+			null);
 
 		var exception = assertThrows(PreconditionViolationException.class, selector::getEnclosingClasses);
 
@@ -51,12 +51,23 @@ class NestedClassSelectorTests extends AbstractEqualsAndHashCodeTests {
 
 	@Test
 	void preservesOriginalExceptionWhenTryingToLoadNestedClass() {
-		var selector = new NestedClassSelector(List.of("org.example.EnclosingTestClass"),
-			"org.example.NestedTestClass");
+		var selector = new NestedClassSelector(List.of("org.example.EnclosingTestClass"), "org.example.NestedTestClass",
+			null);
 
 		var exception = assertThrows(PreconditionViolationException.class, selector::getNestedClass);
 
 		assertThat(exception).hasMessage("Could not load class with name: org.example.NestedTestClass") //
 				.hasCauseInstanceOf(ClassNotFoundException.class);
+	}
+
+	@Test
+	void usesClassClassLoader() {
+		var selector = new NestedClassSelector(List.of(getClass()), NestedTestCase.class);
+
+		assertThat(selector.getClassLoader()).isNotNull().isSameAs(getClass().getClassLoader());
+	}
+
+	@SuppressWarnings("InnerClassMayBeStatic")
+	class NestedTestCase {
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/NestedMethodSelectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/NestedMethodSelectorTests.java
@@ -29,32 +29,33 @@ class NestedMethodSelectorTests extends AbstractEqualsAndHashCodeTests {
 
 	@Test
 	void equalsAndHashCode() {
-		var selector1 = new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method",
-			"int, boolean");
-		var selector2 = new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method",
-			"int, boolean");
+		var selector1 = new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "int, boolean",
+			null);
+		var selector2 = new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "int, boolean",
+			null);
 
 		assertEqualsAndHashCode(selector1, selector2,
-			new NestedMethodSelector(List.of("X"), "NestedTestClass", "method", "int, boolean"));
+			new NestedMethodSelector(List.of("X"), "NestedTestClass", "method", "int, boolean", null));
 		assertEqualsAndHashCode(selector1, selector2,
-			new NestedMethodSelector(List.of("X"), "NestedTestClass", "method"));
+			new NestedMethodSelector(List.of("X"), "NestedTestClass", "method", "", null));
 		assertEqualsAndHashCode(selector1, selector2,
-			new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "int"));
+			new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "int", null));
 		assertEqualsAndHashCode(selector1, selector2,
-			new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method"));
+			new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "", null));
 		assertEqualsAndHashCode(selector1, selector2,
-			new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "X", "int, boolean"));
+			new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "X", "int, boolean", null));
 		assertEqualsAndHashCode(selector1, selector2,
-			new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "X"));
+			new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "X", "", null));
 		assertEqualsAndHashCode(selector1, selector2,
-			new NestedMethodSelector(List.of("EnclosingClass"), "X", "method", "int, boolean"));
+			new NestedMethodSelector(List.of("EnclosingClass"), "X", "method", "int, boolean", null));
 		assertEqualsAndHashCode(selector1, selector2,
-			new NestedMethodSelector(List.of("EnclosingClass"), "X", "method"));
+			new NestedMethodSelector(List.of("EnclosingClass"), "X", "method", "", null));
 	}
 
 	@Test
 	void preservesOriginalExceptionWhenTryingToLoadEnclosingClass() {
-		var selector = new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "int, boolean");
+		var selector = new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "int, boolean",
+			null);
 
 		var exception = assertThrows(PreconditionViolationException.class, selector::getEnclosingClasses);
 
@@ -64,12 +65,26 @@ class NestedMethodSelectorTests extends AbstractEqualsAndHashCodeTests {
 
 	@Test
 	void preservesOriginalExceptionWhenTryingToLoadNestedClass() {
-		var selector = new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "int, boolean");
+		var selector = new NestedMethodSelector(List.of("EnclosingClass"), "NestedTestClass", "method", "int, boolean",
+			null);
 
 		var exception = assertThrows(PreconditionViolationException.class, selector::getNestedClass);
 
 		assertThat(exception).hasMessage("Could not load class with name: NestedTestClass") //
 				.hasCauseInstanceOf(ClassNotFoundException.class);
+	}
+
+	@Test
+	void usesClassClassLoader() {
+		var selector = new NestedMethodSelector(List.of(getClass()), NestedTestCase.class, "method", "");
+
+		assertThat(selector.getClassLoader()).isNotNull().isSameAs(getClass().getClassLoader());
+	}
+
+	@SuppressWarnings("InnerClassMayBeStatic")
+	class NestedTestCase {
+		void method() {
+		}
 	}
 
 }


### PR DESCRIPTION
## Overview

- Reduce number of internal constructors
- Support explicit ClassLoader in NestedClassSelector
- Support explicit ClassLoader in NestedMethodSelector

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
