### PR TITLE
Let `@TempDir` fail fast with `File` annotated element and non-default file system temp directory

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.0.adoc
@@ -183,6 +183,9 @@ on GitHub.
   tests, in particular in recent versions of Java that support records.
 * `@TempDir` now fails fast in case `TempDirFactory::createTempDirectory` returns
   `null`, a file, or a symbolic link to a file.
+* `@TempDir` now fails fast in case the annotated target is of type `File` and
+  `TempDirFactory::createTempDirectory` returns a `Path` that does not belong to the
+  default file system.
 
 
 [[release-notes-5.11.0-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
@@ -41,16 +41,20 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  * <p>The temporary directory is only created if a field in a test class or a
  * parameter in a lifecycle method or test method is annotated with
  * {@code @TempDir}.
- * An {@link ExtensionConfigurationException} or a {@link ParameterResolutionException}
- * will be thrown in one of the following cases:
+ * An {@link ExtensionConfigurationException} or a
+ * {@link ParameterResolutionException} will be thrown in one of the following
+ * cases:
  *
  * <ul>
- * <li>If the field type or parameter type is neither {@link Path} nor {@link File}.</li>
+ * <li>If the field type or parameter type is neither {@link Path} nor
+       {@link File}.</li>
  * <li>If a field is declared as {@code final}.</li>
  * <li>If the temporary directory cannot be created.</li>
  * <li>If the field type or parameter type is {@code File} and a custom
- *     {@link TempDir#factory() factory} is used, which creates a temporary directory that does
- *     not belong to the {@link java.nio.file.FileSystems#getDefault() default file system}.</li>
+ *     {@linkplain TempDir#factory() factory} is used, which creates a temporary
+ *     directory that does not belong to the
+ *     {@linkplain java.nio.file.FileSystems#getDefault() default file system}.
+ * </li>
  * </ul>
  *
  * In addition, a {@code ParameterResolutionException} will be thrown for a

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
@@ -40,11 +40,20 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  *
  * <p>The temporary directory is only created if a field in a test class or a
  * parameter in a lifecycle method or test method is annotated with
- * {@code @TempDir}. If the field type or parameter type is neither {@link Path}
- * nor {@link File}, if a field is declared as {@code final}, or if the temporary
- * directory cannot be created, an {@link ExtensionConfigurationException} or a
- * {@link ParameterResolutionException} will be thrown as appropriate. In
- * addition, a {@code ParameterResolutionException} will be thrown for a
+ * {@code @TempDir}.
+ * An {@link ExtensionConfigurationException} or a {@link ParameterResolutionException}
+ * will be thrown in one of the following cases:
+ *
+ * <ul>
+ * <li>If the field type or parameter type is neither {@link Path} nor {@link File}.</li>
+ * <li>If a field is declared as {@code final}.</li>
+ * <li>If the temporary directory cannot be created.</li>
+ * <li>If the field type or parameter type is {@code File} and a custom
+ *     {@link TempDir#factory() factory} is used, which creates a temporary directory that does
+ *     not belong to the {@link java.nio.file.FileSystems#getDefault() default file system}.</li>
+ * </ul>
+ *
+ * In addition, a {@code ParameterResolutionException} will be thrown for a
  * constructor parameter annotated with {@code @TempDir}.
  *
  * <h2>Scope</h2>

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
@@ -146,7 +146,7 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 		@DisplayName("succeeds if the factory returns a directory on a non-default file system for a Path annotated element")
 		@Test
 		void factoryReturnsDirectoryOnNonDefaultFileSystemWithPath() throws IOException {
-			TempDirFactory factory = spy(new JimfsFactory());
+			TempDirFactory factory = new JimfsFactory();
 
 			closeablePath = TempDirectory.createTempDir(factory, DEFAULT, Path.class, elementContext, extensionContext);
 			assertThat(closeablePath.get()).isDirectory();


### PR DESCRIPTION
## Overview

Closes #3910.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
