### PR TITLE
Provide access to source element annotations for `TempDirFactory`

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2672,6 +2672,11 @@ The following example demonstrates how to use the custom `@JimfsTempDir` annotat
 include::{testDir}/example/TempDirectoryDemo.java[tags=user_guide_composed_annotation_usage]
 ----
 
+Meta-annotations or additional annotations on the field or parameter the `TempDir`
+annotation is declared on might expose additional attributes to configure the factory.
+Such annotations and related attributes can be accessed via the `AnnotatedElementContext`
+parameter of `createTempDirectory`.
+
 You can use the `junit.jupiter.tempdir.factory.default`
 <<running-tests-config-params, configuration parameter>> to specify the fully qualified
 class name of the `TempDirFactory` you would like to use by default. Just like for

--- a/documentation/src/test/java/example/TempDirectoryDemo.java
+++ b/documentation/src/test/java/example/TempDirectoryDemo.java
@@ -32,6 +32,7 @@ import example.TempDirectoryDemo.InMemoryTempDirDemo.JimfsTempDirFactory;
 import example.util.ListWriter;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AnnotatedElementContext;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.io.TempDirFactory;
@@ -110,8 +111,9 @@ class TempDirectoryDemo {
 		static class Factory implements TempDirFactory {
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws IOException {
-				return Files.createTempDirectory(context.getRequiredTestMethod().getName());
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws IOException {
+				return Files.createTempDirectory(extensionContext.getRequiredTestMethod().getName());
 			}
 
 		}
@@ -133,7 +135,8 @@ class TempDirectoryDemo {
 			private final FileSystem fileSystem = Jimfs.newFileSystem(Configuration.unix());
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws IOException {
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws IOException {
 				return Files.createTempDirectory(fileSystem.getPath("/"), "junit");
 			}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
@@ -23,6 +23,20 @@ import org.apiguardian.api.API;
 public interface AnnotatedElementContext {
 
 	/**
+	 * Get the {@link AnnotatedElement} for this context.
+	 *
+	 * <h4>WARNING</h4>
+	 * <p>When searching for annotations on the parameter in this context,
+	 * favor {@link #isAnnotated(Class)}, {@link #findAnnotation(Class)}, and
+	 * {@link #findRepeatableAnnotations(Class)} over methods in the
+	 * {@link AnnotatedElement} API due to a bug in {@code javac} on JDK versions prior
+	 * to JDK 9.
+	 *
+	 * @return the annotated element; never {@code null}
+	 */
+	AnnotatedElement getAnnotatedElement();
+
+	/**
 	 * Determine if an annotation of {@code annotationType} is either
 	 * <em>present</em> or <em>meta-present</em> on the {@link AnnotatedElement} for
 	 * this context.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
@@ -19,6 +19,19 @@ import java.util.Optional;
 
 import org.apiguardian.api.API;
 
+/**
+ * {@code AnnotatedElementContext} encapsulates the <em>context</em> in which an
+ * {@link #getAnnotatedElement() AnnotatedElement} is declared.
+ *
+ * <p>For example, an {@code AnnotatedElementContext} is used in
+ * {@link org.junit.jupiter.api.io.TempDirFactory TempDirFactory} to allow inspecting
+ * the field or parameter the {@link org.junit.jupiter.api.io.TempDir TempDir}
+ * annotation is declared on.
+ *
+ * <p>This interface is not intended to be implemented by clients.
+ *
+ * @since 5.10
+ */
 @API(status = EXPERIMENTAL, since = "5.10")
 public interface AnnotatedElementContext {
 
@@ -26,7 +39,7 @@ public interface AnnotatedElementContext {
 	 * Get the {@link AnnotatedElement} for this context.
 	 *
 	 * <h4>WARNING</h4>
-	 * <p>When searching for annotations on the parameter in this context,
+	 * <p>When searching for annotations on the annotated element in this context,
 	 * favor {@link #isAnnotated(Class)}, {@link #findAnnotation(Class)}, and
 	 * {@link #findRepeatableAnnotations(Class)} over methods in the
 	 * {@link AnnotatedElement} API due to a bug in {@code javac} on JDK versions prior
@@ -48,7 +61,6 @@ public interface AnnotatedElementContext {
 	 *
 	 * @param annotationType the annotation type to search for; never {@code null}
 	 * @return {@code true} if the annotation is present or meta-present
-	 * @since 5.1.1
 	 * @see #findAnnotation(Class)
 	 * @see #findRepeatableAnnotations(Class)
 	 */
@@ -68,7 +80,6 @@ public interface AnnotatedElementContext {
 	 * @param annotationType the annotation type to search for; never {@code null}
 	 * @return an {@code Optional} containing the annotation; never {@code null} but
 	 * potentially empty
-	 * @since 5.1.1
 	 * @see #isAnnotated(Class)
 	 * @see #findRepeatableAnnotations(Class)
 	 */
@@ -89,7 +100,6 @@ public interface AnnotatedElementContext {
 	 * {@code null}
 	 * @return the list of all such annotations found; neither {@code null} nor
 	 * mutable, but potentially empty
-	 * @since 5.1.1
 	 * @see #isAnnotated(Class)
 	 * @see #findAnnotation(Class)
 	 * @see java.lang.annotation.Repeatable

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
  * {@code AnnotatedElementContext} encapsulates the <em>context</em> in which an
@@ -64,7 +65,9 @@ public interface AnnotatedElementContext {
 	 * @see #findAnnotation(Class)
 	 * @see #findRepeatableAnnotations(Class)
 	 */
-	boolean isAnnotated(Class<? extends Annotation> annotationType);
+	default boolean isAnnotated(Class<? extends Annotation> annotationType) {
+		return AnnotationSupport.isAnnotated(getAnnotatedElement(), annotationType);
+	}
 
 	/**
 	 * Find the first annotation of {@code annotationType} that is either
@@ -83,7 +86,9 @@ public interface AnnotatedElementContext {
 	 * @see #isAnnotated(Class)
 	 * @see #findRepeatableAnnotations(Class)
 	 */
-	<A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType);
+	default <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
+		return AnnotationSupport.findAnnotation(getAnnotatedElement(), annotationType);
+	}
 
 	/**
 	 * Find all <em>repeatable</em> {@linkplain Annotation annotations} of
@@ -104,6 +109,8 @@ public interface AnnotatedElementContext {
 	 * @see #findAnnotation(Class)
 	 * @see java.lang.annotation.Repeatable
 	 */
-	<A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType);
+	default <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
+		return AnnotationSupport.findRepeatableAnnotations(getAnnotatedElement(), annotationType);
+	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+
+@API(status = EXPERIMENTAL, since = "5.10")
+public interface AnnotatedElementContext {
+
+	/**
+	 * Determine if an annotation of {@code annotationType} is either
+	 * <em>present</em> or <em>meta-present</em> on the {@link AnnotatedElement} for
+	 * this context.
+	 *
+	 * <h4>WARNING</h4>
+	 * <p>Favor the use of this method over directly invoking
+	 * {@link AnnotatedElement#isAnnotationPresent(Class)} due to a bug in {@code javac}
+	 * on JDK versions prior to JDK 9.
+	 *
+	 * @param annotationType the annotation type to search for; never {@code null}
+	 * @return {@code true} if the annotation is present or meta-present
+	 * @since 5.1.1
+	 * @see #findAnnotation(Class)
+	 * @see #findRepeatableAnnotations(Class)
+	 */
+	boolean isAnnotated(Class<? extends Annotation> annotationType);
+
+	/**
+	 * Find the first annotation of {@code annotationType} that is either
+	 * <em>present</em> or <em>meta-present</em> on the {@link AnnotatedElement} for
+	 * this context.
+	 *
+	 * <h4>WARNING</h4>
+	 * <p>Favor the use of this method over directly invoking annotation lookup
+	 * methods in the {@link AnnotatedElement} API due to a bug in {@code javac} on JDK
+	 * versions prior to JDK 9.
+	 *
+	 * @param <A> the annotation type
+	 * @param annotationType the annotation type to search for; never {@code null}
+	 * @return an {@code Optional} containing the annotation; never {@code null} but
+	 * potentially empty
+	 * @since 5.1.1
+	 * @see #isAnnotated(Class)
+	 * @see #findRepeatableAnnotations(Class)
+	 */
+	<A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType);
+
+	/**
+	 * Find all <em>repeatable</em> {@linkplain Annotation annotations} of
+	 * {@code annotationType} that are either <em>present</em> or
+	 * <em>meta-present</em> on the {@link AnnotatedElement} for this context.
+	 *
+	 * <h4>WARNING</h4>
+	 * <p>Favor the use of this method over directly invoking annotation lookup
+	 * methods in the {@link AnnotatedElement} API due to a bug in {@code javac} on JDK
+	 * versions prior to JDK 9.
+	 *
+	 * @param <A> the annotation type
+	 * @param annotationType the repeatable annotation type to search for; never
+	 * {@code null}
+	 * @return the list of all such annotations found; neither {@code null} nor
+	 * mutable, but potentially empty
+	 * @since 5.1.1
+	 * @see #isAnnotated(Class)
+	 * @see #findAnnotation(Class)
+	 * @see java.lang.annotation.Repeatable
+	 */
+	<A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType);
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -13,11 +13,9 @@ package org.junit.jupiter.api.extension;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
-import java.util.List;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
@@ -99,29 +97,5 @@ public interface ParameterContext extends AnnotatedElementContext {
 	default AnnotatedElement getAnnotatedElement() {
 		return getParameter();
 	}
-
-	/**
-	 * {@inheritDoc}
-	 * @since 5.1.1
-	 */
-	@API(status = STABLE, since = "5.10")
-	@Override
-	boolean isAnnotated(Class<? extends Annotation> annotationType);
-
-	/**
-	 * {@inheritDoc}
-	 * @since 5.1.1
-	 */
-	@API(status = STABLE, since = "5.10")
-	@Override
-	<A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType);
-
-	/**
-	 * {@inheritDoc}
-	 * @since 5.1.1
-	 */
-	@API(status = STABLE, since = "5.10")
-	@Override
-	<A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType);
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -13,9 +13,11 @@ package org.junit.jupiter.api.extension;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
+import java.util.List;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
@@ -96,6 +98,36 @@ public interface ParameterContext extends AnnotatedElementContext {
 	@Override
 	default AnnotatedElement getAnnotatedElement() {
 		return getParameter();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * @since 5.1.1
+	 */
+	@API(status = STABLE, since = "5.10")
+	@Override
+	default boolean isAnnotated(Class<? extends Annotation> annotationType) {
+		return AnnotatedElementContext.super.isAnnotated(annotationType);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * @since 5.1.1
+	 */
+	@API(status = STABLE, since = "5.10")
+	@Override
+	default <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
+		return AnnotatedElementContext.super.findAnnotation(annotationType);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * @since 5.1.1
+	 */
+	@API(status = STABLE, since = "5.10")
+	@Override
+	default <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
+		return AnnotatedElementContext.super.findRepeatableAnnotations(annotationType);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -55,14 +55,6 @@ public interface ParameterContext extends AnnotatedElementContext {
 	Parameter getParameter();
 
 	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	default AnnotatedElement getAnnotatedElement() {
-		return getParameter();
-	}
-
-	/**
 	 * Get the index of the {@link Parameter} for this context within the
 	 * parameter list of the {@link #getDeclaringExecutable Executable} that
 	 * declares the parameter.
@@ -98,6 +90,14 @@ public interface ParameterContext extends AnnotatedElementContext {
 	Optional<Object> getTarget();
 
 	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	default AnnotatedElement getAnnotatedElement() {
+		return getParameter();
+	}
+
+	/**
 	 * Determine if an annotation of {@code annotationType} is either
 	 * <em>present</em> or <em>meta-present</em> on the {@link Parameter} for
 	 * this context.
@@ -113,6 +113,7 @@ public interface ParameterContext extends AnnotatedElementContext {
 	 * @see #findAnnotation(Class)
 	 * @see #findRepeatableAnnotations(Class)
 	 */
+	@Override
 	boolean isAnnotated(Class<? extends Annotation> annotationType);
 
 	/**
@@ -133,6 +134,7 @@ public interface ParameterContext extends AnnotatedElementContext {
 	 * @see #isAnnotated(Class)
 	 * @see #findRepeatableAnnotations(Class)
 	 */
+	@Override
 	<A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType);
 
 	/**
@@ -155,6 +157,7 @@ public interface ParameterContext extends AnnotatedElementContext {
 	 * @see #findAnnotation(Class)
 	 * @see java.lang.annotation.Repeatable
 	 */
+	@Override
 	<A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType);
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Annotation;
@@ -91,72 +92,35 @@ public interface ParameterContext extends AnnotatedElementContext {
 
 	/**
 	 * {@inheritDoc}
+	 * @since 5.10
 	 */
+	@API(status = EXPERIMENTAL, since = "5.10")
 	@Override
 	default AnnotatedElement getAnnotatedElement() {
 		return getParameter();
 	}
 
 	/**
-	 * Determine if an annotation of {@code annotationType} is either
-	 * <em>present</em> or <em>meta-present</em> on the {@link Parameter} for
-	 * this context.
-	 *
-	 * <h4>WARNING</h4>
-	 * <p>Favor the use of this method over directly invoking
-	 * {@link Parameter#isAnnotationPresent(Class)} due to a bug in {@code javac}
-	 * on JDK versions prior to JDK 9.
-	 *
-	 * @param annotationType the annotation type to search for; never {@code null}
-	 * @return {@code true} if the annotation is present or meta-present
+	 * {@inheritDoc}
 	 * @since 5.1.1
-	 * @see #findAnnotation(Class)
-	 * @see #findRepeatableAnnotations(Class)
 	 */
+	@API(status = STABLE, since = "5.10")
 	@Override
 	boolean isAnnotated(Class<? extends Annotation> annotationType);
 
 	/**
-	 * Find the first annotation of {@code annotationType} that is either
-	 * <em>present</em> or <em>meta-present</em> on the {@link Parameter} for
-	 * this context.
-	 *
-	 * <h4>WARNING</h4>
-	 * <p>Favor the use of this method over directly invoking annotation lookup
-	 * methods in the {@link Parameter} API due to a bug in {@code javac} on JDK
-	 * versions prior to JDK 9.
-	 *
-	 * @param <A> the annotation type
-	 * @param annotationType the annotation type to search for; never {@code null}
-	 * @return an {@code Optional} containing the annotation; never {@code null} but
-	 * potentially empty
+	 * {@inheritDoc}
 	 * @since 5.1.1
-	 * @see #isAnnotated(Class)
-	 * @see #findRepeatableAnnotations(Class)
 	 */
+	@API(status = STABLE, since = "5.10")
 	@Override
 	<A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType);
 
 	/**
-	 * Find all <em>repeatable</em> {@linkplain Annotation annotations} of
-	 * {@code annotationType} that are either <em>present</em> or
-	 * <em>meta-present</em> on the {@link Parameter} for this context.
-	 *
-	 * <h4>WARNING</h4>
-	 * <p>Favor the use of this method over directly invoking annotation lookup
-	 * methods in the {@link Parameter} API due to a bug in {@code javac} on JDK
-	 * versions prior to JDK 9.
-	 *
-	 * @param <A> the annotation type
-	 * @param annotationType the repeatable annotation type to search for; never
-	 * {@code null}
-	 * @return the list of all such annotations found; neither {@code null} nor
-	 * mutable, but potentially empty
+	 * {@inheritDoc}
 	 * @since 5.1.1
-	 * @see #isAnnotated(Class)
-	 * @see #findAnnotation(Class)
-	 * @see java.lang.annotation.Repeatable
 	 */
+	@API(status = STABLE, since = "5.10")
 	@Override
 	<A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType);
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.api.extension;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
 import java.util.List;
@@ -52,6 +53,14 @@ public interface ParameterContext extends AnnotatedElementContext {
 	 * @see #getIndex()
 	 */
 	Parameter getParameter();
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	default AnnotatedElement getAnnotatedElement() {
+		return getParameter();
+	}
 
 	/**
 	 * Get the index of the {@link Parameter} for this context within the

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -36,7 +36,7 @@ import org.apiguardian.api.API;
  * @see java.lang.reflect.Constructor
  */
 @API(status = STABLE, since = "5.0")
-public interface ParameterContext {
+public interface ParameterContext extends AnnotatedElementContext {
 
 	/**
 	 * Get the {@link Parameter} for this context.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.AnnotatedElementContext;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
@@ -30,8 +31,9 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  *
  * <p>Implementations must provide a no-args constructor and should not make any
  * assumptions regarding when and how many times they are instantiated, but they
- * can assume that {@link #createTempDirectory(ExtensionContext)} and {@link #close()}
- * will both be called once per instance, in this order, and from the same thread.
+ * can assume that {@link #createTempDirectory(AnnotatedElementContext, ExtensionContext)}
+ * and {@link #close()} will both be called once per instance, in this order,
+ * and from the same thread.
  *
  * <p>A {@link TempDirFactory} can be configured <em>globally</em> for the
  * entire test suite via the {@value TempDir#DEFAULT_FACTORY_PROPERTY_NAME}
@@ -53,11 +55,13 @@ public interface TempDirFactory extends Closeable {
 	 * not be associated with the {@link java.nio.file.FileSystems#getDefault()
 	 * default FileSystem}.
 	 *
-	 * @param context the current extension context; never {@code null}
+	 * @param elementContext   the current annotated element context; never {@code null}
+	 * @param extensionContext the current extension context; never {@code null}
 	 * @return the path to the newly created temporary directory; never {@code null}
 	 * @throws Exception in case of failures
 	 */
-	Path createTempDirectory(ExtensionContext context) throws Exception;
+	Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+			throws Exception;
 
 	/**
 	 * {@inheritDoc}
@@ -82,7 +86,8 @@ public interface TempDirFactory extends Closeable {
 		}
 
 		@Override
-		public Path createTempDirectory(ExtensionContext context) throws IOException {
+		public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+				throws IOException {
 			return Files.createTempDirectory(TEMP_DIR_PREFIX);
 		}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
@@ -55,7 +55,8 @@ public interface TempDirFactory extends Closeable {
 	 * not be associated with the {@link java.nio.file.FileSystems#getDefault()
 	 * default FileSystem}.
 	 *
-	 * @param elementContext   the current annotated element context; never {@code null}
+	 * @param elementContext   the context of the field or parameter where
+	 *                         {@code @TempDir} is declared; never {@code null}
 	 * @param extensionContext the current extension context; never {@code null}
 	 * @return the path to the newly created temporary directory; never {@code null}
 	 * @throws Exception in case of failures

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
@@ -55,8 +55,8 @@ public interface TempDirFactory extends Closeable {
 	 * not be associated with the {@link java.nio.file.FileSystems#getDefault()
 	 * default FileSystem}.
 	 *
-	 * @param elementContext   the context of the field or parameter where
-	 *                         {@code @TempDir} is declared; never {@code null}
+	 * @param elementContext the context of the field or parameter where
+	 * {@code @TempDir} is declared; never {@code null}
 	 * @param extensionContext the current extension context; never {@code null}
 	 * @return the path to the newly created temporary directory; never {@code null}
 	 * @throws Exception in case of failures

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -22,6 +22,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
@@ -445,6 +446,11 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 		FieldContext(Field field) {
 			this.field = field;
+		}
+
+		@Override
+		public AnnotatedElement getAnnotatedElement() {
+			return this.field;
 		}
 
 		@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -21,7 +21,6 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -37,8 +36,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -62,7 +59,6 @@ import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
-import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
@@ -468,21 +464,6 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		@Override
 		public AnnotatedElement getAnnotatedElement() {
 			return this.field;
-		}
-
-		@Override
-		public boolean isAnnotated(Class<? extends Annotation> annotationType) {
-			return AnnotationUtils.isAnnotated(field, annotationType);
-		}
-
-		@Override
-		public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
-			return AnnotationUtils.findAnnotation(field, annotationType);
-		}
-
-		@Override
-		public <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
-			return AnnotationUtils.findRepeatableAnnotations(field, annotationType);
 		}
 
 		@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -252,9 +252,9 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 	}
 
 	static CloseablePath createTempDir(TempDirFactory factory, CleanupMode cleanupMode,
-			AnnotatedElementContext elementContext, ExtensionContext executionContext) {
+			AnnotatedElementContext elementContext, ExtensionContext extensionContext) {
 		try {
-			return new CloseablePath(factory, cleanupMode, elementContext, executionContext);
+			return new CloseablePath(factory, cleanupMode, elementContext, extensionContext);
 		}
 		catch (Exception ex) {
 			throw new ExtensionConfigurationException("Failed to create default temp directory", ex);
@@ -268,14 +268,14 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		private final Path dir;
 		private final TempDirFactory factory;
 		private final CleanupMode cleanupMode;
-		private final ExtensionContext executionContext;
+		private final ExtensionContext extensionContext;
 
 		CloseablePath(TempDirFactory factory, CleanupMode cleanupMode, AnnotatedElementContext elementContext,
-				ExtensionContext executionContext) throws Exception {
-			this.dir = factory.createTempDirectory(elementContext, executionContext);
+				ExtensionContext extensionContext) throws Exception {
+			this.dir = factory.createTempDirectory(elementContext, extensionContext);
 			this.factory = factory;
 			this.cleanupMode = cleanupMode;
-			this.executionContext = executionContext;
+			this.extensionContext = extensionContext;
 		}
 
 		Path get() {
@@ -286,12 +286,12 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		public void close() throws IOException {
 			try {
 				if (cleanupMode == NEVER
-						|| (cleanupMode == ON_SUCCESS && executionContext.getExecutionException().isPresent())) {
+						|| (cleanupMode == ON_SUCCESS && extensionContext.getExecutionException().isPresent())) {
 					logger.info(() -> "Skipping cleanup of temp dir " + dir + " due to cleanup mode configuration.");
 					return;
 				}
 
-				FileOperations fileOperations = executionContext.getStore(NAMESPACE) //
+				FileOperations fileOperations = extensionContext.getStore(NAMESPACE) //
 						.getOrDefault(FILE_OPERATIONS_KEY, FileOperations.class, FileOperations.DEFAULT);
 
 				SortedMap<Path, IOException> failures = deleteAllFilesAndDirectories(fileOperations);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -64,6 +64,7 @@ import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.commons.util.ToStringBuilder;
 
@@ -440,12 +441,28 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		}
 	}
 
-	static class FieldContext implements AnnotatedElementContext {
+	enum Scope {
+
+		PER_CONTEXT,
+
+		PER_DECLARATION
+
+	}
+
+	interface FileOperations {
+
+		FileOperations DEFAULT = Files::delete;
+
+		void delete(Path path) throws IOException;
+
+	}
+
+	private static class FieldContext implements AnnotatedElementContext {
 
 		private final Field field;
 
-		FieldContext(Field field) {
-			this.field = field;
+		private FieldContext(Field field) {
+			this.field = Preconditions.notNull(field, "field must not be null");
 		}
 
 		@Override
@@ -476,22 +493,6 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 					.toString();
 			// @formatter:on
 		}
-
-	}
-
-	enum Scope {
-
-		PER_CONTEXT,
-
-		PER_DECLARATION
-
-	}
-
-	interface FileOperations {
-
-		FileOperations DEFAULT = Files::delete;
-
-		void delete(Path path) throws IOException;
 
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/config/DefaultJupiterConfigurationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/config/DefaultJupiterConfigurationTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.AnnotatedElementContext;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDirFactory;
@@ -127,7 +128,7 @@ class DefaultJupiterConfigurationTests {
 	private static class CustomFactory implements TempDirFactory {
 
 		@Override
-		public Path createTempDirectory(ExtensionContext context) {
+		public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext) {
 			throw new UnsupportedOperationException();
 		}
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/CloseablePathCleanupTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/CloseablePathCleanupTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AnnotatedElementContext;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.io.CleanupMode;
@@ -48,6 +49,7 @@ import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
  */
 class CloseablePathCleanupTests extends AbstractJupiterTestEngineTests {
 
+	private final AnnotatedElementContext elementContext = mock();
 	private final ExtensionContext extensionContext = mock();
 	private final TempDirFactory factory = spy(TempDirFactory.Standard.INSTANCE);
 
@@ -67,7 +69,7 @@ class CloseablePathCleanupTests extends AbstractJupiterTestEngineTests {
 	@Test
 	@DisplayName("is cleaned up for a cleanup mode of ALWAYS")
 	void always() throws IOException {
-		closeablePath = TempDirectory.createTempDir(factory, ALWAYS, extensionContext);
+		closeablePath = TempDirectory.createTempDir(factory, ALWAYS, elementContext, extensionContext);
 		assertThat(closeablePath.get()).exists();
 
 		closeablePath.close();
@@ -78,7 +80,7 @@ class CloseablePathCleanupTests extends AbstractJupiterTestEngineTests {
 	@Test
 	@DisplayName("is not cleaned up for a cleanup mode of NEVER")
 	void never() throws IOException {
-		closeablePath = TempDirectory.createTempDir(factory, NEVER, extensionContext);
+		closeablePath = TempDirectory.createTempDir(factory, NEVER, elementContext, extensionContext);
 		assertThat(closeablePath.get()).exists();
 
 		closeablePath.close();
@@ -91,7 +93,7 @@ class CloseablePathCleanupTests extends AbstractJupiterTestEngineTests {
 	void onSuccessWithException() throws IOException {
 		when(extensionContext.getExecutionException()).thenReturn(Optional.of(new Exception()));
 
-		closeablePath = TempDirectory.createTempDir(factory, ON_SUCCESS, extensionContext);
+		closeablePath = TempDirectory.createTempDir(factory, ON_SUCCESS, elementContext, extensionContext);
 		assertThat(closeablePath.get()).exists();
 
 		closeablePath.close();
@@ -104,7 +106,7 @@ class CloseablePathCleanupTests extends AbstractJupiterTestEngineTests {
 	void onSuccessWithNoException() throws IOException {
 		when(extensionContext.getExecutionException()).thenReturn(Optional.empty());
 
-		closeablePath = TempDirectory.createTempDir(factory, ON_SUCCESS, extensionContext);
+		closeablePath = TempDirectory.createTempDir(factory, ON_SUCCESS, elementContext, extensionContext);
 		assertThat(closeablePath.get()).exists();
 
 		closeablePath.close();

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerContextTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerContextTests.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.AnnotatedElementContext;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -318,7 +319,8 @@ class TempDirectoryPerContextTests extends AbstractJupiterTestEngineTests {
 		private static class Factory implements TempDirFactory {
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws Exception {
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws Exception {
 				return Files.createTempDirectory("junit");
 			}
 		}
@@ -693,7 +695,8 @@ class TempDirectoryPerContextTests extends AbstractJupiterTestEngineTests {
 		private static class Factory implements TempDirFactory {
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws Exception {
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws Exception {
 				return Files.createTempDirectory("junit");
 			}
 		}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -363,9 +363,9 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Test
-		@DisplayName("that uses custom annotation")
-		void supportsFactoryWithCustomAnnotation() {
-			executeTestsForClass(FactoryWithCustomAnnotationTestCase.class).testEvents()//
+		@DisplayName("that uses custom meta-annotation")
+		void supportsFactoryWithCustomMetaAnnotation() {
+			executeTestsForClass(FactoryWithCustomMetaAnnotationTestCase.class).testEvents()//
 					.assertStatistics(stats -> stats.started(1).succeeded(1));
 		}
 
@@ -1328,21 +1328,20 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 
 	}
 
-	static class FactoryWithCustomAnnotationTestCase {
+	static class FactoryWithCustomMetaAnnotationTestCase {
 
-		@Prefix("field")
-		@TempDir(factory = Factory.class)
+		@CustomTempDir("field")
 		private Path tempDir1;
 
 		private Path tempDir2;
 
 		@BeforeEach
-		void beforeEach(@Prefix("beforeEach") @TempDir(factory = Factory.class) Path tempDir2) {
+		void beforeEach(@CustomTempDir("beforeEach") Path tempDir2) {
 			this.tempDir2 = tempDir2;
 		}
 
 		@Test
-		void test(@Prefix("method") @TempDir(factory = Factory.class) Path tempDir3) {
+		void test(@CustomTempDir("method") Path tempDir3) {
 			assertThat(tempDir1.getFileName()).asString().startsWith("field");
 			assertThat(tempDir2.getFileName()).asString().startsWith("beforeEach");
 			assertThat(tempDir3.getFileName()).asString().startsWith("method");
@@ -1350,7 +1349,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 
 		@Target({ ANNOTATION_TYPE, FIELD, PARAMETER })
 		@Retention(RUNTIME)
-		private @interface Prefix {
+		@TempDir(factory = FactoryWithCustomMetaAnnotationTestCase.Factory.class)
+		private @interface CustomTempDir {
 
 			String value();
 
@@ -1361,7 +1361,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 			@Override
 			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
 					throws Exception {
-				String prefix = elementContext.findAnnotation(Prefix.class).map(Prefix::value).orElseThrow();
+				String prefix = elementContext.findAnnotation(CustomTempDir.class).map(
+					CustomTempDir::value).orElseThrow();
 				return Files.createTempDirectory(prefix);
 			}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.AnnotatedElementContext;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -390,7 +391,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 			private boolean closed;
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws Exception {
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws Exception {
 				return Files.createTempDirectory("custom");
 			}
 
@@ -1178,8 +1180,9 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 		private static class Factory implements TempDirFactory {
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws Exception {
-				return Files.createTempDirectory(context.getRequiredTestMethod().getName());
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws Exception {
+				return Files.createTempDirectory(extensionContext.getRequiredTestMethod().getName());
 			}
 		}
 
@@ -1203,7 +1206,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 			}
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws Exception {
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws Exception {
 				return Files.createTempDirectory(parent, "prefix");
 			}
 		}
@@ -1223,7 +1227,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 			private static FileSystem fileSystem;
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws Exception {
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws Exception {
 				fileSystem = MemoryFileSystemBuilder.newEmpty().build();
 				return Files.createTempDirectory(fileSystem.getPath("/"), "prefix");
 			}
@@ -1250,7 +1255,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 			private static FileSystem fileSystem;
 
 			@Override
-			public Path createTempDirectory(ExtensionContext context) throws Exception {
+			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
+					throws Exception {
 				fileSystem = Jimfs.newFileSystem(Configuration.unix());
 				return Files.createTempDirectory(fileSystem.getPath("/"), "prefix");
 			}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -1298,18 +1298,10 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 		@TempDir(factory = Factory.class)
 		private Path tempDir1;
 
-		private Path tempDir2;
-
-		@BeforeEach
-		void setUp(@TempDir(factory = Factory.class) Path tempDir2) {
-			this.tempDir2 = tempDir2;
-		}
-
 		@Test
-		void test(@TempDir(factory = Factory.class) Path tempDir3) {
+		void test(@TempDir(factory = Factory.class) Path tempDir2) {
 			assertThat(tempDir1.getFileName()).asString().startsWith("tempDir1");
 			assertThat(tempDir2.getFileName()).asString().startsWith("tempDir2");
-			assertThat(tempDir3.getFileName()).asString().startsWith("tempDir3");
 		}
 
 		private static class Factory implements TempDirFactory {
@@ -1330,30 +1322,34 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 
 	static class FactoryWithCustomMetaAnnotationTestCase {
 
-		@TempDirWithPrefix("field")
+		@TempDirForField
 		private Path tempDir1;
 
-		private Path tempDir2;
-
-		@BeforeEach
-		void beforeEach(@TempDirWithPrefix("beforeEach") Path tempDir2) {
-			this.tempDir2 = tempDir2;
-		}
-
 		@Test
-		void test(@TempDirWithPrefix("method") Path tempDir3) {
+		void test(@TempDirForParameter Path tempDir2) {
 			assertThat(tempDir1.getFileName()).asString().startsWith("field");
-			assertThat(tempDir2.getFileName()).asString().startsWith("beforeEach");
-			assertThat(tempDir3.getFileName()).asString().startsWith("method");
+			assertThat(tempDir2.getFileName()).asString().startsWith("parameter");
 		}
 
-		@Target({ ANNOTATION_TYPE, FIELD, PARAMETER })
+		@Target(ANNOTATION_TYPE)
 		@Retention(RUNTIME)
 		@TempDir(factory = FactoryWithCustomMetaAnnotationTestCase.Factory.class)
 		private @interface TempDirWithPrefix {
 
 			String value();
 
+		}
+
+		@Target(FIELD)
+		@Retention(RUNTIME)
+		@TempDirWithPrefix("field")
+		private @interface TempDirForField {
+		}
+
+		@Target(PARAMETER)
+		@Retention(RUNTIME)
+		@TempDirWithPrefix("parameter")
+		private @interface TempDirForParameter {
 		}
 
 		private static class Factory implements TempDirFactory {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -1330,18 +1330,18 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 
 	static class FactoryWithCustomMetaAnnotationTestCase {
 
-		@CustomTempDir("field")
+		@TempDirWithPrefix("field")
 		private Path tempDir1;
 
 		private Path tempDir2;
 
 		@BeforeEach
-		void beforeEach(@CustomTempDir("beforeEach") Path tempDir2) {
+		void beforeEach(@TempDirWithPrefix("beforeEach") Path tempDir2) {
 			this.tempDir2 = tempDir2;
 		}
 
 		@Test
-		void test(@CustomTempDir("method") Path tempDir3) {
+		void test(@TempDirWithPrefix("method") Path tempDir3) {
 			assertThat(tempDir1.getFileName()).asString().startsWith("field");
 			assertThat(tempDir2.getFileName()).asString().startsWith("beforeEach");
 			assertThat(tempDir3.getFileName()).asString().startsWith("method");
@@ -1350,7 +1350,7 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 		@Target({ ANNOTATION_TYPE, FIELD, PARAMETER })
 		@Retention(RUNTIME)
 		@TempDir(factory = FactoryWithCustomMetaAnnotationTestCase.Factory.class)
-		private @interface CustomTempDir {
+		private @interface TempDirWithPrefix {
 
 			String value();
 
@@ -1361,8 +1361,8 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 			@Override
 			public Path createTempDirectory(AnnotatedElementContext elementContext, ExtensionContext extensionContext)
 					throws Exception {
-				String prefix = elementContext.findAnnotation(CustomTempDir.class).map(
-					CustomTempDir::value).orElseThrow();
+				String prefix = elementContext.findAnnotation(TempDirWithPrefix.class) //
+						.map(TempDirWithPrefix::value).orElseThrow();
 				return Files.createTempDirectory(prefix);
 			}
 


### PR DESCRIPTION
## Overview

Closes #3390.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
