### PR TITLE
Fix `NO_COLOR` support

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -16,7 +16,8 @@ JUnit repository on GitHub.
 [[release-notes-5.12.0-M1-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Fix support for disabling ANSI colors on the console when the `NO_COLOR` environment
+  variable is available.
 
 [[release-notes-5.12.0-M1-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/AnsiColorOptionMixin.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/AnsiColorOptionMixin.java
@@ -23,7 +23,9 @@ class AnsiColorOptionMixin {
 	@Spec(MIXEE)
 	CommandSpec commandSpec;
 
-	private boolean disableAnsiColors;
+	// https://no-color.org
+	// ANSI is disabled when environment variable NO_COLOR is defined (regardless of its value).
+	private boolean disableAnsiColors = System.getenv("NO_COLOR") != null;
 
 	public boolean isDisableAnsiColors() {
 		return disableAnsiColors;

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -383,13 +383,13 @@ class StandaloneTests {
 
 	private static Result discover(String... args) {
 		var result = Request.builder() //
+				.putEnvironment("NO_COLOR", "1") // --disable-ansi-colors
 				.setTool(new Java()) //
 				.setProject(Projects.STANDALONE) //
 				.addArguments("-jar", MavenRepo.jar("junit-platform-console-standalone")) //
 				.addArguments("discover") //
 				.addArguments("--scan-class-path") //
 				.addArguments("--disable-banner") //
-				.addArguments("--disable-ansi-colors") //
 				.addArguments("--include-classname", "standalone.*") //
 				.addArguments("--classpath", "bin") //
 				.addArguments((Object[]) args) //
@@ -405,6 +405,7 @@ class StandaloneTests {
 	@Order(3)
 	void execute() throws IOException {
 		var result = Request.builder() //
+				.putEnvironment("NO_COLOR", "1") // --disable-ansi-colors
 				.setTool(new Java()) //
 				.setProject(Projects.STANDALONE) //
 				.addArguments("--show-version") //


### PR DESCRIPTION
## Overview

Fix support for `NO_COLOR` environment variable by initializing the `boolean disableAnsiColors` correctly.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
