### PR TITLE
Return subcommand execution result

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
@@ -135,6 +135,15 @@ class MainCommand implements Callable<Object>, IExitCodeGenerator {
 				.setOut(out) //
 				.setErr(err) //
 				.execute(args);
-		return CommandResult.create(exitCode, commandLine.getExecutionResult());
+		return CommandResult.create(exitCode, getLikelyExecutedCommand(commandLine).getExecutionResult());
+	}
+
+	/**
+	 * Gets the most likely executed subcommand, if any, or the main command otherwise.
+	 * @see <a href="https://picocli.info/#_executing_commands_with_subcommands">Executing Commands with Subcommands</a>
+	 */
+	private static CommandLine getLikelyExecutedCommand(final CommandLine commandLine) {
+		return Optional.ofNullable(commandLine.getParseResult().subcommand()).map(
+			parseResult -> parseResult.commandSpec().commandLine()).orElse(commandLine);
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
@@ -139,11 +139,12 @@ class MainCommand implements Callable<Object>, IExitCodeGenerator {
 	}
 
 	/**
-	 * Gets the most likely executed subcommand, if any, or the main command otherwise.
+	 * Get the most likely executed subcommand, if any, or the main command otherwise.
 	 * @see <a href="https://picocli.info/#_executing_commands_with_subcommands">Executing Commands with Subcommands</a>
 	 */
 	private static CommandLine getLikelyExecutedCommand(final CommandLine commandLine) {
-		return Optional.ofNullable(commandLine.getParseResult().subcommand()).map(
-			parseResult -> parseResult.commandSpec().commandLine()).orElse(commandLine);
+		return Optional.ofNullable(commandLine.getParseResult().subcommand()) //
+				.map(parseResult -> parseResult.commandSpec().commandLine()) //
+				.orElse(commandLine);
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
@@ -35,8 +35,10 @@ class ConsoleLauncherIntegrationTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "-e junit-jupiter -p org.junit.platform.console.subpackage",
-			"execute -e junit-jupiter -p org.junit.platform.console.subpackage" })
+	@ValueSource(strings = { //
+			"-e junit-jupiter -p org.junit.platform.console.subpackage", //
+			"execute -e junit-jupiter -p org.junit.platform.console.subpackage" //
+	})
 	void executeWithoutExcludeClassnameOptionDoesNotExcludeClassesAndMustIncludeAllClassesMatchingTheStandardClassnamePattern(
 			final String line) {
 		String[] args = line.split(" ");
@@ -48,7 +50,8 @@ class ConsoleLauncherIntegrationTests {
 			"-e junit-jupiter -p org.junit.platform.console.subpackage --exclude-classname"
 					+ " ^org\\.junit\\.platform\\.console\\.subpackage\\..*",
 			"execute -e junit-jupiter -p org.junit.platform.console.subpackage --exclude-classname"
-					+ " ^org\\.junit\\.platform\\.console\\.subpackage\\..*" })
+					+ " ^org\\.junit\\.platform\\.console\\.subpackage\\..*" //
+	})
 	void executeWithExcludeClassnameOptionExcludesClasses(final String line) {
 		String[] args = line.split(" ");
 		var result = new ConsoleLauncherWrapper().execute(args);
@@ -60,8 +63,10 @@ class ConsoleLauncherIntegrationTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "-e junit-jupiter -o java.base", "-e junit-jupiter --select-module java.base",
-			"execute -e junit-jupiter -o java.base", "execute -e junit-jupiter --select-module java.base" })
+	@ValueSource(strings = { //
+			"-e junit-jupiter -o java.base", "-e junit-jupiter --select-module java.base", //
+			"execute -e junit-jupiter -o java.base", "execute -e junit-jupiter --select-module java.base" //
+	})
 	void executeSelectingModuleNames(final String line) {
 		String[] args1 = line.split(" ");
 		assertEquals(0, new ConsoleLauncherWrapper().execute(args1).getTestsFoundCount());

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
@@ -16,6 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * @since 1.0
@@ -32,16 +34,23 @@ class ConsoleLauncherIntegrationTests {
 		);
 	}
 
