### PR TITLE
Disable Picocli's usage help auto width computation

### DIFF
--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
@@ -33,7 +33,7 @@ import picocli.CommandLine.Unmatched;
 		sortOptions = false, //
 		usageHelpWidth = 95, //
 		showAtFileInUsageHelp = true, //
-		usageHelpAutoWidth = true, //
+		usageHelpAutoWidth = false, // https://github.com/remkop/picocli/issues/1104
 		description = "Launches the JUnit Platform for test discovery and execution.", //
 		footerHeading = "%n", //
 		footer = "For more information, please refer to the JUnit User Guide at%n" //

--- a/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
+++ b/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
@@ -16,6 +16,7 @@ import java.io.Console;
 import java.nio.charset.Charset;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.JUnitException;
 
 /**
  * Collection of utilities for working with {@code java.io.Console}
@@ -37,6 +38,17 @@ public class ConsoleUtils {
 	 */
 	public static Charset charset() {
 		Console console = System.console();
-		return console != null ? console.charset() : Charset.defaultCharset();
+		return console != null && isTerminal() ? console.charset() : Charset.defaultCharset();
+	}
+
+	private static boolean isTerminal() {
+		try {
+			//noinspection JavaReflectionMemberAccess
+			return (boolean) Console.class.getDeclaredMethod("isTerminal").invoke(null);
+		} catch (NoSuchMethodException exception) {
+			return false; // Console.isTerminal() was introduced in Java 22
+		} catch (ReflectiveOperationException exception) {
+			throw new JUnitException("Failed to call Console.isTerminal()", exception);
+		}
 	}
 }

--- a/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
+++ b/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
@@ -39,5 +39,4 @@ public class ConsoleUtils {
 		Console console = System.console();
 		return console != null ? console.charset() : Charset.defaultCharset();
 	}
-
 }

--- a/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
+++ b/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
@@ -16,7 +16,6 @@ import java.io.Console;
 import java.nio.charset.Charset;
 
 import org.apiguardian.api.API;
-import org.junit.platform.commons.JUnitException;
 
 /**
  * Collection of utilities for working with {@code java.io.Console}
@@ -38,19 +37,7 @@ public class ConsoleUtils {
 	 */
 	public static Charset charset() {
 		Console console = System.console();
-		return console != null && isTerminal(console) ? console.charset() : Charset.defaultCharset();
+		return console != null ? console.charset() : Charset.defaultCharset();
 	}
 
-	private static boolean isTerminal(Console console) {
-		try {
-			//noinspection JavaReflectionMemberAccess
-			return (boolean) Console.class.getDeclaredMethod("isTerminal").invoke(console);
-		}
-		catch (NoSuchMethodException exception) {
-			return false; // Console::isTerminal was introduced in Java 22
-		}
-		catch (ReflectiveOperationException exception) {
-			throw new JUnitException("Failed to call Console.isTerminal()", exception);
-		}
-	}
 }

--- a/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
+++ b/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
@@ -38,16 +38,16 @@ public class ConsoleUtils {
 	 */
 	public static Charset charset() {
 		Console console = System.console();
-		return console != null && isTerminal() ? console.charset() : Charset.defaultCharset();
+		return console != null && isTerminal(console) ? console.charset() : Charset.defaultCharset();
 	}
 
-	private static boolean isTerminal() {
+	private static boolean isTerminal(Console console) {
 		try {
 			//noinspection JavaReflectionMemberAccess
-			return (boolean) Console.class.getDeclaredMethod("isTerminal").invoke(null);
+			return (boolean) Console.class.getDeclaredMethod("isTerminal").invoke(console);
 		}
 		catch (NoSuchMethodException exception) {
-			return false; // Console.isTerminal() was introduced in Java 22
+			return false; // Console::isTerminal was introduced in Java 22
 		}
 		catch (ReflectiveOperationException exception) {
 			throw new JUnitException("Failed to call Console.isTerminal()", exception);

--- a/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
+++ b/junit-platform-console/src/main/java17/org/junit/platform/console/options/ConsoleUtils.java
@@ -45,9 +45,11 @@ public class ConsoleUtils {
 		try {
 			//noinspection JavaReflectionMemberAccess
 			return (boolean) Console.class.getDeclaredMethod("isTerminal").invoke(null);
-		} catch (NoSuchMethodException exception) {
+		}
+		catch (NoSuchMethodException exception) {
 			return false; // Console.isTerminal() was introduced in Java 22
-		} catch (ReflectiveOperationException exception) {
+		}
+		catch (ReflectiveOperationException exception) {
 			throw new JUnitException("Failed to call Console.isTerminal()", exception);
 		}
 	}

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherTests.java
@@ -47,8 +47,8 @@ class ConsoleLauncherTests {
 		var consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, printSink, printSink);
 		consoleLauncher.run(command);
 
-		assertThat(stringWriter.toString()).contains(
-			"Thanks for using JUnit! Support its development at https://junit.org/sponsoring");
+		var actual = stringWriter.toString();
+		assertThat(actual).contains("Thanks for using JUnit!");
 	}
 
 	@ParameterizedTest(name = "{0}")

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherTests.java
@@ -47,8 +47,7 @@ class ConsoleLauncherTests {
 		var consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, printSink, printSink);
 		consoleLauncher.run(command);
 
-		var actual = stringWriter.toString();
-		assertThat(actual).contains("Thanks for using JUnit!");
+		assertThat(stringWriter.toString()).contains("Thanks for using JUnit!");
 	}
 
 	@ParameterizedTest(name = "{0}")

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -66,7 +66,7 @@ class StandaloneTests {
 				.setTool(new Java()) //
 				.setProject("standalone") //
 				.addArguments("-jar", MavenRepo.jar("junit-platform-console-standalone")) //
-				.addArguments("engines", "--disable-banner").build() //
+				.addArguments("engines", "--disable-ansi-colors", "--disable-banner").build() //
 				.run(false);
 
 		assertEquals(0, result.getExitCode(), String.join("\n", result.getOutputLines("out")));


### PR DESCRIPTION
## Overview

Fixes #3419 by disabling Picocli's usage help auto width computation and tweaking tests.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
