### PR TITLE
Fix potential double acquisition in `SingleLock`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.1.adoc
@@ -16,7 +16,8 @@ JUnit repository on GitHub.
 [[release-notes-5.11.1-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Fix potential locking issue with `ExclusiveResource` in the `HierarchicalTestExecutorService`.
+  This could lead to deadlocks in certain scenarios.
 
 [[release-notes-5.11.1-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
@@ -68,8 +68,10 @@ class CompositeLock implements ResourceLock {
 
 		@Override
 		public boolean block() throws InterruptedException {
-			acquireAllLocks();
-			acquired = true;
+			if (!acquired) {
+				acquireAllLocks();
+				acquired = true;
+			}
 			return true;
 		}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
@@ -46,14 +46,16 @@ class SingleLock implements ResourceLock {
 
 		@Override
 		public boolean block() throws InterruptedException {
-			lock.lockInterruptibly();
-			acquired = true;
+			if (!acquired) {
+				lock.lockInterruptibly();
+				acquired = true;
+			}
 			return true;
 		}
 
 		@Override
 		public boolean isReleasable() {
-			return acquired || lock.tryLock();
+			return acquired || (acquired = lock.tryLock());
 		}
 
 	}


### PR DESCRIPTION
`SingleLock` uses a `ForkJoinPool.ManagedBlocker` for efficient blocking in a fork-join pool. In the `isReleasable()` method it calls `tryLock()` without remembering the outcome. The `block` method also unconditionally called `lockInterruptibly()` even if the lock was already acquired. The problem that can arise is that the lock is acquired multiple times, but only released once.

`CompositeLockManagedBlocker` is also updated, so that `block()` checks for `acquired` before locking.

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
