### PR TITLE
Revise stacktrace pruning

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0-RC1.adoc
@@ -33,7 +33,10 @@ JUnit repository on GitHub.
 * New `selectMethod()` and `selectNestedMethod()` variants in `DiscoverySelectors` that
   accept a `Class<?>...` argument of parameter types as a type-safe alternative to
   providing the names of parameter types as a comma-delimited string.
-
+* Stack trace pruning has been revised and now only removes calls from the `org.junit`,
+  `jdk.internal.reflect`, and `sun.reflect` packages. Please refer to the
+  <<../user-guide/index.adoc#stacktrace-pruning, User Guide>> for details.
+* New `getAncestors()` method in `TestDescriptor`.
 
 [[release-notes-5.10.0-RC1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -1138,18 +1138,13 @@ Since version 1.10, the JUnit Platform provides built-in support for pruning sta
 produced by failing tests. This feature can be enabled or disabled via the
 `junit.platform.stacktrace.pruning.enabled` _configuration parameter_.
 
-By default, all calls from the `org.junit`, `java`, and `jdk` packages are removed from the
-stack trace. You can also configure the JUnit Platform to exclude different or additional
-calls. To do this, provide a pattern for the `junit.platform.stacktrace.pruning.pattern`
-_configuration parameter_ to specify which fully qualified class names should be excluded
-from the stack traces.
+If enabled, all calls from the `org.junit`, `jdk.internal.reflect`, and `sun.reflect`
+packages are removed from the stack trace, unless they are subsequent to the test itself
+or any of its ancestors. For that reason, calls to `{Assertions}` or `{Assumptions}` will
+never be excluded.
 
-In addition, and independently of the provided pattern, all elements prior to and
-including the first call from the JUnit Platform Launcher will be removed.
-
-NOTE: Since they provide necessary insights to understand a test failure, calls to
-`{Assertions}` or `{Assumptions}` will never be excluded from stack traces even though
-they are part of the `org.junit` package.
+In addition, all elements prior to and including the first call from the JUnit Platform
+Launcher will be removed.
 
 [[stacktrace-pruning-pattern]]
 ==== Pattern Matching Syntax

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.testing-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.testing-conventions.gradle.kts
@@ -41,7 +41,6 @@ tasks.withType<Test>().configureEach {
 		server.set(uri("https://ge.junit.org"))
 	}
 	systemProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager")
-	systemProperty("junit.platform.stacktrace.pruning.enabled", false)
 	// Required until ASM officially supports the JDK 14
 	systemProperty("net.bytebuddy.experimental", true)
 	if (buildParameters.testing.enableJFR) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
@@ -42,7 +42,8 @@ public final class ExceptionUtils {
 
 	private static final String JUNIT_PLATFORM_LAUNCHER_PACKAGE_PREFIX = "org.junit.platform.launcher.";
 
-	private static final String STACK_TRACE_ELEMENTS_TO_EXCLUDE = "org.junit.*,jdk.internal.reflect.*,sun.reflect.*";
+	private static final Predicate<String> STACK_TRACE_ELEMENT_FILTER = ClassNamePatternFilterUtils //
+			.excludeMatchingClassNames("org.junit.*,jdk.internal.reflect.*,sun.reflect.*");
 
 	private ExceptionUtils() {
 		/* no-op */
@@ -114,9 +115,6 @@ public final class ExceptionUtils {
 		Preconditions.notNull(throwable, "Throwable must not be null");
 		Preconditions.notNull(testClassNames, "List of test class names must not be null");
 
-		Predicate<String> stackTraceElementFilter = ClassNamePatternFilterUtils //
-				.excludeMatchingClassNames(STACK_TRACE_ELEMENTS_TO_EXCLUDE);
-
 		List<StackTraceElement> stackTrace = Arrays.asList(throwable.getStackTrace());
 		List<StackTraceElement> prunedStackTrace = new ArrayList<>();
 
@@ -134,7 +132,7 @@ public final class ExceptionUtils {
 			else if (className.startsWith(JUNIT_PLATFORM_LAUNCHER_PACKAGE_PREFIX)) {
 				prunedStackTrace.clear();
 			}
-			else if (stackTraceElementFilter.test(className)) {
+			else if (STACK_TRACE_ELEMENT_FILTER.test(className)) {
 				prunedStackTrace.add(element);
 			}
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -107,6 +107,26 @@ public interface TestDescriptor {
 	Set<? extends TestDescriptor> getChildren();
 
 	/**
+	 * Get the immutable set of all <em>ancestors</em> of this descriptor.
+	 *
+	 * <p>An <em>ancestors</em> is the parent of this descriptor or the parent
+	 * of one of its parents, recursively.
+	 *
+	 * @see #getParent()
+	 */
+	@API(status = STABLE, since = "5.10")
+	default Set<? extends TestDescriptor> getAncestors() {
+		if (!getParent().isPresent()) {
+			return Collections.emptySet();
+		}
+		TestDescriptor parent = getParent().get();
+		Set<TestDescriptor> ancestors = new LinkedHashSet<>();
+		ancestors.add(parent);
+		ancestors.addAll(parent.getAncestors());
+		return Collections.unmodifiableSet(ancestors);
+	}
+
+	/**
 	 * Get the immutable set of all <em>descendants</em> of this descriptor.
 	 *
 	 * <p>A <em>descendant</em> is a child of this descriptor or a child of one of

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -174,50 +174,6 @@ public class LauncherConstants {
 	@API(status = EXPERIMENTAL, since = "1.10")
 	public static final String STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME = "junit.platform.stacktrace.pruning.enabled";
 
-	/**
-	 * Property name used to provide patterns to remove elements from stack traces.
-	 *
-	 * <h4>Pattern Matching Syntax</h4>
-	 *
-	 * <p>If the property value consists solely of an asterisk ({@code *}), all
-	 * elements will be removed. Otherwise, the property value will be treated
-	 * as a comma-separated list of patterns where each individual pattern will
-	 * be matched against the fully qualified class name (<em>FQCN</em>) of the
-	 * stack trace element. Any dot ({@code .}) in a pattern will match against
-	 * a dot ({@code .}) or a dollar sign ({@code $}) in a FQCN. Any asterisk
-	 * ({@code *}) will match against one or more characters in a FQCN. All
-	 * other characters in a pattern will be matched one-to-one against a FQCN.
-	 *
-	 * <h4>Examples</h4>
-	 *
-	 * <ul>
-	 * <li>{@code *}: remove all elements.
-	 * <li>{@code org.junit.*}: remove every element with the {@code org.junit}
-	 * base package and any of its subpackages.
-	 * <li>{@code *.MyClass}: remove every element whose simple class name is
-	 * exactly {@code MyClass}.
-	 * <li>{@code *System*, *Dev*}: exclude every element whose FQCN contains
-	 * {@code System} or {@code Dev}.
-	 * <li>{@code org.example.MyClass, org.example.TheirClass}: remove
-	 * elements whose FQCN is exactly {@code org.example.MyClass} or
-	 * {@code org.example.TheirClass}.
-	 * </ul>
-	 *
-	 * @see #STACKTRACE_PRUNING_DEFAULT_PATTERN
-	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
-	public static final String STACKTRACE_PRUNING_PATTERN_PROPERTY_NAME = "junit.platform.stacktrace.pruning.pattern";
-
-	/**
-	 * Default pattern for stack trace pruning which matches the
-	 * {@code org.junit}, {@code java}, and {@code jdk} base packages as well
-	 * as any of their subpackages.
-	 *
-	 * @see #STACKTRACE_PRUNING_PATTERN_PROPERTY_NAME
-	 */
-	@API(status = EXPERIMENTAL, since = "1.10")
-	public static final String STACKTRACE_PRUNING_DEFAULT_PATTERN = "org.junit.*,java.*,jdk.*";
-
 	private LauncherConstants() {
 		/* no-op */
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -12,9 +12,7 @@ package org.junit.platform.launcher.core;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.launcher.LauncherConstants.DRY_RUN_PROPERTY_NAME;
-import static org.junit.platform.launcher.LauncherConstants.STACKTRACE_PRUNING_DEFAULT_PATTERN;
 import static org.junit.platform.launcher.LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME;
-import static org.junit.platform.launcher.LauncherConstants.STACKTRACE_PRUNING_PATTERN_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.ListenerRegistry.forEngineExecutionListeners;
 
 import java.util.Optional;
@@ -179,9 +177,7 @@ public class EngineExecutionOrchestrator {
 		boolean stackTracePruningEnabled = configurationParameters.getBoolean(STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME) //
 				.orElse(true);
 		if (stackTracePruningEnabled) {
-			String pruningPattern = configurationParameters.get(STACKTRACE_PRUNING_PATTERN_PROPERTY_NAME) //
-					.orElse(STACKTRACE_PRUNING_DEFAULT_PATTERN);
-			return new StackTracePruningEngineExecutionListener(engineExecutionListener, pruningPattern);
+			return new StackTracePruningEngineExecutionListener(engineExecutionListener);
 		}
 		return engineExecutionListener;
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
@@ -10,11 +10,9 @@
 
 package org.junit.platform.launcher.core;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.platform.commons.util.ExceptionUtils;
@@ -49,9 +47,10 @@ class StackTracePruningEngineExecutionListener extends DelegatingEngineExecution
 	}
 
 	private static List<String> getTestClassNames(TestDescriptor testDescriptor) {
-		return findAllParentDescriptors(testDescriptor) //
+		return testDescriptor.getAncestors() //
 				.stream() //
-				.map(TestDescriptor::getSource).filter(Optional::isPresent) //
+				.map(TestDescriptor::getSource) //
+				.filter(Optional::isPresent) //
 				.map(Optional::get) //
 				.map(source -> {
 					if (source instanceof ClassSource) {
@@ -66,20 +65,6 @@ class StackTracePruningEngineExecutionListener extends DelegatingEngineExecution
 				}) //
 				.filter(Objects::nonNull) //
 				.collect(Collectors.toList());
-	}
-
-	private static Set<TestDescriptor> findAllParentDescriptors(TestDescriptor testDescriptor) {
-		return findParentDescriptors(testDescriptor, new HashSet<>());
-	}
-
-	private static Set<TestDescriptor> findParentDescriptors(TestDescriptor testDescriptor,
-			Set<TestDescriptor> visitedDescriptors) {
-		if (testDescriptor.isRoot()) {
-			return visitedDescriptors;
-		}
-		TestDescriptor parent = testDescriptor.getParent().get();
-		visitedDescriptors.add(parent);
-		return findParentDescriptors(parent, visitedDescriptors);
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
@@ -11,6 +11,7 @@
 package org.junit.platform.launcher.core;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -61,6 +62,7 @@ class StackTracePruningEngineExecutionListener extends DelegatingEngineExecution
 						return null;
 					}
 				}) //
+				.filter(Objects::nonNull) //
 				.collect(Collectors.toList());
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
@@ -10,49 +10,58 @@
 
 package org.junit.platform.launcher.core;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.function.Predicate;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.junit.platform.commons.util.ClassNamePatternFilterUtils;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
 
 /**
  * Prunes the stack trace in case of a failed event.
  *
  * @since 1.10
- * @see org.junit.platform.commons.util.ExceptionUtils#pruneStackTrace(Throwable, Predicate)
+ * @see org.junit.platform.commons.util.ExceptionUtils#pruneStackTrace(Throwable, List)
  */
 class StackTracePruningEngineExecutionListener extends DelegatingEngineExecutionListener {
 
-	private static final List<String> ALWAYS_INCLUDED_STACK_TRACE_ELEMENTS = Arrays.asList( //
-		"org.junit.jupiter.api.Assertions", //
-		"org.junit.jupiter.api.Assumptions" //
-	);
-
-	private final Predicate<String> stackTraceElementFilter;
-
-	StackTracePruningEngineExecutionListener(EngineExecutionListener delegate, String pruningPattern) {
+	StackTracePruningEngineExecutionListener(EngineExecutionListener delegate) {
 		super(delegate);
-		this.stackTraceElementFilter = ClassNamePatternFilterUtils.excludeMatchingClassNames(pruningPattern) //
-				.or(ALWAYS_INCLUDED_STACK_TRACE_ELEMENTS::contains);
 	}
 
 	@Override
 	public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
+		List<String> testClassNames = getTestClassNames(testDescriptor);
 		if (testExecutionResult.getThrowable().isPresent()) {
 			Throwable throwable = testExecutionResult.getThrowable().get();
 
-			ExceptionUtils.findNestedThrowables(throwable).forEach(this::pruneStackTrace);
+			ExceptionUtils.findNestedThrowables(throwable).forEach(
+				t -> ExceptionUtils.pruneStackTrace(t, testClassNames));
 		}
 		super.executionFinished(testDescriptor, testExecutionResult);
 	}
 
-	private void pruneStackTrace(Throwable throwable) {
-		ExceptionUtils.pruneStackTrace(throwable, stackTraceElementFilter);
+	private static List<String> getTestClassNames(TestDescriptor testDescriptor) {
+		return Stream.of(testDescriptor.getSource(), testDescriptor.getParent().flatMap(TestDescriptor::getSource)) //
+				.filter(Optional::isPresent) //
+				.map(Optional::get) //
+				.map(source -> {
+					if (source instanceof ClassSource) {
+						return ((ClassSource) source).getClassName();
+					}
+					else if (source instanceof MethodSource) {
+						return ((MethodSource) source).getClassName();
+					}
+					else {
+						return null;
+					}
+				}) //
+				.collect(Collectors.toList());
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ExceptionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ExceptionUtilsTests.java
@@ -18,7 +18,7 @@ import static org.junit.platform.commons.util.ExceptionUtils.readStackTrace;
 import static org.junit.platform.commons.util.ExceptionUtils.throwAsUncheckedException;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,42 +70,35 @@ class ExceptionUtilsTests {
 	@ParameterizedTest
 	@ValueSource(strings = { "org.junit.", "jdk.internal.reflect.", "sun.reflect." })
 	void pruneStackTraceOfCallsFromSpecificPackage(String shouldBePruned) {
-		try {
-			throw new JUnitException("expected");
-		}
-		catch (JUnitException e) {
-			pruneStackTrace(e, Collections.emptyList());
-			assertThat(e.getStackTrace()) //
-					.noneMatch(element -> element.toString().contains(shouldBePruned));
-		}
+		JUnitException exception = new JUnitException("expected");
+
+		pruneStackTrace(exception, List.of());
+
+		assertThat(exception.getStackTrace()) //
+				.noneMatch(element -> element.toString().contains(shouldBePruned));
 	}
 
 	@Test
 	void pruneStackTraceOfAllLauncherCalls() {
-		try {
-			throw new JUnitException("expected");
-		}
-		catch (JUnitException e) {
-			pruneStackTrace(e, Collections.emptyList());
-			assertThat(e.getStackTrace()) //
-					.noneMatch(element -> element.toString().contains("org.junit.platform.launcher."));
-		}
+		JUnitException exception = new JUnitException("expected");
+
+		pruneStackTrace(exception, List.of());
+
+		assertThat(exception.getStackTrace()) //
+				.noneMatch(element -> element.toString().contains("org.junit.platform.launcher."));
 	}
 
 	@Test
 	void pruneStackTraceOfEverythingPriorToFirstLauncherCall() {
-		try {
-			throw new JUnitException("expected");
-		}
-		catch (JUnitException e) {
-			StackTraceElement[] stackTrace = e.getStackTrace();
-			stackTrace[stackTrace.length - 1] = new StackTraceElement("org.example.Class", "method", "file", 123);
-			e.setStackTrace(stackTrace);
+		JUnitException exception = new JUnitException("expected");
+		StackTraceElement[] stackTrace = exception.getStackTrace();
+		stackTrace[stackTrace.length - 1] = new StackTraceElement("org.example.Class", "method", "file", 123);
+		exception.setStackTrace(stackTrace);
 
-			pruneStackTrace(e, Collections.emptyList());
-			assertThat(e.getStackTrace()) //
-					.noneMatch(element -> element.toString().contains("org.example.Class.method(file:123)"));
-		}
+		pruneStackTrace(exception, List.of());
+
+		assertThat(exception.getStackTrace()) //
+				.noneMatch(element -> element.toString().contains("org.example.Class.method(file:123)"));
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ExceptionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ExceptionUtilsTests.java
@@ -18,8 +18,11 @@ import static org.junit.platform.commons.util.ExceptionUtils.readStackTrace;
 import static org.junit.platform.commons.util.ExceptionUtils.throwAsUncheckedException;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.PreconditionViolationException;
 
@@ -64,15 +67,16 @@ class ExceptionUtilsTests {
 		}
 	}
 
-	@Test
-	void pruneStackTraceOfCallsFromSpecificPackage() {
+	@ParameterizedTest
+	@ValueSource(strings = { "org.junit.", "jdk.internal.reflect.", "sun.reflect." })
+	void pruneStackTraceOfCallsFromSpecificPackage(String shouldBePruned) {
 		try {
 			throw new JUnitException("expected");
 		}
 		catch (JUnitException e) {
-			pruneStackTrace(e, element -> !element.startsWith("org.junit."));
+			pruneStackTrace(e, Collections.emptyList());
 			assertThat(e.getStackTrace()) //
-					.noneMatch(element -> element.toString().contains("org.junit."));
+					.noneMatch(element -> element.toString().contains(shouldBePruned));
 		}
 	}
 
@@ -82,7 +86,7 @@ class ExceptionUtilsTests {
 			throw new JUnitException("expected");
 		}
 		catch (JUnitException e) {
-			pruneStackTrace(e, element -> true);
+			pruneStackTrace(e, Collections.emptyList());
 			assertThat(e.getStackTrace()) //
 					.noneMatch(element -> element.toString().contains("org.junit.platform.launcher."));
 		}
@@ -98,7 +102,7 @@ class ExceptionUtilsTests {
 			stackTrace[stackTrace.length - 1] = new StackTraceElement("org.example.Class", "method", "file", 123);
 			e.setStackTrace(stackTrace);
 
-			pruneStackTrace(e, element -> true);
+			pruneStackTrace(e, Collections.emptyList());
 			assertThat(e.getStackTrace()) //
 					.noneMatch(element -> element.toString().contains("org.example.Class.method(file:123)"));
 		}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine.support.descriptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -34,15 +35,18 @@ import org.junit.platform.engine.UniqueId;
 class AbstractTestDescriptorTests {
 
 	private EngineDescriptor engineDescriptor;
+	private GroupDescriptor group1;
+	private GroupDescriptor group11;
+	private LeafDescriptor leaf111;
 
 	@BeforeEach
 	void initTree() {
 		engineDescriptor = new EngineDescriptor(UniqueId.forEngine("testEngine"), "testEngine");
-		var group1 = new GroupDescriptor(UniqueId.root("group", "group1"));
+		group1 = new GroupDescriptor(UniqueId.root("group", "group1"));
 		engineDescriptor.addChild(group1);
 		var group2 = new GroupDescriptor(UniqueId.root("group", "group2"));
 		engineDescriptor.addChild(group2);
-		var group11 = new GroupDescriptor(UniqueId.root("group", "group1-1"));
+		group11 = new GroupDescriptor(UniqueId.root("group", "group1-1"));
 		group1.addChild(group11);
 
 		group1.addChild(new LeafDescriptor(UniqueId.root("leaf", "leaf1-1")));
@@ -50,7 +54,8 @@ class AbstractTestDescriptorTests {
 
 		group2.addChild(new LeafDescriptor(UniqueId.root("leaf", "leaf2-1")));
 
-		group11.addChild(new LeafDescriptor(UniqueId.root("leaf", "leaf11-1")));
+		leaf111 = new LeafDescriptor(UniqueId.root("leaf", "leaf11-1"));
+		group11.addChild(leaf111);
 	}
 
 	@Test
@@ -131,6 +136,27 @@ class AbstractTestDescriptorTests {
 
 		assertEquals(3, visited.size());
 		assertFalse(visited.contains(UniqueId.root("group", "group1")));
+	}
+
+	@Test
+	void getAncestors() {
+		assertThat(getAncestorsUniqueIds(engineDescriptor)).isEmpty();
+
+		assertThat(getAncestorsUniqueIds(group1)).containsExactly( //
+			UniqueId.forEngine("testEngine"));
+
+		assertThat(getAncestorsUniqueIds(group11)).containsExactly( //
+			UniqueId.root("group", "group1"), //
+			UniqueId.forEngine("testEngine"));
+
+		assertThat(getAncestorsUniqueIds(leaf111)).containsExactly( //
+			UniqueId.root("group", "group1-1"), //
+			UniqueId.root("group", "group1"), //
+			UniqueId.forEngine("testEngine"));
+	}
+
+	private List<UniqueId> getAncestorsUniqueIds(TestDescriptor descriptor) {
+		return descriptor.getAncestors().stream().map(TestDescriptor::getUniqueId).toList();
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
@@ -38,6 +38,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.fakes.TestEngineSpy;
 import org.junit.platform.launcher.InterceptedTestEngine;
 import org.junit.platform.launcher.InterceptorInjectedLauncherSessionListener;
+import org.junit.platform.launcher.LauncherConstants;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.LauncherSessionListener;
 import org.junit.platform.launcher.TagFilter;
@@ -298,7 +299,8 @@ class LauncherFactoryTests {
 					.addTestEngines(engine) //
 					.build();
 			var launcher = LauncherFactory.create(config);
-			var request = request().build();
+			var request = request().configurationParameter(LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME,
+				"false").build();
 
 			AtomicReference<TestExecutionResult> result = new AtomicReference<>();
 			launcher.execute(request, new TestExecutionListener() {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
@@ -51,6 +51,7 @@ import org.junit.platform.engine.support.hierarchical.DemoHierarchicalContainerD
 import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestDescriptor;
 import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestEngine;
 import org.junit.platform.fakes.TestDescriptorStub;
+import org.junit.platform.launcher.LauncherConstants;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 import org.opentest4j.AssertionFailedError;
@@ -429,7 +430,8 @@ class LegacyXmlReportGeneratingListenerTests {
 		var reportListener = new LegacyXmlReportGeneratingListener(tempDirectory.toString(), out, clock);
 		var launcher = createLauncher(engine);
 		launcher.registerTestExecutionListeners(reportListener);
-		launcher.execute(request().selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))).build());
+		launcher.execute(request().configurationParameter(LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME,
+			"false").selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))).build());
 	}
 
 	private Match readValidXmlFile(Path xmlFile) throws Exception {


### PR DESCRIPTION
## Overview

Resolves #3299

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
