### PR TITLE
Fix NPE when deserializing `TestIdentifier`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M2.adoc
@@ -26,6 +26,7 @@ repository on GitHub.
 [[release-notes-5.11.0-M2-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
+* Fixed a bug where `TestIdentifier` could cause a `NullPointerException` on deserialize when there is no parent identifier. See link:https://github.com/junit-team/junit5/issues/3819[issue 3819].
 * ❓
 
 [[release-notes-5.11.0-M2-junit-platform-deprecations-and-breaking-changes]]

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -284,7 +284,8 @@ public final class TestIdentifier implements Serializable {
 		source = serializedForm.source;
 		tags = serializedForm.tags;
 		type = serializedForm.type;
-		parentId = UniqueId.parse(serializedForm.parentId);
+		String parentId = serializedForm.parentId;
+		this.parentId = parentId == null ? null : UniqueId.parse(parentId);
 		legacyReportingName = serializedForm.legacyReportingName;
 	}
 
@@ -307,7 +308,8 @@ public final class TestIdentifier implements Serializable {
 
 		SerializedForm(TestIdentifier testIdentifier) {
 			this.uniqueId = testIdentifier.uniqueId.toString();
-			this.parentId = testIdentifier.parentId.toString();
+			UniqueId parentId = testIdentifier.parentId;
+			this.parentId = parentId == null ? null : parentId.toString();
 			this.displayName = testIdentifier.displayName;
 			this.legacyReportingName = testIdentifier.legacyReportingName;
 			this.source = testIdentifier.source;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
@@ -16,10 +16,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.commons.util.SerializationUtils.deserialize;
 import static org.junit.platform.commons.util.SerializationUtils.serialize;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
@@ -70,6 +72,74 @@ class TestIdentifierTests {
 			var deserializedIdentifier = (TestIdentifier) deserialize(bytes);
 			assertDeepEquals(createOriginalTestIdentifier(), deserializedIdentifier);
 		}
+	}
+
+	@Test
+	void identifierWithNoParentCanBeSerializedAndDeserialized() throws Exception {
+		TestIdentifier ti = TestIdentifier.from(new TestDescriptor() {
+			@Override
+			public UniqueId getUniqueId() {
+				return UniqueId.root("example", "id");
+			}
+
+			@Override
+			public String getDisplayName() {
+				return "displayName";
+			}
+
+			@Override
+			public Set<TestTag> getTags() {
+				return Set.of();
+			}
+
+			@Override
+			public Optional<TestSource> getSource() {
+				return Optional.empty();
+			}
+
+			@Override
+			public Optional<TestDescriptor> getParent() {
+				return Optional.empty();
+			}
+
+			@Override
+			public void setParent(TestDescriptor parent) {
+				// ignore
+			}
+
+			@Override
+			public Set<? extends TestDescriptor> getChildren() {
+				return Set.of();
+			}
+
+			@Override
+			public void addChild(TestDescriptor descriptor) {
+				// ignore
+			}
+
+			@Override
+			public void removeChild(TestDescriptor descriptor) {
+				// ignore
+			}
+
+			@Override
+			public void removeFromHierarchy() {
+				// ignore
+			}
+
+			@Override
+			public Type getType() {
+				return Type.TEST;
+			}
+
+			@Override
+			public Optional<? extends TestDescriptor> findByUniqueId(UniqueId uniqueId) {
+				return Optional.empty();
+			}
+		});
+		byte[] bytes = serialize(ti);
+		TestIdentifier dti = (TestIdentifier) deserialize(bytes);
+		assertEquals(ti, dti);
 	}
 
 	private static void assertDeepEquals(TestIdentifier first, TestIdentifier second) {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
@@ -16,12 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.commons.util.SerializationUtils.deserialize;
 import static org.junit.platform.commons.util.SerializationUtils.serialize;
 
-import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
@@ -76,70 +74,17 @@ class TestIdentifierTests {
 
 	@Test
 	void identifierWithNoParentCanBeSerializedAndDeserialized() throws Exception {
-		TestIdentifier ti = TestIdentifier.from(new TestDescriptor() {
-			@Override
-			public UniqueId getUniqueId() {
-				return UniqueId.root("example", "id");
-			}
+		TestIdentifier originalIdentifier = TestIdentifier.from(
+			new AbstractTestDescriptor(UniqueId.root("example", "id"), "Example") {
+				@Override
+				public Type getType() {
+					return Type.CONTAINER;
+				}
+			});
 
-			@Override
-			public String getDisplayName() {
-				return "displayName";
-			}
+		var deserializedIdentifier = (TestIdentifier) deserialize(serialize(originalIdentifier));
 
-			@Override
-			public Set<TestTag> getTags() {
-				return Set.of();
-			}
-
-			@Override
-			public Optional<TestSource> getSource() {
-				return Optional.empty();
-			}
-
-			@Override
-			public Optional<TestDescriptor> getParent() {
-				return Optional.empty();
-			}
-
-			@Override
-			public void setParent(TestDescriptor parent) {
-				// ignore
-			}
-
-			@Override
-			public Set<? extends TestDescriptor> getChildren() {
-				return Set.of();
-			}
-
-			@Override
-			public void addChild(TestDescriptor descriptor) {
-				// ignore
-			}
-
-			@Override
-			public void removeChild(TestDescriptor descriptor) {
-				// ignore
-			}
-
-			@Override
-			public void removeFromHierarchy() {
-				// ignore
-			}
-
-			@Override
-			public Type getType() {
-				return Type.TEST;
-			}
-
-			@Override
-			public Optional<? extends TestDescriptor> findByUniqueId(UniqueId uniqueId) {
-				return Optional.empty();
-			}
-		});
-		byte[] bytes = serialize(ti);
-		TestIdentifier dti = (TestIdentifier) deserialize(bytes);
-		assertEquals(ti, dti);
+		assertDeepEquals(originalIdentifier, deserializedIdentifier);
 	}
 
 	private static void assertDeepEquals(TestIdentifier first, TestIdentifier second) {


### PR DESCRIPTION
## Overview

Fix `NullPointerException` when a `TestIdentifier` with no `parentId` is deserialized.

Issue: #3819

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
