### PR TITLE
Document how to use `CloseableResource`

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -1,3 +1,6 @@
+:testDir: ../../../../src/test/java
+:kotlinTestDir: ../../../../src/test/kotlin
+
 [[extensions]]
 == Extension Model
 
@@ -713,25 +716,34 @@ extension context lifecycle ends it closes its associated store. All stored valu
 that are instances of `CloseableResource` are notified by an invocation of their `close()`
 method in the inverse order they were added in.
 
-An example use-case of `CloseableResource` is shown below, using an `HttpServer` resource.
+An example implementation of `CloseableResource` is shown below, using an `HttpServer`
+resource.
 
 [source,java,indent=0]
-.HttpServer resource implementing `CloseableResource`
+.`HttpServer` resource implementing `CloseableResource`
 ----
 include::{testDir}/example/extensions/HttpServerResource.java[tags=user_guide]
 ----
 
-This resource can then be stored in the desired `ExtensionContext`.
-The resource can be stored at class- or method-level if needed,
-but this may add unnecessary overhead for this type of resource.
-For this example it might be prudent to store it at root level
-and instantiate it lazily to ensure it's only created once per execution.
+This resource can then be stored in the desired `ExtensionContext`. It may be stored at
+class or method level, if desired, but this may add unnecessary overhead for this type of
+resource. For this example it might be prudent to store it at root level and instantiate
+it lazily to ensure it's only created once per test run and reused across different test
+classes and methods.
 
 [source,java,indent=0]
-.Storing in root context with `Store.getOrComputeIfAbsent`
+.Lazily storing in root context with `Store.getOrComputeIfAbsent`
 ----
 include::{testDir}/example/extensions/HttpServerExtension.java[tags=user_guide]
 ----
+
+[source,java,indent=0]
+.A test case using the `HttpServerExtension`
+----
+include::{testDir}/example/HttpServerDemo.java[tags=user_guide]
+----
+
+[[extensions-conditional-test-execution]]
 
 [[extensions-supported-utilities]]
 === Supported Utilities in Extensions

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -713,10 +713,10 @@ extension context lifecycle ends it closes its associated store. All stored valu
 that are instances of `CloseableResource` are notified by an invocation of their `close()`
 method in the inverse order they were added in.
 
-An example use-case of `ClosableResource` is shown below, using an `HttpServer` resource.
+An example use-case of `CloseableResource` is shown below, using an `HttpServer` resource.
 
 [source,java,indent=0]
-.HttpServer resource implementing `ClosableResource`
+.HttpServer resource implementing `CloseableResource`
 ----
 include::{testDir}/example/extensions/HttpServerResource.java[tags=user_guide]
 ----

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -693,7 +693,6 @@ Please refer to the implementations of <<writing-tests-repeated-tests>> or
 <<writing-tests-parameterized-tests>> which use this extension point to provide their
 functionality.
 
-
 [[extensions-keeping-state]]
 === Keeping State in Extensions
 
@@ -713,6 +712,26 @@ NOTE: An extension context store is bound to its extension context lifecycle. Wh
 extension context lifecycle ends it closes its associated store. All stored values
 that are instances of `CloseableResource` are notified by an invocation of their `close()`
 method in the inverse order they were added in.
+
+An example use-case of `ClosableResource` is shown below, using an `HttpServer` resource.
+
+[source,java,indent=0]
+.HttpServer resource implementing `ClosableResource`
+----
+include::{testDir}/example/extensions/HttpServerResource.java[tags=user_guide]
+----
+
+This resource can then be stored in the desired `ExtensionContext`.
+The resource can be stored at class- or method-level if needed,
+but this may add unnecessary overhead for this type of resource.
+For this example it might be prudent to store it at root level
+and instantiate it lazily to ensure it's only created once per execution.
+
+[source,java,indent=0]
+.Storing in root context with `Store.getOrComputeIfAbsent`
+----
+include::{testDir}/example/extensions/HttpServerExtension.java[tags=user_guide]
+----
 
 [[extensions-supported-utilities]]
 === Supported Utilities in Extensions

--- a/documentation/src/test/java/example/HttpServerDemo.java
+++ b/documentation/src/test/java/example/HttpServerDemo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+
+import com.sun.net.httpserver.HttpServer;
+
+import example.extensions.HttpServerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+// tag::user_guide[]
+@ExtendWith(HttpServerExtension.class)
+public class HttpServerDemo {
+
+	// end::user_guide[]
+	@SuppressWarnings("HttpUrlsUsage")
+	// tag::user_guide[]
+	@Test
+	void httpCall(HttpServer server) throws Exception {
+		String hostName = server.getAddress().getHostName();
+		int port = server.getAddress().getPort();
+		String rawUrl = String.format("http://%s:%d/example", hostName, port);
+		URL requestUrl = URI.create(rawUrl).toURL();
+
+		String responseBody = sendRequest(requestUrl);
+
+		assertEquals("This is a test", responseBody);
+	}
+
+	private static String sendRequest(URL url) throws IOException {
+		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+		int contentLength = connection.getContentLength();
+		try (InputStream response = url.openStream()) {
+			byte[] content = new byte[contentLength];
+			assertEquals(contentLength, response.read(content));
+			return new String(content, UTF_8);
+		}
+	}
+}
+// end::user_guide[]

