### PR TITLE
Improve error message for Store requiredType mismatch

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
@@ -28,7 +28,7 @@ repository on GitHub.
 * New `StringConversionSupport` in `junit-platform-commons` to expose internal conversion
   logic used by Jupiter's `DefaultArgumentConverter` for use in third-party extensions and
   test engines.
-
+* Improve type mismatch error message in `NamespacedHierarchicalStore` to include actual type and value.
 
 [[release-notes-5.11.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
@@ -252,7 +252,8 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 		}
 		// else
 		throw new NamespacedHierarchicalStoreException(
-			String.format("Object stored under key [%s] is not of required type [%s]", key, requiredType.getName()));
+			String.format("Object stored under key [%s] is not of required type [%s], but was [%s]: %s", key,
+				requiredType.getName(), value.getClass(), value));
 	}
 
 	private static class CompositeKey<N> {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreTests.java
@@ -171,7 +171,8 @@ public class NamespacedHierarchicalStoreTests {
 
 			Exception exception = assertThrows(NamespacedHierarchicalStoreException.class,
 				() -> store.get(namespace, key, Number.class));
-			assertEquals("Object stored under key [42] is not of required type [java.lang.Number]",
+			assertEquals(
+				"Object stored under key [42] is not of required type [java.lang.Number], but was [class java.lang.String]: enigma",
 				exception.getMessage());
 		}
 
@@ -221,7 +222,8 @@ public class NamespacedHierarchicalStoreTests {
 
 			Exception exception = assertThrows(NamespacedHierarchicalStoreException.class,
 				() -> store.getOrComputeIfAbsent(namespace, key, defaultCreator, String.class));
-			assertEquals("Object stored under key [pi] is not of required type [java.lang.String]",
+			assertEquals(
+				"Object stored under key [pi] is not of required type [java.lang.String], but was [class java.lang.Float]: 3.14",
 				exception.getMessage());
 		}
 
@@ -264,7 +266,8 @@ public class NamespacedHierarchicalStoreTests {
 
 			Exception exception = assertThrows(NamespacedHierarchicalStoreException.class,
 				() -> store.remove(namespace, key, Number.class));
-			assertEquals("Object stored under key [42] is not of required type [java.lang.Number]",
+			assertEquals(
+				"Object stored under key [42] is not of required type [java.lang.Number], but was [class java.lang.String]: enigma",
 				exception.getMessage());
 		}
 


### PR DESCRIPTION
## Overview

Prior to this commit, the error message just contained the key and the requiredType, but gave no indication what was actually present. Now, the error message also includes the type of the actual value as well as its toString() representation.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
