### PR TITLE
Delete custom groups

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,42 +7,6 @@
   ],
   packageRules: [
     {
-      groupName: 'Maven dependencies',
-      matchManagers: [
-        'maven'
-      ],
-      matchUpdateTypes: [
-        'major',
-        'minor',
-        'patch',
-      ],
-    },
-    {
-      groupName: 'Gradle dependencies',
-      matchManagers: [
-        'gradle'
-      ],
-      matchUpdateTypes: [
-        'major',
-        'minor',
-        'patch',
-      ]
-    },
-    {
-      groupName: 'GitHub Actions',
-      matchManagers: [
-        'github-actions'
-      ],
-      matchUpdateTypes: [
-        'major',
-        'minor',
-        'patch',
-        'pin',
-        'pinDigest',
-        'digest'
-      ]
-    },
-    {
       matchCurrentValue: '/^2\\./',
       allowedVersions: '(,3.0)',
       matchPackageNames: [


### PR DESCRIPTION
It's easier to revert updates if they're from separate PRs.
