### PR TITLE
Document benefits of `messageSupplier` in `Assertions`

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -293,6 +293,13 @@ JUnit Jupiter comes with many of the assertion methods that JUnit 4 has and adds
 that lend themselves well to being used with Java 8 lambdas. All JUnit Jupiter assertions
 are `static` methods in the `{Assertions}` class.
 
+Assertion methods optionally accept the assertion message as their third parameter, which
+can be either a `String` or a `Supplier<String>`.
+
+When using a `Supplier<String>` (e.g., a lambda expression), the message is evaluated
+lazily. This can provide a performance benefit, especially if message construction is
+complex or time-consuming, as it is only evaluated when the assertion fails.
+
 [source,java,indent=0]
 ----
 include::{testDir}/example/AssertionsDemo.java[tags=user_guide]

--- a/documentation/src/test/java/example/AssertionsDemo.java
+++ b/documentation/src/test/java/example/AssertionsDemo.java
@@ -41,8 +41,9 @@ class AssertionsDemo {
 		assertEquals(2, calculator.add(1, 1));
 		assertEquals(4, calculator.multiply(2, 2),
 				"The optional failure message is now the last parameter");
-		assertTrue('a' < 'b', () -> "Assertion messages can be lazily evaluated -- "
-				+ "to avoid constructing complex messages unnecessarily.");
+
+		// Lazily evaluates generateFailureMessage('a','b').
+		assertTrue('a' < 'b', () -> generateFailureMessage('a','b'));
 	}
 
 	@Test
@@ -160,6 +161,10 @@ class AssertionsDemo {
 		return "Hello, World!";
 	}
 
+	private static String generateFailureMessage(char a, char b) {
+		return "Assertion messages can be lazily evaluated -- "
+				+ "to avoid constructing complex messages unnecessarily." + (a < b);
+	}
 }
 // end::user_guide[]
 // @formatter:on


### PR DESCRIPTION
## Overview

Resolves #3153.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
