### PR TITLE
Ignore `NoSuchFileException` in `TempDir` cleanup

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M1.adoc
@@ -67,6 +67,8 @@ repository on GitHub.
     *** The same applies to other types of test methods (`@TestFactory`,
       `@ParameterizedTest`, etc.) as well as lifecycle methods (`@BeforeAll`,
       `@AfterAll`, `@BeforeEach`, and `@AfterEach`).
+* `TempDir` suppresses `NoSuchFileException` when deleting files that may have been deleted
+  by another thread or process.
 
 [[release-notes-5.11.0-M1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -338,6 +338,9 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 				@Override
 				public FileVisitResult visitFileFailed(Path file, IOException exc) {
+					if (exc instanceof NoSuchFileException) {
+						return CONTINUE;
+					}
 					// IOException includes `AccessDeniedException` thrown by non-readable or non-executable flags
 					resetPermissionsAndTryToDeleteAgain(file, exc);
 					return CONTINUE;


### PR DESCRIPTION
## Overview

In `TempDirectory`'s cleanup logic, while walking the temp directory, the file walker may fail to visit a file that has been removed by another thread or process. In this case, JUnit should ignore the `NoSuchFileException`, because there's nothing to clean up.

I have observed such failures when using JGit to manage repositories in temporary directories. JGit uses lock files that it cleans up in background threads. JGit and JUnit will race to delete the lock file, and the JUnit `TempDirectory` cleanup fails when JGit wins that race.

I considered what an automated test for this new behavior would look like. I could add a clear-box test that uses high-level concurrency objects to make sure that the test can delete a file between the time that the `SimpleFileVisitor` lists the temp directory and the time that the `SimpleFileVisitor` attempts to delete the file, but this would require adding new seams to `TempDirectory` that are inconsistent with the existing tests for that type. Would you accept this change without adding new test coverage?

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
