### PR TITLE
Add separate `dependency-submission` workflow for GitHub actions

### DIFF
--- a/.github/actions/main-build/action.yml
+++ b/.github/actions/main-build/action.yml
@@ -5,10 +5,6 @@ inputs:
     required: true
     description: Gradle arguments
     default: build
-  dependency-graph:
-    required: false
-    description: 'see https://github.com/gradle/gradle-build-action#enable-dependency-graph-generation-for-a-workflow'
-    default: disabled
 runs:
   using: "composite"
   steps:
@@ -16,7 +12,6 @@ runs:
     - uses: ./.github/actions/run-gradle
       with:
         arguments: ${{ inputs.arguments }}
-        dependency-graph: ${{ inputs.dependency-graph }}
     - uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -5,10 +5,6 @@ inputs:
     required: true
     description: Gradle arguments
     default: build
-  dependency-graph:
-    required: false
-    description: 'see https://github.com/gradle/gradle-build-action#enable-dependency-graph-generation-for-a-workflow'
-    default: disabled
 runs:
   using: "composite"
   steps:
@@ -21,7 +17,6 @@ runs:
       env:
         JAVA_HOME: ${{ steps.setup-gradle-jdk.outputs.path }}
       with:
-        dependency-graph: ${{ inputs.dependency-graph }}
         arguments: |
           -Porg.gradle.java.installations.auto-download=false
           -Pjunit.develocity.predictiveTestSelection.enabled=${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -1,0 +1,25 @@
+name: Gradle Dependency Submission
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 21
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,6 @@ jobs:
     - name: Build
       uses: ./.github/actions/main-build
       with:
-        dependency-graph: generate-and-submit
         arguments: |
           -Ptesting.enableJaCoCo
           build


### PR DESCRIPTION
With the introduction of `gradle/actions/dependency-submission`, it is now simpler (and recommended) to use a separate workflow for generation and submission of GitHub Dependency Graph.

This workflow attempts to detect and submit all dependencies that would be resolved during build execution, without requiring the execution of any particular task. In basic testing it appears that the generated dependency graph contains the same dependencies as before.

A few things to note:
The new workflow will submit a dependency graph with a different "correlator" to the previous one. This means that duplicate dependencies (and alerts) may appear until the older graph ages out and is automatically purged. (Period of days).

Manually dismissed Dependabot Alerts may need to be re-dismissed after switching to the new workflow.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
