### PR TITLE
Drop duplicate `isSnapshot` variable in Gradle build script

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.publishing-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.publishing-conventions.gradle.kts
@@ -47,7 +47,6 @@ signing {
 }
 
 tasks.withType<Sign>().configureEach {
-	val isSnapshot = project.version.toString().contains("SNAPSHOT")
 	onlyIf {
 		!isSnapshot // Gradle Module Metadata currently does not support signing snapshots
 	}


### PR DESCRIPTION
Minor Gradle code cleanup.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).