### PR TITLE
Ignore build folders for spotlessDocumentation

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.spotless-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.spotless-conventions.gradle.kts
@@ -20,6 +20,7 @@ spotless {
 
 	format("documentation") {
 		target("*.adoc", "*.md", "src/**/*.adoc", "src/**/*.md")
+		targetExclude("**/build", "**/target")
 		trimTrailingWhitespace()
 		endWithNewline()
 	}


### PR DESCRIPTION
Fix a cache miss on `platform-tests` due to these changing inputs:
<img width="1056" alt="Screenshot 2023-05-22 at 5 08 23 PM" src="https://github.com/junit-team/junit5/assets/10243934/de3d2b49-6d28-45eb-aa30-f02bbaf174d5">
