### PR TITLE
Introduce zero invocations in test templates and parameterized tests

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -66,6 +66,11 @@ JUnit repository on GitHub.
   `@ConvertWith`), and `ArgumentsAggregator` (declared via `@AggregateWith`)
   implementations can now use constructor injection from registered `ParameterResolver`
   extensions.
+* Extensions based on `TestTemplateInvocationContextProvider` can now allow returning zero
+  invocation contexts by overriding the new `mayReturnZeroTestTemplateInvocationContexts`
+  method.
+* The new `@ParameterizedTest(requireArguments = false)` attribute allows to specify that
+  the absence of arguments is expected in some cases and should not cause a test failure.
 * Allow determining "shared resources" at runtime via the new `@ResourceLock#providers`
   attribute that accepts implementations of `ResourceLocksProvider`.
 * Extensions that implement `TestInstancePreConstructCallback`, `TestInstanceFactory`,

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.extension;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.stream.Stream;
@@ -85,5 +86,23 @@ public interface TestTemplateInvocationContextProvider extends Extension {
 	 * @see ExtensionContext
 	 */
 	Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context);
+
+	/**
+	 * Signals that in the supplied {@linkplain ExtensionContext context} the provider may return zero
+	 * {@linkplain TestTemplateInvocationContext invocation contexts}.
+	 *
+	 * <p>If provider returns empty stream from {@link #provideTestTemplateInvocationContexts(ExtensionContext)}
+	 * this will be considered an execution error. Override this method to ignore the absence of invocation contexts.
+	 *
+	 * @param context the extension context for the test template method about
+	 * to be invoked; never {@code null}
+	 * @return {@code true} to allow zero contexts, {@code false} (default) to fail execution in case of zero contexts.
+	 *
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	default boolean mayReturnZeroInvocationContexts(ExtensionContext context) {
+		return false;
+	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -88,15 +88,19 @@ public interface TestTemplateInvocationContextProvider extends Extension {
 	Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context);
 
 	/**
-	 * Signals that in the supplied {@linkplain ExtensionContext context} the provider may return zero
+	 * Signal that in the supplied {@linkplain ExtensionContext context} the
+	 * provider may return zero
 	 * {@linkplain TestTemplateInvocationContext invocation contexts}.
 	 *
-	 * <p>If provider returns empty stream from {@link #provideTestTemplateInvocationContexts(ExtensionContext)}
-	 * this will be considered an execution error. Override this method to ignore the absence of invocation contexts.
+	 * <p>If this method returns {@code false} and the provider returns an empty
+	 * stream from {@link #provideTestTemplateInvocationContexts}, this will be
+	 * considered an execution error. Override this method to ignore the absence
+	 * of invocation contexts for this provider.
 	 *
 	 * @param context the extension context for the test template method about
 	 * to be invoked; never {@code null}
-	 * @return {@code true} to allow zero contexts, {@code false} (default) to fail execution in case of zero contexts.
+	 * @return {@code true} to allow zero contexts, {@code false} (default) to
+	 * fail execution in case of zero contexts.
 	 *
 	 * @since 5.12
 	 */

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContextProvider.java
@@ -105,7 +105,7 @@ public interface TestTemplateInvocationContextProvider extends Extension {
 	 * @since 5.12
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")
-	default boolean mayReturnZeroInvocationContexts(ExtensionContext context) {
+	default boolean mayReturnZeroTestTemplateInvocationContexts(ExtensionContext context) {
 		return false;
 	}
 

--- a/junit-jupiter-params/src/jmh/java/org/junit/jupiter/params/ParameterizedTestNameFormatterBenchmarks.java
+++ b/junit-jupiter-params/src/jmh/java/org/junit/jupiter/params/ParameterizedTestNameFormatterBenchmarks.java
@@ -44,10 +44,10 @@ public class ParameterizedTestNameFormatterBenchmarks {
 
 	@Benchmark
 	public void formatTestNames(Blackhole blackhole) throws Exception {
+		var method = TestCase.class.getDeclaredMethod("parameterizedTest", int.class);
 		var formatter = new ParameterizedTestNameFormatter(
 			ParameterizedTest.DISPLAY_NAME_PLACEHOLDER + " " + ParameterizedTest.DEFAULT_DISPLAY_NAME + " ({0})",
-			"displayName",
-			new ParameterizedTestMethodContext(TestCase.class.getDeclaredMethod("parameterizedTest", int.class), null),
+			"displayName", new ParameterizedTestMethodContext(method, method.getAnnotation(ParameterizedTest.class)),
 			512);
 		for (int i = 0; i < argumentsList.size(); i++) {
 			Arguments arguments = argumentsList.get(i);
@@ -55,8 +55,10 @@ public class ParameterizedTestNameFormatterBenchmarks {
 		}
 	}
 
+	@SuppressWarnings("JUnitMalformedDeclaration")
 	static class TestCase {
 		@SuppressWarnings("unused")
+		@ParameterizedTest
 		void parameterizedTest(int param) {
 		}
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -291,4 +291,17 @@ public @interface ParameterizedTest {
 	@API(status = STABLE, since = "5.10")
 	boolean autoCloseArguments() default true;
 
+	/**
+	 * Configure whether a test requires at least one set of arguments.
+	 * Override this value if the absence of arguments is expected in some cases and
+	 * should not cause the test framework errors.
+	 *
+	 * <p>Defaults to {@code true}.
+	 *
+	 * <p></p>
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	boolean requireArguments() default true;
+
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -292,13 +292,14 @@ public @interface ParameterizedTest {
 	boolean autoCloseArguments() default true;
 
 	/**
-	 * Configure whether a test requires at least one set of arguments.
-	 * Override this value if the absence of arguments is expected in some cases and
-	 * should not cause the test framework errors.
+	 * Configure whether at least one set of arguments is required for this
+	 * parameterized test.
+	 *
+	 * <p>Set this attribute to {@code false} if the absence of arguments is
+	 * expected in some cases and should not cause a test failure.
 	 *
 	 * <p>Defaults to {@code true}.
 	 *
-	 * <p></p>
 	 * @since 5.12
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -12,9 +12,9 @@ package org.junit.jupiter.params;
 
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
-import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
@@ -34,7 +34,7 @@ import org.junit.platform.commons.util.Preconditions;
  */
 class ParameterizedTestExtension implements TestTemplateInvocationContextProvider {
 
-	private static final String METHOD_CONTEXT_KEY = "context";
+	static final String METHOD_CONTEXT_KEY = "context";
 	static final String ARGUMENT_MAX_LENGTH_KEY = "junit.jupiter.params.displayname.argument.maxlength";
 	static final String DEFAULT_DISPLAY_NAME = "{default_display_name}";
 	static final String DISPLAY_NAME_PATTERN_KEY = "junit.jupiter.params.displayname.default";
@@ -45,19 +45,21 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 			return false;
 		}
 
-		Method testMethod = context.getTestMethod().get();
-		if (!isAnnotated(testMethod, ParameterizedTest.class)) {
+		Method templateMethod = context.getTestMethod().get();
+		Optional<ParameterizedTest> annotation = findAnnotation(templateMethod, ParameterizedTest.class);
+		if (!annotation.isPresent()) {
 			return false;
 		}
 
-		ParameterizedTestMethodContext methodContext = new ParameterizedTestMethodContext(testMethod, context);
+		ParameterizedTestMethodContext methodContext = new ParameterizedTestMethodContext(templateMethod,
+			annotation.get());
 
 		Preconditions.condition(methodContext.hasPotentiallyValidSignature(),
 			() -> String.format(
 				"@ParameterizedTest method [%s] declares formal parameters in an invalid order: "
 						+ "argument aggregators must be declared after any indexed arguments "
 						+ "and before any arguments resolved by another ParameterResolver.",
-				testMethod.toGenericString()));
+				templateMethod.toGenericString()));
 
 		getStore(context).put(METHOD_CONTEXT_KEY, methodContext);
 
@@ -68,41 +70,36 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
 			ExtensionContext extensionContext) {
 
-		Method templateMethod = extensionContext.getRequiredTestMethod();
-		String displayName = extensionContext.getDisplayName();
-		ParameterizedTestMethodContext methodContext = getStore(extensionContext)//
-				.get(METHOD_CONTEXT_KEY, ParameterizedTestMethodContext.class);
-		int argumentMaxLength = extensionContext.getConfigurationParameter(ARGUMENT_MAX_LENGTH_KEY,
-			Integer::parseInt).orElse(512);
-		ParameterizedTestNameFormatter formatter = createNameFormatter(extensionContext, templateMethod, methodContext,
-			displayName, argumentMaxLength);
+		ParameterizedTestMethodContext methodContext = getMethodContext(extensionContext);
+		ParameterizedTestNameFormatter formatter = createNameFormatter(extensionContext, methodContext);
 		AtomicLong invocationCount = new AtomicLong(0);
-		ParameterizedTest parameterizedTest = findAnnotation(templateMethod, ParameterizedTest.class).get();
-		boolean ignoreZeroInvocations = !parameterizedTest.requireArguments();
 
 		// @formatter:off
-		return findRepeatableAnnotations(templateMethod, ArgumentsSource.class)
+		return findRepeatableAnnotations(methodContext.method, ArgumentsSource.class)
 				.stream()
 				.map(ArgumentsSource::value)
 				.map(clazz -> ParameterizedTestSpiInstantiator.instantiate(ArgumentsProvider.class, clazz, extensionContext))
-				.map(provider -> AnnotationConsumerInitializer.initialize(templateMethod, provider))
+				.map(provider -> AnnotationConsumerInitializer.initialize(methodContext.method, provider))
 				.flatMap(provider -> arguments(provider, extensionContext))
 				.map(arguments -> {
 					invocationCount.incrementAndGet();
 					return createInvocationContext(formatter, methodContext, arguments, invocationCount.intValue());
 				})
 				.onClose(() ->
-						Preconditions.condition(invocationCount.get() > 0 || ignoreZeroInvocations,
+						Preconditions.condition(invocationCount.get() > 0 || !methodContext.annotation.requireArguments(),
 								"Configuration error: You must configure at least one set of arguments for this @ParameterizedTest"));
 		// @formatter:on
 	}
 
 	@Override
 	public boolean mayReturnZeroTestTemplateInvocationContexts(ExtensionContext extensionContext) {
-		Method templateMethod = extensionContext.getRequiredTestMethod();
-		return findAnnotation(templateMethod, ParameterizedTest.class) //
-				.map(parameterizedTest -> !parameterizedTest.requireArguments()) //
-				.orElse(false);
+		ParameterizedTestMethodContext methodContext = getMethodContext(extensionContext);
+		return !methodContext.annotation.requireArguments();
+	}
+
+	private ParameterizedTestMethodContext getMethodContext(ExtensionContext extensionContext) {
+		return getStore(extensionContext)//
+				.get(METHOD_CONTEXT_KEY, ParameterizedTestMethodContext.class);
 	}
 
 	private ExtensionContext.Store getStore(ExtensionContext context) {
@@ -115,19 +112,24 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 		return new ParameterizedTestInvocationContext(formatter, methodContext, arguments, invocationIndex);
 	}
 
-	private ParameterizedTestNameFormatter createNameFormatter(ExtensionContext extensionContext, Method templateMethod,
-			ParameterizedTestMethodContext methodContext, String displayName, int argumentMaxLength) {
+	private ParameterizedTestNameFormatter createNameFormatter(ExtensionContext extensionContext,
+			ParameterizedTestMethodContext methodContext) {
 
-		ParameterizedTest parameterizedTest = findAnnotation(templateMethod, ParameterizedTest.class).get();
-		String pattern = parameterizedTest.name().equals(DEFAULT_DISPLAY_NAME)
-				? extensionContext.getConfigurationParameter(DISPLAY_NAME_PATTERN_KEY).orElse(
-					ParameterizedTest.DEFAULT_DISPLAY_NAME)
-				: parameterizedTest.name();
+		String name = methodContext.annotation.name();
+		String pattern = name.equals(DEFAULT_DISPLAY_NAME)
+				? extensionContext.getConfigurationParameter(DISPLAY_NAME_PATTERN_KEY) //
+						.orElse(ParameterizedTest.DEFAULT_DISPLAY_NAME)
+				: name;
 		pattern = Preconditions.notBlank(pattern.trim(),
 			() -> String.format(
 				"Configuration error: @ParameterizedTest on method [%s] must be declared with a non-empty name.",
-				templateMethod));
-		return new ParameterizedTestNameFormatter(pattern, displayName, methodContext, argumentMaxLength);
+				methodContext.method));
+
+		int argumentMaxLength = extensionContext.getConfigurationParameter(ARGUMENT_MAX_LENGTH_KEY, Integer::parseInt) //
+				.orElse(512);
+
+		return new ParameterizedTestNameFormatter(pattern, extensionContext.getDisplayName(), methodContext,
+			argumentMaxLength);
 	}
 
 	protected static Stream<? extends Arguments> arguments(ArgumentsProvider provider, ExtensionContext context) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -98,7 +98,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 	}
 
 	@Override
-	public boolean mayReturnZeroInvocationContexts(ExtensionContext extensionContext) {
+	public boolean mayReturnZeroTestTemplateInvocationContexts(ExtensionContext extensionContext) {
 		Method templateMethod = extensionContext.getRequiredTestMethod();
 		return findAnnotation(templateMethod, ParameterizedTest.class) //
 				.map(parameterizedTest -> !parameterizedTest.requireArguments()) //

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
@@ -78,7 +78,8 @@ class ParameterizedTestParameterResolver implements ParameterResolver, AfterTest
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
 			throws ParameterResolutionException {
-		return this.methodContext.resolve(parameterContext, extractPayloads(this.arguments), this.invocationIndex);
+		return this.methodContext.resolve(parameterContext, extensionContext, extractPayloads(this.arguments),
+			this.invocationIndex);
 	}
 
 	/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/KitchenSinkExtension.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/KitchenSinkExtension.java
@@ -168,6 +168,11 @@ public class KitchenSinkExtension implements
 		return null;
 	}
 
+	@Override
+	public boolean mayReturnZeroTestTemplateInvocationContexts(ExtensionContext context) {
+		return false;
+	}
+
 	// --- TestWatcher ---------------------------------------------------------
 
 	@Override

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestTemplateInvocationTests.java
@@ -353,9 +353,10 @@ class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithSupportingProviderButNoInvocations"), started()), //
 				event(container("templateWithSupportingProviderButNoInvocations"),
-					finishedWithFailure(message("Provider ["
-							+ InvocationContextProviderThatSupportsEverythingButProvidesNothing.class.getSimpleName()
-							+ "] did not provide invocation contexts, but is expected to do so")))));
+					finishedWithFailure(message(
+						"Provider [%s] did not provide any invocation contexts, but was expected to do so. ".formatted(
+							InvocationContextProviderThatSupportsEverythingButProvidesNothing.class.getSimpleName())
+								+ "You may override mayReturnZeroTestTemplateInvocationContexts() to allow this.")))));
 	}
 
 	@Test