-	@Test
-	void executeWithoutExcludeClassnameOptionDoesNotExcludeClassesAndMustIncludeAllClassesMatchingTheStandardClassnamePattern() {
-		String[] args = { "-e", "junit-jupiter", "-p", "org.junit.platform.console.subpackage" };
+	@ParameterizedTest
+	@ValueSource(strings = { "-e junit-jupiter -p org.junit.platform.console.subpackage",
+			"execute -e junit-jupiter -p org.junit.platform.console.subpackage" })
+	void executeWithoutExcludeClassnameOptionDoesNotExcludeClassesAndMustIncludeAllClassesMatchingTheStandardClassnamePattern(
+			final String line) {
+		String[] args = line.split(" ");
 		assertEquals(9, new ConsoleLauncherWrapper().execute(args).getTestsFoundCount());
 	}
 
-	@Test
-	void executeWithExcludeClassnameOptionExcludesClasses() {
-		String[] args = { "-e", "junit-jupiter", "-p", "org.junit.platform.console.subpackage", "--exclude-classname",
-				"^org\\.junit\\.platform\\.console\\.subpackage\\..*" };
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"-e junit-jupiter -p org.junit.platform.console.subpackage --exclude-classname"
+					+ " ^org\\.junit\\.platform\\.console\\.subpackage\\..*",
+			"execute -e junit-jupiter -p org.junit.platform.console.subpackage --exclude-classname"
+					+ " ^org\\.junit\\.platform\\.console\\.subpackage\\..*" })
+	void executeWithExcludeClassnameOptionExcludesClasses(final String line) {
+		String[] args = line.split(" ");
 		var result = new ConsoleLauncherWrapper().execute(args);
 		assertAll("all subpackage test classes are excluded by the class name filter", //
 			() -> assertArrayEquals(args, result.args), //
@@ -50,17 +59,18 @@ class ConsoleLauncherIntegrationTests {
 		);
 	}
 
-	@Test
-	void executeSelectingModuleNames() {
-		String[] args1 = { "-e", "junit-jupiter", "-o", "java.base" };
+	@ParameterizedTest
+	@ValueSource(strings = { "-e junit-jupiter -o java.base", "-e junit-jupiter --select-module java.base",
+			"execute -e junit-jupiter -o java.base", "execute -e junit-jupiter --select-module java.base" })
+	void executeSelectingModuleNames(final String line) {
+		String[] args1 = line.split(" ");
 		assertEquals(0, new ConsoleLauncherWrapper().execute(args1).getTestsFoundCount());
-		String[] args2 = { "-e", "junit-jupiter", "--select-module", "java.base" };
-		assertEquals(0, new ConsoleLauncherWrapper().execute(args2).getTestsFoundCount());
 	}
 
-	@Test
-	void executeScanModules() {
-		String[] args1 = { "-e", "junit-jupiter", "--scan-modules" };
+	@ParameterizedTest
+	@ValueSource(strings = { "-e junit-jupiter --scan-modules", "execute -e junit-jupiter --scan-modules" })
+	void executeScanModules(final String line) {
+		String[] args1 = line.split(" ");
 		assertEquals(0, new ConsoleLauncherWrapper().execute(args1).getTestsFoundCount());
 	}
 


### PR DESCRIPTION
## Overview

When explicitly specifying the `execute` subcommand as advised by:
> WARNING: Delegated to the 'execute' command.
>          This behaviour has been deprecated and will be removed in a future release.
>          Please use the 'execute' command directly.

... it happens that `ConsoleLauncher.run` returns a `CommandResult` whose `getValue` method always returns `Optional.empty()` instead of the expected (non-empty) `Optional<TestExecutionSummary>`.

It turns out that, when `picocli` executes a _subcommand_, it doesn't propagate the return value to the parent `CommandLine`, whose `getExecutionResult` method then returns `null`.

There was a question about it last year (https://github.com/remkop/picocli/issues/1656) answered by the [user manual](https://picocli.info/#_executing_commands_with_subcommands):
> The `ParseResult` can be used to get the return value from a Callable or Method subcommand:
> ```java
> // getting return value from Callable or Method command
> Object topResult = cmd.getExecutionResult();
>
> // getting return value from Callable or Method subcommand
> ParseResult parseResult = cmd.getParseResult();
> if (parseResult.subcommand() != null) {
>    CommandLine sub = parseResult.subcommand().commandSpec().commandLine();
>    Object subResult = sub.getExecutionResult();
> }
> ```

The present change therefore consists in implementing it.

Note: prior to the change, presently adapted tests (now parameterized so as to cover both forms) were all failing on:
```java
java.lang.IllegalStateException: TestExecutionSummary not assigned. Exit code is: 0
	at app//org.junit.platform.console.ConsoleLauncherWrapperResult.checkTestExecutionSummaryState(ConsoleLauncherWrapperResult.java:42)
	at app//org.junit.platform.console.ConsoleLauncherWrapperResult.getTestsFoundCount(ConsoleLauncherWrapperResult.java:102)
```

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- ~[ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc~
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- ~[ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)~
- ~[ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~
