### PR TITLE
Work around bndtools/bnd#5695 by configuring jar tasks eagerly

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
@@ -14,7 +14,7 @@ val projectDescription = objects.property<String>().convention(provider { projec
 // metadata into the jar
 tasks.withType<Jar>().matching { task: Jar ->
 	task.name == "jar" || task.name == "shadowJar"
-}.all {
+}.all { // configure tasks eagerly as workaround for https://github.com/bndtools/bnd/issues/5695
 	extra["importAPIGuardian"] = importAPIGuardian
 
 	extensions.create<BundleTaskExtension>(BundleTaskExtension.NAME, this).apply {

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
@@ -14,7 +14,7 @@ val projectDescription = objects.property<String>().convention(provider { projec
 // metadata into the jar
 tasks.withType<Jar>().matching { task: Jar ->
 	task.name == "jar" || task.name == "shadowJar"
-}.configureEach {
+}.all {
 	extra["importAPIGuardian"] = importAPIGuardian
 
 	extensions.create<BundleTaskExtension>(BundleTaskExtension.NAME, this).apply {


### PR DESCRIPTION
Eagerly configure Jar tasks to create the BundleTaskExtension prior to the Gradle compileClasspath configuration becoming locked and triggering it's beforeLocking callback to run.  This allows the BND extension to modify the LibraryElements attribute on that configuration and request a variant with the "jar" value prior to Gradle automatically modifying the attribute to request the "classes" value.  This ensures jars are present on the classpath for BND to use when checked for exported classes to use when building the manifest.  If it only uses the classes directory for this task, it will not have access to version information and will not write version info to the manifest it is assembling for the current project, causing the verifyOSGi task to fail.

Addresses issue bndtools/bnd#5695 and allows merging of junit-team/junit5#3351.