@@ -382,9 +383,10 @@ class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 			wrappedInContainerEvents(MyTestTemplateTestCase.class, //
 				event(container("templateWithMultipleProvidersAllowingAndRestrictingToProvideNothing"), started()), //
 				event(container("templateWithMultipleProvidersAllowingAndRestrictingToProvideNothing"),
-					finishedWithFailure(message("Provider ["
-							+ InvocationContextProviderThatSupportsEverythingButProvidesNothing.class.getSimpleName()
-							+ "] did not provide invocation contexts, but is expected to do so")))));
+					finishedWithFailure(message(
+						"Provider [%s] did not provide any invocation contexts, but was expected to do so. ".formatted(
+							InvocationContextProviderThatSupportsEverythingButProvidesNothing.class.getSimpleName())
+								+ "You may override mayReturnZeroTestTemplateInvocationContexts() to allow this.")))));
 	}
 
 	@Test
@@ -825,7 +827,7 @@ class TestTemplateInvocationTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Override
-		public boolean mayReturnZeroInvocationContexts(ExtensionContext extensionContext) {
+		public boolean mayReturnZeroTestTemplateInvocationContexts(ExtensionContext extensionContext) {
 			return true;
 		}
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -143,6 +143,18 @@ class ParameterizedTestExtensionTests {
 	}
 
 	@Test
+	void doesNotThrowExceptionWhenParametrizedTestDoesNotRequireArguments() {
+		var extensionContextWithAnnotatedTestMethod = getExtensionContextReturningSingleMethod(
+			new TestCaseAllowNoArgumentsMethod());
+
+		var stream = this.parameterizedTestExtension.provideTestTemplateInvocationContexts(
+			extensionContextWithAnnotatedTestMethod);
+		// cause the stream to be evaluated
+		stream.toArray();
+		stream.close();
+	}
+
+	@Test
 	void throwsExceptionWhenArgumentsProviderIsNotStatic() {
 		var extensionContextWithAnnotatedTestMethod = getExtensionContextReturningSingleMethod(
 			new NonStaticArgumentsProviderTestCase());
@@ -306,6 +318,13 @@ class ParameterizedTestExtensionTests {
 
 		@SuppressWarnings("JUnitMalformedDeclaration")
 		@ParameterizedTest
+		void method() {
+		}
+	}
+
+	static class TestCaseAllowNoArgumentsMethod {
+
+		@ParameterizedTest(requireArguments = false)
 		void method() {
 		}
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -31,6 +31,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqu
 import static org.junit.platform.testkit.engine.EventConditions.abortedWithReason;
 import static org.junit.platform.testkit.engine.EventConditions.container;
 import static org.junit.platform.testkit.engine.EventConditions.displayName;
+import static org.junit.platform.testkit.engine.EventConditions.engine;
 import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
@@ -445,6 +446,24 @@ class ParameterizedTestIntegrationTests {
 		results.testEvents().assertThatEvents() //
 				.haveExactly(1, event(displayName("1"), started())) //
 				.haveExactly(1, event(displayName("2"), started()));
+	}
+
+	@Test
+	void failsWhenArgumentsRequiredButNoneProvided() {
+		var result = execute(ZeroArgumentsTestCase.class, "testThatRequiresArguments", String.class);
+		result.containerEvents().assertThatEvents().haveExactly(1, event(finishedWithFailure(message(
+			"Configuration error: You must configure at least one set of arguments for this @ParameterizedTest"))));
+	}
+
+	@Test
+	void failsWhenArgumentsAreNotRequiredAndNoneProvided() {
+		var result = execute(ZeroArgumentsTestCase.class, "testThatDoesNotRequireArguments", String.class);
+		result.allEvents().assertEventsMatchExactly( //
+			event(engine(), started()), event(container(ZeroArgumentsTestCase.class), started()),
+			event(container("testThatDoesNotRequireArguments"), started()),
+			event(container("testThatDoesNotRequireArguments"), finishedSuccessfully()),
+			event(container(ZeroArgumentsTestCase.class), finishedSuccessfully()),
+			event(engine(), finishedSuccessfully()));
 	}
 
 	private EngineExecutionResults execute(DiscoverySelector... selectors) {
@@ -2306,6 +2325,25 @@ class ParameterizedTestIntegrationTests {
 					throws ArgumentsAggregationException {
 				return value;
 			}
+		}
+	}
+
+	static class ZeroArgumentsTestCase {
+
+		@ParameterizedTest
+		@MethodSource("zeroArgumentsProvider")
+		void testThatRequiresArguments(String argument) {
+			fail("This test should not be executed, because no arguments are provided.");
+		}
+
+		@ParameterizedTest(requireArguments = false)
+		@MethodSource("zeroArgumentsProvider")
+		void testThatDoesNotRequireArguments(String argument) {
+			fail("This test should not be executed, because no arguments are provided.");
+		}
+
+		public static Stream<Arguments> zeroArgumentsProvider() {
+			return Stream.empty();
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -52,6 +52,7 @@ import org.junit.platform.commons.support.ReflectionSupport;
 /**
  * @since 5.0
  */
+@SuppressWarnings("ALL")
 class ParameterizedTestNameFormatterTests {
 
 	private final Locale originalLocale = Locale.getDefault();
@@ -330,8 +331,8 @@ class ParameterizedTestNameFormatterTests {
 	}
 
 	private static ParameterizedTestNameFormatter formatter(String pattern, String displayName, Method method) {
-		return new ParameterizedTestNameFormatter(pattern, displayName,
-			new ParameterizedTestMethodContext(method, mock()), 512);
+		var context = new ParameterizedTestMethodContext(method, method.getAnnotation(ParameterizedTest.class));
+		return new ParameterizedTestNameFormatter(pattern, displayName, context, 512);
 	}
 
 	private static String format(ParameterizedTestNameFormatter formatter, int invocationIndex, Arguments arguments) {
@@ -361,15 +362,18 @@ class ParameterizedTestNameFormatterTests {
 		}
 
 		@SuppressWarnings("unused")
+		@ParameterizedTest
 		void parameterizedTest(int someNumber, String someString, Object[] someArray) {
 		}
 
 		@SuppressWarnings("unused")
+		@ParameterizedTest
 		void parameterizedTestWithAggregator(int someNumber,
 				@AggregateWith(CustomAggregator.class) String someAggregatedString) {
 		}
 
 		@SuppressWarnings("unused")
+		@ParameterizedTest
 		void processFruits(String fruit1, String fruit2) {
 		}
 


### PR DESCRIPTION
Add a flag to ParameterizedTest to control arguments requirement. This allows users to explicitly opt out from validation of arguments set count and silently skip a test if no arguments are provided

In general, support TestTemplateInvocationContextProvider returning zero invocation contexts. Such providers must override new interface method to indicate that the framework should expect "no context returned"

Resolves #1477

## Overview

Implemented the team decision described in [this comment](https://github.com/junit-team/junit5/issues/1477#issuecomment-1919412893)

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
