### PR TITLE
Fix broken links to Gradle docs about BOM

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/appendix.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/appendix.adoc
@@ -107,7 +107,7 @@ artifacts are deployed to Sonatype's {snapshot-repo}[snapshots repository] under
 The _Bill of Materials_ POM provided under the following Maven coordinates can be used to
 ease dependency management when referencing multiple of the above artifacts using
 https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies[Maven]
-or https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:bom_import[Gradle].
+or https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import[Gradle].
 
 * *Group ID*: `org.junit`
 * *Artifact ID*: `junit-bom`

--- a/junit-bom/README.md
+++ b/junit-bom/README.md
@@ -4,5 +4,5 @@ This module provides a Bill of Materials POM to ease dependency management using
 or [Gradle]. Please refer to the [User Guide] for details.
 
 [Maven]:      https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies
-[Gradle]:     https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:bom_import
+[Gradle]:     https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import
 [User Guide]: https://junit.org/junit5/docs/current/user-guide/#dependency-metadata-junit-bom


### PR DESCRIPTION
## Overview

[Broken link](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:bom_import) to Gradle documentation about usage of Bill of Materials has been updated to an [up-to-date link](    https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import). 

Details are in the commit message.

I've also checked that all other five URLs to Gradle documentation are live:

1. https://docs.gradle.org/current/userguide/toolchains.html
2. https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:using_wrapper
3. https://docs.gradle.org/current/userguide/java_testing.html#using_junit5
4. https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_test
5. https://docs.gradle.org/4.6/release-notes.html

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).
