### PR TITLE
Use same default seed for method and class ordering

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0-M2.adoc
@@ -62,7 +62,8 @@ repository on GitHub.
 [[release-notes-5.11.0-M2-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* `MethodOrderer.Random` and `ClassOrderer.Random` now use the same default seed that is
+  generated during class initialization.
 
 [[release-notes-5.11.0-M2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -185,8 +185,8 @@ public interface ClassOrderer {
 	 * <h2>Custom Seed</h2>
 	 *
 	 * <p>By default, the random <em>seed</em> used for ordering classes is the
-	 * value returned by {@link System#nanoTime()} during static initialization
-	 * of this class. In order to support repeatable builds, the value of the
+	 * value returned by {@link System#nanoTime()} during static class
+	 * initialization. In order to support repeatable builds, the value of the
 	 * default random seed is logged at {@code CONFIG} level. In addition, a
 	 * custom seed (potentially the default seed from the previous test plan
 	 * execution) may be specified via the {@value Random#RANDOM_SEED_PROPERTY_NAME}
@@ -203,13 +203,12 @@ public interface ClassOrderer {
 		private static final Logger logger = LoggerFactory.getLogger(Random.class);
 
 		/**
-		 * Default seed, which is generated during initialization of this class
-		 * via {@link System#nanoTime()} for reproducibility of tests.
+		 * Default seed, which is generated during initialization of the
+		 * {@link MethodOrderer.Random} class for reproducibility of tests.
 		 */
-		private static final long DEFAULT_SEED;
+		static final long DEFAULT_SEED = MethodOrderer.Random.DEFAULT_SEED;
 
 		static {
-			DEFAULT_SEED = System.nanoTime();
 			logger.config(() -> "ClassOrderer.Random default seed: " + DEFAULT_SEED);
 		}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -202,7 +202,7 @@ public interface ClassOrderer {
 		private static final Logger logger = LoggerFactory.getLogger(Random.class);
 
 		static {
-			logger.config(() -> "ClassOrderer.Random default seed: " + SharedOrderingSeed.DEFAULT_SEED);
+			logger.config(() -> "ClassOrderer.Random default seed: " + RandomOrdererUtils.DEFAULT_SEED);
 		}
 
 		/**
@@ -223,7 +223,7 @@ public interface ClassOrderer {
 		 *
 		 * @see MethodOrderer.Random
 		 */
-		public static final String RANDOM_SEED_PROPERTY_NAME = SharedOrderingSeed.RANDOM_SEED_PROPERTY_NAME;
+		public static final String RANDOM_SEED_PROPERTY_NAME = RandomOrdererUtils.RANDOM_SEED_PROPERTY_NAME;
 
 		public Random() {
 		}
@@ -235,7 +235,7 @@ public interface ClassOrderer {
 		@Override
 		public void orderClasses(ClassOrdererContext context) {
 			Collections.shuffle(context.getClassDescriptors(),
-				new java.util.Random(SharedOrderingSeed.getSeed(context::getConfigurationParameter, logger)));
+				new java.util.Random(RandomOrdererUtils.getSeed(context::getConfigurationParameter, logger)));
 		}
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -15,7 +15,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Optional;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.logging.Logger;
@@ -202,14 +201,8 @@ public interface ClassOrderer {
 
 		private static final Logger logger = LoggerFactory.getLogger(Random.class);
 
-		/**
-		 * Default seed, which is generated during initialization of the
-		 * {@link MethodOrderer.Random} class for reproducibility of tests.
-		 */
-		static final long DEFAULT_SEED = MethodOrderer.Random.DEFAULT_SEED;
-
 		static {
-			logger.config(() -> "ClassOrderer.Random default seed: " + DEFAULT_SEED);
+			logger.config(() -> "ClassOrderer.Random default seed: " + SharedOrderingSeed.DEFAULT_SEED);
 		}
 
 		/**
@@ -230,7 +223,7 @@ public interface ClassOrderer {
 		 *
 		 * @see MethodOrderer.Random
 		 */
-		public static final String RANDOM_SEED_PROPERTY_NAME = MethodOrderer.Random.RANDOM_SEED_PROPERTY_NAME;
+		public static final String RANDOM_SEED_PROPERTY_NAME = SharedOrderingSeed.RANDOM_SEED_PROPERTY_NAME;
 
 		public Random() {
 		}
@@ -242,27 +235,7 @@ public interface ClassOrderer {
 		@Override
 		public void orderClasses(ClassOrdererContext context) {
 			Collections.shuffle(context.getClassDescriptors(),
-				new java.util.Random(getCustomSeed(context).orElse(DEFAULT_SEED)));
-		}
-
-		private Optional<Long> getCustomSeed(ClassOrdererContext context) {
-			return context.getConfigurationParameter(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
-				Long seed = null;
-				try {
-					seed = Long.valueOf(configurationParameter);
-					logger.config(
-						() -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
-							RANDOM_SEED_PROPERTY_NAME, configurationParameter));
-				}
-				catch (NumberFormatException ex) {
-					logger.warn(ex,
-						() -> String.format(
-							"Failed to convert configuration parameter [%s] with value [%s] to a long. "
-									+ "Using default seed [%s] as fallback.",
-							RANDOM_SEED_PROPERTY_NAME, configurationParameter, DEFAULT_SEED));
-				}
-				return seed;
-			});
+				new java.util.Random(SharedOrderingSeed.getSeed(context::getConfigurationParameter, logger)));
 		}
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -266,7 +266,7 @@ public interface MethodOrderer {
 		private static final Logger logger = LoggerFactory.getLogger(Random.class);
 
 		static {
-			logger.config(() -> "MethodOrderer.Random default seed: " + SharedOrderingSeed.DEFAULT_SEED);
+			logger.config(() -> "MethodOrderer.Random default seed: " + RandomOrdererUtils.DEFAULT_SEED);
 		}
 
 		/**
@@ -287,7 +287,7 @@ public interface MethodOrderer {
 		 *
 		 * @see ClassOrderer.Random
 		 */
-		public static final String RANDOM_SEED_PROPERTY_NAME = SharedOrderingSeed.RANDOM_SEED_PROPERTY_NAME;
+		public static final String RANDOM_SEED_PROPERTY_NAME = RandomOrdererUtils.RANDOM_SEED_PROPERTY_NAME;
 
 		public Random() {
 		}
@@ -299,7 +299,7 @@ public interface MethodOrderer {
 		@Override
 		public void orderMethods(MethodOrdererContext context) {
 			Collections.shuffle(context.getMethodDescriptors(),
-				new java.util.Random(SharedOrderingSeed.getSeed(context::getConfigurationParameter, logger)));
+				new java.util.Random(RandomOrdererUtils.getSeed(context::getConfigurationParameter, logger)));
 		}
 
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -269,7 +269,7 @@ public interface MethodOrderer {
 		 * Default seed, which is generated during initialization of this class
 		 * via {@link System#nanoTime()} for reproducibility of tests.
 		 */
-		private static final long DEFAULT_SEED;
+		static final long DEFAULT_SEED;
 
 		static {
 			DEFAULT_SEED = System.nanoTime();

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -248,11 +248,11 @@ public interface MethodOrderer {
 	 * <h2>Custom Seed</h2>
 	 *
 	 * <p>By default, the random <em>seed</em> used for ordering methods is the
-	 * value returned by {@link System#nanoTime()} during static initialization
-	 * of this class. In order to support repeatable builds, the value of the
+	 * value returned by {@link System#nanoTime()} during static class
+	 * initialization. In order to support repeatable builds, the value of the
 	 * default random seed is logged at {@code CONFIG} level. In addition, a
 	 * custom seed (potentially the default seed from the previous test plan
-	 * execution) may be specified via the {@value ClassOrderer.Random#RANDOM_SEED_PROPERTY_NAME}
+	 * execution) may be specified via the {@value Random#RANDOM_SEED_PROPERTY_NAME}
 	 * <em>configuration parameter</em> which can be supplied via the {@code Launcher}
 	 * API, build tools (e.g., Gradle and Maven), a JVM system property, or the JUnit
 	 * Platform configuration file (i.e., a file named {@code junit-platform.properties}
@@ -265,15 +265,8 @@ public interface MethodOrderer {
 
 		private static final Logger logger = LoggerFactory.getLogger(Random.class);
 
-		/**
-		 * Default seed, which is generated during initialization of this class
-		 * via {@link System#nanoTime()} for reproducibility of tests.
-		 */
-		static final long DEFAULT_SEED;
-
 		static {
-			DEFAULT_SEED = System.nanoTime();
-			logger.config(() -> "MethodOrderer.Random default seed: " + DEFAULT_SEED);
+			logger.config(() -> "MethodOrderer.Random default seed: " + SharedOrderingSeed.DEFAULT_SEED);
 		}
 
 		/**
@@ -294,7 +287,7 @@ public interface MethodOrderer {
 		 *
 		 * @see ClassOrderer.Random
 		 */
-		public static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
+		public static final String RANDOM_SEED_PROPERTY_NAME = SharedOrderingSeed.RANDOM_SEED_PROPERTY_NAME;
 
 		public Random() {
 		}
@@ -306,28 +299,9 @@ public interface MethodOrderer {
 		@Override
 		public void orderMethods(MethodOrdererContext context) {
 			Collections.shuffle(context.getMethodDescriptors(),
-				new java.util.Random(getCustomSeed(context).orElse(DEFAULT_SEED)));
+				new java.util.Random(SharedOrderingSeed.getSeed(context::getConfigurationParameter, logger)));
 		}
 
-		private Optional<Long> getCustomSeed(MethodOrdererContext context) {
-			return context.getConfigurationParameter(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
-				Long seed = null;
-				try {
-					seed = Long.valueOf(configurationParameter);
-					logger.config(
-						() -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
-							RANDOM_SEED_PROPERTY_NAME, configurationParameter));
-				}
-				catch (NumberFormatException ex) {
-					logger.warn(ex,
-						() -> String.format(
-							"Failed to convert configuration parameter [%s] with value [%s] to a long. "
-									+ "Using default seed [%s] as fallback.",
-							RANDOM_SEED_PROPERTY_NAME, configurationParameter, DEFAULT_SEED));
-				}
-				return seed;
-			});
-		}
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RandomOrdererUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RandomOrdererUtils.java
@@ -22,7 +22,7 @@ import org.junit.platform.commons.logging.Logger;
  * @see ClassOrderer.Random
  * @see MethodOrderer.Random
  */
-class SharedOrderingSeed {
+class RandomOrdererUtils {
 
 	static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/SharedOrderingSeed.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/SharedOrderingSeed.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.junit.platform.commons.logging.Logger;
+
+/**
+ * Shared utility methods for ordering test classes and test methods randomly.
+ *
+ * @since 5.11
+ * @see ClassOrderer.Random
+ * @see MethodOrderer.Random
+ */
+class SharedOrderingSeed {
+
+	static final String RANDOM_SEED_PROPERTY_NAME = "junit.jupiter.execution.order.random.seed";
+
+	static final long DEFAULT_SEED = System.nanoTime();
+
+	static Long getSeed(Function<String, Optional<String>> configurationParameterLookup, Logger logger) {
+		return getCustomSeed(configurationParameterLookup, logger).orElse(DEFAULT_SEED);
+	}
+
+	private static Optional<Long> getCustomSeed(Function<String, Optional<String>> configurationParameterLookup,
+			Logger logger) {
+		return configurationParameterLookup.apply(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
+			try {
+				logger.config(() -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
+					RANDOM_SEED_PROPERTY_NAME, configurationParameter));
+				return Long.valueOf(configurationParameter);
+			}
+			catch (NumberFormatException ex) {
+				logger.warn(ex,
+					() -> String.format(
+						"Failed to convert configuration parameter [%s] with value [%s] to a long. "
+								+ "Using default seed [%s] as fallback.",
+						RANDOM_SEED_PROPERTY_NAME, configurationParameter, DEFAULT_SEED));
+				return null;
+			}
+		});
+	}
+}

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/RandomlyOrderedTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/RandomlyOrderedTests.java
@@ -11,14 +11,12 @@
 package org.junit.jupiter.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -36,7 +34,7 @@ class RandomlyOrderedTests {
 	void randomSeedForClassAndMethodOrderingIsDeterministic() {
 		IntStream.range(0, 20).forEach(i -> {
 			callSequence.clear();
-			var tests = executeTests(OptionalLong.of(1618034));
+			var tests = executeTests(1618034);
 
 			tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
 			assertThat(callSequence).containsExactlyInAnyOrder("B_TestCase#b", "B_TestCase#c", "B_TestCase#a",
@@ -44,21 +42,13 @@ class RandomlyOrderedTests {
 		});
 	}
 
-	@Test
-	void defaultSeedForClassAndMethodOrderingIsIdentical() {
-		executeTests(OptionalLong.empty());
-
-		assertEquals(MethodOrderer.Random.DEFAULT_SEED, ClassOrderer.Random.DEFAULT_SEED);
-	}
-
-	private Events executeTests(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") OptionalLong randomSeed) {
+	private Events executeTests(@SuppressWarnings("SameParameterValue") long randomSeed) {
 		// @formatter:off
-		var builder = EngineTestKit
+		return EngineTestKit
 				.engine("junit-jupiter")
 				.configurationParameter(DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME, ClassOrderer.Random.class.getName())
-				.configurationParameter(DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME, MethodOrderer.Random.class.getName());
-		randomSeed.ifPresent(seed -> builder.configurationParameter(MethodOrderer.Random.RANDOM_SEED_PROPERTY_NAME, String.valueOf(seed)));
-		return builder
+				.configurationParameter(DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME, MethodOrderer.Random.class.getName())
+				.configurationParameter(MethodOrderer.Random.RANDOM_SEED_PROPERTY_NAME, String.valueOf(randomSeed))
 				.selectors(selectClass(A_TestCase.class), selectClass(B_TestCase.class), selectClass(C_TestCase.class))
 				.execute()
 				.testEvents();
@@ -69,8 +59,8 @@ class RandomlyOrderedTests {
 
 		@BeforeEach
 		void trackInvocations(TestInfo testInfo) {
-			var testClass = testInfo.getTestClass().get();
-			var testMethod = testInfo.getTestMethod().get();
+			var testClass = testInfo.getTestClass().orElseThrow();
+			var testMethod = testInfo.getTestMethod().orElseThrow();
 
 			callSequence.add(testClass.getSimpleName() + "#" + testMethod.getName());
 		}
@@ -88,12 +78,15 @@ class RandomlyOrderedTests {
 		}
 	}
 
+	@SuppressWarnings("NewClassNamingConvention")
 	static class A_TestCase extends BaseTestCase {
 	}
 
+	@SuppressWarnings("NewClassNamingConvention")
 	static class B_TestCase extends BaseTestCase {
 	}
 
+	@SuppressWarnings("NewClassNamingConvention")
 	static class C_TestCase extends BaseTestCase {
 	}
 

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/RandomlyOrderedTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/RandomlyOrderedTests.java
@@ -8,23 +8,20 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.jupiter.engine.extension;
+package org.junit.jupiter.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.ClassOrderer;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.platform.testkit.engine.EngineTestKit;
 import org.junit.platform.testkit.engine.Events;
 
@@ -39,7 +36,7 @@ class RandomlyOrderedTests {
 	void randomSeedForClassAndMethodOrderingIsDeterministic() {
 		IntStream.range(0, 20).forEach(i -> {
 			callSequence.clear();
-			var tests = executeTests(1618034L);
+			var tests = executeTests(OptionalLong.of(1618034));
 
 			tests.assertStatistics(stats -> stats.succeeded(callSequence.size()));
 			assertThat(callSequence).containsExactlyInAnyOrder("B_TestCase#b", "B_TestCase#c", "B_TestCase#a",
@@ -47,13 +44,21 @@ class RandomlyOrderedTests {
 		});
 	}
 
-	private Events executeTests(long randomSeed) {
+	@Test
+	void defaultSeedForClassAndMethodOrderingIsIdentical() {
+		executeTests(OptionalLong.empty());
+
+		assertEquals(MethodOrderer.Random.DEFAULT_SEED, ClassOrderer.Random.DEFAULT_SEED);
+	}
+
+	private Events executeTests(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") OptionalLong randomSeed) {
 		// @formatter:off
-		return EngineTestKit
+		EngineTestKit.Builder builder = EngineTestKit
 				.engine("junit-jupiter")
 				.configurationParameter(DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME, ClassOrderer.Random.class.getName())
-				.configurationParameter(DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME, MethodOrderer.Random.class.getName())
-				.configurationParameter(MethodOrderer.Random.RANDOM_SEED_PROPERTY_NAME, String.valueOf(randomSeed))
+				.configurationParameter(DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME, MethodOrderer.Random.class.getName());
+		randomSeed.ifPresent(seed -> builder.configurationParameter(MethodOrderer.Random.RANDOM_SEED_PROPERTY_NAME, String.valueOf(seed)));
+		return builder
 				.selectors(selectClass(A_TestCase.class), selectClass(B_TestCase.class), selectClass(C_TestCase.class))
 				.execute()
 				.testEvents();

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/RandomlyOrderedTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/api/RandomlyOrderedTests.java
@@ -53,7 +53,7 @@ class RandomlyOrderedTests {
 
 	private Events executeTests(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") OptionalLong randomSeed) {
 		// @formatter:off
-		EngineTestKit.Builder builder = EngineTestKit
+		var builder = EngineTestKit
 				.engine("junit-jupiter")
 				.configurationParameter(DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME, ClassOrderer.Random.class.getName())
 				.configurationParameter(DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME, MethodOrderer.Random.class.getName());


### PR DESCRIPTION
Prior to this commit the default seeds were generated separately but the
configuration parameter that allows using a fixed seed only allowed to
set both to the same value making it impossible to reproduce a failure
for different default seeds. Since the default seed is now identical,
this scenario is avoided.

Fixes #3817.
