### PR TITLE
Measure elapsed time with `System.nanoTime()` in tests

### DIFF
--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -158,11 +158,11 @@ class AssertTimeoutAssertionsTests {
 	 * Take a nap for 100 milliseconds.
 	 */
 	private void nap() throws InterruptedException {
-		long start = System.currentTimeMillis();
+		long start = System.nanoTime();
 		// workaround for imprecise clocks (yes, Windows, I'm talking about you)
 		do {
 			Thread.sleep(100);
-		} while (System.currentTimeMillis() - start < 100);
+		} while (System.nanoTime() - start < 100_000_000L);
 	}
 
 }

--- a/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
+++ b/junit-jupiter-engine/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
@@ -270,11 +270,11 @@ internal class KotlinAssertTimeoutAssertionsTests {
      * Take a nap for 100 milliseconds.
      */
     private fun nap() {
-        val start = System.currentTimeMillis()
+        val start = System.nanoTime()
         // workaround for imprecise clocks (yes, Windows, I'm talking about you)
         do {
             Thread.sleep(100)
-        } while (System.currentTimeMillis() - start < 100)
+        } while (System.nanoTime() - start < 100_000_000L)
     }
 
     private fun waitForInterrupt() {


### PR DESCRIPTION
## Overview

java.lang.System.nanoTime() isn't affected by system clock changes as opposed to `currentTimeMillis()`.

An example can be found in [nanoTime() javadoc](https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#nanoTime--).

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).