### PR TITLE
Support arbitrary Java versions with `JRE` conditions

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-RC1.adoc
@@ -3,11 +3,11 @@
 
 *Date of Release:* ❓
 
-*Scope:* ❓
+*Scope:* Minor enhancements since JUnit 5.12 M1.
 
 For a complete list of all _closed_ issues and pull requests for this release, consult the
-link:{junit5-repo}+/milestone/88?closed=1+[5.12.0-RC1] milestone page in the
-JUnit repository on GitHub.
+link:{junit5-repo}+/milestone/88?closed=1+[5.12.0-RC1] milestone page in the JUnit
+repository on GitHub.
 
 
 [[release-notes-5.12.0-RC1-junit-platform]]
@@ -45,7 +45,10 @@ JUnit repository on GitHub.
 [[release-notes-5.12.0-RC1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* `JRE`-based conditions such as `@EnabledOnJre` and `@DisabledForJreRange` now support
+  arbitrary Java versions. See the
+  <<../user-guide/index.adoc#writing-tests-conditional-execution-jre, User Guide>> for
+  details.
 
 
 [[release-notes-5.12.0-RC1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -646,16 +646,34 @@ include::{testDir}/example/ConditionalTestExecutionDemo.java[tags=user_guide_arc
 [[writing-tests-conditional-execution-jre]]
 ==== Java Runtime Environment Conditions
 
-A container or test may be enabled or disabled on particular versions of the Java
-Runtime Environment (JRE) via the `{EnabledOnJre}` and `{DisabledOnJre}` annotations
-or on a particular range of versions of the JRE via the `{EnabledForJreRange}` and
-`{DisabledForJreRange}` annotations. The range defaults to `{JRE}.JAVA_8` as the lower
-border (`min`) and `{JRE}.OTHER` as the higher border (`max`), which allows usage of
-half open ranges.
+A container or test may be enabled or disabled on particular versions of the Java Runtime
+Environment (JRE) via the `{EnabledOnJre}` and `{DisabledOnJre}` annotations or on a
+particular range of versions of the JRE via the `{EnabledForJreRange}` and
+`{DisabledForJreRange}` annotations. The range effectively defaults to `JRE.JAVA_8` as the
+lower bound and `JRE.OTHER` as the upper bound, which allows usage of half open ranges.
+
+The following listing demonstrates the use of these annotations with predefined {JRE} enum
+constants.
 
 [source,java,indent=0]
 ----
 include::{testDir}/example/ConditionalTestExecutionDemo.java[tags=user_guide_jre]
+----
+
+Since the enum constants defined in {JRE} are static for any given JUnit release, you
+might find that you need to configure a Java version that is not supported by the `JRE`
+enum. For example, as of JUnit Jupiter 5.12 the `JRE` enum defines `JAVA_25` as the
+highest supported Java version. However, you may wish to run your tests against later
+versions of Java. To support such use cases, you can specify arbitrary Java versions via
+the `versions` attributes in `@EnabledOnJre` and `@DisabledOnJre` and via the `minVersion`
+and `maxVersion` attributes in `@EnabledForJreRange` and `@DisabledForJreRange`.
+
+The following listing demonstrates the use of these annotations with arbitrary Java
+versions.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ConditionalTestExecutionDemo.java[tags=user_guide_jre_arbitrary_versions]
 ----
 
 [[writing-tests-conditional-execution-native]]

--- a/documentation/src/test/java/example/ConditionalTestExecutionDemo.java
+++ b/documentation/src/test/java/example/ConditionalTestExecutionDemo.java
@@ -10,11 +10,10 @@
 
 package example;
 
-import static org.junit.jupiter.api.condition.JRE.JAVA_10;
 import static org.junit.jupiter.api.condition.JRE.JAVA_11;
 import static org.junit.jupiter.api.condition.JRE.JAVA_17;
-import static org.junit.jupiter.api.condition.JRE.JAVA_18;
-import static org.junit.jupiter.api.condition.JRE.JAVA_8;
+import static org.junit.jupiter.api.condition.JRE.JAVA_21;
+import static org.junit.jupiter.api.condition.JRE.JAVA_25;
 import static org.junit.jupiter.api.condition.JRE.JAVA_9;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
@@ -25,7 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -41,7 +39,6 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.JRE;
 
 class ConditionalTestExecutionDemo {
 
@@ -103,77 +100,50 @@ class ConditionalTestExecutionDemo {
 	}
 	// end::user_guide_architecture[]
 
-	@Test
-	@EnabledOnJre(value = { JAVA_17, JAVA_18 }, versions = { 20, 21 })
-	void onJava17or18or20or21() {
-	}
-
-	@Test
-	@EnabledOnJre(versions = 21)
-	void onlyOnJava21() {
-	}
-
 	// tag::user_guide_jre[]
 	@Test
-	@EnabledOnJre(JAVA_8)
-	void onlyOnJava8() {
+	@EnabledOnJre(JAVA_17)
+	void onlyOnJava17() {
 		// ...
 	}
 
 	@Test
-	@EnabledOnJre({ JAVA_9, JAVA_10 })
-	void onJava9Or10() {
+	@EnabledOnJre({ JAVA_17, JAVA_21 })
+	void onJava17And21() {
 		// ...
+	}
+
+	@Test
+	@EnabledOnJre(versions = 26)
+	void onlyOnJava26() {
+	}
+
+	@Test
+	@EnabledOnJre(value = JAVA_25, versions = 26)
+	void onJava25And26() {
 	}
 
 	@Test
 	@EnabledForJreRange(min = JAVA_9, max = JAVA_11)
-	void fromJava9to11() {
+	void fromJava9To11() {
 		// ...
 	}
 
 	@Test
 	@EnabledForJreRange(min = JAVA_9)
-	void fromJava9toCurrentJavaFeatureNumber() {
+	void onJava9AndHigher() {
 		// ...
 	}
 
 	@Test
-	@EnabledForJreRange(minVersion = 10)
-	void fromJava10toCurrentJavaFeatureNumber() {
+	@EnabledForJreRange(minVersion = 26)
+	void onJava26AndHigher() {
 		// ...
 	}
 
 	@Test
-	@EnabledForJreRange(minVersion = 25)
-	void fromJava25toCurrentJavaFeatureNumber() {
-		// ...
-	}
-
-	@Disabled("DEMO: intended to fail")
-	@Test
-	@EnabledForJreRange(minVersion = 99, max = JRE.JAVA_17)
-	void fromJava99toJava17() {
-		// ...
-	}
-
-	@Disabled("DEMO: intended to fail")
-	@Test
-	@EnabledForJreRange(min = JAVA_11, minVersion = 10)
-	void competingJreAndMinVersions() {
-		// ...
-	}
-
-	@Disabled("DEMO: intended to fail")
-	@Test
-	@EnabledForJreRange(max = JAVA_11, maxVersion = 10)
-	void competingJreAndMaxVersions() {
-		// ...
-	}
-
-	@Test
-	@EnabledForJreRange(minVersion = 10, maxVersion = 25)
-	void fromJava17to25() {
+	@EnabledForJreRange(min = JAVA_25, maxVersion = 27)
+	void fromJava25To27() {
 		// ...
 	}
 
@@ -191,19 +161,19 @@ class ConditionalTestExecutionDemo {
 
 	@Test
 	@DisabledForJreRange(min = JAVA_9, max = JAVA_11)
-	void notFromJava9to11() {
+	void notFromJava9To11() {
 		// ...
 	}
 
 	@Test
 	@DisabledForJreRange(min = JAVA_9)
-	void notFromJava9toCurrentJavaFeatureNumber() {
+	void notOnJava9AndHigher() {
 		// ...
 	}
 
 	@Test
 	@DisabledForJreRange(max = JAVA_11)
-	void notFromJava8to11() {
+	void notFromJava8To11() {
 		// ...
 	}
 	// end::user_guide_jre[]

--- a/documentation/src/test/java/example/ConditionalTestExecutionDemo.java
+++ b/documentation/src/test/java/example/ConditionalTestExecutionDemo.java
@@ -12,6 +12,8 @@ package example;
 
 import static org.junit.jupiter.api.condition.JRE.JAVA_10;
 import static org.junit.jupiter.api.condition.JRE.JAVA_11;
+import static org.junit.jupiter.api.condition.JRE.JAVA_17;
+import static org.junit.jupiter.api.condition.JRE.JAVA_18;
 import static org.junit.jupiter.api.condition.JRE.JAVA_8;
 import static org.junit.jupiter.api.condition.JRE.JAVA_9;
 import static org.junit.jupiter.api.condition.OS.LINUX;
@@ -23,6 +25,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -38,6 +41,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
 import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.JRE;
 
 class ConditionalTestExecutionDemo {
 
@@ -99,6 +103,16 @@ class ConditionalTestExecutionDemo {
 	}
 	// end::user_guide_architecture[]
 
+	@Test
+	@EnabledOnJre(value = { JAVA_17, JAVA_18 }, versions = { 20, 21 })
+	void onJava17or18or20or21() {
+	}
+
+	@Test
+	@EnabledOnJre(versions = 21)
+	void onlyOnJava21() {
+	}
+
 	// tag::user_guide_jre[]
 	@Test
 	@EnabledOnJre(JAVA_8)
@@ -121,6 +135,45 @@ class ConditionalTestExecutionDemo {
 	@Test
 	@EnabledForJreRange(min = JAVA_9)
 	void fromJava9toCurrentJavaFeatureNumber() {
+		// ...
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 10)
+	void fromJava10toCurrentJavaFeatureNumber() {
+		// ...
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 25)
+	void fromJava25toCurrentJavaFeatureNumber() {
+		// ...
+	}
+
+	@Disabled("DEMO: intended to fail")
+	@Test
+	@EnabledForJreRange(minVersion = 99, max = JRE.JAVA_17)
+	void fromJava99toJava17() {
+		// ...
+	}
+
+	@Disabled("DEMO: intended to fail")
+	@Test
+	@EnabledForJreRange(min = JAVA_11, minVersion = 10)
+	void competingJreAndMinVersions() {
+		// ...
+	}
+
+	@Disabled("DEMO: intended to fail")
+	@Test
+	@EnabledForJreRange(max = JAVA_11, maxVersion = 10)
+	void competingJreAndMaxVersions() {
+		// ...
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 10, maxVersion = 25)
+	void fromJava17to25() {
 		// ...
 	}
 

--- a/documentation/src/test/java/example/ConditionalTestExecutionDemo.java
+++ b/documentation/src/test/java/example/ConditionalTestExecutionDemo.java
@@ -114,16 +114,6 @@ class ConditionalTestExecutionDemo {
 	}
 
 	@Test
-	@EnabledOnJre(versions = 26)
-	void onlyOnJava26() {
-	}
-
-	@Test
-	@EnabledOnJre(value = JAVA_25, versions = 26)
-	void onJava25And26() {
-	}
-
-	@Test
 	@EnabledForJreRange(min = JAVA_9, max = JAVA_11)
 	void fromJava9To11() {
 		// ...
@@ -132,18 +122,6 @@ class ConditionalTestExecutionDemo {
 	@Test
 	@EnabledForJreRange(min = JAVA_9)
 	void onJava9AndHigher() {
-		// ...
-	}
-
-	@Test
-	@EnabledForJreRange(minVersion = 26)
-	void onJava26AndHigher() {
-		// ...
-	}
-
-	@Test
-	@EnabledForJreRange(min = JAVA_25, maxVersion = 27)
-	void fromJava25To27() {
 		// ...
 	}
 
@@ -177,6 +155,56 @@ class ConditionalTestExecutionDemo {
 		// ...
 	}
 	// end::user_guide_jre[]
+
+	// tag::user_guide_jre_arbitrary_versions[]
+	@Test
+	@EnabledOnJre(versions = 26)
+	void onlyOnJava26() {
+		// ...
+	}
+
+	@Test
+	@EnabledOnJre(value = JAVA_25, versions = 26)
+	void onJava25And26() {
+		// ...
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 26)
+	void onJava26AndHigher() {
+		// ...
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_25, maxVersion = 27)
+	void fromJava25To27() {
+		// ...
+	}
+
+	@Test
+	@DisabledOnJre(versions = 26)
+	void notOnJava26() {
+		// ...
+	}
+
+	@Test
+	@DisabledOnJre(value = JAVA_25, versions = 26)
+	void notOnJava25And26() {
+		// ...
+	}
+
+	@Test
+	@DisabledForJreRange(minVersion = 26)
+	void notOnJava26AndHigher() {
+		// ...
+	}
+
+	@Test
+	@DisabledForJreRange(min = JAVA_25, maxVersion = 27)
+	void notFromJava25To27() {
+		// ...
+	}
+	// end::user_guide_jre_arbitrary_versions[]
 
 	// tag::user_guide_native[]
 	@Test

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreCondition.java
@@ -44,9 +44,9 @@ abstract class AbstractJreCondition<A extends Annotation> extends BooleanExecuti
 				() -> "JRE.UNDEFINED is not supported in @" + this.annotationName);
 		}
 		for (int version : versions) {
-			Preconditions.condition(version >= 8,
-				() -> String.format("Version [%d] in @%s must be greater than or equal to 8", version,
-					this.annotationName));
+			Preconditions.condition(version >= JRE.MINIMUM_VERSION,
+				() -> String.format("Version [%d] in @%s must be greater than or equal to %d", version,
+					this.annotationName, JRE.MINIMUM_VERSION));
 		}
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreCondition.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Function;
+
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * Abstract base class for {@link EnabledOnJreCondition} and
+ * {@link DisabledOnJreCondition}.
+ *
+ * @since 5.12
+ */
+abstract class AbstractJreCondition<A extends Annotation> extends BooleanExecutionCondition<A> {
+
+	static final String ENABLED_ON_CURRENT_JRE = //
+		"Enabled on JRE version: " + System.getProperty("java.version");
+
+	static final String DISABLED_ON_CURRENT_JRE = //
+		"Disabled on JRE version: " + System.getProperty("java.version");
+
+	private final String annotationName;
+
+	AbstractJreCondition(Class<A> annotationType, Function<A, String> customDisabledReason) {
+		super(annotationType, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE, customDisabledReason);
+		this.annotationName = annotationType.getSimpleName();
+	}
+
+	protected void validateVersions(JRE[] jres, int[] versions) {
+		Preconditions.condition(jres.length > 0 || versions.length > 0,
+			() -> "You must declare at least one JRE or version in @" + this.annotationName);
+		for (JRE jre : jres) {
+			Preconditions.condition(jre != JRE.UNDEFINED,
+				() -> "JRE.UNDEFINED is not supported in @" + this.annotationName);
+		}
+		for (int version : versions) {
+			Preconditions.condition(version >= 8,
+				() -> String.format("Version [%d] in @%s must be greater than or equal to 8", version,
+					this.annotationName));
+		}
+	}
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.condition;
+
+import static org.junit.jupiter.api.condition.AbstractJreCondition.DISABLED_ON_CURRENT_JRE;
+import static org.junit.jupiter.api.condition.AbstractJreCondition.ENABLED_ON_CURRENT_JRE;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Function;
+
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * Abstract base class for {@link EnabledForJreRangeCondition} and
+ * {@link DisabledForJreRangeCondition}.
+ *
+ * @since 5.12
+ */
+abstract class AbstractJreRangeCondition<A extends Annotation> extends BooleanExecutionCondition<A> {
+
+	private final String annotationName;
+
+	AbstractJreRangeCondition(Class<A> annotationType, Function<A, String> customDisabledReason) {
+		super(annotationType, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE, customDisabledReason);
+		this.annotationName = annotationType.getSimpleName();
+	}
+
+	protected final boolean isCurrentVersionWithinRange(JRE minJre, JRE maxJre, int minVersion, int maxVersion) {
+		boolean minJreSet = minJre != JRE.UNDEFINED;
+		boolean maxJreSet = maxJre != JRE.UNDEFINED;
+		boolean minVersionSet = minVersion != JRE.UNDEFINED_VERSION;
+		boolean maxVersionSet = maxVersion != JRE.UNDEFINED_VERSION;
+
+		// Users must choose between JRE enum constants and version numbers.
+		Preconditions.condition(!minJreSet || !minVersionSet, () -> String.format(
+			"@%s's minimum value must be configured with either a JRE enum constant or numeric version, but not both",
+			this.annotationName));
+		Preconditions.condition(!maxJreSet || !maxVersionSet, () -> String.format(
+			"@%s's maximum value must be configured with either a JRE enum constant or numeric version, but not both",
+			this.annotationName));
+
+		// Users must supply valid values for minVersion and maxVersion.
+		Preconditions.condition(!minVersionSet || (minVersion >= JRE.MINIMUM_VERSION),
+			() -> String.format("@%s's minVersion [%d] must be greater than or equal to %d", this.annotationName,
+				minVersion, JRE.MINIMUM_VERSION));
+		Preconditions.condition(!maxVersionSet || (maxVersion >= JRE.MINIMUM_VERSION),
+			() -> String.format("@%s's maxVersion [%d] must be greater than or equal to %d", this.annotationName,
+				maxVersion, JRE.MINIMUM_VERSION));
+
+		// Now that we have checked the basic preconditions, we need to ensure that we are
+		// using valid JRE enum constants.
+		if (!minJreSet) {
+			minJre = JRE.JAVA_8;
+		}
+		if (!maxJreSet) {
+			maxJre = JRE.OTHER;
+		}
+
+		int min = (minVersionSet ? minVersion : minJre.version());
+		int max = (maxVersionSet ? maxVersion : maxJre.version());
+
+		// Finally, we need to validate the effective minimum and maximum values.
+		Preconditions.condition((min != JRE.MINIMUM_VERSION || max != Integer.MAX_VALUE),
+			() -> "You must declare a non-default value for the minimum or maximum value in @" + this.annotationName);
+		Preconditions.condition(min >= JRE.MINIMUM_VERSION,
+			() -> String.format("@%s's minimum value [%d] must greater than or equal to %d", this.annotationName, min,
+				JRE.MINIMUM_VERSION));
+		Preconditions.condition(min <= max,
+			() -> String.format("@%s's minimum value [%d] must be less than or equal to its maximum value [%d]",
+				this.annotationName, min, max));
+
+		return JRE.isCurrentVersionWithinRange(min, max);
+	}
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
@@ -23,31 +23,32 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 abstract class BooleanExecutionCondition<A extends Annotation> implements ExecutionCondition {
 
-	private final Class<A> annotationType;
+	protected final Class<A> annotationType;
 	private final String enabledReason;
 	private final String disabledReason;
 	private final Function<A, String> customDisabledReason;
 
 	BooleanExecutionCondition(Class<A> annotationType, String enabledReason, String disabledReason,
 			Function<A, String> customDisabledReason) {
+
 		this.annotationType = annotationType;
 		this.enabledReason = enabledReason;
 		this.disabledReason = disabledReason;
 		this.customDisabledReason = customDisabledReason;
 	}
 
-	abstract boolean isEnabled(A annotation);
-
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		return findAnnotation(context.getElement(), annotationType) //
-				.map(annotation -> isEnabled(annotation) ? enabled(enabledReason)
-						: disabled(disabledReason, customDisabledReason.apply(annotation))) //
+		return findAnnotation(context.getElement(), this.annotationType) //
+				.map(annotation -> isEnabled(annotation) ? enabled(this.enabledReason)
+						: disabled(this.disabledReason, this.customDisabledReason.apply(annotation))) //
 				.orElseGet(this::enabledByDefault);
 	}
 
+	abstract boolean isEnabled(A annotation);
+
 	private ConditionEvaluationResult enabledByDefault() {
-		String reason = String.format("@%s is not present", annotationType.getSimpleName());
+		String reason = String.format("@%s is not present", this.annotationType.getSimpleName());
 		return enabled(reason);
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -24,7 +25,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * {@code @DisabledForJreRange} is used to signal that the annotated test class
  * or test method is <em>disabled</em> for a specific range of Java Runtime
- * Environment (JRE) versions from {@link #min} to {@link #max}.
+ * Environment (JRE) versions.
+ *
+ * <p>Version ranges can be specified as {@link JRE} enum constants via {@link #min}
+ * and {@link #max} or as integers via {@link #minVersion} and {@link #maxVersion}.
  *
  * <p>When applied at the class level, all test methods within that class will
  * be disabled on the same specified JRE versions.
@@ -82,28 +86,74 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface DisabledForJreRange {
 
 	/**
-	 * Java Runtime Environment version which is used as the lower boundary
-	 * for the version range that determines if the annotated class or method
-	 * should be disabled.
+	 * Java Runtime Environment version which is used as the lower boundary for
+	 * the version range that determines if the annotated class or method should
+	 * be disabled, specified as a {@link JRE} enum constant.
 	 *
-	 * <p>Defaults to {@link JRE#JAVA_8 JAVA_8}, as this is the lowest
-	 * supported JRE version.
+	 * <p>If a {@code JRE} enum constant does not exist for a particular JRE
+	 * version, you can specify the minimum version via {@link #minVersion()}
+	 * instead.
+	 *
+	 * <p>Defaults to {@link JRE#UNDEFINED UNDEFINED}, which will be interpreted
+	 * as {@link JRE#JAVA_8 JAVA_8} if the {@link #minVersion()} is not set.
 	 *
 	 * @see JRE
+	 * @see #minVersion()
 	 */
-	JRE min() default JRE.JAVA_8;
+	JRE min() default JRE.UNDEFINED;
 
 	/**
-	 * Java Runtime Environment version which is used as the upper boundary
-	 * for the version range that determines if the annotated class or method
-	 * should be disabled.
+	 * Java Runtime Environment version which is used as the upper boundary for
+	 * the version range that determines if the annotated class or method should
+	 * be disabled, specified as a {@link JRE} enum constant.
 	 *
-	 * <p>Defaults to {@link JRE#OTHER OTHER}, as this will always be the highest
-	 * possible version.
+	 * <p>If a {@code JRE} enum constant does not exist for a particular JRE
+	 * version, you can specify the maximum version via {@link #maxVersion()}
+	 * instead.
+	 *
+	 * <p>Defaults to {@link JRE#UNDEFINED UNDEFINED}, which will be interpreted
+	 * as {@link JRE#OTHER OTHER} if the {@link #maxVersion()} is not set.
 	 *
 	 * @see JRE
+	 * @see #maxVersion()
 	 */
-	JRE max() default JRE.OTHER;
+	JRE max() default JRE.UNDEFINED;
+
+	/**
+	 * Java Runtime Environment version which is used as the lower boundary for
+	 * the version range that determines if the annotated class or method should
+	 * be disabled, specified as an integer.
+	 *
+	 * <p>If a {@code JRE} enum constant exists for the particular JRE version,
+	 * you can specify the minimum version via {@link #min()} instead.
+	 *
+	 * <p>Defaults to {@code -1} to signal that {@link #min()} should be used instead.
+	 *
+	 * @since 5.12
+	 * @see #min()
+	 * @see JRE#featureVersion()
+	 * @see Runtime.Version#feature()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	int minVersion() default -1;
+
+	/**
+	 * Java Runtime Environment version which is used as the upper boundary for
+	 * the version range that determines if the annotated class or method should
+	 * be disabled, specified as an integer.
+	 *
+	 * <p>If a {@code JRE} enum constant exists for the particular JRE version,
+	 * you can specify the maximum version via {@link #max()} instead.
+	 *
+	 * <p>Defaults to {@code -1} to signal that {@link #max()} should be used instead.
+	 *
+	 * @since 5.12
+	 * @see #max()
+	 * @see JRE#featureVersion()
+	 * @see Runtime.Version#feature()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	int maxVersion() default -1;
 
 	/**
 	 * Custom reason to provide if the test or container is disabled.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
@@ -131,7 +131,7 @@ public @interface DisabledForJreRange {
 	 *
 	 * @since 5.12
 	 * @see #min()
-	 * @see JRE#featureVersion()
+	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")
@@ -149,7 +149,7 @@ public @interface DisabledForJreRange {
 	 *
 	 * @since 5.12
 	 * @see #max()
-	 * @see JRE#featureVersion()
+	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRangeCondition.java
@@ -10,9 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.condition.AbstractJreCondition.DISABLED_ON_CURRENT_JRE;
-import static org.junit.jupiter.api.condition.AbstractJreCondition.ENABLED_ON_CURRENT_JRE;
-
 import org.junit.jupiter.api.extension.ExecutionCondition;
 
 /**
@@ -21,17 +18,15 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
  * @since 5.6
  * @see DisabledForJreRange
  */
-class DisabledForJreRangeCondition extends BooleanExecutionCondition<DisabledForJreRange> {
+class DisabledForJreRangeCondition extends AbstractJreRangeCondition<DisabledForJreRange> {
 
 	DisabledForJreRangeCondition() {
-		super(DisabledForJreRange.class, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE,
-			DisabledForJreRange::disabledReason);
+		super(DisabledForJreRange.class, DisabledForJreRange::disabledReason);
 	}
 
 	@Override
-	boolean isEnabled(DisabledForJreRange annotation) {
-		return !EnabledForJreRangeCondition.isCurrentVersionWithinRange("DisabledForJreRange", annotation.min(),
-			annotation.max(), annotation.minVersion(), annotation.maxVersion());
+	boolean isEnabled(DisabledForJreRange range) {
+		return !isCurrentVersionWithinRange(range.min(), range.max(), range.minVersion(), range.maxVersion());
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRangeCondition.java
@@ -10,11 +10,10 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.condition.EnabledOnJreCondition.DISABLED_ON_CURRENT_JRE;
-import static org.junit.jupiter.api.condition.EnabledOnJreCondition.ENABLED_ON_CURRENT_JRE;
+import static org.junit.jupiter.api.condition.AbstractJreCondition.DISABLED_ON_CURRENT_JRE;
+import static org.junit.jupiter.api.condition.AbstractJreCondition.ENABLED_ON_CURRENT_JRE;
 
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.platform.commons.util.Preconditions;
 
 /**
  * {@link ExecutionCondition} for {@link DisabledForJreRange @DisabledForJreRange}.
@@ -31,15 +30,8 @@ class DisabledForJreRangeCondition extends BooleanExecutionCondition<DisabledFor
 
 	@Override
 	boolean isEnabled(DisabledForJreRange annotation) {
-		JRE min = annotation.min();
-		JRE max = annotation.max();
-
-		Preconditions.condition((min != JRE.JAVA_8 || max != JRE.OTHER),
-			"You must declare a non-default value for min or max in @DisabledForJreRange");
-		Preconditions.condition(max.compareTo(min) >= 0,
-			"@DisabledForJreRange.min must be less than or equal to @DisabledForJreRange.max");
-
-		return !JRE.isCurrentVersionWithinRange(min, max);
+		return !EnabledForJreRangeCondition.isCurrentVersionWithinRange("DisabledForJreRange", annotation.min(),
+			annotation.max(), annotation.minVersion(), annotation.maxVersion());
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -24,7 +25,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * {@code @DisabledOnJre} is used to signal that the annotated test class or
  * test method is <em>disabled</em> on one or more specified Java Runtime
- * Environment (JRE) {@linkplain #value versions}.
+ * Environment (JRE) versions.
+ *
+ * <p>Versions can be specified as {@link JRE} enum constants via {@link #value()}
+ * or as integers via {@link #versions()}.
  *
  * <p>When applied at the class level, all test methods within that class
  * will be disabled on the same specified JRE versions.
@@ -82,12 +86,31 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface DisabledOnJre {
 
 	/**
-	 * Java Runtime Environment versions on which the annotated class or
-	 * method should be disabled.
+	 * Java Runtime Environment versions on which the annotated class or method
+	 * should be disabled, specified as {@link JRE} enum constants.
+	 *
+	 * <p>If a {@code JRE} enum constant does not exist for a particular JRE
+	 * version, you can specify the version via {@link #versions()} instead.
 	 *
 	 * @see JRE
+	 * @see #versions()
 	 */
-	JRE[] value();
+	JRE[] value() default {};
+
+	/**
+	 * Java Runtime Environment versions on which the annotated class or method
+	 * should be disabled, specified as integers.
+	 *
+	 * <p>If a {@code JRE} enum constant exists for a particular JRE version, you
+	 * can specify the version via {@link #value()} instead.
+	 *
+	 * @since 5.12
+	 * @see #value()
+	 * @see JRE#featureVersion()
+	 * @see Runtime.Version#feature()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	int[] versions() default {};
 
 	/**
 	 * Custom reason to provide if the test or container is disabled.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
@@ -106,7 +106,7 @@ public @interface DisabledOnJre {
 	 *
 	 * @since 5.12
 	 * @see #value()
-	 * @see JRE#featureVersion()
+	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJreCondition.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.api.condition;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.extension.ExecutionCondition;
 
@@ -31,8 +32,8 @@ class DisabledOnJreCondition extends AbstractJreCondition<DisabledOnJre> {
 		JRE[] jres = annotation.value();
 		int[] versions = annotation.versions();
 		validateVersions(jres, versions);
-		return Arrays.stream(jres).noneMatch(JRE::isCurrentVersion)
-				&& Arrays.stream(versions).noneMatch(JRE::isCurrentVersion);
+		return IntStream.concat(Arrays.stream(jres).mapToInt(JRE::version), Arrays.stream(versions))//
+				.noneMatch(JRE::isCurrentVersion);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJreCondition.java
@@ -10,9 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import java.util.Arrays;
-import java.util.stream.IntStream;
-
 import org.junit.jupiter.api.extension.ExecutionCondition;
 
 /**
@@ -29,11 +26,7 @@ class DisabledOnJreCondition extends AbstractJreCondition<DisabledOnJre> {
 
 	@Override
 	boolean isEnabled(DisabledOnJre annotation) {
-		JRE[] jres = annotation.value();
-		int[] versions = annotation.versions();
-		validateVersions(jres, versions);
-		return IntStream.concat(Arrays.stream(jres).mapToInt(JRE::version), Arrays.stream(versions))//
-				.noneMatch(JRE::isCurrentVersion);
+		return validatedVersions(annotation.value(), annotation.versions()).noneMatch(JRE::isCurrentVersion);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJreCondition.java
@@ -10,13 +10,9 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.condition.EnabledOnJreCondition.DISABLED_ON_CURRENT_JRE;
-import static org.junit.jupiter.api.condition.EnabledOnJreCondition.ENABLED_ON_CURRENT_JRE;
-
 import java.util.Arrays;
 
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.platform.commons.util.Preconditions;
 
 /**
  * {@link ExecutionCondition} for {@link DisabledOnJre @DisabledOnJre}.
@@ -24,17 +20,19 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see DisabledOnJre
  */
-class DisabledOnJreCondition extends BooleanExecutionCondition<DisabledOnJre> {
+class DisabledOnJreCondition extends AbstractJreCondition<DisabledOnJre> {
 
 	DisabledOnJreCondition() {
-		super(DisabledOnJre.class, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE, DisabledOnJre::disabledReason);
+		super(DisabledOnJre.class, DisabledOnJre::disabledReason);
 	}
 
 	@Override
 	boolean isEnabled(DisabledOnJre annotation) {
-		JRE[] versions = annotation.value();
-		Preconditions.condition(versions.length > 0, "You must declare at least one JRE in @DisabledOnJre");
-		return Arrays.stream(versions).noneMatch(JRE::isCurrentVersion);
+		JRE[] jres = annotation.value();
+		int[] versions = annotation.versions();
+		validateVersions(jres, versions);
+		return Arrays.stream(jres).noneMatch(JRE::isCurrentVersion)
+				&& Arrays.stream(versions).noneMatch(JRE::isCurrentVersion);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
@@ -131,7 +131,7 @@ public @interface EnabledForJreRange {
 	 *
 	 * @since 5.12
 	 * @see #min()
-	 * @see JRE#featureVersion()
+	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")
@@ -149,7 +149,7 @@ public @interface EnabledForJreRange {
 	 *
 	 * @since 5.12
 	 * @see #max()
-	 * @see JRE#featureVersion()
+	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -24,7 +25,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * {@code @EnabledForJreRange} is used to signal that the annotated test class or
  * test method is only <em>enabled</em> for a specific range of Java Runtime
- * Environment (JRE) versions from {@link #min} to {@link #max}.
+ * Environment (JRE) versions.
+ *
+ * <p>Version ranges can be specified as {@link JRE} enum constants via {@link #min}
+ * and {@link #max} or as integers via {@link #minVersion} and {@link #maxVersion}.
  *
  * <p>When applied at the class level, all test methods within that class will
  * be enabled on the same specified JRE versions.
@@ -82,28 +86,74 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface EnabledForJreRange {
 
 	/**
-	 * Java Runtime Environment version which should be used as the lower boundary
-	 * for the version range that determines if the annotated class or method
-	 * should be enabled.
+	 * Java Runtime Environment version which is used as the lower boundary for
+	 * the version range that determines if the annotated class or method should
+	 * be enabled, specified as a {@link JRE} enum constant.
 	 *
-	 * <p>Defaults to {@link JRE#JAVA_8 JAVA_8}, as this is the lowest
-	 * supported JRE version.
+	 * <p>If a {@code JRE} enum constant does not exist for a particular JRE
+	 * version, you can specify the minimum version via {@link #minVersion()}
+	 * instead.
+	 *
+	 * <p>Defaults to {@link JRE#UNDEFINED UNDEFINED}, which will be interpreted
+	 * as {@link JRE#JAVA_8 JAVA_8} if the {@link #minVersion()} is not set.
 	 *
 	 * @see JRE
+	 * @see #minVersion()
 	 */
-	JRE min() default JRE.JAVA_8;
+	JRE min() default JRE.UNDEFINED;
 
 	/**
-	 * Java Runtime Environment version which should be used as the upper boundary
-	 * for the version range that determines if the annotated class or method
-	 * should be enabled.
+	 * Java Runtime Environment version which is used as the upper boundary for
+	 * the version range that determines if the annotated class or method should
+	 * be enabled, specified as a {@link JRE} enum constant.
 	 *
-	 * <p>Defaults to {@link JRE#OTHER OTHER}, as this will always be the highest
-	 * possible version.
+	 * <p>If a {@code JRE} enum constant does not exist for a particular JRE
+	 * version, you can specify the maximum version via {@link #maxVersion()}
+	 * instead.
+	 *
+	 * <p>Defaults to {@link JRE#UNDEFINED UNDEFINED}, which will be interpreted
+	 * as {@link JRE#OTHER OTHER} if the {@link #maxVersion()} is not set.
 	 *
 	 * @see JRE
+	 * @see #maxVersion()
 	 */
-	JRE max() default JRE.OTHER;
+	JRE max() default JRE.UNDEFINED;
+
+	/**
+	 * Java Runtime Environment version which is used as the lower boundary for
+	 * the version range that determines if the annotated class or method should
+	 * be enabled, specified as an integer.
+	 *
+	 * <p>If a {@code JRE} enum constant exists for the particular JRE version,
+	 * you can specify the minimum version via {@link #min()} instead.
+	 *
+	 * <p>Defaults to {@code -1} to signal that {@link #min()} should be used instead.
+	 *
+	 * @since 5.12
+	 * @see #min()
+	 * @see JRE#featureVersion()
+	 * @see Runtime.Version#feature()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	int minVersion() default -1;
+
+	/**
+	 * Java Runtime Environment version which is used as the upper boundary for
+	 * the version range that determines if the annotated class or method should
+	 * be enabled, specified as an integer.
+	 *
+	 * <p>If a {@code JRE} enum constant exists for the particular JRE version,
+	 * you can specify the maximum version via {@link #max()} instead.
+	 *
+	 * <p>Defaults to {@code -1} to signal that {@link #max()} should be used instead.
+	 *
+	 * @since 5.12
+	 * @see #max()
+	 * @see JRE#featureVersion()
+	 * @see Runtime.Version#feature()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	int maxVersion() default -1;
 
 	/**
 	 * Custom reason to provide if the test or container is disabled.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRangeCondition.java
@@ -52,12 +52,12 @@ class EnabledForJreRangeCondition extends BooleanExecutionCondition<EnabledForJr
 			annotationName));
 
 		// Users must supply valid values for minVersion and maxVersion.
-		Preconditions.condition(!minVersionSet || (minVersion >= 8),
-			() -> String.format("@%s's minVersion [%d] must be greater than or equal to 8", annotationName,
-				minVersion));
-		Preconditions.condition(!maxVersionSet || (maxVersion >= 8),
-			() -> String.format("@%s's maxVersion [%d] must be greater than or equal to 8", annotationName,
-				maxVersion));
+		Preconditions.condition(!minVersionSet || (minVersion >= JRE.MINIMUM_VERSION),
+			() -> String.format("@%s's minVersion [%d] must be greater than or equal to %d", annotationName, minVersion,
+				JRE.MINIMUM_VERSION));
+		Preconditions.condition(!maxVersionSet || (maxVersion >= JRE.MINIMUM_VERSION),
+			() -> String.format("@%s's maxVersion [%d] must be greater than or equal to %d", annotationName, maxVersion,
+				JRE.MINIMUM_VERSION));
 
 		// Now that we have checked the basic preconditions, we need to ensure that we are
 		// using valid JRE enum constants.
@@ -72,10 +72,11 @@ class EnabledForJreRangeCondition extends BooleanExecutionCondition<EnabledForJr
 		int max = (maxVersionSet ? maxVersion : maxJre.version());
 
 		// Finally, we need to validate the effective minimum and maximum values.
-		Preconditions.condition((min != 8 || max != Integer.MAX_VALUE),
+		Preconditions.condition((min != JRE.MINIMUM_VERSION || max != Integer.MAX_VALUE),
 			() -> "You must declare a non-default value for the minimum or maximum value in @" + annotationName);
-		Preconditions.condition(min >= 8,
-			() -> String.format("@%s's minimum value [%d] must greater than or equal to 8", annotationName, min));
+		Preconditions.condition(min >= JRE.MINIMUM_VERSION,
+			() -> String.format("@%s's minimum value [%d] must greater than or equal to %d", annotationName, min,
+				JRE.MINIMUM_VERSION));
 		Preconditions.condition(min <= max,
 			() -> String.format("@%s's minimum value [%d] must be less than or equal to its maximum value [%d]",
 				annotationName, min, max));

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRangeCondition.java
@@ -10,11 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.condition.AbstractJreCondition.DISABLED_ON_CURRENT_JRE;
-import static org.junit.jupiter.api.condition.AbstractJreCondition.ENABLED_ON_CURRENT_JRE;
-
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.platform.commons.util.Preconditions;
 
 /**
  * {@link ExecutionCondition} for {@link EnabledForJreRange @EnabledForJreRange}.
@@ -22,66 +18,15 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.6
  * @see EnabledForJreRange
  */
-class EnabledForJreRangeCondition extends BooleanExecutionCondition<EnabledForJreRange> {
+class EnabledForJreRangeCondition extends AbstractJreRangeCondition<EnabledForJreRange> {
 
 	EnabledForJreRangeCondition() {
-		super(EnabledForJreRange.class, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE,
-			EnabledForJreRange::disabledReason);
+		super(EnabledForJreRange.class, EnabledForJreRange::disabledReason);
 	}
 
 	@Override
-	boolean isEnabled(EnabledForJreRange annotation) {
-		return isCurrentVersionWithinRange("EnabledForJreRange", annotation.min(), annotation.max(),
-			annotation.minVersion(), annotation.maxVersion());
-	}
-
-	static boolean isCurrentVersionWithinRange(String annotationName, JRE minJre, JRE maxJre, int minVersion,
-			int maxVersion) {
-
-		boolean minJreSet = minJre != JRE.UNDEFINED;
-		boolean maxJreSet = maxJre != JRE.UNDEFINED;
-		boolean minVersionSet = minVersion != JRE.UNDEFINED_VERSION;
-		boolean maxVersionSet = maxVersion != JRE.UNDEFINED_VERSION;
-
-		// Users must choose between JRE enum constants and version numbers.
-		Preconditions.condition(!minJreSet || !minVersionSet, () -> String.format(
-			"@%s's minimum value must be configured with either a JRE enum constant or numeric version, but not both",
-			annotationName));
-		Preconditions.condition(!maxJreSet || !maxVersionSet, () -> String.format(
-			"@%s's maximum value must be configured with either a JRE enum constant or numeric version, but not both",
-			annotationName));
-
-		// Users must supply valid values for minVersion and maxVersion.
-		Preconditions.condition(!minVersionSet || (minVersion >= JRE.MINIMUM_VERSION),
-			() -> String.format("@%s's minVersion [%d] must be greater than or equal to %d", annotationName, minVersion,
-				JRE.MINIMUM_VERSION));
-		Preconditions.condition(!maxVersionSet || (maxVersion >= JRE.MINIMUM_VERSION),
-			() -> String.format("@%s's maxVersion [%d] must be greater than or equal to %d", annotationName, maxVersion,
-				JRE.MINIMUM_VERSION));
-
-		// Now that we have checked the basic preconditions, we need to ensure that we are
-		// using valid JRE enum constants.
-		if (!minJreSet) {
-			minJre = JRE.JAVA_8;
-		}
-		if (!maxJreSet) {
-			maxJre = JRE.OTHER;
-		}
-
-		int min = (minVersionSet ? minVersion : minJre.version());
-		int max = (maxVersionSet ? maxVersion : maxJre.version());
-
-		// Finally, we need to validate the effective minimum and maximum values.
-		Preconditions.condition((min != JRE.MINIMUM_VERSION || max != Integer.MAX_VALUE),
-			() -> "You must declare a non-default value for the minimum or maximum value in @" + annotationName);
-		Preconditions.condition(min >= JRE.MINIMUM_VERSION,
-			() -> String.format("@%s's minimum value [%d] must greater than or equal to %d", annotationName, min,
-				JRE.MINIMUM_VERSION));
-		Preconditions.condition(min <= max,
-			() -> String.format("@%s's minimum value [%d] must be less than or equal to its maximum value [%d]",
-				annotationName, min, max));
-
-		return JRE.isCurrentVersionWithinRange(min, max);
+	boolean isEnabled(EnabledForJreRange range) {
+		return isCurrentVersionWithinRange(range.min(), range.max(), range.minVersion(), range.maxVersion());
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
@@ -106,7 +106,7 @@ public @interface EnabledOnJre {
 	 *
 	 * @since 5.12
 	 * @see #value()
-	 * @see JRE#featureVersion()
+	 * @see JRE#version()
 	 * @see Runtime.Version#feature()
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api.condition;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
@@ -23,8 +24,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * {@code @EnabledOnJre} is used to signal that the annotated test class or
- * test method is only <em>enabled</em> on one or more specified Java
- * Runtime Environment (JRE) {@linkplain #value versions}.
+ * test method is only <em>enabled</em> on one or more specified Java Runtime
+ * Environment (JRE) versions.
+ *
+ * <p>Versions can be specified as {@link JRE} enum constants via {@link #value()}
+ * or as integers via {@link #versions()}.
  *
  * <p>When applied at the class level, all test methods within that class
  * will be enabled on the same specified JRE versions.
@@ -82,12 +86,31 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface EnabledOnJre {
 
 	/**
-	 * Java Runtime Environment versions on which the annotated class or
-	 * method should be enabled.
+	 * Java Runtime Environment versions on which the annotated class or method
+	 * should be enabled, specified as {@link JRE} enum constants.
+	 *
+	 * <p>If a {@code JRE} enum constant does not exist for a particular JRE
+	 * version, you can specify the version via {@link #versions()} instead.
 	 *
 	 * @see JRE
+	 * @see #versions()
 	 */
-	JRE[] value();
+	JRE[] value() default {};
+
+	/**
+	 * Java Runtime Environment versions on which the annotated class or method
+	 * should be enabled, specified as integers.
+	 *
+	 * <p>If a {@code JRE} enum constant exists for a particular JRE version, you
+	 * can specify the version via {@link #value()} instead.
+	 *
+	 * @since 5.12
+	 * @see #value()
+	 * @see JRE#featureVersion()
+	 * @see Runtime.Version#feature()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	int[] versions() default {};
 
 	/**
 	 * Custom reason to provide if the test or container is disabled.
@@ -100,4 +123,5 @@ public @interface EnabledOnJre {
 	 */
 	@API(status = STABLE, since = "5.7")
 	String disabledReason() default "";
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJreCondition.java
@@ -13,7 +13,6 @@ package org.junit.jupiter.api.condition;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.extension.ExecutionCondition;
-import org.junit.platform.commons.util.Preconditions;
 
 /**
  * {@link ExecutionCondition} for {@link EnabledOnJre @EnabledOnJre}.
@@ -21,23 +20,19 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.1
  * @see EnabledOnJre
  */
-class EnabledOnJreCondition extends BooleanExecutionCondition<EnabledOnJre> {
-
-	static final String ENABLED_ON_CURRENT_JRE = //
-		"Enabled on JRE version: " + System.getProperty("java.version");
-
-	static final String DISABLED_ON_CURRENT_JRE = //
-		"Disabled on JRE version: " + System.getProperty("java.version");
+class EnabledOnJreCondition extends AbstractJreCondition<EnabledOnJre> {
 
 	EnabledOnJreCondition() {
-		super(EnabledOnJre.class, ENABLED_ON_CURRENT_JRE, DISABLED_ON_CURRENT_JRE, EnabledOnJre::disabledReason);
+		super(EnabledOnJre.class, EnabledOnJre::disabledReason);
 	}
 
 	@Override
 	boolean isEnabled(EnabledOnJre annotation) {
-		JRE[] versions = annotation.value();
-		Preconditions.condition(versions.length > 0, "You must declare at least one JRE in @EnabledOnJre");
-		return Arrays.stream(versions).anyMatch(JRE::isCurrentVersion);
+		JRE[] jres = annotation.value();
+		int[] versions = annotation.versions();
+		validateVersions(jres, versions);
+		return Arrays.stream(jres).anyMatch(JRE::isCurrentVersion)
+				|| Arrays.stream(versions).anyMatch(JRE::isCurrentVersion);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJreCondition.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.api.condition;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.extension.ExecutionCondition;
 
@@ -31,8 +32,8 @@ class EnabledOnJreCondition extends AbstractJreCondition<EnabledOnJre> {
 		JRE[] jres = annotation.value();
 		int[] versions = annotation.versions();
 		validateVersions(jres, versions);
-		return Arrays.stream(jres).anyMatch(JRE::isCurrentVersion)
-				|| Arrays.stream(versions).anyMatch(JRE::isCurrentVersion);
+		return IntStream.concat(Arrays.stream(jres).mapToInt(JRE::version), Arrays.stream(versions))//
+				.anyMatch(JRE::isCurrentVersion);
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJreCondition.java
@@ -10,9 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import java.util.Arrays;
-import java.util.stream.IntStream;
-
 import org.junit.jupiter.api.extension.ExecutionCondition;
 
 /**
@@ -29,11 +26,7 @@ class EnabledOnJreCondition extends AbstractJreCondition<EnabledOnJre> {
 
 	@Override
 	boolean isEnabled(EnabledOnJre annotation) {
-		JRE[] jres = annotation.value();
-		int[] versions = annotation.versions();
-		validateVersions(jres, versions);
-		return IntStream.concat(Arrays.stream(jres).mapToInt(JRE::version), Arrays.stream(versions))//
-				.anyMatch(JRE::isCurrentVersion);
+		return validatedVersions(annotation.value(), annotation.versions()).anyMatch(JRE::isCurrentVersion);
 	}
 
 }

--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -189,7 +189,7 @@ public enum JRE {
 	 * @since 5.12
 	 * @see #currentVersionNumber()
 	 */
-	@API(status = EXPERIMENTAL, since = "5.12")
+	@API(status = STABLE, since = "5.12")
 	public static JRE currentJre() {
 		return CURRENT_JRE;
 	}

--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -82,6 +82,8 @@ public enum JRE {
 
 	static final int UNDEFINED_VERSION = -1;
 
+	static final int MINIMUM_VERSION = 8;
+
 	private static final Logger logger = LoggerFactory.getLogger(JRE.class);
 
 	private static final int CURRENT_VERSION = determineCurrentVersion();

--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -120,8 +120,7 @@ public enum JRE {
 	private static JRE determineCurrentJre(int currentVersion) {
 		switch (currentVersion) {
 			case UNDEFINED_VERSION:
-				// null signals that the current JRE version is undefined.
-				return null;<%--
+				return UNDEFINED;<%--
 			--%>@for(var jre : jres)
 			case ${jre.getVersion()}:
 				return JAVA_${jre.getVersion()};<%--
@@ -157,7 +156,7 @@ public enum JRE {
 	/**
 	 * @return {@code true} if <em>this</em> {@code JRE} is known to be the
 	 * Java Runtime Environment version for the currently executing JVM or if
-	 * the version is {@link #OTHER}
+	 * the version is {@link #OTHER} or {@link #UNDEFINED}
 	 *
 	 * @see #currentJre()
 	 * @see #currentVersionNumber()
@@ -168,8 +167,7 @@ public enum JRE {
 
 	/**
 	 * @return the {@link JRE} for the currently executing JVM, potentially
-	 * {@link #OTHER} or {@code null} if the current JVM version could not be
-	 * determined
+	 * {@link #OTHER} or {@link #UNDEFINED}
 	 *
 	 * @since 5.7
 	 * @see #currentVersionNumber()
@@ -183,8 +181,7 @@ public enum JRE {
 
 	/**
 	 * @return the {@link JRE} for the currently executing JVM, potentially
-	 * {@link #OTHER} or {@code null} if the current JVM version could not be
-	 * determined
+	 * {@link #OTHER} or {@link #UNDEFINED}
 	 *
 	 * @since 5.12
 	 * @see #currentVersionNumber()

--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -46,7 +46,7 @@ public enum JRE {
 	 * <p>This constant is used by JUnit as a default configuration value but is
 	 * not intended to be used by users.
 	 *
-	 * <p>This constant returns {@code -1} for its {@link #version() version}.
+	 * <p>This constant returns {@code -1} for its {@linkplain #version() version}.
 	 *
 	 * @since 5.12
 	 */
@@ -76,7 +76,7 @@ public enum JRE {
 --%>@endfor
 	 *
 	 * <p>This constant returns {@link Integer#MAX_VALUE} for its
-	 * {@link #version() version}.
+	 * {@linkplain #version() version}.
 	 */
 	OTHER(Integer.MAX_VALUE);
 

--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -7,10 +7,11 @@
 ${licenseHeader}
 package org.junit.jupiter.api.condition;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.Method;
-import java.util.EnumSet;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.logging.Logger;
@@ -38,6 +39,19 @@ import org.junit.platform.commons.util.StringUtils;
  */
 @API(status = STABLE, since = "5.1")
 public enum JRE {
+
+	/**
+	 * An undefined JRE version.
+	 *
+	 * <p>This constant is used by JUnit as a default configuration value but is
+	 * not intended to be used by users.
+	 *
+	 * <p>This constant returns {@code -1} for its {@link #version() version}.
+	 *
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	UNDEFINED(-1),
 @for(var jre : jres)
 	/**
 	 * Java ${jre.getVersion()}.
@@ -49,7 +63,7 @@ public enum JRE {
 	@if(jre.getSince() != null)<%--
 --%>@API(status = STABLE, since = "${jre.getSince()}")
 	@endif<%--
---%>JAVA_${jre.getVersion()},
+--%>JAVA_${jre.getVersion()}(${jre.getVersion()}),
 @endfor
 	/**
 	 * A JRE version other than <%--
@@ -60,14 +74,21 @@ public enum JRE {
 	--%>@if(jre.getIndex() % 3 == 1 && !jre.isLast())
 	 * @elseif(!jre.isLast()) @endif<%--
 --%>@endfor
+	 *
+	 * <p>This constant returns {@link Integer#MAX_VALUE} for its
+	 * {@link #version() version}.
 	 */
-	OTHER;
+	OTHER(Integer.MAX_VALUE);
+
+	static final int UNDEFINED_VERSION = -1;
 
 	private static final Logger logger = LoggerFactory.getLogger(JRE.class);
 
-	private static final JRE CURRENT_VERSION = determineCurrentVersion();
+	private static final int CURRENT_VERSION = determineCurrentVersion();
 
-	private static JRE determineCurrentVersion() {
+	private static final JRE CURRENT_JRE = determineCurrentJre(CURRENT_VERSION);
+
+	private static int determineCurrentVersion() {
 		String javaVersion = System.getProperty("java.version");
 		boolean javaVersionIsBlank = StringUtils.isBlank(javaVersion);
 
@@ -77,7 +98,7 @@ public enum JRE {
 		}
 
 		if (!javaVersionIsBlank && javaVersion.startsWith("1.8")) {
-			return JAVA_8;
+			return 8;
 		}
 
 		try {
@@ -87,48 +108,121 @@ public enum JRE {
 			Method versionMethod = Runtime.class.getMethod("version");
 			Object version = ReflectionSupport.invokeMethod(versionMethod, null);
 			Method majorMethod = version.getClass().getMethod("major");
-			int major = (int) ReflectionSupport.invokeMethod(majorMethod, version);
-			switch (major) {<%--
-				--%>@for(var jre : jres)<%--
-					--%>@if(jre.getVersion() != 8)
-				case ${jre.getVersion()}:
-					return JAVA_${jre.getVersion()};<%--
-					--%>@endif<%--
-				--%>@endfor
-				default:
-					return OTHER;
-			}
+			return (int) ReflectionSupport.invokeMethod(majorMethod, version);
 		}
 		catch (Exception ex) {
 			logger.debug(ex, () -> "Failed to determine the current JRE version via java.lang.Runtime.Version.");
 		}
 
-		// null signals that the current JRE version is "unknown"
-		return null;
+		return UNDEFINED_VERSION;
+	}
+
+	private static JRE determineCurrentJre(int currentVersion) {
+		switch (currentVersion) {
+			case UNDEFINED_VERSION:
+				// null signals that the current JRE version is undefined.
+				return null;<%--
+			--%>@for(var jre : jres)
+			case ${jre.getVersion()}:
+				return JAVA_${jre.getVersion()};<%--
+			--%>@endfor
+			default:
+				return OTHER;
+		}
+	}
+
+	private final int version;
+
+	private JRE(int version) {
+		this.version = version;
+	}
+
+	/**
+	 * Get the version of <em>this</em> {@code JRE}.
+	 *
+	 * <p>If this {@code JRE} is {@link #UNDEFINED}, this method returns
+	 * {@code -1}. If this {@code JRE} is {@link #OTHER}, this method returns
+	 * {@link Integer#MAX_VALUE}.
+	 *
+	 * @return the version of this {@code JRE}
+	 * @since 5.12
+	 * @see Runtime.Version#feature()
+	 * @see #currentVersionNumber()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	public int version() {
+		return this.version;
 	}
 
 	/**
 	 * @return {@code true} if <em>this</em> {@code JRE} is known to be the
 	 * Java Runtime Environment version for the currently executing JVM or if
 	 * the version is {@link #OTHER}
+	 *
+	 * @see #currentJre()
+	 * @see #currentVersionNumber()
 	 */
 	public boolean isCurrentVersion() {
-		return this == CURRENT_VERSION;
+		return this == CURRENT_JRE;
 	}
 
 	/**
 	 * @return the {@link JRE} for the currently executing JVM, potentially
-	 * {@link #OTHER}
+	 * {@link #OTHER} or {@code null} if the current JVM version could not be
+	 * determined
 	 *
 	 * @since 5.7
+	 * @see #currentVersionNumber()
+	 * @deprecated in favor of {@link #currentJre()}
 	 */
-	@API(status = STABLE, since = "5.7")
+	@API(status = DEPRECATED, since = "5.12")
+	@Deprecated
 	public static JRE currentVersion() {
+		return currentJre();
+	}
+
+	/**
+	 * @return the {@link JRE} for the currently executing JVM, potentially
+	 * {@link #OTHER} or {@code null} if the current JVM version could not be
+	 * determined
+	 *
+	 * @since 5.12
+	 * @see #currentVersionNumber()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	public static JRE currentJre() {
+		return CURRENT_JRE;
+	}
+
+	/**
+	 * @return the version number for the currently executing JVM, or {@code -1}
+	 * if the current JVM version could not be determined
+	 *
+	 * @since 5.12
+	 * @see Runtime.Version#feature()
+	 * @see #currentJre()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	public static int currentVersionNumber() {
 		return CURRENT_VERSION;
 	}
 
-	static boolean isCurrentVersionWithinRange(JRE min, JRE max) {
-		return EnumSet.range(min, max).contains(CURRENT_VERSION);
+	/**
+	 * @return {@code true} if the supplied version number is known to be the
+	 * Java Runtime Environment version for the currently executing JVM or if
+	 * the supplied version number is {@code -1} and the current JVM version
+	 * could not be determined
+	 *
+	 * @since 5.12
+	 * @see Runtime.Version#feature()
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	public static boolean isCurrentVersion(int version) {
+		return version == CURRENT_VERSION;
+	}
+
+	static boolean isCurrentVersionWithinRange(int min, int max) {
+		return CURRENT_VERSION >= min && CURRENT_VERSION <= max;
 	}
 
 }

--- a/junit-jupiter-api/src/templates/resources/testFixtures/org/junit/jupiter/api/condition/JavaVersionPredicates.java.jte
+++ b/junit-jupiter-api/src/templates/resources/testFixtures/org/junit/jupiter/api/condition/JavaVersionPredicates.java.jte
@@ -9,10 +9,10 @@ package org.junit.jupiter.api.condition;
 
 public class JavaVersionPredicates {
 
-	private static final String JAVA_VERSION = System.getProperty("java.version");
+	private static final int JAVA_VERSION = Runtime.version().feature();
 @for(JRE jre : jres)
 	static boolean onJava${jre.getVersion()}() {
-		return JAVA_VERSION.startsWith("@if(jre.getVersion() == 8)1.@endif${jre.getVersion()}");
+		return JAVA_VERSION == ${jre.getVersion()};
 	}
 @endfor
 	static boolean onKnownVersion() {

--- a/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/DisabledOnJreConditionTests.java.jte
+++ b/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/DisabledOnJreConditionTests.java.jte
@@ -7,8 +7,7 @@
 ${licenseHeader}
 package org.junit.jupiter.api.condition;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @for(var jre : jresSortedByStringValue)<%--
 --%>import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava${jre.getVersion()};
 @endfor<%--
@@ -19,7 +18,8 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.platform.commons.PreconditionViolationException;
 
 /**
- * Unit tests for {@link DisabledOnJreCondition}.
+ * Unit tests for {@link DisabledOnJreCondition}, generated from
+ * {@code DisabledOnJreConditionTests.java.jte}.
  *
  * <p>Note that test method names MUST match the test method names in
  * {@link DisabledOnJreIntegrationTests}.
@@ -27,6 +27,8 @@ import org.junit.platform.commons.PreconditionViolationException;
  * @since 5.1
  */
 class DisabledOnJreConditionTests extends AbstractExecutionConditionTests {
+
+	private static final String JAVA_VERSION = System.getProperty("java.version");
 
 	@Override
 	protected ExecutionCondition getExecutionCondition() {
@@ -49,12 +51,33 @@ class DisabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
-	 * @see DisabledOnJreIntegrationTests#missingJreDeclaration()
+	 * @see DisabledOnJreIntegrationTests#missingVersionDeclaration()
 	 */
 	@Test
-	void missingJreDeclaration() {
-		Exception exception = assertThrows(PreconditionViolationException.class, this::evaluateCondition);
-		assertThat(exception).hasMessageContaining("You must declare at least one JRE");
+	void missingVersionDeclaration() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("You must declare at least one JRE or version in @DisabledOnJre");
+	}
+
+	/**
+	 * @see DisabledOnJreIntegrationTests#jreUndefined()
+	 */
+	@Test
+	void jreUndefined() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("JRE.UNDEFINED is not supported in @DisabledOnJre");
+	}
+
+	/**
+	 * @see DisabledOnJreIntegrationTests#version7()
+	 */
+	@Test
+	void version7() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("Version [7] in @DisabledOnJre must be greater than or equal to 8");
 	}
 
 	/**
@@ -68,10 +91,20 @@ class DisabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	}
 @for(var jre : jres)
 	/**
-	 * @see DisabledOnJreIntegrationTests#java${jre.getVersion()}()
+	 * @see DisabledOnJreIntegrationTests#jre${jre.getVersion()}()
 	 */
 	@Test
-	void java${jre.getVersion()}() {
+	void jre${jre.getVersion()}() {
+		evaluateCondition();
+		assertDisabledOnCurrentJreIf(onJava${jre.getVersion()}());
+	}
+@endfor<%--
+--%>@for(var jre : jres)
+	/**
+	 * @see DisabledOnJreIntegrationTests#version${jre.getVersion()}()
+	 */
+	@Test
+	void version${jre.getVersion()}() {
 		evaluateCondition();
 		assertDisabledOnCurrentJreIf(onJava${jre.getVersion()}());
 	}
@@ -88,11 +121,11 @@ class DisabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	private void assertDisabledOnCurrentJreIf(boolean condition) {
 		if (condition) {
 			assertDisabled();
-			assertReasonContains("Disabled on JRE version: " + System.getProperty("java.version"));
+			assertReasonContains("Disabled on JRE version: " + JAVA_VERSION);
 		}
 		else {
 			assertEnabled();
-			assertReasonContains("Enabled on JRE version: " + System.getProperty("java.version"));
+			assertReasonContains("Enabled on JRE version: " + JAVA_VERSION);
 		}
 	}
 

--- a/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java.jte
+++ b/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java.jte
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 --%>import static org.junit.jupiter.api.condition.JRE.JAVA_${jre.getVersion()};
 @endfor<%--
 --%>import static org.junit.jupiter.api.condition.JRE.OTHER;
+import static org.junit.jupiter.api.condition.JRE.UNDEFINED;
 @for(var jre : jresSortedByStringValue)<%--
 --%>import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava${jre.getVersion()};
 @endfor<%--
@@ -23,7 +24,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integration tests for {@link DisabledOnJre}.
+ * Integration tests for {@link DisabledOnJre @DisabledOnJre}, generated from
+ * {@code DisabledOnJreIntegrationTests.java.jte}.
  *
  * @since 5.1
  */
@@ -37,7 +39,19 @@ class DisabledOnJreIntegrationTests {
 	@Test
 	@Disabled("Only used in a unit test via reflection")
 	@DisabledOnJre({})
-	void missingJreDeclaration() {
+	void missingVersionDeclaration() {
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledOnJre(UNDEFINED)
+	void jreUndefined() {
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledOnJre(versions = 7)
+	void version7() {
 	}
 
 	@Test
@@ -53,7 +67,14 @@ class DisabledOnJreIntegrationTests {
 @for(var jre : jres)
 	@Test
 	@DisabledOnJre(JAVA_${jre.getVersion()})
-	void java${jre.getVersion()}() {
+	void jre${jre.getVersion()}() {
+		assertFalse(onJava${jre.getVersion()}());
+	}
+@endfor<%--
+--%>@for(var jre : jres)
+	@Test
+	@DisabledOnJre(versions = ${jre.getVersion()})
+	void version${jre.getVersion()}() {
 		assertFalse(onJava${jre.getVersion()}());
 	}
 @endfor

--- a/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/EnabledOnJreConditionTests.java.jte
+++ b/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/EnabledOnJreConditionTests.java.jte
@@ -7,8 +7,7 @@
 ${licenseHeader}
 package org.junit.jupiter.api.condition;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @for(var jre : jresSortedByStringValue)<%--
 --%>import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava${jre.getVersion()};
 @endfor<%--
@@ -19,7 +18,8 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.platform.commons.PreconditionViolationException;
 
 /**
- * Unit tests for {@link EnabledOnJreCondition}.
+ * Unit tests for {@link EnabledOnJreCondition}, generated from
+ * {@code EnabledOnJreConditionTests.java.jte}.
  *
  * <p>Note that test method names MUST match the test method names in
  * {@link EnabledOnJreIntegrationTests}.
@@ -27,6 +27,8 @@ import org.junit.platform.commons.PreconditionViolationException;
  * @since 5.1
  */
 class EnabledOnJreConditionTests extends AbstractExecutionConditionTests {
+
+	private static final String JAVA_VERSION = System.getProperty("java.version");
 
 	@Override
 	protected ExecutionCondition getExecutionCondition() {
@@ -49,12 +51,33 @@ class EnabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	}
 
 	/**
-	 * @see EnabledOnJreIntegrationTests#missingJreDeclaration()
+	 * @see EnabledOnJreIntegrationTests#missingVersionDeclaration()
 	 */
 	@Test
-	void missingJreDeclaration() {
-		Exception exception = assertThrows(PreconditionViolationException.class, this::evaluateCondition);
-		assertThat(exception).hasMessageContaining("You must declare at least one JRE");
+	void missingVersionDeclaration() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("You must declare at least one JRE or version in @EnabledOnJre");
+	}
+
+	/**
+	 * @see EnabledOnJreIntegrationTests#jreUndefined()
+	 */
+	@Test
+	void jreUndefined() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("JRE.UNDEFINED is not supported in @EnabledOnJre");
+	}
+
+	/**
+	 * @see EnabledOnJreIntegrationTests#version7()
+	 */
+	@Test
+	void version7() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("Version [7] in @EnabledOnJre must be greater than or equal to 8");
 	}
 
 	/**
@@ -67,10 +90,20 @@ class EnabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	}
 @for(var jre : jres)
 	/**
-	 * @see EnabledOnJreIntegrationTests#java${jre.getVersion()}()
+	 * @see EnabledOnJreIntegrationTests#jre${jre.getVersion()}()
 	 */
 	@Test
-	void java${jre.getVersion()}() {
+	void jre${jre.getVersion()}() {
+		evaluateCondition();
+		assertEnabledOnCurrentJreIf(onJava${jre.getVersion()}());
+	}
+@endfor<%--
+--%>@for(var jre : jres)
+	/**
+	 * @see EnabledOnJreIntegrationTests#version${jre.getVersion()}()
+	 */
+	@Test
+	void version${jre.getVersion()}() {
 		evaluateCondition();
 		assertEnabledOnCurrentJreIf(onJava${jre.getVersion()}());
 	}
@@ -88,11 +121,11 @@ class EnabledOnJreConditionTests extends AbstractExecutionConditionTests {
 	private void assertEnabledOnCurrentJreIf(boolean condition) {
 		if (condition) {
 			assertEnabled();
-			assertReasonContains("Enabled on JRE version: " + System.getProperty("java.version"));
+			assertReasonContains("Enabled on JRE version: " + JAVA_VERSION);
 		}
 		else {
 			assertDisabled();
-			assertReasonContains("Disabled on JRE version: " + System.getProperty("java.version"));
+			assertReasonContains("Disabled on JRE version: " + JAVA_VERSION);
 		}
 	}
 

--- a/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java.jte
+++ b/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java.jte
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 --%>import static org.junit.jupiter.api.condition.JRE.JAVA_${jre.getVersion()};
 @endfor<%--
 --%>import static org.junit.jupiter.api.condition.JRE.OTHER;
+import static org.junit.jupiter.api.condition.JRE.UNDEFINED;
 @for(var jre : jresSortedByStringValue)<%--
 --%>import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava${jre.getVersion()};
 @endfor<%--
@@ -22,7 +23,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integration tests for {@link EnabledOnJre}.
+ * Integration tests for {@link EnabledOnJre @EnabledOnJre}, generated from
+ * {@code EnabledOnJreIntegrationTests.java.jte}.
  *
  * @since 5.1
  */
@@ -36,7 +38,19 @@ class EnabledOnJreIntegrationTests {
 	@Test
 	@Disabled("Only used in a unit test via reflection")
 	@EnabledOnJre({})
-	void missingJreDeclaration() {
+	void missingVersionDeclaration() {
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledOnJre(UNDEFINED)
+	void jreUndefined() {
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledOnJre(versions = 7)
+	void version7() {
 	}
 
 	@Test
@@ -51,7 +65,14 @@ class EnabledOnJreIntegrationTests {
 @for(var jre : jres)
 	@Test
 	@EnabledOnJre(JAVA_${jre.getVersion()})
-	void java${jre.getVersion()}() {
+	void jre${jre.getVersion()}() {
+		assertTrue(onJava${jre.getVersion()}());
+	}
+@endfor<%--
+--%>@for(var jre : jres)
+	@Test
+	@EnabledOnJre(versions = ${jre.getVersion()})
+	void version${jre.getVersion()}() {
 		assertTrue(onJava${jre.getVersion()}());
 	}
 @endfor

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/AbstractExecutionConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/AbstractExecutionConditionTests.java
@@ -65,7 +65,7 @@ abstract class AbstractExecutionConditionTests {
 		List<String> localTestMethods = findMethods(getClass(), isTestMethod, TOP_DOWN).stream()//
 				.map(Method::getName).sorted().toList();
 
-		assertThat(localTestMethods).isEqualTo(methodsToTest);
+		assertThat(localTestMethods).containsExactlyElementsOf(methodsToTest);
 	}
 
 	@BeforeEach

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeConditionTests.java
@@ -39,6 +39,8 @@ import org.junit.platform.commons.PreconditionViolationException;
  */
 class DisabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 
+	private static final String JAVA_VERSION = System.getProperty("java.version");
+
 	@Override
 	protected ExecutionCondition getExecutionCondition() {
 		return new DisabledForJreRangeCondition();
@@ -66,64 +68,230 @@ class DisabledForJreRangeConditionTests extends AbstractExecutionConditionTests 
 	void defaultValues() {
 		assertThatExceptionOfType(PreconditionViolationException.class)//
 				.isThrownBy(this::evaluateCondition)//
-				.withMessageContaining("You must declare a non-default value for min or max in @DisabledForJreRange");
+				.withMessage(
+					"You must declare a non-default value for the minimum or maximum value in @DisabledForJreRange");
 	}
 
 	/**
-	 * @see DisabledForJreRangeIntegrationTests#java17()
+	 * @see DisabledForJreRangeIntegrationTests#effectiveJreDefaultValues()
 	 */
 	@Test
-	void java17() {
+	void effectiveJreDefaultValues() {
+		defaultValues();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#effectiveVersionDefaultValues()
+	 */
+	@Test
+	void effectiveVersionDefaultValues() {
+		defaultValues();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#min8()
+	 */
+	@Test
+	void min8() {
+		defaultValues();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minVersion8()
+	 */
+	@Test
+	void minVersion8() {
+		defaultValues();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#maxOther()
+	 */
+	@Test
+	void maxOther() {
+		defaultValues();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#maxVersionMaxInteger()
+	 */
+	@Test
+	void maxVersionMaxInteger() {
+		defaultValues();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minVersion7()
+	 */
+	@Test
+	void minVersion7() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("@DisabledForJreRange's minVersion [7] must be greater than or equal to 8");
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#maxVersion7()
+	 */
+	@Test
+	void maxVersion7() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("@DisabledForJreRange's maxVersion [7] must be greater than or equal to 8");
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minAndMinVersion()
+	 */
+	@Test
+	void minAndMinVersion() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage(
+					"@DisabledForJreRange's minimum value must be configured with either a JRE enum constant or numeric version, but not both");
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#maxAndMaxVersion()
+	 */
+	@Test
+	void maxAndMaxVersion() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage(
+					"@DisabledForJreRange's maximum value must be configured with either a JRE enum constant or numeric version, but not both");
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minGreaterThanMax()
+	 */
+	@Test
+	void minGreaterThanMax() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage(
+					"@DisabledForJreRange's minimum value [21] must be less than or equal to its maximum value [11]");
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minGreaterThanMaxVersion()
+	 */
+	@Test
+	void minGreaterThanMaxVersion() {
+		minGreaterThanMax();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minVersionGreaterThanMaxVersion()
+	 */
+	@Test
+	void minVersionGreaterThanMaxVersion() {
+		minGreaterThanMax();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minVersionGreaterThanMax()
+	 */
+	@Test
+	void minVersionGreaterThanMax() {
+		minGreaterThanMax();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#min18()
+	 */
+	@Test
+	void min18() {
 		evaluateCondition();
-		assertDisabledOnCurrentJreIf(onJava17());
+		assertDisabledOnCurrentJreIf(!onJava17());
 	}
 
 	/**
-	 * @see DisabledForJreRangeIntegrationTests#java18to19()
+	 * @see DisabledForJreRangeIntegrationTests#minVersion18()
 	 */
 	@Test
-	void java18to19() {
-		evaluateCondition();
-		assertDisabledOnCurrentJreIf(onJava18() || onJava19());
-		assertCustomDisabledReasonIs("Disabled on some JRE");
+	void minVersion18() {
+		min18();
 	}
 
 	/**
-	 * @see DisabledForJreRangeIntegrationTests#javaMax18()
+	 * @see DisabledForJreRangeIntegrationTests#max18()
 	 */
 	@Test
-	void javaMax18() {
+	void max18() {
 		evaluateCondition();
 		assertDisabledOnCurrentJreIf(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13()
 				|| onJava14() || onJava15() || onJava16() || onJava17() || onJava18());
 	}
 
 	/**
-	 * @see DisabledForJreRangeIntegrationTests#javaMin18()
+	 * @see DisabledForJreRangeIntegrationTests#maxVersion18()
 	 */
 	@Test
-	void javaMin18() {
-		evaluateCondition();
-		assertDisabledOnCurrentJreIf(!onJava17());
+	void maxVersion18() {
+		max18();
 	}
 
 	/**
-	 * @see DisabledForJreRangeIntegrationTests#other()
+	 * @see DisabledForJreRangeIntegrationTests#min17Max17()
 	 */
 	@Test
-	void other() {
+	void min17Max17() {
+		evaluateCondition();
+		assertDisabledOnCurrentJreIf(onJava17());
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minVersion17MaxVersion17()
+	 */
+	@Test
+	void minVersion17MaxVersion17() {
+		min17Max17();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#min18Max19()
+	 */
+	@Test
+	void min18Max19() {
+		evaluateCondition();
+		assertDisabledOnCurrentJreIf(onJava18() || onJava19());
+		assertCustomDisabledReasonIs("Disabled on Java 18 & 19");
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minVersion18MaxVersion19()
+	 */
+	@Test
+	void minVersion18MaxVersion19() {
+		min18Max19();
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minOtherMaxOther()
+	 */
+	@Test
+	void minOtherMaxOther() {
 		evaluateCondition();
 		assertDisabledOnCurrentJreIf(!onKnownVersion());
+	}
+
+	/**
+	 * @see DisabledForJreRangeIntegrationTests#minMaxIntegerMaxMaxInteger()
+	 */
+	@Test
+	void minMaxIntegerMaxMaxInteger() {
+		minOtherMaxOther();
 	}
 
 	private void assertDisabledOnCurrentJreIf(boolean condition) {
 		if (condition) {
 			assertDisabled();
-			assertReasonContains("Disabled on JRE version: " + System.getProperty("java.version"));
+			assertReasonContains("Disabled on JRE version: " + JAVA_VERSION);
 		}
 		else {
 			assertEnabled();
-			assertReasonContains("Enabled on JRE version: " + System.getProperty("java.version"));
+			assertReasonContains("Enabled on JRE version: " + JAVA_VERSION);
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
@@ -13,9 +13,12 @@ package org.junit.jupiter.api.condition;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.condition.JRE.JAVA_11;
 import static org.junit.jupiter.api.condition.JRE.JAVA_17;
 import static org.junit.jupiter.api.condition.JRE.JAVA_18;
 import static org.junit.jupiter.api.condition.JRE.JAVA_19;
+import static org.junit.jupiter.api.condition.JRE.JAVA_21;
+import static org.junit.jupiter.api.condition.JRE.JAVA_8;
 import static org.junit.jupiter.api.condition.JRE.OTHER;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava10;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava11;
@@ -35,7 +38,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integration tests for {@link DisabledForJreRange}.
+ * Integration tests for {@link DisabledForJreRange @DisabledForJreRange}.
  *
  * @since 5.6
  */
@@ -53,35 +56,163 @@ class DisabledForJreRangeIntegrationTests {
 	}
 
 	@Test
-	@DisabledForJreRange(min = JAVA_17, max = JAVA_17)
-	void java17() {
-		assertFalse(onJava17());
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(min = JAVA_8, max = OTHER)
+	void effectiveJreDefaultValues() {
+		fail("should result in a configuration exception");
 	}
 
 	@Test
-	@DisabledForJreRange(min = JAVA_18, max = JAVA_19, disabledReason = "Disabled on some JRE")
-	void java18to19() {
-		assertFalse(onJava18() || onJava19());
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(minVersion = 8, maxVersion = Integer.MAX_VALUE)
+	void effectiveVersionDefaultValues() {
+		fail("should result in a configuration exception");
 	}
 
 	@Test
-	@DisabledForJreRange(max = JAVA_18)
-	void javaMax18() {
-		assertFalse(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14()
-				|| onJava15() || onJava16() || onJava17() || onJava18());
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(min = JAVA_8)
+	void min8() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(minVersion = 8)
+	void minVersion8() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(max = OTHER)
+	void maxOther() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(maxVersion = Integer.MAX_VALUE)
+	void maxVersionMaxInteger() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(minVersion = 7)
+	void minVersion7() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(maxVersion = 7)
+	void maxVersion7() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(min = JAVA_18, minVersion = 21)
+	void minAndMinVersion() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(max = JAVA_18, maxVersion = 21)
+	void maxAndMaxVersion() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(min = JAVA_21, max = JAVA_11)
+	void minGreaterThanMax() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(min = JAVA_21, maxVersion = 11)
+	void minGreaterThanMaxVersion() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(minVersion = 21, maxVersion = 11)
+	void minVersionGreaterThanMaxVersion() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@DisabledForJreRange(minVersion = 21, max = JAVA_11)
+	void minVersionGreaterThanMax() {
+		fail("should result in a configuration exception");
 	}
 
 	@Test
 	@DisabledForJreRange(min = JAVA_18)
-	void javaMin18() {
+	void min18() {
 		assertFalse(onJava18() || onJava19());
 		assertTrue(onJava17());
 	}
 
 	@Test
+	@DisabledForJreRange(minVersion = 18)
+	void minVersion18() {
+		min18();
+	}
+
+	@Test
+	@DisabledForJreRange(max = JAVA_18)
+	void max18() {
+		assertFalse(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14()
+				|| onJava15() || onJava16() || onJava17() || onJava18());
+	}
+
+	@Test
+	@DisabledForJreRange(maxVersion = 18)
+	void maxVersion18() {
+		max18();
+	}
+
+	@Test
+	@DisabledForJreRange(min = JAVA_17, max = JAVA_17)
+	void min17Max17() {
+		assertFalse(onJava17());
+	}
+
+	@Test
+	@DisabledForJreRange(minVersion = 17, maxVersion = 17)
+	void minVersion17MaxVersion17() {
+		min17Max17();
+	}
+
+	@Test
+	@DisabledForJreRange(min = JAVA_18, max = JAVA_19, disabledReason = "Disabled on Java 18 & 19")
+	void min18Max19() {
+		assertFalse(onJava18() || onJava19());
+	}
+
+	@Test
+	@DisabledForJreRange(minVersion = 18, maxVersion = 19, disabledReason = "Disabled on Java 18 & 19")
+	void minVersion18MaxVersion19() {
+		min18Max19();
+	}
+
+	@Test
 	@DisabledForJreRange(min = OTHER, max = OTHER)
-	void other() {
+	void minOtherMaxOther() {
 		assertTrue(onKnownVersion());
+	}
+
+	@Test
+	@DisabledForJreRange(minVersion = Integer.MAX_VALUE, maxVersion = Integer.MAX_VALUE)
+	void minMaxIntegerMaxMaxInteger() {
+		minOtherMaxOther();
 	}
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
@@ -287,7 +287,6 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void min20Max21() {
 		evaluateCondition();
-		assertEnabledOnCurrentJreIf(!(onJava19() || onJava22()));
 		assertEnabledOnCurrentJreIf(onJava20() || onJava21());
 	}
 
@@ -321,7 +320,6 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void minVersion17MaxVersionMaxInteger() {
 		evaluateCondition();
-		assertEnabledOnCurrentJreIf(!onJava16());
 		assertEnabledOnCurrentJreIf(onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22()
 				|| onJava23() || onJava24() || onJava25());
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
@@ -21,6 +21,12 @@ import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava16;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava17;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava18;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava19;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava20;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava21;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava22;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava23;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava24;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava25;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava8;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava9;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onKnownVersion;
@@ -30,7 +36,7 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.platform.commons.PreconditionViolationException;
 
 /**
- * Unit tests for {@link EnabledForJreRange}.
+ * Unit tests for {@link EnabledForJreRange @EnabledForJreRange}.
  *
  * <p>Note that test method names MUST match the test method names in
  * {@link EnabledForJreRangeIntegrationTests}.
@@ -38,6 +44,8 @@ import org.junit.platform.commons.PreconditionViolationException;
  * @since 5.6
  */
 class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
+
+	private static final String JAVA_VERSION = System.getProperty("java.version");
 
 	@Override
 	protected ExecutionCondition getExecutionCondition() {
@@ -66,63 +74,283 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	void defaultValues() {
 		assertThatExceptionOfType(PreconditionViolationException.class)//
 				.isThrownBy(this::evaluateCondition)//
-				.withMessageContaining("You must declare a non-default value for min or max in @EnabledForJreRange");
+				.withMessage(
+					"You must declare a non-default value for the minimum or maximum value in @EnabledForJreRange");
 	}
 
 	/**
-	 * @see EnabledForJreRangeIntegrationTests#java17()
+	 * @see EnabledForJreRangeIntegrationTests#effectiveJreDefaultValues()
 	 */
 	@Test
-	void java17() {
+	void effectiveJreDefaultValues() {
+		defaultValues();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#effectiveVersionDefaultValues()
+	 */
+	@Test
+	void effectiveVersionDefaultValues() {
+		defaultValues();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#min8()
+	 */
+	@Test
+	void min8() {
+		defaultValues();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minVersion8()
+	 */
+	@Test
+	void minVersion8() {
+		defaultValues();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#maxOther()
+	 */
+	@Test
+	void maxOther() {
+		defaultValues();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#maxVersionMaxInteger()
+	 */
+	@Test
+	void maxVersionMaxInteger() {
+		defaultValues();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minVersion7()
+	 */
+	@Test
+	void minVersion7() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("@EnabledForJreRange's minVersion [7] must be greater than or equal to 8");
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#maxVersion7()
+	 */
+	@Test
+	void maxVersion7() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage("@EnabledForJreRange's maxVersion [7] must be greater than or equal to 8");
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minAndMinVersion()
+	 */
+	@Test
+	void minAndMinVersion() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage(
+					"@EnabledForJreRange's minimum value must be configured with either a JRE enum constant or numeric version, but not both");
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#maxAndMaxVersion()
+	 */
+	@Test
+	void maxAndMaxVersion() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage(
+					"@EnabledForJreRange's maximum value must be configured with either a JRE enum constant or numeric version, but not both");
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minGreaterThanMax()
+	 */
+	@Test
+	void minGreaterThanMax() {
+		assertThatExceptionOfType(PreconditionViolationException.class)//
+				.isThrownBy(this::evaluateCondition)//
+				.withMessage(
+					"@EnabledForJreRange's minimum value [21] must be less than or equal to its maximum value [11]");
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minGreaterThanMaxVersion()
+	 */
+	@Test
+	void minGreaterThanMaxVersion() {
+		minGreaterThanMax();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minVersionGreaterThanMaxVersion()
+	 */
+	@Test
+	void minVersionGreaterThanMaxVersion() {
+		minGreaterThanMax();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minVersionGreaterThanMax()
+	 */
+	@Test
+	void minVersionGreaterThanMax() {
+		minGreaterThanMax();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#min20()
+	 */
+	@Test
+	void min20() {
+		evaluateCondition();
+		assertEnabledOnCurrentJreIf(!onJava19());
+		assertEnabledOnCurrentJreIf(onJava20() || onJava21() || onJava22() || onJava23());
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minVersion20()
+	 */
+	@Test
+	void minVersion20() {
+		min20();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#max21()
+	 */
+	@Test
+	void max21() {
+		evaluateCondition();
+		assertEnabledOnCurrentJreIf(
+			onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14() || onJava15()
+					|| onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21());
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#maxVersion21()
+	 */
+	@Test
+	void maxVersion21() {
+		max21();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#min8Max21()
+	 */
+	@Test
+	void min8Max21() {
+		max21();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#min17Max17()
+	 */
+	@Test
+	void min17Max17() {
 		evaluateCondition();
 		assertEnabledOnCurrentJreIf(onJava17());
 	}
 
 	/**
-	 * @see EnabledForJreRangeIntegrationTests#java18to19()
+	 * @see EnabledForJreRangeIntegrationTests#min17MaxVersion17()
 	 */
 	@Test
-	void java18to19() {
-		evaluateCondition();
-		assertEnabledOnCurrentJreIf(onJava18() || onJava19());
+	void min17MaxVersion17() {
+		min17Max17();
 	}
 
 	/**
-	 * @see EnabledForJreRangeIntegrationTests#javaMax18()
+	 * @see EnabledForJreRangeIntegrationTests#minVersion17Max17()
 	 */
 	@Test
-	void javaMax18() {
-		evaluateCondition();
-		assertEnabledOnCurrentJreIf(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13()
-				|| onJava14() || onJava15() || onJava16() || onJava17() || onJava18());
+	void minVersion17Max17() {
+		min17Max17();
 	}
 
 	/**
-	 * @see EnabledForJreRangeIntegrationTests#javaMin18()
+	 * @see EnabledForJreRangeIntegrationTests#minVersion17MaxVersion17()
 	 */
 	@Test
-	void javaMin18() {
-		evaluateCondition();
-		assertEnabledOnCurrentJreIf(!(onJava17()));
+	void minVersion17MaxVersion17() {
+		min17Max17();
 	}
 
 	/**
-	 * @see EnabledForJreRangeIntegrationTests#other()
+	 * @see EnabledForJreRangeIntegrationTests#min20Max21()
 	 */
 	@Test
-	void other() {
+	void min20Max21() {
+		evaluateCondition();
+		assertEnabledOnCurrentJreIf(!(onJava19() || onJava22()));
+		assertEnabledOnCurrentJreIf(onJava20() || onJava21());
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#min20MaxVersion21()
+	 */
+	@Test
+	void min20MaxVersion21() {
+		min20Max21();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minVersion20Max21()
+	 */
+	@Test
+	void minVersion20Max21() {
+		min20Max21();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minVersion20MaxVersion21()
+	 */
+	@Test
+	void minVersion20MaxVersion21() {
+		min20Max21();
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minVersion17MaxVersionMaxInteger()
+	 */
+	@Test
+	void minVersion17MaxVersionMaxInteger() {
+		evaluateCondition();
+		assertEnabledOnCurrentJreIf(!onJava16());
+		assertEnabledOnCurrentJreIf(onJava17() || onJava18() || onJava19() || onJava20() || onJava21() || onJava22()
+				|| onJava23() || onJava24() || onJava25());
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minOtherMaxOther()
+	 */
+	@Test
+	void minOtherMaxOther() {
 		evaluateCondition();
 		assertEnabledOnCurrentJreIf(!onKnownVersion());
+	}
+
+	/**
+	 * @see EnabledForJreRangeIntegrationTests#minMaxIntegerMaxMaxInteger()
+	 */
+	@Test
+	void minMaxIntegerMaxMaxInteger() {
+		minOtherMaxOther();
 	}
 
 	private void assertEnabledOnCurrentJreIf(boolean condition) {
 		if (condition) {
 			assertEnabled();
-			assertReasonContains("Enabled on JRE version: " + System.getProperty("java.version"));
+			assertReasonContains("Enabled on JRE version: " + JAVA_VERSION);
 		}
 		else {
 			assertDisabled();
-			assertReasonContains("Disabled on JRE version: " + System.getProperty("java.version"));
+			assertReasonContains("Disabled on JRE version: " + JAVA_VERSION);
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeConditionTests.java
@@ -209,8 +209,7 @@ class EnabledForJreRangeConditionTests extends AbstractExecutionConditionTests {
 	@Test
 	void min20() {
 		evaluateCondition();
-		assertEnabledOnCurrentJreIf(!onJava19());
-		assertEnabledOnCurrentJreIf(onJava20() || onJava21() || onJava22() || onJava23());
+		assertEnabledOnCurrentJreIf(onJava20() || onJava21() || onJava22() || onJava23() || onJava24() || onJava25());
 	}
 
 	/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
@@ -13,9 +13,12 @@ package org.junit.jupiter.api.condition;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.condition.JRE.JAVA_11;
 import static org.junit.jupiter.api.condition.JRE.JAVA_17;
 import static org.junit.jupiter.api.condition.JRE.JAVA_18;
-import static org.junit.jupiter.api.condition.JRE.JAVA_19;
+import static org.junit.jupiter.api.condition.JRE.JAVA_20;
+import static org.junit.jupiter.api.condition.JRE.JAVA_21;
+import static org.junit.jupiter.api.condition.JRE.JAVA_8;
 import static org.junit.jupiter.api.condition.JRE.OTHER;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava10;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava11;
@@ -27,6 +30,10 @@ import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava16;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava17;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava18;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava19;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava20;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava21;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava22;
+import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava23;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava8;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onJava9;
 import static org.junit.jupiter.api.condition.JavaVersionPredicates.onKnownVersion;
@@ -35,11 +42,13 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integration tests for {@link EnabledForJreRange}.
+ * Integration tests for {@link EnabledForJreRange @EnabledForJreRange}.
  *
  * @since 5.6
  */
 class EnabledForJreRangeIntegrationTests {
+
+	private static final JRE CURRENT_JRE = JRE.currentJre();
 
 	@Test
 	@Disabled("Only used in a unit test via reflection")
@@ -54,38 +63,211 @@ class EnabledForJreRangeIntegrationTests {
 	}
 
 	@Test
-	@EnabledForJreRange(min = JAVA_17, max = JAVA_17)
-	void java17() {
-		assertTrue(onJava17());
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(min = JAVA_8, max = OTHER)
+	void effectiveJreDefaultValues() {
+		fail("should result in a configuration exception");
 	}
 
 	@Test
-	@EnabledForJreRange(min = JAVA_18, max = JAVA_19)
-	void java18to19() {
-		assertTrue(onJava18() || onJava19());
-		assertFalse(onJava17());
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(minVersion = 8, maxVersion = Integer.MAX_VALUE)
+	void effectiveVersionDefaultValues() {
+		fail("should result in a configuration exception");
 	}
 
 	@Test
-	@EnabledForJreRange(max = JAVA_18)
-	void javaMax18() {
-		assertTrue(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14()
-				|| onJava15() || onJava16() || onJava17() || onJava18());
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(min = JAVA_8)
+	void min8() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(minVersion = 8)
+	void minVersion8() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(max = OTHER)
+	void maxOther() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(maxVersion = Integer.MAX_VALUE)
+	void maxVersionMaxInteger() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(minVersion = 7)
+	void minVersion7() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(maxVersion = 7)
+	void maxVersion7() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(min = JAVA_18, minVersion = 21)
+	void minAndMinVersion() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(max = JAVA_18, maxVersion = 21)
+	void maxAndMaxVersion() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(min = JAVA_21, max = JAVA_11)
+	void minGreaterThanMax() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(min = JAVA_21, maxVersion = 11)
+	void minGreaterThanMaxVersion() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(minVersion = 21, maxVersion = 11)
+	void minVersionGreaterThanMaxVersion() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@Disabled("Only used in a unit test via reflection")
+	@EnabledForJreRange(minVersion = 21, max = JAVA_11)
+	void minVersionGreaterThanMax() {
+		fail("should result in a configuration exception");
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_20)
+	void min20() {
+		assertTrue(onKnownVersion());
+		assertTrue(JRE.currentVersionNumber() >= 20);
+		assertTrue(CURRENT_JRE.compareTo(JAVA_20) >= 0);
+		assertTrue(CURRENT_JRE.version() >= 20);
 		assertFalse(onJava19());
 	}
 
 	@Test
-	@EnabledForJreRange(min = JAVA_18)
-	void javaMin18() {
+	@EnabledForJreRange(minVersion = 20)
+	void minVersion20() {
+		min20();
+	}
+
+	@Test
+	@EnabledForJreRange(max = JAVA_21)
+	void max21() {
 		assertTrue(onKnownVersion());
-		assertTrue(JRE.currentVersion().compareTo(JAVA_18) >= 0);
-		assertFalse(onJava17());
+		assertTrue(JRE.currentVersionNumber() <= 21);
+		assertTrue(CURRENT_JRE.compareTo(JAVA_21) <= 0);
+		assertTrue(CURRENT_JRE.version() <= 21);
+
+		assertTrue(onJava8() || onJava9() || onJava10() || onJava11() || onJava12() || onJava13() || onJava14()
+				|| onJava15() || onJava16() || onJava17() || onJava18() || onJava19() || onJava20() || onJava21());
+		assertFalse(onJava22());
+	}
+
+	@Test
+	@EnabledForJreRange(maxVersion = 21)
+	void maxVersion21() {
+		max21();
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_8, max = JAVA_21)
+	void min8Max21() {
+		max21();
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_17, max = JAVA_17)
+	void min17Max17() {
+		assertTrue(onJava17());
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_17, maxVersion = 17)
+	void min17MaxVersion17() {
+		min17Max17();
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 17, max = JAVA_17)
+	void minVersion17Max17() {
+		min17Max17();
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 17, maxVersion = 17)
+	void minVersion17MaxVersion17() {
+		min17Max17();
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_20, max = JAVA_21)
+	void min20Max21() {
+		assertTrue(onJava20() || onJava21());
+		assertFalse(onJava17() || onJava23());
+	}
+
+	@Test
+	@EnabledForJreRange(min = JAVA_20, maxVersion = 21)
+	void min20MaxVersion21() {
+		min20Max21();
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 20, max = JAVA_21)
+	void minVersion20Max21() {
+		min20Max21();
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 20, maxVersion = 21)
+	void minVersion20MaxVersion21() {
+		min20Max21();
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = 17, maxVersion = Integer.MAX_VALUE)
+	void minVersion17MaxVersionMaxInteger() {
+		assertTrue(onKnownVersion());
+		assertTrue(JRE.currentVersionNumber() >= 17);
+		assertTrue(JRE.currentVersionNumber() <= Integer.MAX_VALUE);
 	}
 
 	@Test
 	@EnabledForJreRange(min = OTHER, max = OTHER)
-	void other() {
+	void minOtherMaxOther() {
 		assertFalse(onKnownVersion());
+	}
+
+	@Test
+	@EnabledForJreRange(minVersion = Integer.MAX_VALUE, maxVersion = Integer.MAX_VALUE)
+	void minMaxIntegerMaxMaxInteger() {
+		minOtherMaxOther();
 	}
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/JRETests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/JRETests.java
@@ -10,13 +10,15 @@
 
 package org.junit.jupiter.api.condition;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.condition.JRE.JAVA_17;
 import static org.junit.jupiter.api.condition.JRE.JAVA_18;
 import static org.junit.jupiter.api.condition.JRE.JAVA_19;
 import static org.junit.jupiter.api.condition.JRE.JAVA_20;
 import static org.junit.jupiter.api.condition.JRE.JAVA_21;
 import static org.junit.jupiter.api.condition.JRE.JAVA_22;
+import static org.junit.jupiter.api.condition.JRE.JAVA_23;
+import static org.junit.jupiter.api.condition.JRE.JAVA_24;
 import static org.junit.jupiter.api.condition.JRE.OTHER;
 
 import org.junit.jupiter.api.Test;
@@ -28,45 +30,123 @@ import org.junit.jupiter.api.Test;
  */
 public class JRETests {
 
+	private static final JRE CURRENT_JRE = JRE.currentJre();
+
 	@Test
 	@EnabledOnJre(JAVA_17)
-	void java17() {
-		assertEquals(JAVA_17, JRE.currentVersion());
+	void jre17() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(JAVA_17);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(17);
 	}
 
 	@Test
 	@EnabledOnJre(JAVA_18)
-	void java18() {
-		assertEquals(JAVA_18, JRE.currentVersion());
+	void jre18() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(JAVA_18);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(18);
 	}
 
 	@Test
 	@EnabledOnJre(JAVA_19)
-	void java19() {
-		assertEquals(JAVA_19, JRE.currentVersion());
+	void jre19() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(JAVA_19);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(19);
 	}
 
 	@Test
 	@EnabledOnJre(JAVA_20)
-	void java20() {
-		assertEquals(JAVA_20, JRE.currentVersion());
+	void jre20() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(JAVA_20);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(20);
 	}
 
 	@Test
 	@EnabledOnJre(JAVA_21)
-	void java21() {
-		assertEquals(JAVA_21, JRE.currentVersion());
+	void jre21() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(JAVA_21);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(21);
 	}
 
 	@Test
 	@EnabledOnJre(JAVA_22)
-	void java22() {
-		assertEquals(JAVA_22, JRE.currentVersion());
+	void jre22() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(JAVA_21);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(22);
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_23)
+	void jre23() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(JAVA_23);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(23);
+	}
+
+	@Test
+	@EnabledOnJre(JAVA_24)
+	void jre24() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(JAVA_24);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(24);
+	}
+
+	@Test
+	@EnabledOnJre(versions = 17)
+	void version17() {
+		jre17();
+	}
+
+	@Test
+	@EnabledOnJre(versions = 18)
+	void version18() {
+		jre18();
+	}
+
+	@Test
+	@EnabledOnJre(versions = 19)
+	void version19() {
+		jre19();
+	}
+
+	@Test
+	@EnabledOnJre(versions = 20)
+	void version20() {
+		jre20();
+	}
+
+	@Test
+	@EnabledOnJre(versions = 21)
+	void version21() {
+		jre21();
+	}
+
+	@Test
+	@EnabledOnJre(versions = 22)
+	void version22() {
+		jre22();
+	}
+
+	@Test
+	@EnabledOnJre(versions = 23)
+	void version23() {
+		jre23();
+	}
+
+	@Test
+	@EnabledOnJre(versions = 24)
+	void version24() {
+		jre24();
 	}
 
 	@Test
 	@EnabledOnJre(OTHER)
-	void other() {
-		assertEquals(OTHER, JRE.currentVersion());
+	void jreOther() {
+		assertThat(CURRENT_JRE).as("current version").isEqualTo(OTHER);
+		assertThat(CURRENT_JRE.version()).as("current feature version").isEqualTo(Integer.MAX_VALUE);
 	}
+
+	@Test
+	@EnabledOnJre(versions = Integer.MAX_VALUE)
+	void versionMaxInteger() {
+		jreOther();
+	}
+
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
@@ -51,7 +51,7 @@ class JavaVersionsTests {
 
 	@Test
 	void java_default(@FilePrefix("maven") OutputFiles outputFiles) throws Exception {
-		var actualLines = execute(currentJdkHome(), outputFiles, MavenEnvVars.forJre(JRE.currentVersion()));
+		var actualLines = execute(currentJdkHome(), outputFiles, MavenEnvVars.forJre(JRE.currentJre()));
 
 		assertTrue(actualLines.contains("[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 1"));
 	}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
@@ -77,7 +77,7 @@ class MultiReleaseJarTests {
 				.addArguments("-Dsnapshot.repo.url=" + mavenRepoProxy.getBaseUri()) //
 				.addArguments("--update-snapshots", "--show-version", "--errors", "--batch-mode") //
 				.addArguments("test") //
-				.putEnvironment(MavenEnvVars.forJre(JRE.currentVersion())) //
+				.putEnvironment(MavenEnvVars.forJre(JRE.currentJre())) //
 				.redirectOutput(outputFiles) //
 				.startAndWait();
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/UnalignedClasspathTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/UnalignedClasspathTests.java
@@ -69,7 +69,7 @@ class UnalignedClasspathTests {
 	static Stream<Arguments> javaVersions() {
 		return Stream.concat( //
 			Helper.getJavaHome("8").map(path -> Arguments.of(JRE.JAVA_8, path)).stream(), //
-			Stream.of(Arguments.of(JRE.currentVersion(), currentJdkHome())) //
+			Stream.of(Arguments.of(JRE.currentJre(), currentJdkHome())) //
 		);
 	}
 }


### PR DESCRIPTION
## Overview

This PR introduces support for arbitrary Java versions in the `JRE` enum, `@EnabledOnJre`, `@DisabledOnJre`, `@EnabledForJreRange`, and `@DisabledForJreRange`.

Closes: #3930

## Related Issues

- #3918
- #3930

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
