### PR TITLE
Use explicit link label in AnnotationConsumer Javadoc

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumer.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumer.java
@@ -24,7 +24,7 @@ import org.apiguardian.api.API;
  * <p>It is typically implemented by implementations of
  * {@link org.junit.jupiter.params.provider.ArgumentsProvider ArgumentsProvider}
  * and {@link org.junit.jupiter.params.converter.ArgumentConverter ArgumentConverter}
- * in order to signal that they can {@link #accept} a certain annotation.
+ * in order to signal that they can {@link #accept accept} a certain annotation.
  *
  * @since 5.0
  */


### PR DESCRIPTION
## Overview

The [`AnnotationConsumer`](https://junit.org/junit5/docs/5.10.0-RC1/api/org.junit.jupiter.params/org/junit/jupiter/params/support/AnnotationConsumer.html) Javadoc page currently displays `{@link #accept}` as follows:

![Screenshot 2023-07-08 at 01 11 27](https://github.com/junit-team/junit5/assets/26772046/201c6a17-b3fa-4aa7-b376-335ce38fc7b8)

With this change, `{@link #accept accept}` is displayed as follows (locally generated):

![Screenshot 2023-07-08 at 01 23 03](https://github.com/junit-team/junit5/assets/26772046/3e614b4d-4080-4bec-b7e7-243a0328afb7)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).
