### PR TITLE
Correct Javadoc text references to "arguments providers".

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * <p>Such methods must not be {@code private} or {@code static}.
  *
- * <h2>Argument Providers and Sources</h2>
+ * <h2>Arguments Providers and Sources</h2>
  *
  * <p>{@code @ParameterizedTest} methods must specify at least one
  * {@link org.junit.jupiter.params.provider.ArgumentsProvider ArgumentsProvider}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSource.java
@@ -23,7 +23,7 @@ import org.apiguardian.api.API;
 
 /**
  * {@code @ArgumentsSource} is a {@linkplain Repeatable repeatable} annotation
- * that is used to register {@linkplain ArgumentsProvider argument providers}
+ * that is used to register {@linkplain ArgumentsProvider arguments providers}
  * for the annotated test method.
  *
  * <p>{@code @ArgumentsSource} may also be used as a meta-annotation in order to


### PR DESCRIPTION
Issue: #3579

## Overview

Replace references to "argument providers" with "arguments providers".

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
