### PR TITLE
Document replacement for `@Test(expected = ...)` in JUnit 4 migration tips

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -63,6 +63,10 @@ tests to JUnit Jupiter.
 * `@Rule` and `@ClassRule` no longer exist; superseded by `@ExtendWith` and
   `@RegisterExtension`.
   - See also <<migrating-from-junit4-rule-support>>.
+* `@Test(expected = ...)` and the `ExpectedException` rule no longer exist; use
+  `Assertions.assertThrows(...)` instead.
+  See <<migrating-from-junit4-rule-support>> if you still do need to use
+  `ExpectedException`.
 * Assertions and assumptions in JUnit Jupiter accept the failure message as their last
   argument instead of the first one.
   - See <<migrating-from-junit4-failure-message-arguments>> for details.


### PR DESCRIPTION
## Overview

I believe that the `expected` property is widely used in JUnit 4, so it would deserve a note in the migration guide.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

