### PR TITLE
Refine implementation and usage of `throwAsUncheckedException(..)`

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -69,7 +69,7 @@ class AssertTimeout {
 			result = supplier.get();
 		}
 		catch (Throwable ex) {
-			throwAsUncheckedException(ex);
+			throw throwAsUncheckedException(ex);
 		}
 
 		long timeElapsed = System.currentTimeMillis() - start;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assumptions.java
@@ -248,7 +248,7 @@ public class Assumptions {
 				executable.execute();
 			}
 			catch (Throwable t) {
-				ExceptionUtils.throwAsUncheckedException(t);
+				throw ExceptionUtils.throwAsUncheckedException(t);
 			}
 		}
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -383,7 +383,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor {
 			executable.execute();
 		}
 		catch (Throwable throwable) {
-			ExceptionUtils.throwAsUncheckedException(throwable);
+			throw ExceptionUtils.throwAsUncheckedException(throwable);
 		}
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -117,7 +117,7 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 
 		// No handlers left?
 		if (exceptionHandlers.isEmpty()) {
-			ExceptionUtils.throwAsUncheckedException(throwable);
+			throw ExceptionUtils.throwAsUncheckedException(throwable);
 		}
 
 		try {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -147,7 +147,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 					getPathOrFile(new FieldContext(field), field.getType(), factory, cleanupMode, scope, context));
 			}
 			catch (Throwable t) {
-				ExceptionUtils.throwAsUncheckedException(t);
+				throw ExceptionUtils.throwAsUncheckedException(t);
 			}
 		});
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -153,11 +153,11 @@ class AssertTimeoutAssertionsTests {
 	 * Take a nap for 100 milliseconds.
 	 */
 	private void nap() throws InterruptedException {
-		long start = System.nanoTime();
+		long start = System.currentTimeMillis();
 		// workaround for imprecise clocks (yes, Windows, I'm talking about you)
 		do {
 			Thread.sleep(100);
-		} while (System.nanoTime() - start < 100_000_000L);
+		} while (System.currentTimeMillis() - start < 100);
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -102,10 +102,8 @@ class AssertTimeoutAssertionsTests {
 	@Test
 	void assertTimeoutForSupplierThatThrowsAnException() {
 		RuntimeException exception = assertThrows(RuntimeException.class, () -> {
-			assertTimeout(ofMillis(500), () -> {
-				ExceptionUtils.throwAsUncheckedException(new RuntimeException("not this time"));
-				return "Tempus Fugit";
-			});
+			assertTimeout(ofMillis(500),
+				() -> ExceptionUtils.throwAsUncheckedException(new RuntimeException("not this time")));
 		});
 		assertMessageEquals(exception, "not this time");
 	}
@@ -113,10 +111,7 @@ class AssertTimeoutAssertionsTests {
 	@Test
 	void assertTimeoutForSupplierThatThrowsAnAssertionFailedError() {
 		AssertionFailedError exception = assertThrows(AssertionFailedError.class, () -> {
-			assertTimeout(ofMillis(500), () -> {
-				fail("enigma");
-				return "Tempus Fugit";
-			});
+			assertTimeout(ofMillis(500), () -> fail("enigma"));
 		});
 		assertMessageEquals(exception, "enigma");
 	}
@@ -158,11 +153,11 @@ class AssertTimeoutAssertionsTests {
 	 * Take a nap for 100 milliseconds.
 	 */
 	private void nap() throws InterruptedException {
-		long start = System.currentTimeMillis();
+		long start = System.nanoTime();
 		// workaround for imprecise clocks (yes, Windows, I'm talking about you)
 		do {
 			Thread.sleep(100);
-		} while (System.currentTimeMillis() - start < 100);
+		} while (System.nanoTime() - start < 100_000_000L);
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutPreemptivelyAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutPreemptivelyAssertionsTests.java
@@ -128,10 +128,8 @@ class AssertTimeoutPreemptivelyAssertionsTests {
 	@Test
 	void assertTimeoutPreemptivelyForSupplierThatThrowsAnException() {
 		RuntimeException exception = assertThrows(RuntimeException.class, () -> {
-			assertTimeoutPreemptively(ofMillis(500), () -> {
-				ExceptionUtils.throwAsUncheckedException(new RuntimeException("not this time"));
-				return "Tempus Fugit";
-			});
+			assertTimeoutPreemptively(ofMillis(500),
+				() -> ExceptionUtils.throwAsUncheckedException(new RuntimeException("not this time")));
 		});
 		assertMessageEquals(exception, "not this time");
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -865,7 +865,7 @@ class BaseFieldExtension<T extends Annotation> implements BeforeAllCallback, Bef
 				makeAccessible(field).set(instance, trigger + " - " + field.getName());
 			}
 			catch (Throwable t) {
-				ExceptionUtils.throwAsUncheckedException(t);
+				throw ExceptionUtils.throwAsUncheckedException(t);
 			}
 		});
 	}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ProgrammaticExtensionRegistrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/ProgrammaticExtensionRegistrationTests.java
@@ -708,7 +708,7 @@ class ProgrammaticExtensionRegistrationTests extends AbstractJupiterTestEngineTe
 						field.set(testInstance, new CrystalBall("Outlook good"));
 					}
 					catch (Throwable t) {
-						ExceptionUtils.throwAsUncheckedException(t);
+						throw ExceptionUtils.throwAsUncheckedException(t);
 					}
 				});
 			// @formatter:on

