### PR TITLE
Document that `Lifecycle.PER_CLASS` implies `@Execution(SAME_THREAD)` in the JavaDoc

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
@@ -81,6 +81,11 @@ public @interface TestInstance {
 		 * When using this mode, a new test instance will be created once per
 		 * test class.
 		 *
+		 * <p>Note: Test methods in classes using this mode are executed in
+		 * the same thread by default. To enable concurrent execution,
+		 * annotate the test class or methods with
+		 * {@code @Execution(CONCURRENT)}.
+		 *
 		 * @see #PER_METHOD
 		 */
 		PER_CLASS,

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
@@ -20,6 +20,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * {@code @TestInstance} is a type-level annotation that is used to configure
@@ -81,10 +83,11 @@ public @interface TestInstance {
 		 * When using this mode, a new test instance will be created once per
 		 * test class.
 		 *
-		 * <p>Note: Test methods in classes using this mode are executed in
-		 * the same thread by default. To enable concurrent execution,
-		 * annotate the test class or methods with
-		 * {@code @Execution(CONCURRENT)}.
+		 * <p>Note: To avoid concurrency issues, class-level lifecycle methods
+		 * and tests in classes using this mode are executed in the
+		 * {@linkplain ExecutionMode#SAME_THREAD same thread} by default. You
+		 * can enable concurrent execution, by explicitly annotating the test
+		 * class or methods with {@link Execution @Execution(CONCURRENT)}.
 		 *
 		 * @see #PER_METHOD
 		 */


### PR DESCRIPTION
## Overview

Closes issue #3849

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
