### PR TITLE
Fix typo

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/launcher-api.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/launcher-api.adoc
@@ -168,7 +168,7 @@ include::{testDir}/example/session/HttpTests.java[tags=user_guide]
 
 In order to intercept the creation of instances of `{Launcher}` and
 `{LauncherSessionListener}` and calls to the `discover` and `execute` methods of the
-former, clients can registercustom implementations of `{LauncherInterceptor}` via Java's
+former, clients can register custom implementations of `{LauncherInterceptor}` via Java's
 `{ServiceLoader}` mechanism by additionally setting the
 `junit.platform.launcher.interceptors.enabled` <<running-tests-config-params,
 configuration parameter>> to `true`.


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

I fixed a typo.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done
Some of these are not relevant, but I checked the boxes.

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [X] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
