### PR TITLE
Rename artifacts before attestation

### DIFF
--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -521,8 +521,7 @@ tasks {
 	val prepareGitHubAttestation by registering(Sync::class) {
 		from(attestationClasspath)
 		into(layout.buildDirectory.dir("attestation"))
-		var suffix = githubSha ?: datetime
-		rename("(.*)-SNAPSHOT.jar", "$1-SNAPSHOT+" + suffix + ".jar")
+		rename("(.*)-SNAPSHOT.jar", "$1-SNAPSHOT+${buildRevision}.jar")
 	}
 }
 

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -1,5 +1,3 @@
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import junitbuild.exec.CaptureJavaExecOutput
 import junitbuild.exec.ClasspathSystemPropertyProvider
 import junitbuild.exec.GenerateStandaloneConsoleLauncherShadowedArtifactsFile
@@ -92,8 +90,6 @@ asciidoctorj {
 	requires(file("src/docs/asciidoc/resources/themes/rouge_junit.rb"))
 }
 
-
-val datetime = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd.HH.mm"))
 val buildRevision: String by rootProject.extra
 val snapshot = rootProject.version.toString().contains("SNAPSHOT")
 val docsVersion = if (snapshot) "snapshot" else rootProject.version
@@ -521,7 +517,7 @@ tasks {
 	val prepareGitHubAttestation by registering(Sync::class) {
 		from(attestationClasspath)
 		into(layout.buildDirectory.dir("attestation"))
-		rename("(.*)-SNAPSHOT.jar", "$1-SNAPSHOT+${buildRevision}.jar")
+		rename("(.*)-SNAPSHOT.jar", "$1-SNAPSHOT+${buildRevision.substring(0, 7)}.jar")
 	}
 }
 

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -94,7 +94,7 @@ asciidoctorj {
 
 
 val datetime = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd.HH.mm"))
-var githubSha : String? = System.getenv("GITHUB_SHA")
+val buildRevision: String by rootProject.extra
 val snapshot = rootProject.version.toString().contains("SNAPSHOT")
 val docsVersion = if (snapshot) "snapshot" else rootProject.version
 val releaseBranch = if (snapshot) "HEAD" else "r${rootProject.version}"

--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import junitbuild.exec.CaptureJavaExecOutput
 import junitbuild.exec.ClasspathSystemPropertyProvider
 import junitbuild.exec.GenerateStandaloneConsoleLauncherShadowedArtifactsFile
@@ -90,6 +92,9 @@ asciidoctorj {
 	requires(file("src/docs/asciidoc/resources/themes/rouge_junit.rb"))
 }
 
+
+val datetime = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd.HH.mm"))
+var githubSha : String? = System.getenv("GITHUB_SHA")
 val snapshot = rootProject.version.toString().contains("SNAPSHOT")
 val docsVersion = if (snapshot) "snapshot" else rootProject.version
 val releaseBranch = if (snapshot) "HEAD" else "r${rootProject.version}"
@@ -516,6 +521,8 @@ tasks {
 	val prepareGitHubAttestation by registering(Sync::class) {
 		from(attestationClasspath)
 		into(layout.buildDirectory.dir("attestation"))
+		var suffix = githubSha ?: datetime
+		rename("(.*)-SNAPSHOT.jar", "$1-SNAPSHOT+" + suffix + ".jar")
 	}
 }
 

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.build-metadata.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.build-metadata.gradle.kts
@@ -30,5 +30,5 @@ val buildTime: String by extra { timeFormatter.format(buildTimeAndDate) }
 val buildRevision: String by extra {
 	providers.exec {
 		commandLine("git", "rev-parse", "--verify", "HEAD")
-	}.standardOutput.asText.get()
+	}.standardOutput.asText.get().trim()
 }


### PR DESCRIPTION
## Overview

Rename artifacts before attestation to include information which snapshot revision is being published.

Note that the information used by Maven (as in `<lastUpdated>20240606092913</lastUpdated>` of https://oss.sonatype.org/content/repositories/snapshots/org/junit/jupiter/junit-jupiter/maven-metadata.xml) is not available at this stage of the release/publish process.

Addresses part of #3128 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
