### PR TITLE
Update picocli to 4.7.5 and enable help width computation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ mockito = { module = "org.mockito:mockito-junit-jupiter", version = "5.4.0" }
 opentest4j = { module = "org.opentest4j:opentest4j", version.ref = "opentest4j" }
 openTestReporting-events = { module = "org.opentest4j.reporting:open-test-reporting-events", version.ref = "openTestReporting" }
 openTestReporting-tooling = { module = "org.opentest4j.reporting:open-test-reporting-tooling", version.ref = "openTestReporting" }
-picocli = { module = "info.picocli:picocli", version = "4.7.4" }
+picocli = { module = "info.picocli:picocli", version = "4.7.5" }
 slf4j-julBinding = { module = "org.slf4j:slf4j-jdk14", version = "2.0.7" }
 spock1 = { module = "org.spockframework:spock-core", version = "1.3-groovy-2.5" }
 univocity-parsers = { module = "com.univocity:univocity-parsers", version = "2.9.1" }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
@@ -33,7 +33,7 @@ import picocli.CommandLine.Unmatched;
 		sortOptions = false, //
 		usageHelpWidth = 95, //
 		showAtFileInUsageHelp = true, //
-		usageHelpAutoWidth = false, // https://github.com/remkop/picocli/issues/1104
+		usageHelpAutoWidth = true, //
 		description = "Launches the JUnit Platform for test discovery and execution.", //
 		footerHeading = "%n", //
 		footer = "For more information, please refer to the JUnit User Guide at%n" //


### PR DESCRIPTION
## Overview

Update picocli to 4.7.5 and enable help width computation in JUnit's console launcher application.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
