### PR TITLE
Extend `JRE` enum to support Java 23

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [22]
+        jdk: [22, 23]
     name: "OpenJDK ${{ matrix.jdk }}"
     runs-on: ubuntu-latest
     steps:

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
@@ -50,6 +50,7 @@ repository on GitHub.
 [[release-notes-5.11.0-M1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
+* `JAVA_23` has been added to the `JRE` enum for use with JRE-based execution conditions.
 * New `@AutoClose` annotation that can be applied to fields within tests to automatically
   close the annotated resource after test execution. See the
   <<../user-guide/index.adoc#writing-tests-built-in-extensions-AutoClose, User Guide>> for

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.caching=true
 org.gradle.parallel=true
-org.gradle.java.installations.fromEnv=JDK8,JDK18,JDK19,JDK20,JDK21,JDK22
+org.gradle.java.installations.fromEnv=JDK8,JDK18,JDK19,JDK20,JDK21,JDK22,JDK23
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # Test Distribution

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/JRE.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/JRE.java
@@ -163,12 +163,20 @@ public enum JRE {
 	JAVA_22,
 
 	/**
+	 * Java 23.
+	 *
+	 * @since 5.11
+	 */
+	@API(status = STABLE, since = "5.11")
+	JAVA_23,
+
+	/**
 	 * A JRE version other than {@link #JAVA_8}, {@link #JAVA_9},
 	 * {@link #JAVA_10}, {@link #JAVA_11}, {@link #JAVA_12},
 	 * {@link #JAVA_13}, {@link #JAVA_14}, {@link #JAVA_15},
 	 * {@link #JAVA_16}, {@link #JAVA_17}, {@link #JAVA_18},
-	 * {@link #JAVA_19}, {@link #JAVA_20}, {@link #JAVA_21}, or
-	 * {@link #JAVA_22}.
+	 * {@link #JAVA_19}, {@link #JAVA_20}, {@link #JAVA_21},
+	 * {@link #JAVA_22}, or {@link #JAVA_23}.
 	 */
 	OTHER;
 
@@ -226,6 +234,8 @@ public enum JRE {
 					return JAVA_21;
 				case 22:
 					return JAVA_22;
+				case 23:
+					return JAVA_23;
 				default:
 					return OTHER;
 			}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeConditionTests.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJav
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava20;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava21;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava22;
+import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava23;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava8;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava9;
 
@@ -115,9 +116,9 @@ class DisabledForJreRangeConditionTests extends AbstractExecutionConditionTests 
 	@Test
 	void other() {
 		evaluateCondition();
-		assertDisabledOnCurrentJreIf(
-			!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15()
-					|| onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22()));
+		assertDisabledOnCurrentJreIf(!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13()
+				|| onJava14() || onJava15() || onJava16() || onJava17() || onJava18() || onJava19() || onJava20()
+				|| onJava21() || onJava22() || onJava23()));
 	}
 
 	private void assertDisabledOnCurrentJreIf(boolean condition) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJav
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava20;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava21;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava22;
+import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava23;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava8;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava9;
 import static org.junit.jupiter.api.condition.JRE.JAVA_17;
@@ -83,9 +84,9 @@ class DisabledForJreRangeIntegrationTests {
 	@Test
 	@DisabledForJreRange(min = OTHER, max = OTHER)
 	void other() {
-		assertTrue(
-			onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15()
-					|| onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22());
+		assertTrue(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14()
+				|| onJava15() || onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21()
+				|| onJava22() || onJava23());
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnJreConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnJreConditionTests.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJav
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava20;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava21;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava22;
+import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava23;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava8;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava9;
 
@@ -217,14 +218,23 @@ class DisabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
+	 * @see DisabledOnJreIntegrationTests#java23()
+	 */
+	@Test
+	void java23() {
+		evaluateCondition();
+		assertDisabledOnCurrentJreIf(onJava23());
+	}
+
+	/**
 	 * @see DisabledOnJreIntegrationTests#other()
 	 */
 	@Test
 	void other() {
 		evaluateCondition();
-		assertDisabledOnCurrentJreIf(
-			!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15()
-					|| onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22()));
+		assertDisabledOnCurrentJreIf(!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13()
+				|| onJava14() || onJava15() || onJava16() || onJava17() || onJava18() || onJava19() || onJava20()
+				|| onJava21() || onJava22() || onJava23()));
 	}
 
 	private void assertDisabledOnCurrentJreIf(boolean condition) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJav
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava20;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava21;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava22;
+import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava23;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava8;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava9;
 import static org.junit.jupiter.api.condition.JRE.JAVA_10;
@@ -41,6 +42,7 @@ import static org.junit.jupiter.api.condition.JRE.JAVA_19;
 import static org.junit.jupiter.api.condition.JRE.JAVA_20;
 import static org.junit.jupiter.api.condition.JRE.JAVA_21;
 import static org.junit.jupiter.api.condition.JRE.JAVA_22;
+import static org.junit.jupiter.api.condition.JRE.JAVA_23;
 import static org.junit.jupiter.api.condition.JRE.JAVA_8;
 import static org.junit.jupiter.api.condition.JRE.JAVA_9;
 import static org.junit.jupiter.api.condition.JRE.OTHER;
@@ -68,7 +70,7 @@ class DisabledOnJreIntegrationTests {
 
 	@Test
 	@DisabledOnJre(value = { JAVA_8, JAVA_9, JAVA_10, JAVA_11, JAVA_12, JAVA_13, JAVA_14, JAVA_15, JAVA_16, JAVA_17,
-			JAVA_18, JAVA_19, JAVA_20, JAVA_21, JAVA_22, OTHER }, disabledReason = "Disabled on every JRE")
+			JAVA_18, JAVA_19, JAVA_20, JAVA_21, JAVA_22, JAVA_23, OTHER }, disabledReason = "Disabled on every JRE")
 	void disabledOnAllJavaVersions() {
 		fail("should be disabled");
 	}
