### PR TITLE
Bump Gradle Wrapper from 8.6-rc-2 to 8.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=3a36cedd25c02335d991e3684e17985239150e24b744a8513d466543083ca250
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-rc-2-bin.zip
+distributionSha256Sum=9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bumps Gradle Wrapper from 8.6-rc-2 to 8.6.

Release notes of Gradle 8.6 can be found here:
https://docs.gradle.org/8.6/release-notes.html