### PR TITLE
Document that `assertThrows` allows exception subtypes

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -3105,11 +3105,16 @@ public class Assertions {
 	 * <em>Assert</em> that execution of the supplied {@code executable} throws
 	 * an exception of the {@code expectedType} and return the exception.
 	 *
-	 * <p>If no exception is thrown, or if an exception of a different type is
-	 * thrown, this method will fail.
+	 * <p>The assertion passes if the thrown exception type is the same as
+	 * {@code expectedType} or a subtype of it. To check for the exact thrown
+	 * type use {@link #assertThrowsExactly(Class, Executable) assertThrowsExactly}.
+	 * If no exception is thrown, or if an exception of a different type is thrown,
+	 * this method will fail.
 	 *
 	 * <p>If you do not want to perform additional checks on the exception instance,
 	 * ignore the return value.
+	 *
+	 * @see #assertThrowsExactly(Class, Executable)
 	 */
 	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
 		return AssertThrows.assertThrows(expectedType, executable);
@@ -3119,13 +3124,18 @@ public class Assertions {
 	 * <em>Assert</em> that execution of the supplied {@code executable} throws
 	 * an exception of the {@code expectedType} and return the exception.
 	 *
-	 * <p>If no exception is thrown, or if an exception of a different type is
-	 * thrown, this method will fail.
+	 * <p>The assertion passes if the thrown exception type is the same as
+	 * {@code expectedType} or a subtype of it. To check for the exact thrown
+	 * type use {@link #assertThrowsExactly(Class, Executable, String) assertThrowsExactly}.
+	 * If no exception is thrown, or if an exception of a different type is thrown,
+	 * this method will fail.
 	 *
 	 * <p>If you do not want to perform additional checks on the exception instance,
 	 * ignore the return value.
 	 *
 	 * <p>Fails with the supplied failure {@code message}.
+	 *
+	 * @see #assertThrowsExactly(Class, Executable, String)
 	 */
 	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable, String message) {
 		return AssertThrows.assertThrows(expectedType, executable, message);
@@ -3135,14 +3145,19 @@ public class Assertions {
 	 * <em>Assert</em> that execution of the supplied {@code executable} throws
 	 * an exception of the {@code expectedType} and return the exception.
 	 *
-	 * <p>If no exception is thrown, or if an exception of a different type is
-	 * thrown, this method will fail.
+	 * <p>The assertion passes if the thrown exception type is the same as
+	 * {@code expectedType} or a subtype of it. To check for the exact thrown
+	 * type use {@link #assertThrowsExactly(Class, Executable, Supplier) assertThrowsExactly}.
+	 * If no exception is thrown, or if an exception of a different type is thrown,
+	 * this method will fail.
 	 *
 	 * <p>If necessary, the failure message will be retrieved lazily from the
 	 * supplied {@code messageSupplier}.
 	 *
 	 * <p>If you do not want to perform additional checks on the exception instance,
 	 * ignore the return value.
+	 *
+	 * @see #assertThrowsExactly(Class, Executable, Supplier)
 	 */
 	public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable,
 			Supplier<String> messageSupplier) {


### PR DESCRIPTION
## Overview

Currently the `assertThrows` documentation does not mention that exception subtypes will cause the assertion to succeed as well. This caused some confusion for #2505 (and lead to the introduction of `assertThrowsExactly`).

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
