### PR TITLE
Ensure `TempDir` cleanup is executed when validation fails

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -287,21 +287,22 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 		private CloseablePath(TempDirFactory factory, CleanupMode cleanupMode, AnnotatedElementContext elementContext,
 				ExtensionContext extensionContext) throws Exception {
+			this.dir = factory.createTempDirectory(elementContext, extensionContext);
+			this.factory = factory;
+			this.cleanupMode = cleanupMode;
+			this.extensionContext = extensionContext;
+
 			try {
-				this.dir = validateTempDirectory(factory.createTempDirectory(elementContext, extensionContext));
-				this.factory = factory;
-				this.cleanupMode = cleanupMode;
-				this.extensionContext = extensionContext;
+				validateTempDirectory(this.dir);
 			}
 			catch (PreconditionViolationException e) {
-				factory.close();
+				close();
 				throw e;
 			}
 		}
 
-		private static Path validateTempDirectory(Path dir) {
+		private static void validateTempDirectory(Path dir) {
 			Preconditions.condition(dir != null && Files.isDirectory(dir), "temp directory must be a directory");
-			return dir;
 		}
 
 		Path get() {
@@ -331,7 +332,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 		private SortedMap<Path, IOException> deleteAllFilesAndDirectories(FileOperations fileOperations)
 				throws IOException {
-			if (Files.notExists(dir)) {
+			if (dir == null || Files.notExists(dir)) {
 				return Collections.emptySortedMap();
 			}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -292,17 +292,10 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 			this.cleanupMode = cleanupMode;
 			this.extensionContext = extensionContext;
 
-			try {
-				validateTempDirectory(this.dir);
-			}
-			catch (PreconditionViolationException e) {
+			if (dir == null || !Files.isDirectory(dir)) {
 				close();
-				throw e;
+				throw new PreconditionViolationException("temp directory must be a directory");
 			}
-		}
-
-		private static void validateTempDirectory(Path dir) {
-			Preconditions.condition(dir != null && Files.isDirectory(dir), "temp directory must be a directory");
 		}
 
 		Path get() {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.api.io.TempDirFactory;
 import org.junit.jupiter.engine.config.EnumConfigurationParameterConverter;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.ExceptionUtils;
@@ -286,10 +287,16 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 		private CloseablePath(TempDirFactory factory, CleanupMode cleanupMode, AnnotatedElementContext elementContext,
 				ExtensionContext extensionContext) throws Exception {
-			this.dir = validateTempDirectory(factory.createTempDirectory(elementContext, extensionContext));
-			this.factory = factory;
-			this.cleanupMode = cleanupMode;
-			this.extensionContext = extensionContext;
+			try {
+				this.dir = validateTempDirectory(factory.createTempDirectory(elementContext, extensionContext));
+				this.factory = factory;
+				this.cleanupMode = cleanupMode;
+				this.extensionContext = extensionContext;
+			}
+			catch (PreconditionViolationException e) {
+				factory.close();
+				throw e;
+			}
 		}
 
 		private static Path validateTempDirectory(Path dir) {

--- a/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
+++ b/junit-jupiter-engine/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
@@ -124,6 +124,7 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 
 			assertThatExtensionConfigurationExceptionIsThrownBy(
 				() -> TempDirectory.createTempDir(factory, DEFAULT, elementContext, extensionContext));
+
 			verify(factory).close();
 		}
 
@@ -135,9 +136,9 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 
 			assertThatExtensionConfigurationExceptionIsThrownBy(
 				() -> TempDirectory.createTempDir(factory, DEFAULT, elementContext, extensionContext));
-			verify(factory).close();
 
-			delete(file);
+			verify(factory).close();
+			assertThat(file).doesNotExist();
 		}
 
 		@Test
@@ -149,9 +150,10 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 
 			assertThatExtensionConfigurationExceptionIsThrownBy(
 				() -> TempDirectory.createTempDir(factory, DEFAULT, elementContext, extensionContext));
-			verify(factory).close();
 
-			delete(symbolicLink);
+			verify(factory).close();
+			assertThat(symbolicLink).doesNotExist();
+
 			delete(file);
 		}
 
@@ -202,8 +204,9 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 			assertThat(closeablePath.get()).isDirectory();
 
 			closeablePath.close();
-			assertThat(closeablePath.get()).doesNotExist();
+
 			verify(factory).close();
+			assertThat(closeablePath.get()).doesNotExist();
 		}
 
 		@Test
@@ -213,8 +216,9 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 			assertThat(closeablePath.get()).isDirectory();
 
 			closeablePath.close();
-			assertThat(closeablePath.get()).exists();
+
 			verify(factory).close();
+			assertThat(closeablePath.get()).exists();
 		}
 
 		@Test
@@ -226,8 +230,9 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 			assertThat(closeablePath.get()).isDirectory();
 
 			closeablePath.close();
-			assertThat(closeablePath.get()).exists();
+
 			verify(factory).close();
+			assertThat(closeablePath.get()).exists();
 		}
 
 		@Test
@@ -239,8 +244,9 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 			assertThat(closeablePath.get()).isDirectory();
 
 			closeablePath.close();
-			assertThat(closeablePath.get()).doesNotExist();
+
 			verify(factory).close();
+			assertThat(closeablePath.get()).doesNotExist();
 		}
 
 	}


### PR DESCRIPTION
## Overview

See https://github.com/junit-team/junit5/pull/3901#discussion_r1699972486.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
