### PR TITLE
Fix console-related test failures on JDK 22

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.testing-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.testing-conventions.gradle.kts
@@ -51,6 +51,9 @@ tasks.withType<Test>().configureEach {
 			"-XX:FlightRecorderOptions=stackdepth=1024"
 		)
 	}
+	if (buildParameters.javaToolchainVersion.get() >= 22) {
+		jvmArgs("-Djdk.console=java.base")
+	}
 
 	// Track OS as input so that tests are executed on all configured operating systems on CI
 	trackOperationSystemAsInput()


### PR DESCRIPTION
## Overview

Details are in the commit message.

I'm not sure if this is a good approach, or how JUnit project likes to handle compatibility issues like this. I tried to follow the example of surrounding code in `junitbuild.testing-conventions.gradle.kts` as best as I could.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).