### PR TITLE
Fix reflection issue on JDK 8 for synthetic bridge methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M2.adoc
@@ -10,6 +10,15 @@ link:{junit5-repo}+/milestone/74?closed=1+[5.11.0-M2] milestone page in the
 JUnit repository on GitHub.
 
 
+[[release-notes-5.11.0-M2-overall-improvements]]
+=== Overall Improvements
+
+[[release-notes-5.11.0-M2-overall-new-features-and-improvements]]
+==== New Features and Improvements
+* The shipped bytecode was compiled with the `-parameters` option of `javac` and thus now
+  contains metadata for reflection on parameters such as their names.
+
+
 [[release-notes-5.11.0-M2-junit-platform]]
 === JUnit Platform
 

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
@@ -238,7 +238,9 @@ tasks.compileJava {
 	// See: https://docs.oracle.com/en/java/javase/12/tools/javac.html
 	options.compilerArgs.addAll(listOf(
 			"-Xlint:all", // Enables all recommended warnings.
-			"-Werror" // Terminates compilation when warnings occur.
+			"-Werror", // Terminates compilation when warnings occur.
+			// Required for compatibility with Java 8's reflection APIs (see https://github.com/junit-team/junit5/issues/3797).
+			"-parameters", // Generates metadata for reflection on method parameters.
 	))
 }
 

--- a/platform-tooling-support-tests/projects/reflection-tests/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/reflection-tests/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+	java
+}
+
+// grab jupiter version from system environment
+val jupiterVersion: String = System.getenv("JUNIT_JUPITER_VERSION")
+val vintageVersion: String = System.getenv("JUNIT_VINTAGE_VERSION")
+val platformVersion: String = System.getenv("JUNIT_PLATFORM_VERSION")
+
+repositories {
+	maven { url = uri(file(System.getProperty("maven.repo"))) }
+	mavenCentral()
+}
+
+dependencies {
+	testImplementation("org.junit.jupiter:junit-jupiter:$jupiterVersion")
+	testImplementation("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
+	testRuntimeOnly("org.junit.platform:junit-platform-reporting:$platformVersion")
+}
+
+tasks.test {
+	useJUnitPlatform()
+
+	testLogging {
+		events("failed")
+	}
+
+	reports {
+		html.required = true
+	}
+
+	val outputDir = reports.junitXml.outputLocation
+	jvmArgumentProviders += CommandLineArgumentProvider {
+		listOf(
+			"-Djunit.platform.reporting.open.xml.enabled=true",
+			"-Djunit.platform.reporting.output.dir=${outputDir.get().asFile.absolutePath}"
+		)
+	}
+
+	doFirst {
+		println("Using Java version: ${JavaVersion.current()}")
+	}
+}

--- a/platform-tooling-support-tests/projects/reflection-tests/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/reflection-tests/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "reflection-tests"

--- a/platform-tooling-support-tests/projects/reflection-tests/src/test/java/ReflectionTestCase.java
+++ b/platform-tooling-support-tests/projects/reflection-tests/src/test/java/ReflectionTestCase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package standalone;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
+import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.JupiterTestDescriptor;
+import org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor;
+import org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestTemplateInvocationTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor;
+
+class ReflectionTestCase {
+
+	@TestFactory
+	Stream<DynamicNode> canReadParameters() {
+		return Stream.of(JupiterTestDescriptor.class, ClassBasedTestDescriptor.class, ClassTestDescriptor.class,
+			MethodBasedTestDescriptor.class, TestMethodTestDescriptor.class, TestTemplateTestDescriptor.class,
+			TestTemplateInvocationTestDescriptor.class, TestFactoryTestDescriptor.class,
+			NestedClassTestDescriptor.class) //
+				.map(descriptorClass -> dynamicContainer(descriptorClass.getSimpleName(),
+					Arrays.stream(descriptorClass.getDeclaredMethods()) //
+							.map(method -> dynamicTest(method.getName(),
+								() -> assertDoesNotThrow(method::getParameters)))));
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ReflectionCompatibilityTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ReflectionCompatibilityTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static platform.tooling.support.Helper.TOOL_TIMEOUT;
+
+import java.nio.file.Paths;
+
+import de.sormuras.bartholdy.tool.GradleWrapper;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
+import platform.tooling.support.MavenRepo;
+import platform.tooling.support.Request;
+
+/**
+ * @since 1.11
+ */
+class ReflectionCompatibilityTests {
+
+	@Test
+	void gradle_wrapper() {
+		var request = Request.builder() //
+				.setTool(new GradleWrapper(Paths.get(".."))) //
+				.setProject("reflection-tests") //
+				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments("build", "--no-daemon", "--stacktrace") //
+				.setTimeout(TOOL_TIMEOUT) //
+				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
+				.build();
+
+		var result = request.run();
+
+		assertFalse(result.isTimedOut(), () -> "tool timed out: " + result);
+
+		assertEquals(0, result.getExitCode());
+		assertTrue(result.getOutputLines("out").stream().anyMatch(line -> line.contains("BUILD SUCCESSFUL")));
+		assertThat(result.getOutput("out")).contains("Using Java version: 1.8");
+	}
+}


### PR DESCRIPTION
By enabling `-parameters` their names are written to the compiled bytecode in addition to the synthetic flag thereby avoiding to trip up the `Method#getParameters` API when running on JDK 8.

Fixes #3797.