### PR TITLE
Avoid `NullPointerException` when deserializing `TestIdentifier`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.3.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.10.3.adoc
@@ -1,0 +1,31 @@
+[[release-notes-5.10.3]]
+== 5.10.3
+
+*Date of Release:* 
+
+*Scope:* minor bug fixes and changes since 5.10.2.
+
+For a complete list of all _closed_ issues and pull requests for this release, consult the
+link:{junit5-repo}+/milestone/73?closed=1+[5.10.3] milestone page in the JUnit repository
+on GitHub.
+
+
+[[release-notes-5.10.3-junit-platform]]
+=== JUnit Platform
+
+==== Bug Fixes
+
+* Fixed a bug where `TestIdentifier` could cause a `NullPointerException` on deserialize when there is no parent identifier.
+  - See issue link:https://github.com/junit-team/junit5/issues/3819[#3819] for details.
+
+
+[[release-notes-5.10.3-junit-jupiter]]
+=== JUnit Jupiter
+
+No changes.
+
+
+[[release-notes-5.10.3-junit-vintage]]
+=== JUnit Vintage
+
+No changes.

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -284,7 +284,8 @@ public final class TestIdentifier implements Serializable {
 		source = serializedForm.source;
 		tags = serializedForm.tags;
 		type = serializedForm.type;
-		parentId = UniqueId.parse(serializedForm.parentId);
+		String parentId = serializedForm.parentId;
+		this.parentId = parentId == null ? null : UniqueId.parse(parentId);
 		legacyReportingName = serializedForm.legacyReportingName;
 	}
 
@@ -307,7 +308,8 @@ public final class TestIdentifier implements Serializable {
 
 		SerializedForm(TestIdentifier testIdentifier) {
 			this.uniqueId = testIdentifier.uniqueId.toString();
-			this.parentId = testIdentifier.parentId.toString();
+			UniqueId parentId = testIdentifier.parentId;
+			this.parentId = parentId == null ? null : parentId.toString();
 			this.displayName = testIdentifier.displayName;
 			this.legacyReportingName = testIdentifier.legacyReportingName;
 			this.source = testIdentifier.source;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/TestIdentifierTests.java
@@ -72,6 +72,21 @@ class TestIdentifierTests {
 		}
 	}
 
+	@Test
+	void identifierWithNoParentCanBeSerializedAndDeserialized() throws Exception {
+		TestIdentifier originalIdentifier = TestIdentifier.from(
+			new AbstractTestDescriptor(UniqueId.root("example", "id"), "Example") {
+				@Override
+				public Type getType() {
+					return Type.CONTAINER;
+				}
+			});
+
+		var deserializedIdentifier = (TestIdentifier) deserialize(serialize(originalIdentifier));
+
+		assertDeepEquals(originalIdentifier, deserializedIdentifier);
+	}
+
 	private static void assertDeepEquals(TestIdentifier first, TestIdentifier second) {
 		assertEquals(first, second);
 		assertEquals(first.getUniqueId(), second.getUniqueId());


### PR DESCRIPTION
## Overview

An NPE was thrown when (de)serializing `TestIdentifiers` without a parent.

Fixes #3819.

This is a backport of #3820 to the 5.10.x branch.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
