### PR TITLE
Bump Gradle Wrapper from 8.7-rc-4 to 8.7

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=a14ad975075d5d2dcc1fa1667e622597c6f8721e2ca42dff54ebe40c07eb1bc5
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-rc-4-bin.zip
+distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bumps Gradle Wrapper from 8.7-rc-4 to 8.7.

Release notes of Gradle 8.7 can be found here:
https://docs.gradle.org/8.7/release-notes.html