### PR TITLE
Fix typo in AfterAll documentation

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterAll.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AfterAll.java
@@ -40,7 +40,7 @@ import org.apiguardian.api.API;
  * methods may optionally declare parameters to be resolved by
  * {@link org.junit.jupiter.api.extension.ParameterResolver ParameterResolvers}.
  *
- * <p>Using {@code private} visibility for {@code @BeforeAll} methods is
+ * <p>Using {@code private} visibility for {@code @AfterAll} methods is
  * strongly discouraged and will be disallowed in a future release.
  *
  * <h2>Inheritance and Execution Order</h2>


### PR DESCRIPTION
## Overview

Looks like this was a copy & paste error from the same text from `@BeforeAll`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
