### PR TITLE
Introduce PreInterruptCallback extension point

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -156,6 +156,7 @@ endif::[]
 :TestTemplateInvocationContext:              {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/TestTemplateInvocationContext.html[TestTemplateInvocationContext]
 :TestTemplateInvocationContextProvider:      {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.html[TestTemplateInvocationContextProvider]
 :TestWatcher:                                {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/TestWatcher.html[TestWatcher]
+:PreInterruptCallback:                       {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/extension/PreInterruptCallback.html[PreInterruptCallback]
 // Jupiter Conditions
 :DisabledForJreRange:                        {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/condition/DisabledForJreRange.html[@DisabledForJreRange]
 :DisabledIf:                                 {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/condition/DisabledIf.html[@DisabledIf]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -87,6 +87,7 @@ JUnit repository on GitHub.
   a test-scoped `ExtensionContext` in `Extension` methods called during test class
   instantiation. This behavior will become the default in future versions of JUnit.
 * `@TempDir` is now supported on test class constructors.
+* Added `PreInterruptCallback`
 
 
 [[release-notes-5.12.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -715,6 +715,15 @@ test methods.
 include::{testDir}/example/exception/MultipleHandlersTestCase.java[tags=user_guide]
 ----
 
+[[extensions-preinterrupt-callback]]
+=== Pre-Interrupt Callback
+
+`{PreInterruptCallback}` defines the API for `Extensions` that wish to react on
+timeouts before the `Thread.interrupt()` is called.
+
+Please refer to <<writing-tests-declarative-timeouts-debugging>> for additional information.
+
+
 [[extensions-intercepting-invocations]]
 === Intercepting Invocations
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2659,6 +2659,22 @@ asynchronous tests, consider using a dedicated library such as
 link:https://github.com/awaitility/awaitility[Awaitility].
 
 
+[[writing-tests-declarative-timeouts-debugging]]
+===  Debugging Timeouts
+
+Registered <<extensions-preinterrupt-callback>> extensions are called prior to invoking
+`Thread.interrupt()` on the thread that is executing the timed out method. This allows to
+inspect the application state and output additional information that might be helpful for
+diagnosing the cause of a timeout.
+
+
+[[writing-tests-declarative-timeouts-debugging-thread-dump]]
+==== Thread Dump on Timeout
+JUnit registers a default implementation of the <<extensions-preinterrupt-callback>> extension point that
+dumps the stacks of all threads to `System.out` if enabled by setting the
+`junit.jupiter.execution.timeout.threaddump.enabled` configuration parameter to `true`.
+
+
 [[writing-tests-declarative-timeouts-mode]]
 ==== Disable @Timeout Globally
 When stepping through your code in a debug session, a fixed timeout limit may influence

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeoutPreemptively.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeoutPreemptively.java
@@ -113,7 +113,7 @@ class AssertTimeoutPreemptively {
 				cause = new ExecutionTimeoutException("Execution timed out in thread " + thread.getName());
 				cause.setStackTrace(thread.getStackTrace());
 			}
-			throw failureFactory.createTimeoutFailure(timeout, messageSupplier, cause);
+			throw failureFactory.createTimeoutFailure(timeout, messageSupplier, cause, thread);
 		}
 		catch (ExecutionException ex) {
 			throw throwAsUncheckedException(ex.getCause());
@@ -124,7 +124,7 @@ class AssertTimeoutPreemptively {
 	}
 
 	private static AssertionFailedError createAssertionFailure(Duration timeout, Supplier<String> messageSupplier,
-			Throwable cause) {
+			Throwable cause, Thread thread) {
 		return assertionFailure() //
 				.message(messageSupplier) //
 				.reason("execution timed out after " + timeout.toMillis() + " ms") //

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3662,6 +3662,6 @@ public class Assertions {
 		 *
 		 * @return timeout failure; never {@code null}
 		 */
-		T createTimeoutFailure(Duration timeout, Supplier<String> messageSupplier, Throwable cause);
+		T createTimeoutFailure(Duration timeout, Supplier<String> messageSupplier, Throwable cause, Thread testThread);
 	}
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptCallback.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code PreInterruptCallback} defines the API for {@link Extension
+ * Extensions} that wish to be called prior to invocations of
+ * {@link Thread#interrupt()} by the {@link org.junit.jupiter.api.Timeout}
+ * extension.
+ *
+ * <p>JUnit registers a default implementation that dumps the stacks of all
+ * {@linkplain Thread threads} to {@code System.out} if the
+ * {@value #THREAD_DUMP_ENABLED_PROPERTY_NAME} configuration parameter is set to
+ * {@code true}.
+ *
+ * @since 5.12
+ * @see org.junit.jupiter.api.Timeout
+ */
+@API(status = EXPERIMENTAL, since = "5.12")
+public interface PreInterruptCallback extends Extension {
+
+	/**
+	 * Property name used to enable dumping the stack of all
+	 * {@linkplain Thread threads} to {@code System.out} when a timeout has occurred.
+	 *
+	 * <p>This behavior is disabled by default.
+	 *
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	String THREAD_DUMP_ENABLED_PROPERTY_NAME = "junit.jupiter.execution.timeout.threaddump.enabled";
+
+	/**
+	 * Callback that is invoked <em>before</em> a {@link Thread} is interrupted with
+	 * {@link Thread#interrupt()}.
+	 *
+	 * <p>Note: There is no guarantee on which {@link Thread} this callback will be
+	 * executed.
+	 *
+	 * @param preInterruptContext the context with the target {@link Thread}, which will get interrupted.
+	 * @param extensionContext the extension context for the callback; never {@code null}
+	 * @since 5.12
+	 * @see PreInterruptContext
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	void beforeThreadInterrupt(PreInterruptContext preInterruptContext, ExtensionContext extensionContext)
+			throws Exception;
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code PreInterruptContext} encapsulates the <em>context</em> in which an
+ * {@link PreInterruptCallback#beforeThreadInterrupt(PreInterruptContext) beforeThreadInterrupt} method is called.
+ *
+ * @since 5.12
+ * @see PreInterruptCallback
+ */
+@API(status = EXPERIMENTAL, since = "5.12")
+public interface PreInterruptContext {
+
+	/**
+	 * Get the {@link Thread} which will be interrupted.
+	 *
+	 * @return the Thread; never {@code null}
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	Thread getThreadToInterrupt();
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/PreInterruptContext.java
@@ -16,7 +16,7 @@ import org.apiguardian.api.API;
 
 /**
  * {@code PreInterruptContext} encapsulates the <em>context</em> in which an
- * {@link PreInterruptCallback#beforeThreadInterrupt(PreInterruptContext) beforeThreadInterrupt} method is called.
+ * {@link PreInterruptCallback#beforeThreadInterrupt(PreInterruptContext, ExtensionContext) beforeThreadInterrupt} method is called.
  *
  * @since 5.12
  * @see PreInterruptCallback

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -109,6 +109,17 @@ public final class Constants {
 	public static final String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = JupiterConfiguration.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME;
 
 	/**
+	 * Property name used to enable dumping the stack of all
+	 * {@linkplain Thread threads} to {@code System.out} when a timeout has occurred.
+	 *
+	 * <p>This behavior is disabled by default.
+	 *
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	public static final String EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME = JupiterConfiguration.EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME;
+
+	/**
 	 * Property name used to set the default test instance lifecycle mode: {@value}
 	 *
 	 * @see TestInstance.Lifecycle#DEFAULT_LIFECYCLE_PROPERTY_NAME
@@ -192,7 +203,7 @@ public final class Constants {
 	 * <p>When set to {@code false} the underlying fork-join pool will reject
 	 * additional tasks if all available workers are busy and the maximum
 	 * pool-size would be exceeded.
-
+	 *
 	 * <p>Value must either {@code true} or {@code false}; defaults to {@code true}.
 	 *
 	 * <p>Note: This property only takes affect on Java 9+.

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
@@ -69,6 +69,12 @@ public class CachingJupiterConfiguration implements JupiterConfiguration {
 	}
 
 	@Override
+	public boolean isThreadDumpOnTimeoutEnabled() {
+		return (boolean) cache.computeIfAbsent(EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME,
+			__ -> delegate.isThreadDumpOnTimeoutEnabled());
+	}
+
+	@Override
 	public ExecutionMode getDefaultExecutionMode() {
 		return (ExecutionMode) cache.computeIfAbsent(DEFAULT_EXECUTION_MODE_PROPERTY_NAME,
 			__ -> delegate.getDefaultExecutionMode());

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
@@ -94,6 +94,11 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 	}
 
 	@Override
+	public boolean isThreadDumpOnTimeoutEnabled() {
+		return configurationParameters.getBoolean(EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME).orElse(false);
+	}
+
+	@Override
 	public ExecutionMode getDefaultExecutionMode() {
 		return executionModeConverter.get(configurationParameters, DEFAULT_EXECUTION_MODE_PROPERTY_NAME,
 			ExecutionMode.SAME_THREAD);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.PreInterruptCallback;
 import org.junit.jupiter.api.extension.TestInstantiationAwareExtension.ExtensionContextScope;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDirFactory;
@@ -40,6 +41,7 @@ public interface JupiterConfiguration {
 	String DEFAULT_EXECUTION_MODE_PROPERTY_NAME = Execution.DEFAULT_EXECUTION_MODE_PROPERTY_NAME;
 	String DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME = Execution.DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME;
 	String EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME = "junit.jupiter.extensions.autodetection.enabled";
+	String EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME = PreInterruptCallback.THREAD_DUMP_ENABLED_PROPERTY_NAME;
 	String DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME = TestInstance.Lifecycle.DEFAULT_LIFECYCLE_PROPERTY_NAME;
 	String DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME = DisplayNameGenerator.DEFAULT_GENERATOR_PROPERTY_NAME;
 	String DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME = MethodOrderer.DEFAULT_ORDER_PROPERTY_NAME;
@@ -53,6 +55,8 @@ public interface JupiterConfiguration {
 	boolean isParallelExecutionEnabled();
 
 	boolean isExtensionAutoDetectionEnabled();
+
+	boolean isThreadDumpOnTimeoutEnabled();
 
 	ExecutionMode getDefaultExecutionMode();
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -55,7 +55,6 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.AfterEachMethodAdapter;
 import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
-import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.execution.DefaultTestInstances;
 import org.junit.jupiter.engine.execution.ExtensionContextSupplier;
 import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker;
@@ -181,8 +180,8 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor imp
 
 		ThrowableCollector throwableCollector = createThrowableCollector();
 		ClassExtensionContext extensionContext = new ClassExtensionContext(context.getExtensionContext(),
-			context.getExecutionListener(), this, this.lifecycle, context.getConfiguration(), throwableCollector,
-			it -> new DefaultExecutableInvoker(it, registry));
+			context.getExecutionListener(), this, this.lifecycle, context.getConfiguration(), registry,
+			throwableCollector);
 
 		// @formatter:off
 		return context.extend()

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassExtensionContext.java
@@ -13,13 +13,12 @@ package org.junit.jupiter.engine.descriptor;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.support.hierarchical.Node;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
@@ -39,23 +38,21 @@ final class ClassExtensionContext extends AbstractExtensionContext<ClassBasedTes
 	 * Create a new {@code ClassExtensionContext} with {@link Lifecycle#PER_METHOD}.
 	 *
 	 * @see #ClassExtensionContext(ExtensionContext, EngineExecutionListener, ClassBasedTestDescriptor,
-	 * Lifecycle, JupiterConfiguration, ThrowableCollector, Function)
+	 * Lifecycle, JupiterConfiguration, ExtensionRegistry, ThrowableCollector)
 	 */
 	ClassExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
 			ClassBasedTestDescriptor testDescriptor, JupiterConfiguration configuration,
-			ThrowableCollector throwableCollector,
-			Function<ExtensionContext, ExecutableInvoker> executableInvokerFactory) {
+			ExtensionRegistry extensionRegistry, ThrowableCollector throwableCollector) {
 
-		this(parent, engineExecutionListener, testDescriptor, Lifecycle.PER_METHOD, configuration, throwableCollector,
-			executableInvokerFactory);
+		this(parent, engineExecutionListener, testDescriptor, Lifecycle.PER_METHOD, configuration, extensionRegistry,
+			throwableCollector);
 	}
 
 	ClassExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
 			ClassBasedTestDescriptor testDescriptor, Lifecycle lifecycle, JupiterConfiguration configuration,
-			ThrowableCollector throwableCollector,
-			Function<ExtensionContext, ExecutableInvoker> executableInvokerFactory) {
+			ExtensionRegistry extensionRegistry, ThrowableCollector throwableCollector) {
 
-		super(parent, engineExecutionListener, testDescriptor, configuration, executableInvokerFactory);
+		super(parent, engineExecutionListener, testDescriptor, configuration, extensionRegistry);
 
 		this.lifecycle = lifecycle;
 		this.throwableCollector = throwableCollector;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicExtensionContext.java
@@ -13,13 +13,12 @@ package org.junit.jupiter.engine.descriptor;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.support.hierarchical.Node;
 
@@ -27,8 +26,8 @@ class DynamicExtensionContext extends AbstractExtensionContext<DynamicNodeTestDe
 
 	DynamicExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
 			DynamicNodeTestDescriptor testDescriptor, JupiterConfiguration configuration,
-			Function<ExtensionContext, ExecutableInvoker> executableInvokerFactory) {
-		super(parent, engineExecutionListener, testDescriptor, configuration, executableInvokerFactory);
+			ExtensionRegistry extensionRegistry) {
+		super(parent, engineExecutionListener, testDescriptor, configuration, extensionRegistry);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicNodeTestDescriptor.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.engine.descriptor;
 
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
-import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
@@ -46,8 +45,7 @@ abstract class DynamicNodeTestDescriptor extends JupiterTestDescriptor {
 	@Override
 	public JupiterEngineExecutionContext prepare(JupiterEngineExecutionContext context) {
 		DynamicExtensionContext extensionContext = new DynamicExtensionContext(context.getExtensionContext(),
-			context.getExecutionListener(), this, context.getConfiguration(),
-			it -> new DefaultExecutableInvoker(it, context.getExtensionRegistry()));
+			context.getExecutionListener(), this, context.getConfiguration(), context.getExtensionRegistry());
 		// @formatter:off
 		return context.extend()
 				.withExtensionContext(extensionContext)

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineDescriptor.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.engine.descriptor.JupiterTestDescriptor.toExecut
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
-import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
@@ -53,7 +52,7 @@ public class JupiterEngineDescriptor extends EngineDescriptor implements Node<Ju
 			context.getConfiguration());
 		EngineExecutionListener executionListener = context.getExecutionListener();
 		ExtensionContext extensionContext = new JupiterEngineExtensionContext(executionListener, this,
-			context.getConfiguration(), it -> new DefaultExecutableInvoker(it, extensionRegistry));
+			context.getConfiguration(), extensionRegistry);
 
 		// @formatter:off
 		return context.extend()

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterEngineExtensionContext.java
@@ -13,13 +13,11 @@ package org.junit.jupiter.engine.descriptor;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.extension.ExecutableInvoker;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.support.hierarchical.Node;
 
@@ -30,9 +28,9 @@ final class JupiterEngineExtensionContext extends AbstractExtensionContext<Jupit
 
 	JupiterEngineExtensionContext(EngineExecutionListener engineExecutionListener,
 			JupiterEngineDescriptor testDescriptor, JupiterConfiguration configuration,
-			Function<ExtensionContext, ExecutableInvoker> executableInvokerFactory) {
+			ExtensionRegistry extensionRegistry) {
 
-		super(null, engineExecutionListener, testDescriptor, configuration, executableInvokerFactory);
+		super(null, engineExecutionListener, testDescriptor, configuration, extensionRegistry);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodExtensionContext.java
@@ -13,13 +13,12 @@ package org.junit.jupiter.engine.descriptor;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.support.hierarchical.Node;
 import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
@@ -35,10 +34,9 @@ final class MethodExtensionContext extends AbstractExtensionContext<TestMethodTe
 
 	MethodExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
 			TestMethodTestDescriptor testDescriptor, JupiterConfiguration configuration,
-			ThrowableCollector throwableCollector,
-			Function<ExtensionContext, ExecutableInvoker> executableInvokerFactory) {
+			ExtensionRegistry extensionRegistry, ThrowableCollector throwableCollector) {
 
-		super(parent, engineExecutionListener, testDescriptor, configuration, executableInvokerFactory);
+		super(parent, engineExecutionListener, testDescriptor, configuration, extensionRegistry);
 
 		this.throwableCollector = throwableCollector;
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.AfterEachMethodAdapter;
 import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
-import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker;
 import org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.ReflectiveInterceptorCall;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
@@ -99,8 +98,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 		MutableExtensionRegistry registry = populateNewExtensionRegistry(context);
 		ThrowableCollector throwableCollector = createThrowableCollector();
 		MethodExtensionContext extensionContext = new MethodExtensionContext(context.getExtensionContext(),
-			context.getExecutionListener(), this, context.getConfiguration(), throwableCollector,
-			it -> new DefaultExecutableInvoker(it, registry));
+			context.getExecutionListener(), this, context.getConfiguration(), registry, throwableCollector);
 		// @formatter:off
 		JupiterEngineExecutionContext newContext = context.extend()
 				.withExtensionRegistry(registry)

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateExtensionContext.java
@@ -13,13 +13,12 @@ package org.junit.jupiter.engine.descriptor;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.support.hierarchical.Node;
 
@@ -31,10 +30,10 @@ final class TestTemplateExtensionContext extends AbstractExtensionContext<TestTe
 	private final TestInstances testInstances;
 
 	TestTemplateExtensionContext(ExtensionContext parent, EngineExecutionListener engineExecutionListener,
-			TestTemplateTestDescriptor testDescriptor, JupiterConfiguration configuration, TestInstances testInstances,
-			Function<ExtensionContext, ExecutableInvoker> executableInvokerFactory) {
+			TestTemplateTestDescriptor testDescriptor, JupiterConfiguration configuration,
+			ExtensionRegistry extensionRegistry, TestInstances testInstances) {
 
-		super(parent, engineExecutionListener, testDescriptor, configuration, executableInvokerFactory);
+		super(parent, engineExecutionListener, testDescriptor, configuration, extensionRegistry);
 		this.testInstances = testInstances;
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
-import org.junit.jupiter.engine.execution.DefaultExecutableInvoker;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
@@ -81,8 +80,7 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 		TestInstances testInstances = context.getExtensionContext().getTestInstances().orElse(null);
 
 		ExtensionContext extensionContext = new TestTemplateExtensionContext(context.getExtensionContext(),
-			context.getExecutionListener(), this, context.getConfiguration(), testInstances,
-			it -> new DefaultExecutableInvoker(it, registry));
+			context.getExecutionListener(), this, context.getConfiguration(), registry, testInstances);
 
 		// @formatter:off
 		return context.extend()

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/DefaultPreInterruptContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/DefaultPreInterruptContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import org.junit.jupiter.api.extension.PreInterruptContext;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ToStringBuilder;
+
+/**
+ * @since 5.12
+ */
+class DefaultPreInterruptContext implements PreInterruptContext {
+	private final Thread threadToInterrupt;
+
+	DefaultPreInterruptContext(Thread threadToInterrupt) {
+		Preconditions.notNull(threadToInterrupt, "threadToInterrupt must not be null");
+		this.threadToInterrupt = threadToInterrupt;
+	}
+
+	@Override
+	public Thread getThreadToInterrupt() {
+		return threadToInterrupt;
+	}
+
+	@Override
+	public String toString() {
+		// @formatter:off
+		return new ToStringBuilder(this)
+				.append("threadToInterrupt", this.threadToInterrupt)
+				.toString();
+		// @formatter:on
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionContextInternal.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionContextInternal.java
@@ -33,8 +33,6 @@ public interface ExtensionContextInternal extends ExtensionContext {
 	 * @param <E> the extension type
 	 * @param extensionType the extension type
 	 * @return the list of extensions
-	 * @since 5.12
 	 */
-	@API(status = INTERNAL, since = "5.12")
 	<E extends Extension> List<E> getExtensions(Class<E> extensionType);
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionContextInternal.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionContextInternal.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.List;
+
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * {@code ExtensionContextInternal} extends the {@link ExtensionContext} with internal API.
+ *
+ * @since 5.12
+ * @see ExtensionContext
+ */
+@API(status = INTERNAL, since = "5.12")
+public interface ExtensionContextInternal extends ExtensionContext {
+
+	/**
+	 * Returns a list of registered extension at this context of the passed {@code extensionType}.
+	 *
+	 * @param <E> the extension type
+	 * @param extensionType the extension type
+	 * @return the list of extensions
+	 * @since 5.12
+	 */
+	@API(status = INTERNAL, since = "5.12")
+	<E extends Extension> List<E> getExtensions(Class<E> extensionType);
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -66,6 +66,11 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 	 * auto-detected using Java's {@link ServiceLoader} mechanism and automatically
 	 * registered after the default extensions.
 	 *
+	 * <p>If the
+	 * {@value org.junit.jupiter.engine.Constants#EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME}
+	 * configuration parameter has been set to {@code true}, the
+	 * {@link PreInterruptThreadDumpPrinter} will be registered.
+	 *
 	 * @param configuration configuration parameters used to retrieve the extension
 	 * auto-detection flag; never {@code null}
 	 * @return a new {@code ExtensionRegistry}; never {@code null}
@@ -79,6 +84,10 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 
 		if (configuration.isExtensionAutoDetectionEnabled()) {
 			registerAutoDetectedExtensions(extensionRegistry);
+		}
+
+		if (configuration.isThreadDumpOnTimeoutEnabled()) {
+			extensionRegistry.registerDefaultExtension(new PreInterruptThreadDumpPrinter());
 		}
 
 		return extensionRegistry;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/PreInterruptCallbackInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/PreInterruptCallbackInvocation.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import java.util.function.Consumer;
+
+/**
+ * @since 5.12
+ */
+@FunctionalInterface
+interface PreInterruptCallbackInvocation {
+	PreInterruptCallbackInvocation NOOP = (t, e) -> {
+	};
+
+	void executePreInterruptCallback(Thread threadToInterrupt, Consumer<Throwable> errorHandler);
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/PreInterruptCallbackInvocationFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/PreInterruptCallbackInvocationFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import java.util.List;
+
+import org.junit.jupiter.api.extension.PreInterruptCallback;
+import org.junit.jupiter.api.extension.PreInterruptContext;
+import org.junit.platform.commons.util.UnrecoverableExceptions;
+
+/**
+ * @since 5.12
+ * @see PreInterruptCallbackInvocation
+ */
+final class PreInterruptCallbackInvocationFactory {
+
+	private PreInterruptCallbackInvocationFactory() {
+	}
+
+	static PreInterruptCallbackInvocation create(ExtensionContextInternal extensionContext) {
+		final List<PreInterruptCallback> callbacks = extensionContext.getExtensions(PreInterruptCallback.class);
+		if (callbacks.isEmpty()) {
+			return PreInterruptCallbackInvocation.NOOP;
+		}
+		return (thread, errorHandler) -> {
+			PreInterruptContext preInterruptContext = new DefaultPreInterruptContext(thread);
+			for (PreInterruptCallback callback : callbacks) {
+				try {
+					callback.beforeThreadInterrupt(preInterruptContext, extensionContext);
+				}
+				catch (Throwable ex) {
+					UnrecoverableExceptions.rethrowIfUnrecoverable(ex);
+					errorHandler.accept(ex);
+				}
+			}
+		};
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/PreInterruptThreadDumpPrinter.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/PreInterruptThreadDumpPrinter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.PreInterruptCallback;
+import org.junit.jupiter.api.extension.PreInterruptContext;
+import org.junit.jupiter.engine.Constants;
+
+/**
+ * The default implementation for {@link PreInterruptCallback},
+ * which will print the stacks of all {@link Thread}s to {@code System.out}.
+ *
+ * <p>Note: This is disabled by default, and must be enabled with
+ * {@link Constants#EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME}
+ *
+ * @since 5.12
+ */
+final class PreInterruptThreadDumpPrinter implements PreInterruptCallback {
+	private static final String NL = "\n";
+
+	@Override
+	public void beforeThreadInterrupt(PreInterruptContext preInterruptContext, ExtensionContext extensionContext) {
+		Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
+		StringBuilder sb = new StringBuilder();
+		sb.append("Thread ");
+		appendThreadName(sb, preInterruptContext.getThreadToInterrupt());
+		sb.append(" will be interrupted.");
+		sb.append(NL);
+		for (Map.Entry<Thread, StackTraceElement[]> entry : stackTraces.entrySet()) {
+			Thread thread = entry.getKey();
+			StackTraceElement[] stack = entry.getValue();
+			if (stack.length > 0) {
+				sb.append(NL);
+				appendThreadName(sb, thread);
+				for (StackTraceElement stackTraceElement : stack) {
+					sb.append(NL);
+					//Do the same prefix as java.lang.Throwable.printStackTrace(java.lang.Throwable.PrintStreamOrWriter)
+					sb.append("\tat ");
+					sb.append(stackTraceElement.toString());
+
+				}
+				sb.append(NL);
+			}
+		}
+		System.out.println(sb);
+	}
+
+	/**
+	 * Appends the {@link Thread} name and ID in a similar fashion as {@code jstack}.
+	 * @param sb the buffer
+	 * @param th the thread to append
+	 */
+	private void appendThreadName(StringBuilder sb, Thread th) {
+		sb.append("\"");
+		sb.append(th.getName());
+		sb.append("\"");
+		sb.append(" #");
+		sb.append(th.getId());
+		if (th.isDaemon()) {
+			sb.append(" daemon");
+		}
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
@@ -182,8 +182,8 @@ class TimeoutExtension implements BeforeAllCallback, BeforeEachCallback, Invocat
 
 		ThreadMode threadMode = resolveTimeoutThreadMode(extensionContext);
 		return new TimeoutInvocationFactory(extensionContext.getRoot().getStore(NAMESPACE)).create(threadMode,
-			new TimeoutInvocationParameters<>(invocation, timeout,
-				() -> describe(invocationContext, extensionContext)));
+			new TimeoutInvocationParameters<>(invocation, timeout, () -> describe(invocationContext, extensionContext),
+				PreInterruptCallbackInvocationFactory.create((ExtensionContextInternal) extensionContext)));
 	}
 
 	private ThreadMode resolveTimeoutThreadMode(ExtensionContext extensionContext) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
@@ -39,11 +39,13 @@ class TimeoutInvocationFactory {
 		Preconditions.notNull(timeoutInvocationParameters, "timeout invocation parameters must not be null");
 		if (threadMode == ThreadMode.SEPARATE_THREAD) {
 			return new SeparateThreadTimeoutInvocation<>(timeoutInvocationParameters.getInvocation(),
-				timeoutInvocationParameters.getTimeoutDuration(), timeoutInvocationParameters.getDescriptionSupplier());
+				timeoutInvocationParameters.getTimeoutDuration(), timeoutInvocationParameters.getDescriptionSupplier(),
+				timeoutInvocationParameters.getPreInterruptCallback());
 		}
 		return new SameThreadTimeoutInvocation<>(timeoutInvocationParameters.getInvocation(),
 			timeoutInvocationParameters.getTimeoutDuration(), getThreadExecutorForSameThreadInvocation(),
-			timeoutInvocationParameters.getDescriptionSupplier());
+			timeoutInvocationParameters.getDescriptionSupplier(),
+			timeoutInvocationParameters.getPreInterruptCallback());
 	}
 
 	private ScheduledExecutorService getThreadExecutorForSameThreadInvocation() {
@@ -90,13 +92,16 @@ class TimeoutInvocationFactory {
 		private final Invocation<T> invocation;
 		private final TimeoutDuration timeout;
 		private final Supplier<String> descriptionSupplier;
+		private final PreInterruptCallbackInvocation preInterruptCallback;
 
 		TimeoutInvocationParameters(Invocation<T> invocation, TimeoutDuration timeout,
-				Supplier<String> descriptionSupplier) {
+				Supplier<String> descriptionSupplier, PreInterruptCallbackInvocation preInterruptCallback) {
 			this.invocation = Preconditions.notNull(invocation, "invocation must not be null");
 			this.timeout = Preconditions.notNull(timeout, "timeout must not be null");
 			this.descriptionSupplier = Preconditions.notNull(descriptionSupplier,
 				"description supplier must not be null");
+			this.preInterruptCallback = Preconditions.notNull(preInterruptCallback,
+				"preInterruptCallback must not be null");
 		}
 
 		public Invocation<T> getInvocation() {
@@ -109,6 +114,10 @@ class TimeoutInvocationFactory {
 
 		public Supplier<String> getDescriptionSupplier() {
 			return descriptionSupplier;
+		}
+
+		public PreInterruptCallbackInvocation getPreInterruptCallback() {
+			return preInterruptCallback;
 		}
 	}
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertTimeoutPreemptivelyAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertTimeoutPreemptivelyAssertionsTests.java
@@ -40,8 +40,8 @@ import org.opentest4j.AssertionFailedError;
 class AssertTimeoutPreemptivelyAssertionsTests {
 
 	private static final Duration PREEMPTIVE_TIMEOUT = ofMillis(WINDOWS.isCurrentOs() ? 1000 : 100);
-	private static final Assertions.TimeoutFailureFactory<TimeoutException> TIMEOUT_EXCEPTION_FACTORY = (__, ___,
-			____) -> new TimeoutException();
+	private static final Assertions.TimeoutFailureFactory<TimeoutException> TIMEOUT_EXCEPTION_FACTORY = (__, ___, ____,
+			_____) -> new TimeoutException();
 
 	private static final ThreadLocal<AtomicBoolean> changed = ThreadLocal.withInitial(() -> new AtomicBoolean(false));
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/KitchenSinkExtension.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/KitchenSinkExtension.java
@@ -60,7 +60,8 @@ public class KitchenSinkExtension implements
 
 	// Miscellaneous
 	TestWatcher,
-	InvocationInterceptor
+	InvocationInterceptor,
+	PreInterruptCallback
 
 // @formatter:on
 {
@@ -253,5 +254,13 @@ public class KitchenSinkExtension implements
 	public void interceptAfterAllMethod(Invocation<Void> invocation,
 			ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
 		InvocationInterceptor.super.interceptAfterAllMethod(invocation, invocationContext, extensionContext);
+	}
+
+	// --- PreInterruptCallback ------------------------------------------------
+
+	@Override
+	public void beforeThreadInterrupt(PreInterruptContext preInterruptContext, ExtensionContext extensionContext)
+			throws Exception {
+
 	}
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/PreInterruptCallbackTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/PreInterruptCallbackTests.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_OUT;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.suppressed;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.PreInterruptCallback;
+import org.junit.jupiter.api.extension.PreInterruptContext;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.jupiter.engine.Constants;
+import org.junit.platform.testkit.engine.Events;
+
+/**
+ * @since 5.12
+ */
+@Isolated
+class PreInterruptCallbackTests extends AbstractJupiterTestEngineTests {
+	private static final String TC = "test";
+	private static final String TIMEOUT_ERROR_MSG = TC + "() timed out after 1 microsecond";
+	private static final String DEFAULT_ENABLE_PROPERTY = Constants.EXTENSIONS_TIMEOUT_THREAD_DUMP_ENABLED_PROPERTY_NAME;
+	private static final AtomicBoolean interruptedTest = new AtomicBoolean();
+	private static final CompletableFuture<Void> testThreadExecutionDone = new CompletableFuture<>();
+	private static final AtomicReference<Thread> interruptedTestThread = new AtomicReference<>();
+	private static final AtomicBoolean interruptCallbackShallThrowException = new AtomicBoolean();
+	private static final AtomicReference<PreInterruptContext> calledPreInterruptContext = new AtomicReference<>();
+
+	@BeforeEach
+	void setUp() {
+		interruptedTest.set(false);
+		interruptCallbackShallThrowException.set(false);
+		calledPreInterruptContext.set(null);
+	}
+
+	@AfterEach
+	void tearDown() {
+		calledPreInterruptContext.set(null);
+		interruptedTestThread.set(null);
+	}
+
+	@Test
+	@ResourceLock(value = SYSTEM_PROPERTIES, mode = READ_WRITE)
+	@ResourceLock(value = SYSTEM_OUT, mode = READ_WRITE)
+	void testCaseWithDefaultInterruptCallbackEnabled() {
+		String orgValue = System.getProperty(DEFAULT_ENABLE_PROPERTY);
+		System.setProperty(DEFAULT_ENABLE_PROPERTY, Boolean.TRUE.toString());
+		PrintStream orgOutStream = System.out;
+		Events tests;
+		String output;
+		try {
+			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			PrintStream outStream = new PrintStream(buffer);
+			System.setOut(outStream);
+			tests = executeTestsForClass(DefaultPreInterruptCallbackTimeoutOnMethodTestCase.class).testEvents();
+			output = buffer.toString(StandardCharsets.UTF_8);
+		}
+		finally {
+			System.setOut(orgOutStream);
+			if (orgValue != null) {
+				System.setProperty(DEFAULT_ENABLE_PROPERTY, orgValue);
+			}
+			else {
+				System.clearProperty(DEFAULT_ENABLE_PROPERTY);
+			}
+		}
+
+		assertTestHasTimedOut(tests);
+		assertTrue(interruptedTest.get());
+		Thread thread = Thread.currentThread();
+		assertTrue(
+			output.contains("Thread \"" + thread.getName() + "\" #" + thread.threadId() + " will be interrupted."),
+			output);
+		assertTrue(output.contains("java.lang.Thread.sleep"), output);
+		assertTrue(output.contains(
+			"org.junit.jupiter.engine.extension.PreInterruptCallbackTests$DefaultPreInterruptCallbackTimeoutOnMethodTestCase.test(PreInterruptCallbackTests.java"),
+			output);
+
+		assertTrue(output.contains("junit-jupiter-timeout-watcher"), output);
+		assertTrue(
+			output.contains("org.junit.jupiter.engine.extension.PreInterruptThreadDumpPrinter.beforeThreadInterrupt"),
+			output);
+	}
+
+	@Test
+	void testCaseWithNoInterruptCallbackEnabled() {
+		Events tests = executeTestsForClass(DefaultPreInterruptCallbackTimeoutOnMethodTestCase.class).testEvents();
+		assertTestHasTimedOut(tests);
+		assertTrue(interruptedTest.get());
+	}
+
+	@Test
+	void testCaseWithDeclaredInterruptCallbackEnabled() {
+		Events tests = executeTestsForClass(DefaultPreInterruptCallbackWithExplicitCallbackTestCase.class).testEvents();
+		assertTestHasTimedOut(tests);
+		assertTrue(interruptedTest.get());
+		PreInterruptContext preInterruptContext = calledPreInterruptContext.get();
+		assertNotNull(preInterruptContext);
+		assertNotNull(preInterruptContext.getThreadToInterrupt());
+		assertEquals(preInterruptContext.getThreadToInterrupt(), interruptedTestThread.get());
+	}
+
+	@Test
+	void testCaseWithDeclaredInterruptCallbackEnabledWithSeparateThread() throws Exception {
+		Events tests = executeTestsForClass(
+			DefaultPreInterruptCallbackWithExplicitCallbackWithSeparateThreadTestCase.class).testEvents();
+		assertOneFailedTest(tests);
+		tests.failed().assertEventsMatchExactly(
+			event(test(TC), finishedWithFailure(instanceOf(TimeoutException.class))));
+
+		//Wait until the real test thread was interrupted due to executor.shutdown(), otherwise the asserts below will be flaky.
+		testThreadExecutionDone.get(1, TimeUnit.SECONDS);
+
+		assertTrue(interruptedTest.get());
+		PreInterruptContext preInterruptContext = calledPreInterruptContext.get();
+		assertNotNull(preInterruptContext);
+		assertNotNull(preInterruptContext.getThreadToInterrupt());
+		assertEquals(preInterruptContext.getThreadToInterrupt(), interruptedTestThread.get());
+	}
+
+	@Test
+	void testCaseWithDeclaredInterruptCallbackThrowsException() {
+		interruptCallbackShallThrowException.set(true);
+		Events tests = executeTestsForClass(DefaultPreInterruptCallbackWithExplicitCallbackTestCase.class).testEvents();
+		tests.failed().assertEventsMatchExactly(event(test(TC),
+			finishedWithFailure(instanceOf(TimeoutException.class), message(TIMEOUT_ERROR_MSG),
+				suppressed(0, instanceOf(InterruptedException.class)),
+				suppressed(1, instanceOf(IllegalStateException.class)))));
+		assertTrue(interruptedTest.get());
+		PreInterruptContext preInterruptContext = calledPreInterruptContext.get();
+		assertNotNull(preInterruptContext);
+		assertNotNull(preInterruptContext.getThreadToInterrupt());
+		assertEquals(preInterruptContext.getThreadToInterrupt(), interruptedTestThread.get());
+	}
+
+	private static void assertTestHasTimedOut(Events tests) {
+		assertOneFailedTest(tests);
+		tests.failed().assertEventsMatchExactly(
+			event(test(TC), finishedWithFailure(instanceOf(TimeoutException.class), message(TIMEOUT_ERROR_MSG), //
+				suppressed(0, instanceOf(InterruptedException.class))//
+			)));
+	}
+
+	private static void assertOneFailedTest(Events tests) {
+		tests.assertStatistics(stats -> stats.started(1).succeeded(0).failed(1));
+	}
+
+	static class TestPreInterruptCallback implements PreInterruptCallback {
+
+		@Override
+		public void beforeThreadInterrupt(PreInterruptContext preInterruptContext, ExtensionContext extensionContext) {
+			assertNotNull(extensionContext);
+
+			calledPreInterruptContext.set(preInterruptContext);
+			if (interruptCallbackShallThrowException.get()) {
+				throw new IllegalStateException("Test-Ex");
+			}
+		}
+	}
+
+	static class DefaultPreInterruptCallbackTimeoutOnMethodTestCase {
+		@Test
+		@Timeout(value = 1, unit = TimeUnit.MICROSECONDS)
+		void test() throws InterruptedException {
+			try {
+				Thread.sleep(1000);
+			}
+			catch (InterruptedException ex) {
+				interruptedTest.set(true);
+				interruptedTestThread.set(Thread.currentThread());
+				throw ex;
+			}
+		}
+	}
+
+	@ExtendWith(TestPreInterruptCallback.class)
+	static class DefaultPreInterruptCallbackWithExplicitCallbackTestCase {
+		@Test
+		@Timeout(value = 1, unit = TimeUnit.MICROSECONDS)
+		void test() throws InterruptedException {
+			try {
+				Thread.sleep(1000);
+			}
+			catch (InterruptedException ex) {
+				interruptedTest.set(true);
+				interruptedTestThread.set(Thread.currentThread());
+				throw ex;
+			}
+		}
+	}
+
+	@ExtendWith(TestPreInterruptCallback.class)
+	static class DefaultPreInterruptCallbackWithExplicitCallbackWithSeparateThreadTestCase {
+		@Test
+		@Timeout(value = 200, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+		void test() throws InterruptedException {
+			try {
+				Thread.sleep(2000);
+			}
+			catch (InterruptedException ex) {
+				interruptedTest.set(true);
+				interruptedTestThread.set(Thread.currentThread());
+				throw ex;
+			}
+			finally {
+				testThreadExecutionDone.complete(null);
+			}
+		}
+	}
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocationTests.java
@@ -34,7 +34,8 @@ class SameThreadTimeoutInvocationTests {
 		var exception = assertThrows(TimeoutException.class, () -> withExecutor(executor -> {
 			var delegate = new EventuallyInterruptibleInvocation();
 			var duration = new TimeoutDuration(1, NANOSECONDS);
-			var timeoutInvocation = new SameThreadTimeoutInvocation<>(delegate, duration, executor, () -> "execution");
+			var timeoutInvocation = new SameThreadTimeoutInvocation<>(delegate, duration, executor, () -> "execution",
+				PreInterruptCallbackInvocation.NOOP);
 			timeoutInvocation.proceed();
 		}));
 		assertFalse(Thread.currentThread().isInterrupted());

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTests.java
@@ -73,7 +73,8 @@ class SeparateThreadTimeoutInvocationTests {
 		var namespace = ExtensionContext.Namespace.create(SeparateThreadTimeoutInvocationTests.class);
 		var store = new NamespaceAwareStore(new NamespacedHierarchicalStore<>(null), namespace);
 		var parameters = new TimeoutInvocationParameters<>(invocation,
-			new TimeoutDuration(PREEMPTIVE_TIMEOUT_MILLIS, MILLISECONDS), () -> "method()");
+			new TimeoutDuration(PREEMPTIVE_TIMEOUT_MILLIS, MILLISECONDS), () -> "method()",
+			PreInterruptCallbackInvocation.NOOP);
 		return (SeparateThreadTimeoutInvocation<T>) new TimeoutInvocationFactory(store) //
 				.create(ThreadMode.SEPARATE_THREAD, parameters);
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactoryTests.java
@@ -56,7 +56,8 @@ class TimeoutInvocationFactoryTests {
 
 	@BeforeEach
 	void setUp() {
-		parameters = new TimeoutInvocationParameters<>(invocation, timeoutDuration, () -> "description");
+		parameters = new TimeoutInvocationParameters<>(invocation, timeoutDuration, () -> "description",
+			PreInterruptCallbackInvocation.NOOP);
 		timeoutInvocationFactory = new TimeoutInvocationFactory(store);
 	}
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
@@ -108,6 +108,8 @@ class ArchUnitTests {
 				.that(are(not(name("org.junit.platform.runner.JUnitPlatformRunnerListener")))) //
 				.that(are(not(name("org.junit.platform.testkit.engine.Events")))) //
 				.that(are(not(name("org.junit.platform.testkit.engine.Executions")))) //
+				//The PreInterruptThreadDumpPrinter writes to StdOut by contract to dump threads
+				.that(are(not(name("org.junit.jupiter.engine.extension.PreInterruptThreadDumpPrinter")))) //
 				.that(are(not(resideInAPackage("org.junit.platform.console.shadow.picocli"))));
 		GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS.check(subset);
 	}


### PR DESCRIPTION
## Overview

Added PreInterruptCallback extension to allow to hook into the `@Timeout` extension before the executing Thread is interrupted.

The default implementation of PreInterruptCallback will simply print the stacks of all Thread to System.out.
It is disabled by default and must be enabled with: junit.jupiter.execution.timeout.threaddump.enabled = true

Issue: #2938

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