--- a/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
+++ b/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
@@ -270,11 +270,11 @@ internal class KotlinAssertTimeoutAssertionsTests {
      * Take a nap for 100 milliseconds.
      */
     private fun nap() {
-        val start = System.nanoTime()
+        val start = System.currentTimeMillis()
         // workaround for imprecise clocks (yes, Windows, I'm talking about you)
         do {
             Thread.sleep(100)
-        } while (System.nanoTime() - start < 100_000_000)
+        } while (System.currentTimeMillis() - start < 100)
     }
 
     private fun waitForInterrupt() {

--- a/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
+++ b/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
@@ -270,11 +270,11 @@ internal class KotlinAssertTimeoutAssertionsTests {
      * Take a nap for 100 milliseconds.
      */
     private fun nap() {
-        val start = System.currentTimeMillis()
+        val start = System.nanoTime()
         // workaround for imprecise clocks (yes, Windows, I'm talking about you)
         do {
             Thread.sleep(100)
-        } while (System.currentTimeMillis() - start < 100)
+        } while (System.nanoTime() - start < 100_000_000)
     }
 
     private fun waitForInterrupt() {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
@@ -71,14 +71,12 @@ public final class ExceptionUtils {
 	 */
 	public static RuntimeException throwAsUncheckedException(Throwable t) {
 		Preconditions.notNull(t, "Throwable must not be null");
-		ExceptionUtils.throwAs(t);
-
-		// Appeasing the compiler: the following line will never be executed.
-		return null;
+		// the following line will never return but throw t
+		return ExceptionUtils.throwAs(t);
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <T extends Throwable> void throwAs(Throwable t) throws T {
+	private static <T extends Throwable> T throwAs(Throwable t) throws T {
 		throw (T) t;
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/UnrecoverableExceptions.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/UnrecoverableExceptions.java
@@ -49,7 +49,7 @@ public final class UnrecoverableExceptions {
 	 */
 	public static void rethrowIfUnrecoverable(Throwable exception) {
 		if (exception instanceof OutOfMemoryError) {
-			ExceptionUtils.throwAsUncheckedException(exception);
+			throw ExceptionUtils.throwAsUncheckedException(exception);
 		}
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -202,7 +202,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 				testTask.execute();
 			}
 			catch (InterruptedException e) {
-				ExceptionUtils.throwAsUncheckedException(e);
+				throw ExceptionUtils.throwAsUncheckedException(e);
 			}
 		}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -239,7 +239,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 					// Futures returned by execute() may have been cancelled
 				}
 				catch (ExecutionException e) {
-					ExceptionUtils.throwAsUncheckedException(e.getCause());
+					throw ExceptionUtils.throwAsUncheckedException(e.getCause());
 				}
 			}
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ThrowableCollector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ThrowableCollector.java
@@ -158,7 +158,7 @@ public class ThrowableCollector {
 	 */
 	public void assertEmpty() {
 		if (!isEmpty()) {
-			ExceptionUtils.throwAsUncheckedException(this.throwable);
+			throw ExceptionUtils.throwAsUncheckedException(this.throwable);
 		}
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
@@ -362,7 +362,7 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 				computeValue();
 			}
 			if (this.value instanceof Failure) {
-				ExceptionUtils.throwAsUncheckedException(((Failure) this.value).throwable);
+				throw ExceptionUtils.throwAsUncheckedException(((Failure) this.value).throwable);
 			}
 			return this.value;
 		}


### PR DESCRIPTION
Use `throw` with `throwAsUncheckedException(..)`.

Reason:

`ExceptionUtils.throwAsUncheckedException(t)` emits the following warning in IntelliJ:

> Result of 'throwAsUncheckedException()' not thrown

and `throw ExceptionUtils.throwAsUncheckedException(t)` also emits a warning:

> Dereference of 'ExceptionUtils.throwAsUncheckedException(t)' may produce 'NullPointerException' 

Therefore following recommendation: `throwAsUncheckedException` shouldn't return a null value.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).