### PR TITLE
Add optional reason attribute in @Execution

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Execution.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/Execution.java
@@ -99,4 +99,10 @@ public @interface Execution {
 	 */
 	ExecutionMode value();
 
+	/**
+	 * The reason of using a non-default execution mode.
+	 *
+	 */
+	String reason() default "";
+
 }


### PR DESCRIPTION
## Overview

I added an optional reason attribute in execution interface
---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