@@ -164,11 +166,17 @@ class DisabledOnJreIntegrationTests {
 	}
 
 	@Test
+	@DisabledOnJre(JAVA_23)
+	void java23() {
+		assertFalse(onJava23());
+	}
+
+	@Test
 	@DisabledOnJre(OTHER)
 	void other() {
-		assertTrue(
-			onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15()
-					|| onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22());
+		assertTrue(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14()
+				|| onJava15() || onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21()
+				|| onJava22() || onJava23());
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJav
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava20;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava21;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava22;
+import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava23;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava8;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava9;
 
@@ -114,9 +115,9 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void other() {
 		evaluateCondition();
-		assertEnabledOnCurrentJreIf(
-			!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15()
-					|| onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22()));
+		assertEnabledOnCurrentJreIf(!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13()
+				|| onJava14() || onJava15() || onJava16() || onJava17() || onJava18() || onJava19() || onJava20()
+				|| onJava21() || onJava22() || onJava23()));
 	}
 
 	private void assertEnabledOnCurrentJreIf(boolean condition) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJav
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava20;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava21;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava22;
+import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava23;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava8;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava9;
 import static org.junit.jupiter.api.condition.JRE.JAVA_17;
@@ -79,16 +80,16 @@ class EnabledForJreRangeIntegrationTests {
 	@Test
 	@EnabledForJreRange(min = JAVA_18)
 	void javaMin18() {
-		assertTrue(onJava18() || onJava19() || onJava20() || onJava21() || onJava22());
+		assertTrue(onJava18() || onJava19() || onJava20() || onJava21() || onJava22() || onJava23());
 		assertFalse(onJava17());
 	}
 
 	@Test
 	@EnabledForJreRange(min = OTHER, max = OTHER)
 	void other() {
-		assertFalse(
-			onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15()
-					|| onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22());
+		assertFalse(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14()
+				|| onJava15() || onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21()
+				|| onJava22() || onJava23());
 	}
 
 }

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnJreConditionTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnJreConditionTests.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJav
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava20;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava21;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava22;
+import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava23;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava8;
 import static org.junit.jupiter.api.condition.EnabledOnJreIntegrationTests.onJava9;
 
@@ -216,14 +217,23 @@ class EnabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
+	 * @see EnabledOnJreIntegrationTests#java23()
+	 */
+	@Test
+	void java23() {
+		evaluateCondition();
+		assertEnabledOnCurrentJreIf(onJava23());
+	}
+
+	/**
 	 * @see EnabledOnJreIntegrationTests#other()
 	 */
 	@Test
 	void other() {
 		evaluateCondition();
-		assertEnabledOnCurrentJreIf(
-			!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15()
-					|| onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22()));
+		assertEnabledOnCurrentJreIf(!(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13()
+				|| onJava14() || onJava15() || onJava16() || onJava17() || onJava18() || onJava19() || onJava20()
+				|| onJava21() || onJava22() || onJava23()));
 		assertCustomDisabledReasonIs("Disabled on almost every JRE");
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.condition.JRE.JAVA_19;
 import static org.junit.jupiter.api.condition.JRE.JAVA_20;
 import static org.junit.jupiter.api.condition.JRE.JAVA_21;
 import static org.junit.jupiter.api.condition.JRE.JAVA_22;
+import static org.junit.jupiter.api.condition.JRE.JAVA_23;
 import static org.junit.jupiter.api.condition.JRE.JAVA_8;
 import static org.junit.jupiter.api.condition.JRE.JAVA_9;
 import static org.junit.jupiter.api.condition.JRE.OTHER;
@@ -54,7 +55,7 @@ class EnabledOnJreIntegrationTests {
 
 	@Test
 	@EnabledOnJre({ JAVA_8, JAVA_9, JAVA_10, JAVA_11, JAVA_12, JAVA_13, JAVA_14, JAVA_15, JAVA_16, JAVA_17, JAVA_18,
-			JAVA_19, JAVA_20, JAVA_21, JAVA_22, OTHER })
+			JAVA_19, JAVA_20, JAVA_21, JAVA_22, JAVA_23, OTHER })
 	void enabledOnAllJavaVersions() {
 	}
 
@@ -149,6 +150,12 @@ class EnabledOnJreIntegrationTests {
 	}
 
 	@Test
+	@EnabledOnJre(JAVA_23)
+	void java23() {
+		assertTrue(onJava23());
+	}
+
+	@Test
 	@EnabledOnJre(value = OTHER, disabledReason = "Disabled on almost every JRE")
 	void other() {
 		assertFalse(
@@ -216,4 +223,7 @@ class EnabledOnJreIntegrationTests {
 		return JAVA_VERSION.startsWith("22");
 	}
 
+	static boolean onJava23() {
+		return JAVA_VERSION.startsWith("23");
+	}
 }


### PR DESCRIPTION
## Overview

Add JDK 23-ea CI build to "test early and often". See also: https://wiki.openjdk.org/display/quality/Quality+Outreach

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
