### PR TITLE
fix #944: provide the resolved parameters in the ExtensionContext

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -402,6 +402,30 @@ public interface ExtensionContext {
 	ExecutableInvoker getExecutableInvoker();
 
 	/**
+	 * Get the {@link ResolvedParameters} implementation to find the parameters that have been resolved
+	 * by some {@link ParameterResolver} for the current test.
+	 */
+	Optional<ResolvedParameters> getResolvedParameters();
+
+	/**
+	 * Get the <em>required</em> {@link ResolvedParameters} implementation to find the parameters
+	 * that have been resolved by some {@link ParameterResolver} for the current test.
+	 *
+	 * <p>Use this method as an alternative to {@link #getResolvedParameters()} for use
+	 * cases in which the resolved parameters is required to be present.
+	 *
+	 * @return the resolved parameters; never {@code null}
+	 * @throws PreconditionViolationException if the resolved parameters is not present
+	 * in this {@code ExtensionContext}
+	 *
+	 * @see #getRequiredResolvedParameters()
+	 */
+	default ResolvedParameters getRequiredResolvedParameters() {
+		return Preconditions.notNull(getResolvedParameters().orElse(null),
+				"Illegal state: required resolved parameters is not present in the current ExtensionContext");
+	}
+
+	/**
 	 * {@code Store} provides methods for extensions to save and retrieve data.
 	 */
 	interface Store {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ResolvedParameters.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ResolvedParameters.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.extension;
+
+import java.util.List;
+
+/**
+ * Get the parameters that have been resolved by some {@link ParameterResolver} for the current test.
+ * <p>
+ * We may add more convenience methods to this interface in the future.
+ */
+public interface ResolvedParameters {
+	/**
+	 * Get all the parameters that have been resolved by some {@link ParameterResolver} for the current test.
+	 */
+	List<?> getAllParameters();
+
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -135,6 +135,7 @@ public class ParameterResolutionUtils {
 			ParameterResolver resolver = matchingResolvers.get(0);
 			Object value = resolver.resolveParameter(parameterContext, extensionContext);
 			validateResolvedType(parameterContext.getParameter(), value, executable, resolver);
+			recordResolvedParameter(extensionContext, value);
 
 			logger.trace(() -> String.format(
 				"ParameterResolver [%s] resolved a value of type [%s] for parameter [%s] in %s [%s].",
@@ -184,6 +185,12 @@ public class ParameterResolutionUtils {
 			}
 
 			throw new ParameterResolutionException(message);
+		}
+	}
+
+	private static void recordResolvedParameter(ExtensionContext extensionContext, Object value) {
+		if (extensionContext instanceof ResolvedParametersStore) {
+			((ResolvedParametersStore) extensionContext).recordResolvedParameter(value);
 		}
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ResolvedParametersStore.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ResolvedParametersStore.java
@@ -1,0 +1,8 @@
+package org.junit.jupiter.engine.execution;
+
+/**
+ * Internal interface to be implemented by extension contexts that store resolved parameters.
+ */
+public interface ResolvedParametersStore {
+	void recordResolvedParameter(Object value);
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ResolvedParameters;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.engine.execution.NamespaceAwareStore;
@@ -278,6 +279,11 @@ class ParameterizedTestExtensionTests {
 			@Override
 			public ExecutableInvoker getExecutableInvoker() {
 				return null;
+			}
+
+			@Override
+			public Optional<ResolvedParameters> getResolvedParameters() {
+				return Optional.empty();
 			}
 		};
 	}


### PR DESCRIPTION
## Overview

As (almost) suggested in #944, I've added a method `ExtensionContext#getResolvedParameters` (and `getRequiredResolvedParameters`) and an interface `ResolvedParameters`. The `AbstractExtensionContext` can store and return those. The `ParameterResolutionUtils` store them, but I had to introduce another but internal interface `ResolvedParametersStore` to make this possible without hurting the visibility scopes between `descriptor` and `execution`.

The problem I ran into is that `TestMethodTestDescriptor#execute` calls the parameter resolvers _after_ all `BeforeEach` callbacks and methods. So they can't see them, but that was the purpose of it all.

I'm not sure, if this ordering could be inverted: first the parameter resolvers, then the `BeforeEach` handling.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
