### PR TITLE
Document benefits of `messageSupplier` in `Assertions`

### DIFF
--- a/documentation/src/test/java/example/AssertionsDemo.java
+++ b/documentation/src/test/java/example/AssertionsDemo.java
@@ -39,10 +39,14 @@ class AssertionsDemo {
 	@Test
 	void standardAssertions() {
 		assertEquals(2, calculator.add(1, 1));
+		// When assertion failure message is used as a plain expression,
+		// the expression will be evaluated irrespective of the assertion result.
 		assertEquals(4, calculator.multiply(2, 2),
-				"The optional failure message is now the last parameter");
-		assertTrue('a' < 'b', () -> "Assertion messages can be lazily evaluated -- "
-				+ "to avoid constructing complex messages unnecessarily.");
+				"This expression will always evaluate irrespective of assertion result.");
+		// When assertion failure message is created as a lambda expression,
+		// expression will only evaluate when assertion result is failed (lazy evaluation)
+		// and can help us save unnecessary computations when they are not needed.
+		assertTrue('a' < 'b', () -> "This lambda will evaluate only if assertion fails.");
 	}
 
 	@Test

--- a/documentation/src/test/java/example/AssertionsDemo.java
+++ b/documentation/src/test/java/example/AssertionsDemo.java
@@ -39,6 +39,16 @@ class AssertionsDemo {
 	@Test
 	void standardAssertions() {
 		assertEquals(2, calculator.add(1, 1));
+		assertEquals(4, calculator.multiply(2, 2),
+				"The optional failure message is now the last parameter");
+		// When third parameter is used as message supplier (lambda expression)
+		// it will be lazily evaluated, only when the assertion fails.
+		assertTrue('a' < 'b', () -> "Assertion messages can be lazily evaluated -- "
+				+ "to avoid constructing complex messages unnecessarily.");
+	}
+
+	@Test
+	void assertWithMessageSupplier() {
 		// When assertion failure message is used as a plain expression,
 		// the expression will be evaluated irrespective of the assertion result.
 		assertEquals(4, calculator.multiply(2, 2),


### PR DESCRIPTION
## Overview

Documented the benefits of MessageSupplier in assertion, as per the discussion on issue #3153 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