--- a/documentation/src/test/java/example/extensions/HttpServerExtension.java
+++ b/documentation/src/test/java/example/extensions/HttpServerExtension.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.extensions;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+
+// tag::user_guide[]
+public class HttpServerExtension implements BeforeAllCallback {
+	@Override
+	public void beforeAll(ExtensionContext context) throws Exception {
+		HttpServerResource resource = context.getRoot().getStore(Namespace.GLOBAL).getOrComputeIfAbsent(
+			HttpServerResource.class.getName(), key -> {
+				try {
+					HttpServerResource serverResource = new HttpServerResource(8080);
+					serverResource.start();
+					return serverResource;
+				}
+				catch (IOException e) {
+					throw new RuntimeException("Failed to create HttpServerResource", e);
+				}
+			}, HttpServerResource.class);
+		// Now you can use the resource within your tests
+	}
+}
+// end::user_guide[]

--- a/documentation/src/test/java/example/extensions/HttpServerResource.java
+++ b/documentation/src/test/java/example/extensions/HttpServerResource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.extensions;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+
+/**
+ * Demonstrates an implementation of {@link CloseableResource} using an {@link HttpServer}.
+ */
+// tag::user_guide[]
+public class HttpServerResource implements CloseableResource {
+	private final HttpServer httpServer;
+
+	// end::user_guide[]
+	/**
+	 * Initializes the Http server resource, using the given port.
+	 *
+	 * @param port (int) The port number for the server, must be in the range 0-65535.
+	 * @throws IOException if an IOException occurs during initialization.
+	 */
+	// tag::user_guide[]
+	public HttpServerResource(int port) throws IOException {
+		this.httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+	}
+
+	// end::user_guide[]
+
+	/**
+	 * Starts the Http server with an example handler.
+	 */
+	// tag::user_guide[]
+	public void start() {
+		//Example handler
+		httpServer.createContext("/example", exchange -> {
+			String test = "This is a test.";
+			exchange.sendResponseHeaders(200, test.length());
+			try (OutputStream os = exchange.getResponseBody()) {
+				os.write(test.getBytes());
+			}
+		});
+		httpServer.setExecutor(null);
+		httpServer.start();
+	}
+
+	@Override
+	public void close() throws Throwable {
+		httpServer.stop(0);
+	}
+}
+// end::user_guide[]

--- a/documentation/src/test/java/example/extensions/HttpServerResource.java
+++ b/documentation/src/test/java/example/extensions/HttpServerResource.java
@@ -10,8 +10,11 @@
 
 package example.extensions;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import com.sun.net.httpserver.HttpServer;
@@ -22,10 +25,12 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
  * Demonstrates an implementation of {@link CloseableResource} using an {@link HttpServer}.
  */
 // tag::user_guide[]
-public class HttpServerResource implements CloseableResource {
+class HttpServerResource implements CloseableResource {
+
 	private final HttpServer httpServer;
 
 	// end::user_guide[]
+
 	/**
 	 * Initializes the Http server resource, using the given port.
 	 *
@@ -33,8 +38,13 @@ public class HttpServerResource implements CloseableResource {
 	 * @throws IOException if an IOException occurs during initialization.
 	 */
 	// tag::user_guide[]
-	public HttpServerResource(int port) throws IOException {
-		this.httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+	HttpServerResource(int port) throws IOException {
+		InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
+		this.httpServer = HttpServer.create(new InetSocketAddress(loopbackAddress, port), 0);
+	}
+
+	HttpServer getHttpServer() {
+		return httpServer;
 	}
 
 	// end::user_guide[]
@@ -43,13 +53,13 @@ public class HttpServerResource implements CloseableResource {
 	 * Starts the Http server with an example handler.
 	 */
 	// tag::user_guide[]
-	public void start() {
-		//Example handler
+	void start() {
+		// Example handler
 		httpServer.createContext("/example", exchange -> {
-			String test = "This is a test.";
-			exchange.sendResponseHeaders(200, test.length());
+			String body = "This is a test";
+			exchange.sendResponseHeaders(200, body.length());
 			try (OutputStream os = exchange.getResponseBody()) {
-				os.write(test.getBytes());
+				os.write(body.getBytes(UTF_8));
 			}
 		});
 		httpServer.setExecutor(null);
@@ -57,7 +67,7 @@ public class HttpServerResource implements CloseableResource {
 	}
 
 	@Override
-	public void close() throws Throwable {
+	public void close() {
 		httpServer.stop(0);
 	}
 }


### PR DESCRIPTION
Issue: #1555

## Overview

Added an explanation in the user guide for how `CloseableResource` can be used, with an example using an `HttpServer` resource.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
