### PR TITLE
Introduce `--redirect-stdout` and `--redirect-stderr` CLI options to redirect STDOUT and STDERR

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
@@ -30,7 +30,9 @@ repository on GitHub.
   -- for use in third-party extensions and test engines.
 * Error messages for type mismatches in `NamespacedHierarchicalStore` now include the
   actual type and value in addition to the required type.
-
+* New optional config parameter `junit.platform.output.capture.merge` that can be used to merge stdout and stderr and
+  capture it as stdout.
+* New optional CLI options `--redirect-stdout` and `--redirect-stderr` to redirect stdout and stderr outputs to a file.
 
 [[release-notes-5.11.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -1019,6 +1019,8 @@ expressions can be useful.
 Since version 1.3, the JUnit Platform provides opt-in support for capturing output
 printed to `System.out` and `System.err`. To enable it, set the
 `junit.platform.output.capture.stdout` and/or `junit.platform.output.capture.stderr`
+<<running-tests-config-params, configuration parameter>> to `true`. And since version 5.11
+you can capture a merged stdout/stderr output by setting the `junit.platform.output.capture.merge`
 <<running-tests-config-params, configuration parameter>> to `true`. In addition, you may
 configure the maximum number of buffered bytes to be used per executed test or container
 using `junit.platform.output.capture.maxBuffer`.
@@ -1026,7 +1028,8 @@ using `junit.platform.output.capture.maxBuffer`.
 If enabled, the JUnit Platform captures the corresponding output and publishes it as a
 report entry using the `stdout` or `stderr` keys to all registered
 `{TestExecutionListener}` instances immediately before reporting the test or container as
-finished.
+finished, in case of a `junit.platform.output.capture.merge` <<running-tests-config-params, configuration parameter>>,
+the merged output will be published as a report entry using the `stdout` key.
 
 Please note that the captured output will only contain output emitted by the thread that
 was used to execute a container or test. Any output by other threads will be omitted

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/TestConsoleOutputOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/TestConsoleOutputOptions.java
@@ -75,18 +75,22 @@ public class TestConsoleOutputOptions {
 		this.theme = theme;
 	}
 
+	@API(status = INTERNAL, since = "5.11")
 	public Path getStdoutPath() {
 		return this.stdoutPath;
 	}
 
+	@API(status = INTERNAL, since = "5.11")
 	public void setStdoutPath(Path stdoutPath) {
 		this.stdoutPath = stdoutPath;
 	}
 
+	@API(status = INTERNAL, since = "5.11")
 	public Path getStderrPath() {
 		return this.stderrPath;
 	}
 
+	@API(status = INTERNAL, since = "5.11")
 	public void setStderrPath(Path stderrPath) {
 		this.stderrPath = stderrPath;
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/TestConsoleOutputOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/TestConsoleOutputOptions.java
@@ -32,6 +32,8 @@ public class TestConsoleOutputOptions {
 	private boolean isSingleColorPalette;
 	private Details details = DEFAULT_DETAILS;
 	private Theme theme = DEFAULT_THEME;
+	private Path stdoutPath;
+	private Path stderrPath;
 
 	public boolean isAnsiColorOutputDisabled() {
 		return this.ansiColorOutputDisabled;
@@ -71,6 +73,22 @@ public class TestConsoleOutputOptions {
 
 	public void setTheme(Theme theme) {
 		this.theme = theme;
+	}
+
+	public Path getStdoutPath() {
+		return this.stdoutPath;
+	}
+
+	public void setStdoutPath(Path stdoutPath) {
+		this.stdoutPath = stdoutPath;
+	}
+
+	public Path getStderrPath() {
+		return this.stderrPath;
+	}
+
+	public void setStderrPath(Path stderrPath) {
+		this.stderrPath = stderrPath;
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/TestConsoleOutputOptionsMixin.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/TestConsoleOutputOptionsMixin.java
@@ -51,11 +51,25 @@ class TestConsoleOutputOptionsMixin {
 		@Option(names = "-details-theme", hidden = true)
 		private Theme theme2 = DEFAULT_THEME;
 
+		@Option(names = "--redirect-stdout", paramLabel = "FILE", description = "Redirect tests stdout to a file.")
+		private Path stdout;
+
+		@Option(names = "-redirect-stdout", hidden = true)
+		private Path stdout2;
+
+		@Option(names = "--redirect-stderr", paramLabel = "FILE", description = "Redirect tests stderr to a file.")
+		private Path stderr;
+
+		@Option(names = "-redirect-stderr", hidden = true)
+		private Path stderr2;
+
 		private void applyTo(TestConsoleOutputOptions result) {
 			result.setColorPalettePath(choose(colorPalette, colorPalette2, null));
 			result.setSingleColorPalette(singleColorPalette || singleColorPalette2);
 			result.setDetails(choose(details, details2, DEFAULT_DETAILS));
 			result.setTheme(choose(theme, theme2, DEFAULT_THEME));
+			result.setStdoutPath(choose(stdout, stdout2, null));
+			result.setStderrPath(choose(stderr, stderr2, null));
 		}
 	}
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -206,24 +206,28 @@ public class ConsoleTestExecutor {
 		summary.printTo(out);
 	}
 
+	@API(status = INTERNAL, since = "5.11")
 	private boolean isSameFile(Path path1, Path path2) {
 		if (path1 == null || path2 == null)
 			return false;
 		return (path1.normalize().toAbsolutePath().equals(path2.normalize().toAbsolutePath()));
 	}
 
+	@API(status = INTERNAL, since = "5.11")
 	private void captureStdout() {
 		Map<String, String> configParameters = new HashMap<>(discoveryOptions.getConfigurationParameters());
 		configParameters.put(LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME, "true");
 		discoveryOptions.setConfigurationParameters(configParameters);
 	}
 
+	@API(status = INTERNAL, since = "5.11")
 	private void captureStderr() {
 		Map<String, String> configParameters = new HashMap<>(discoveryOptions.getConfigurationParameters());
 		configParameters.put(LauncherConstants.CAPTURE_STDERR_PROPERTY_NAME, "true");
 		discoveryOptions.setConfigurationParameters(configParameters);
 	}
 
+	@API(status = INTERNAL, since = "5.11")
 	private void captureMergedStandardStreams() {
 		Map<String, String> configParameters = new HashMap<>(discoveryOptions.getConfigurationParameters());
 		configParameters.put(LauncherConstants.CAPTURE_MERGED_STANDARD_STREAMS_PROPERTY_NAME, "true");

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ConsoleTestExecutor.java
@@ -156,7 +156,7 @@ public class ConsoleTestExecutor {
 		launcher.registerTestExecutionListeners(summaryListener);
 		// optionally, register test plan execution details printing listener
 		createDetailsPrintingListener(out).ifPresent(launcher::registerTestExecutionListeners);
-		// optionally, register XML reports writingCAPTURE_STDERR_PROPERTY_NAME listener
+		// optionally, register XML reports writing listener
 		createXmlWritingListener(out, reportsDir).ifPresent(launcher::registerTestExecutionListeners);
 		return summaryListener;
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/RedirectStdoutAndStderrListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/RedirectStdoutAndStderrListener.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console.tasks;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apiguardian.api.API;
+import org.junit.platform.engine.reporting.ReportEntry;
+import org.junit.platform.launcher.LauncherConstants;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+@API(status = INTERNAL, since = "5.11")
+public class RedirectStdoutAndStderrListener implements TestExecutionListener {
+	private final Path stdoutOutputPath;
+	private final Path stderrOutputPath;
+	private final StringWriter stdoutBuffer;
+	private final StringWriter stderrBuffer;
+	private final PrintWriter out;
+
+	public RedirectStdoutAndStderrListener(Path stdoutOutputPath, Path stderrOutputPath, PrintWriter out) {
+		this.stdoutOutputPath = stdoutOutputPath;
+		this.stderrOutputPath = stderrOutputPath;
+		this.stdoutBuffer = new StringWriter();
+		this.stderrBuffer = new StringWriter();
+		this.out = out;
+	}
+
+	public void reportingEntryPublished(TestIdentifier testIdentifier, ReportEntry entry) {
+		if (testIdentifier.isTest()) {
+			String redirectedStdoutContent = entry.getKeyValuePairs().get(LauncherConstants.STDOUT_REPORT_ENTRY_KEY);
+			String redirectedStderrContent = entry.getKeyValuePairs().get(LauncherConstants.STDERR_REPORT_ENTRY_KEY);
+
+			if (redirectedStdoutContent != null && !redirectedStdoutContent.isEmpty()) {
+				this.stdoutBuffer.append(redirectedStdoutContent);
+			}
+			if (redirectedStderrContent != null && !redirectedStderrContent.isEmpty()) {
+				this.stderrBuffer.append(redirectedStderrContent);
+			}
+		}
+	}
+
+	public void testPlanExecutionFinished(TestPlan testPlan) {
+		if (stdoutBuffer.getBuffer().length() > 0) {
+			flushBufferedOutputToFile(this.stdoutOutputPath, this.stdoutBuffer);
+		}
+		if (stderrBuffer.getBuffer().length() > 0) {
+			flushBufferedOutputToFile(this.stderrOutputPath, this.stderrBuffer);
+		}
+	}
+
+	private void flushBufferedOutputToFile(Path file, StringWriter buffer) {
+		deleteFile(file);
+		createFile(file);
+		writeContentToFile(file, buffer.toString());
+	}
+
+	private void writeContentToFile(Path file, String buffer) {
+		try (Writer fileWriter = Files.newBufferedWriter(file)) {
+			fileWriter.write(buffer);
+		}
+		catch (IOException e) {
+			printException("Failed to write content to file: " + file, e);
+		}
+	}
+
+	private void deleteFile(Path file) {
+		try {
+			Files.deleteIfExists(file);
+		}
+		catch (IOException e) {
+			printException("Failed to delete file: " + file, e);
+		}
+	}
+
+	private void createFile(Path file) {
+		try {
+			Files.createFile(file);
+		}
+		catch (IOException e) {
+			printException("Failed to create file: " + file, e);
+		}
+	}
+
+	private void printException(String message, Exception exception) {
+		out.println(message);
+		exception.printStackTrace(out);
+	}
+}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -61,6 +61,21 @@ public class LauncherConstants {
 	public static final String CAPTURE_STDERR_PROPERTY_NAME = "junit.platform.output.capture.stderr";
 
 	/**
+	 * Property name used to enable merging and capturing output to {@link System#err} and {@link System#out}:
+	 * {@value}
+	 *
+	 * <p>If enabled, the JUnit Platform merges stdout and stderr and publishes
+	 * it as a {@link ReportEntry} using the
+	 * {@value #STDOUT_REPORT_ENTRY_KEY} key immediately before reporting the
+	 * test identifier as finished.
+	 *
+	 * @see #STDOUT_REPORT_ENTRY_KEY
+	 * @see ReportEntry
+	 * @see TestExecutionListener#reportingEntryPublished(TestIdentifier, ReportEntry)
+	 */
+	public static final String CAPTURE_MERGED_STANDARD_STREAMS_PROPERTY_NAME = "junit.platform.output.capture.merge";
+
+	/**
 	 * Property name used to configure the maximum number of bytes for buffering
 	 * to use per thread and output type if output capturing is enabled:
 	 * {@value}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
@@ -37,6 +37,12 @@ class StreamInterceptor extends PrintStream {
 		return register(System.err, System::setErr, maxNumberOfBytesPerThread);
 	}
 
+	static Optional<StreamInterceptor> registerMergedStandardStreams(int maxNumberOfBytesPerThread) {
+		Optional<StreamInterceptor> interceptor = registerStdout(maxNumberOfBytesPerThread);
+		interceptor.ifPresent((System::setErr));
+		return interceptor;
+	}
+
 	static Optional<StreamInterceptor> register(PrintStream originalStream, Consumer<PrintStream> streamSetter,
 			int maxNumberOfBytesPerThread) {
 		if (originalStream instanceof StreamInterceptor) {

--- a/platform-tests/src/test/java/org/junit/platform/console/options/CommandLineOptionsParsingTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/CommandLineOptionsParsingTests.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.engine.discovery.ClassNameFilter.STANDARD_INCLUDE_PATTERN;
@@ -56,23 +57,25 @@ class CommandLineOptionsParsingTests {
 		// @formatter:off
 		assertAll(
 			() -> assertFalse(options.output.isAnsiColorOutputDisabled()),
-			() -> assertEquals(TestConsoleOutputOptions.DEFAULT_DETAILS, options.output.getDetails()),
-			() -> assertFalse(options.discovery.isScanClasspath()),
-			() -> assertEquals(List.of(STANDARD_INCLUDE_PATTERN), options.discovery.getIncludedClassNamePatterns()),
-			() -> assertEquals(List.of(), options.discovery.getExcludedClassNamePatterns()),
-			() -> assertEquals(List.of(), options.discovery.getIncludedPackages()),
-			() -> assertEquals(List.of(), options.discovery.getExcludedPackages()),
-			() -> assertEquals(List.of(), options.discovery.getIncludedTagExpressions()),
-			() -> assertEquals(List.of(), options.discovery.getExcludedTagExpressions()),
-			() -> assertEquals(List.of(), options.discovery.getAdditionalClasspathEntries()),
-			() -> assertEquals(List.of(), options.discovery.getSelectedUris()),
-			() -> assertEquals(List.of(), options.discovery.getSelectedFiles()),
-			() -> assertEquals(List.of(), options.discovery.getSelectedDirectories()),
-			() -> assertEquals(List.of(), options.discovery.getSelectedModules()),
-			() -> assertEquals(List.of(), options.discovery.getSelectedPackages()),
-			() -> assertEquals(List.of(), options.discovery.getSelectedMethods()),
-			() -> assertEquals(List.of(), options.discovery.getSelectedClasspathEntries()),
-			() -> assertEquals(Map.of(), options.discovery.getConfigurationParameters())
+				() -> assertNull(options.output.getStdoutPath()),
+				() -> assertNull(options.output.getStderrPath()),
+		() -> assertEquals(TestConsoleOutputOptions.DEFAULT_DETAILS, options.output.getDetails()),
+		() -> assertFalse(options.discovery.isScanClasspath()),
+		() -> assertEquals(List.of(STANDARD_INCLUDE_PATTERN), options.discovery.getIncludedClassNamePatterns()),
+		() -> assertEquals(List.of(), options.discovery.getExcludedClassNamePatterns()),
+		() -> assertEquals(List.of(), options.discovery.getIncludedPackages()),
+		() -> assertEquals(List.of(), options.discovery.getExcludedPackages()),
+		() -> assertEquals(List.of(), options.discovery.getIncludedTagExpressions()),
+		() -> assertEquals(List.of(), options.discovery.getExcludedTagExpressions()),
+		() -> assertEquals(List.of(), options.discovery.getAdditionalClasspathEntries()),
+		() -> assertEquals(List.of(), options.discovery.getSelectedUris()),
+		() -> assertEquals(List.of(), options.discovery.getSelectedFiles()),
+		() -> assertEquals(List.of(), options.discovery.getSelectedDirectories()),
+		() -> assertEquals(List.of(), options.discovery.getSelectedModules()),
+		() -> assertEquals(List.of(), options.discovery.getSelectedPackages()),
+		() -> assertEquals(List.of(), options.discovery.getSelectedMethods()),
+		() -> assertEquals(List.of(), options.discovery.getSelectedClasspathEntries()),
+		() -> assertEquals(Map.of(), options.discovery.getConfigurationParameters())
 		);
 		// @formatter:on
 	}
@@ -539,6 +542,48 @@ class CommandLineOptionsParsingTests {
 	@Test
 	void parseInvalidConfigurationParameters() {
 		assertOptionWithMissingRequiredArgumentThrowsException("-config", "--config");
+	}
+
+	@ParameterizedTest
+	@EnumSource
+	void parseValidStdoutRedirectionFile(ArgsType type) {
+		var file = Paths.get("foo.txt");
+		// @formatter:off
+		assertAll(
+				() -> assertNull(type.parseArgLine("").output.getStdoutPath()),
+				() -> assertEquals(file, type.parseArgLine("--redirect-stdout=foo.txt").output.getStdoutPath()),
+				() -> assertEquals(file, type.parseArgLine("-redirect-stdout=foo.txt").output.getStdoutPath()),
+				() -> assertEquals(file, type.parseArgLine("--redirect-stdout foo.txt").output.getStdoutPath()),
+				() -> assertEquals(file, type.parseArgLine("-redirect-stdout foo.txt").output.getStdoutPath()),
+				() -> assertEquals(file, type.parseArgLine("-redirect-stdout bar.txt -redirect-stdout foo.txt").output.getStdoutPath())
+		);
+		// @formatter:on
+	}
+
+	@Test
+	void parseInvalidStdoutRedirectionFile() {
+		assertOptionWithMissingRequiredArgumentThrowsException("--redirect-stdout", "-redirect-stdout");
+	}
+
+	@ParameterizedTest
+	@EnumSource
+	void parseValidStderrRedirectionFile(ArgsType type) {
+		var file = Paths.get("foo.txt");
+		// @formatter:off
+		assertAll(
+				() -> assertNull(type.parseArgLine("").output.getStderrPath()),
+				() -> assertEquals(file, type.parseArgLine("--redirect-stderr=foo.txt").output.getStderrPath()),
+				() -> assertEquals(file, type.parseArgLine("-redirect-stderr=foo.txt").output.getStderrPath()),
+				() -> assertEquals(file, type.parseArgLine("--redirect-stderr foo.txt").output.getStderrPath()),
+				() -> assertEquals(file, type.parseArgLine("-redirect-stderr foo.txt").output.getStderrPath()),
+				() -> assertEquals(file, type.parseArgLine("-redirect-stderr bar.txt -redirect-stderr foo.txt").output.getStderrPath())
+		);
+		// @formatter:on
+	}
+
+	@Test
+	void parseInvalidStderrRedirectionFile() {
+		assertOptionWithMissingRequiredArgumentThrowsException("--redirect-stderr", "-redirect-stderr");
 	}
 
 	@ParameterizedTest

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListenerIntegrationTests.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.junit.platform.engine.TestExecutionResult.successful;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
+import static org.junit.platform.launcher.LauncherConstants.CAPTURE_MERGED_STANDARD_STREAMS_PROPERTY_NAME;
 import static org.junit.platform.launcher.LauncherConstants.CAPTURE_STDERR_PROPERTY_NAME;
 import static org.junit.platform.launcher.LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME;
 import static org.junit.platform.launcher.LauncherConstants.STDERR_REPORT_ENTRY_KEY;
@@ -119,7 +120,8 @@ class StreamInterceptingTestExecutionListenerIntegrationTests {
 	private static Stream<Arguments> systemStreams() {
 		return Stream.of(//
 			streamType(CAPTURE_STDOUT_PROPERTY_NAME, () -> System.out, STDOUT_REPORT_ENTRY_KEY), //
-			streamType(CAPTURE_STDERR_PROPERTY_NAME, () -> System.err, STDERR_REPORT_ENTRY_KEY));
+			streamType(CAPTURE_STDERR_PROPERTY_NAME, () -> System.err, STDERR_REPORT_ENTRY_KEY), //
+			streamType(CAPTURE_MERGED_STANDARD_STREAMS_PROPERTY_NAME, () -> System.out, STDOUT_REPORT_ENTRY_KEY));
 	}
 
 	private static Arguments streamType(String configParam, Supplier<PrintStream> printStreamSupplier,


### PR DESCRIPTION
## Overview

Add new CLI options `--redirect-stdout` and `--redirect-stderr` to redirect stdout and stderr respectively to a file,
if both are set to the same file, stdout and stderr will be merged using the configuration parameter
`CAPTURE_MERGED_STANDARD_STREAMS_PROPERTY_NAME` and captured from stdout key `STDOUT_REPORT_ENTRY_KEY` in a new TestExecutionListener : `RedirectStdoutAndStderrListener`

Issue: #3166

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
