### PR TITLE
Add a test executor not based on ForkJoinPool

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
@@ -134,6 +134,17 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 	public static final String CONFIG_FIXED_PARALLELISM_PROPERTY_NAME = "fixed.parallelism";
 
 	/**
+	 * Property name used to determine the executor to use for the
+	 * {@link #FIXED} configuration strategy.
+	 *
+	 * <p>Value must be either {@code forkjoinpool} or {@code threadpoolexecutor};
+	 * defaults to {@code forkjoinpool}.
+	 *
+	 * @see #FIXED
+	 */
+	public static final String CONFIG_FIXED_EXECUTOR_PROPERTY_NAME = "fixed.executor";
+
+	/**
 	 * Property name used to configure the maximum pool size of the underlying
 	 * fork-join pool for the {@link #FIXED} configuration strategy.
 	 *


### PR DESCRIPTION

## Overview

Adding a new executor based on #3108. This new executor will be opt-in via configuration, use a `ForkJoinPool` to schedule tests, and won't use instances of `ForkJoinPool` to execute the tests (most likely, a separate `ThreadPool` will be used). By making use of this executor, developers that are testing code which makes use of a `ForkJoinPool` won't experience issues with multiple tests being started without prior tests being finished.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
