### PR TITLE
Add diff section to report of AssertionFailedError failures

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.0.adoc
@@ -9,6 +9,7 @@
 * New `LauncherInterceptor` SPI
 * New `testfeed` details mode for `ConsoleLauncher`
 * New `ConsoleLauncher` subcommand for test discovery without execution
+* `ConsoleLauncher` shows expected, actual, and a diff for failed assertions on `CharSequence` objects
 * Dry-run mode for test execution
 * New `NamespacedHierarchicalStore` for use in third-party test engines
 * Stacktrace pruning to hide internal JUnit calls

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ gradle-versions = { module = "com.github.ben-manes:gradle-versions-plugin", vers
 groovy4 = { module = "org.apache.groovy:groovy", version = "4.0.13" }
 groovy2-bom = { module = "org.codehaus.groovy:groovy-bom", version = "2.5.21" }
 hamcrest = { module = "org.hamcrest:hamcrest", version = "2.2" }
+java-diff-utils = { module = "io.github.java-diff-utils:java-diff-utils", version = "4.12" }
 jfrunit = { module = "org.moditect.jfrunit:jfrunit-core", version = "1.0.0.Alpha2" }
 jimfs = { module = "com.google.jimfs:jimfs", version = "1.3.0" }
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
 
 	compileOnly(libs.openTestReporting.events)
 
+	implementation(libs.java.diff.utils)
+
 	shadowed(libs.picocli)
 
 	osgiVerification(projects.junitJupiterEngine)
@@ -27,7 +29,9 @@ tasks {
 			"--add-modules", "org.opentest4j.reporting.events",
 			"--add-reads", "${project.projects.junitPlatformReporting.dependencyProject.javaModuleName}=org.opentest4j.reporting.events",
 			"--add-modules", "info.picocli",
-			"--add-reads", "${javaModuleName}=info.picocli"
+			"--add-reads", "${javaModuleName}=info.picocli",
+			"--add-modules", "io.github.javadiffutils",
+			"--add-reads", "${javaModuleName}=io.github.javadiffutils"
 		))
 	}
 	shadowJar {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -143,6 +143,7 @@ public class ConsoleTestExecutor {
 	private Optional<DetailsPrintingListener> createDetailsPrintingListener(PrintWriter out) {
 		ColorPalette colorPalette = getColorPalette();
 		Theme theme = outputOptions.getTheme();
+
 		switch (outputOptions.getDetails()) {
 			case SUMMARY:
 				// summary listener is always created and registered

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
@@ -11,12 +11,20 @@
 package org.junit.platform.console.tasks;
 
 import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.github.difflib.text.DiffRow;
+import com.github.difflib.text.DiffRowGenerator;
 
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
+import org.opentest4j.AssertionFailedError;
+import org.opentest4j.ValueWrapper;
 
 /**
  * @since 1.0
@@ -27,10 +35,19 @@ class FlatPrintingListener implements DetailsPrintingListener {
 
 	private final PrintWriter out;
 	private final ColorPalette colorPalette;
+	private final DiffRowGenerator diffRowGenerator;
 
 	FlatPrintingListener(PrintWriter out, ColorPalette colorPalette) {
 		this.out = out;
 		this.colorPalette = colorPalette;
+		this.diffRowGenerator = DiffRowGenerator.create() //
+				.showInlineDiffs(true) //
+				.mergeOriginalRevised(true) //
+				.inlineDiffByWord(true) //
+				.oldTag(f -> "~") //
+				.newTag(f -> "**") //
+				.build();
+		;
 	}
 
 	@Override
@@ -78,7 +95,29 @@ class FlatPrintingListener implements DetailsPrintingListener {
 	}
 
 	private void printlnException(Style style, Throwable throwable) {
+		if (throwable instanceof AssertionFailedError) {
+			AssertionFailedError assertionFailedError = (AssertionFailedError) throwable;
+			ValueWrapper expected = assertionFailedError.getExpected();
+			ValueWrapper actual = assertionFailedError.getActual();
+
+			if (isCharSequence(expected) && isCharSequence(actual)) {
+				printlnMessage(style, "Expected ", expected.getStringRepresentation());
+				printlnMessage(style, "Actual   ", actual.getStringRepresentation());
+				printlnMessage(style, "Diff     ", calculateDiff(expected, actual));
+			}
+		}
 		printlnMessage(style, "Exception", ExceptionUtils.readStackTrace(throwable));
+	}
+
+	private boolean isCharSequence(ValueWrapper value) {
+		return value != null && CharSequence.class.isAssignableFrom(value.getType());
+	}
+
+	private String calculateDiff(ValueWrapper expected, ValueWrapper actual) {
+		List<String> expectedLines = Arrays.asList(expected.getStringRepresentation());
+		List<String> actualLines = Arrays.asList(actual.getStringRepresentation());
+		List<DiffRow> diffRows = diffRowGenerator.generateDiffRows(expectedLines, actualLines);
+		return diffRows.stream().map(DiffRow::getOldLine).collect(Collectors.joining("\n"));
 	}
 
 	private void printlnMessage(Style style, String message, String detail) {

--- a/junit-platform-console/src/module/org.junit.platform.console/module-info.java
+++ b/junit-platform-console/src/module/org.junit.platform.console/module-info.java
@@ -20,6 +20,7 @@ module org.junit.platform.console {
 	requires org.junit.platform.engine;
 	requires org.junit.platform.launcher;
 	requires org.junit.platform.reporting;
+	requires io.github.javadiffutils;
 
 	provides java.util.spi.ToolProvider with org.junit.platform.console.ConsoleLauncherToolProvider;
 }


### PR DESCRIPTION
## Overview

With this commit, a dependency to https://github.com/java-diff-utils/java-diff-utils is introduced. java-diff-utils is used to create a diff from the expected and the actual result and report it.

See #3139

Open questions:

- Shall we shadow the external library?
- Shall we provide configuration parameters for the console launcher to adjust the markers for "old" (currently: ~) and "new" (currently: **) text.
- Shall we include these changes also into other `DetailsPrintingListener`s or is it already sufficient for the `FlatPrintingListener` (I started with this in the sense of a small PoC)?

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
