### PR TITLE
Generate default error message

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -135,6 +135,9 @@ public class Assertions {
 	 * }</pre>
 	 */
 	public static <V> V fail(String message) {
+		if (message.isBlank()) {
+			message = "Something went wrong...";
+		}
 		AssertionUtils.fail(message);
 		return null; // appeasing the compiler: this line will never be executed.
 	}
@@ -147,6 +150,9 @@ public class Assertions {
 	 * generic return type {@code V}.
 	 */
 	public static <V> V fail(String message, Throwable cause) {
+		if (message.isBlank()) {
+			message = "Something went wrong...";
+		}
 		AssertionUtils.fail(message, cause);
 		return null; // appeasing the compiler: this line will never be executed.
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java
@@ -136,7 +136,7 @@ public class Assertions {
 	 */
 	public static <V> V fail(String message) {
 		if (message.isBlank()) {
-			message = "Something went wrong...";
+			message = "Assertions.fail() called";
 		}
 		AssertionUtils.fail(message);
 		return null; // appeasing the compiler: this line will never be executed.
@@ -151,7 +151,7 @@ public class Assertions {
 	 */
 	public static <V> V fail(String message, Throwable cause) {
 		if (message.isBlank()) {
-			message = "Something went wrong...";
+			message = "Assertions.fail() called";
 		}
 		AssertionUtils.fail(message, cause);
 		return null; // appeasing the compiler: this line will never be executed.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
@@ -62,7 +62,7 @@ public final class ReportEntry {
 	/**
 	 * Factory for creating a new {@code ReportEntry} from a key-value pair.
 	 *
-	 * @param key the key under which the value should published; never
+	 * @param key the key under which the value should be published; never
 	 * {@code null} or blank
 	 * @param value the value to publish; never {@code null} or blank
 	 */

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
@@ -83,7 +83,7 @@ public final class ReportEntry {
 	 *
 	 * @return a copy of the map of key-value pairs; never {@code null}
 	 */
-	public final Map<String, String> getKeyValuePairs() {
+	public Map<String, String> getKeyValuePairs() {
 		return Collections.unmodifiableMap(this.keyValuePairs);
 	}
 
@@ -94,7 +94,7 @@ public final class ReportEntry {
 	 *
 	 * @return when this entry was created; never {@code null}
 	 */
-	public final LocalDateTime getTimestamp() {
+	public LocalDateTime getTimestamp() {
 		return this.timestamp;
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
@@ -73,8 +73,8 @@ public final class ReportEntry {
 	}
 
 	private void add(String key, String value) {
-		Preconditions.notBlank(key, "key must not be null or blank");
-		Preconditions.notBlank(value, "value must not be null or blank");
+		Preconditions.notBlank(key, "Key must not be null or blank");
+		Preconditions.notBlank(value, "Value must not be null or blank");
 		this.keyValuePairs.put(key, value);
 	}
 


### PR DESCRIPTION
## Overview

I have added a default error message for the [Assertions.fail()](https://github.com/junit-team/junit5/blob/1c294651ab3965a8bfe8909f6efdc56c5a47c4f0/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java#L106-L118) function as discussed in the issue, and made some grammatical changes in the surrounding areas. As said in the issue, it's a very minor problem, so nothing is really lost if this doesn't get implemented, but the option's there.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
