### PR TITLE
Support `@TempDir` as a meta-annotation

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-RC1.adoc
@@ -24,6 +24,7 @@ JUnit repository on GitHub.
 ==== New Features and Improvements
 
 * Add `@SelectMethod` selector support to `@Suite` test engine
+* `@TempDir` can now be used in meta-annotations
 
 
 [[release-notes-5.10.0-RC1-junit-jupiter]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2644,6 +2644,19 @@ temporary directory. The following example shows how to do it.
 include::{testDir}/example/TempDirectoryDemo.java[tags=user_guide_factory_jimfs]
 ----
 
+`@TempDir` can also be used in meta-annotations to reduce repetition.
+
+[source,java,indent=0]
+.A definition of a meta-annotation using `@TempDir`
+----
+include::{testDir}/example/TempDirectoryDemo.java[tags=user_guide_meta_annotation]
+----
+[source,java,indent=0]
+.A test class using a meta-annotation
+----
+include::{testDir}/example/TempDirectoryDemo.java[tags=user_guide_meta_annotation_usage]
+----
+
 You can use the `junit.jupiter.tempdir.factory.default`
 <<running-tests-config-params, configuration parameter>> to specify the fully qualified
 class name of the `TempDirFactory` you would like to use by default. Just like for

--- a/documentation/src/test/java/example/TempDirectoryDemo.java
+++ b/documentation/src/test/java/example/TempDirectoryDemo.java
@@ -17,6 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.io.CleanupMode.ON_SUCCESS;
 
 import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,6 +28,7 @@ import java.nio.file.Path;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 
+import example.TempDirectoryDemo.InMemoryTempDirDemo.JimfsTempDirFactory;
 import example.util.ListWriter;
 
 import org.junit.jupiter.api.Test;
@@ -141,5 +146,26 @@ class TempDirectoryDemo {
 
 	}
 	// end::user_guide_factory_jimfs[]
+
+	// tag::user_guide_meta_annotation[]
+	@Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.PARAMETER })
+	@Retention(RetentionPolicy.RUNTIME)
+	@TempDir(factory = JimfsTempDirFactory.class)
+	@interface JimfsTempDir {
+
+	}
+	// end::user_guide_meta_annotation[]
+
+	static
+	// tag::user_guide_meta_annotation_usage[]
+	class JimfsTempDirAnnotationDemo {
+
+		@Test
+		void test(@JimfsTempDir Path tempDir) {
+			// perform test
+		}
+
+	}
+	// end::user_guide_meta_annotation_usage[]
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
@@ -90,7 +90,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  *
  * @since 5.4
  */
-@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(status = STABLE, since = "5.10")

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryMetaAnnotationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryMetaAnnotationTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+
+/**
+ * Integration tests for the use of {@link TempDir} as a meta-annotation.
+ *
+ * @since 5.10
+ */
+@DisplayName("@TempDir as a meta-annotation")
+class TempDirectoryMetaAnnotationTests extends AbstractJupiterTestEngineTests {
+
+	@Test
+	void annotationOnField() {
+		executeTestsForClass(AnnotationOnFieldTestCase.class).testEvents().assertStatistics(
+			stats -> stats.started(1).succeeded(1));
+	}
+
+	@Test
+	void annotationOnParameter() {
+		executeTestsForClass(AnnotationOnParameterTestCase.class).testEvents().assertStatistics(
+			stats -> stats.started(1).succeeded(1));
+	}
+
+	static class AnnotationOnFieldTestCase {
+
+		@MetaTempDir
+		private Path tempDir;
+
+		@Test
+		void test() {
+			assertTrue(Files.exists(tempDir));
+		}
+
+	}
+
+	static class AnnotationOnParameterTestCase {
+
+		@Test
+		void test(@MetaTempDir Path tempDir) {
+			assertTrue(Files.exists(tempDir));
+		}
+
+	}
+
+	@TempDir
+	@Target({ ElementType.FIELD, ElementType.PARAMETER })
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface MetaTempDir {
+
+	}
+
+}


### PR DESCRIPTION
## Overview

Add `ANNOTATION_TYPE` as a target to `@TempDir` to allow it to be used as a meta-annotation.

Issue: #3311

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
