### PR TITLE
Allow `LauncherInterceptor`s to be discovered when the launcher is used as a Java module

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
@@ -16,6 +16,8 @@ JUnit repository on GitHub.
 ==== Bug Fixes
 
 * ❓
+* Fixes use of the launcher as a Java module when `junit.platform.launcher.interceptors.enabled` is enabled
+  - See link:https://github.com/junit-team/junit5/issues/3561[issue 3561] for details.
 
 ==== Deprecations and Breaking Changes
 

--- a/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
+++ b/junit-platform-launcher/src/module/org.junit.platform.launcher/module-info.java
@@ -16,6 +16,8 @@
  * @since 1.0
  * @uses org.junit.platform.engine.TestEngine
  * @uses org.junit.platform.launcher.LauncherDiscoveryListener
+ * @uses org.junit.platform.launcher.LauncherInterceptor
+ * @uses org.junit.platform.launcher.LauncherSessionListener
  * @uses org.junit.platform.launcher.PostDiscoveryFilter
  * @uses org.junit.platform.launcher.TestExecutionListener
  */
@@ -32,6 +34,7 @@ module org.junit.platform.launcher {
 
 	uses org.junit.platform.engine.TestEngine;
 	uses org.junit.platform.launcher.LauncherDiscoveryListener;
+	uses org.junit.platform.launcher.LauncherInterceptor;
 	uses org.junit.platform.launcher.LauncherSessionListener;
 	uses org.junit.platform.launcher.PostDiscoveryFilter;
 	uses org.junit.platform.launcher.TestExecutionListener;

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-launcher.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-launcher.expected.txt
@@ -10,6 +10,7 @@ requires org.junit.platform.commons transitive
 requires org.junit.platform.engine transitive
 uses org.junit.platform.engine.TestEngine
 uses org.junit.platform.launcher.LauncherDiscoveryListener
+uses org.junit.platform.launcher.LauncherInterceptor
 uses org.junit.platform.launcher.LauncherSessionListener
 uses org.junit.platform.launcher.PostDiscoveryFilter
 uses org.junit.platform.launcher.TestExecutionListener


### PR DESCRIPTION
## Overview

Fixes #3561 by including the new LauncherInterceptor service in the module metadata for the launcher JPMS module.
Otherwise in the context of Java Modules, it cannot use ServiceLoader to look up implementations of LauncherInterceptor.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling **(NOTE: ~~I do not think there are automated tests for JPMS~~ Found a test that checks for the module declarations and adapted it)**
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [X] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
