### PR TITLE
Fix deadlock in `ForkJoinPoolHierarchicalTestExecutorService`

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.locks.Lock;
 
+import org.junit.platform.commons.util.Preconditions;
+
 /**
  * @since 1.3
  */
@@ -23,7 +25,7 @@ class CompositeLock implements ResourceLock {
 	private final List<Lock> locks;
 
 	CompositeLock(List<Lock> locks) {
-		this.locks = locks;
+		this.locks = Preconditions.notEmpty(locks, "Locks must not be empty");
 	}
 
 	// for tests only

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -183,9 +183,9 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 			if (threadLock != null) {
 				List<ExclusiveTask> deferredTasks = threadLock.deferredTasks;
 				for (ExclusiveTask deferredTask : deferredTasks) {
-					//					if (!deferredTask.isDone()) {
-					deferredTask.fork();
-					//					}
+					if (!deferredTask.isDone()) {
+						deferredTask.fork();
+					}
 				}
 				deferredTasks.clear();
 			}
@@ -231,11 +231,11 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 			ResourceLock resourceLock = testTask.getResourceLock();
 			ThreadLock threadLock = threadLocks.get();
 			if (threadLock != null) {
-				System.out.println("Checking " + this + " lock compatibility: " + resourceLock + " vs "
-						+ threadLock.locks + " " + Thread.currentThread());
+				//				System.out.println(
+				//						"Checking " + this + " lock compatibility: " + resourceLock + " vs " + threadLock.locks + " " + Thread.currentThread());
 				if (!threadLock.isLockCompatible(resourceLock)) {
-					System.out.println("Deferring task " + this + " because of lock incompatibility: " + resourceLock
-							+ " vs " + threadLock.locks);
+					//					System.out.println(
+					//							"Deferring task " + this + " because of lock incompatibility: " + resourceLock + " vs " + threadLock.locks);
 
 					threadLock.addDeferredTask(this);
 					// Return false to indicate that this task is not done yet
@@ -243,9 +243,9 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 					return false;
 				}
 			}
-			else {
-				System.out.println("No existing thread lock for " + this + " " + Thread.currentThread());
-			}
+			//			else {
+			//				System.out.println("No existing thread lock for " + this + " " + Thread.currentThread());
+			//			}
 			try (ResourceLock lock = resourceLock.acquire()) {
 				if (threadLock == null) {
 					threadLocks.set(threadLock = new ThreadLock());
@@ -302,6 +302,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 			locks.push(lock);
 		}
 
+		@SuppressWarnings("resource")
 		boolean decrementNesting() {
 			locks.pop();
 			return locks.isEmpty();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -183,9 +183,9 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 			if (threadLock != null) {
 				List<ExclusiveTask> deferredTasks = threadLock.deferredTasks;
 				for (ExclusiveTask deferredTask : deferredTasks) {
-//					if (!deferredTask.isDone()) {
-						deferredTask.fork();
-//					}
+					//					if (!deferredTask.isDone()) {
+					deferredTask.fork();
+					//					}
 				}
 				deferredTasks.clear();
 			}
@@ -231,16 +231,19 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 			ResourceLock resourceLock = testTask.getResourceLock();
 			ThreadLock threadLock = threadLocks.get();
 			if (threadLock != null) {
-					System.out.println("Checking " + this + " lock compatibility: " + resourceLock + " vs " + threadLock.locks + " " + Thread.currentThread());
+				System.out.println("Checking " + this + " lock compatibility: " + resourceLock + " vs "
+						+ threadLock.locks + " " + Thread.currentThread());
 				if (!threadLock.isLockCompatible(resourceLock)) {
-					System.out.println("Deferring task " + this + " because of lock incompatibility: " + resourceLock + " vs " + threadLock.locks);
+					System.out.println("Deferring task " + this + " because of lock incompatibility: " + resourceLock
+							+ " vs " + threadLock.locks);
 
 					threadLock.addDeferredTask(this);
 					// Return false to indicate that this task is not done yet
 					// this means that .join() will wait.
 					return false;
 				}
-			} else {
+			}
+			else {
 				System.out.println("No existing thread lock for " + this + " " + Thread.currentThread());
 			}
 			try (ResourceLock lock = resourceLock.acquire()) {
@@ -305,7 +308,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 		}
 
 		boolean isLockCompatible(ResourceLock lock) {
-			return locks.stream().allMatch( l -> l.isCompatible(lock));
+			return locks.stream().allMatch(l -> l.isCompatible(lock));
 		}
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -191,16 +191,13 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 	}
 
 	private void resubmitDeferredTasks() {
-		ThreadLock threadLock = threadLocks.get();
-		if (threadLock != null) {
-			List<ExclusiveTask> deferredTasks = threadLock.deferredTasks;
-			for (ExclusiveTask deferredTask : deferredTasks) {
-				if (!deferredTask.isDone()) {
-					deferredTask.fork();
-				}
+		List<ExclusiveTask> deferredTasks = threadLocks.get().deferredTasks;
+		for (ExclusiveTask deferredTask : deferredTasks) {
+			if (!deferredTask.isDone()) {
+				deferredTask.fork();
 			}
-			deferredTasks.clear();
 		}
+		deferredTasks.clear();
 	}
 
 	@Override
@@ -265,9 +262,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 				throw ExceptionUtils.throwAsUncheckedException(e);
 			}
 			finally {
-				if (threadLock.decrementNesting()) {
-					threadLocks.remove();
-				}
+				threadLock.decrementNesting();
 			}
 		}
 
@@ -310,9 +305,8 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 		}
 
 		@SuppressWarnings("resource")
-		boolean decrementNesting() {
+		void decrementNesting() {
 			locks.pop();
-			return locks.isEmpty();
 		}
 
 		boolean areAllHeldLocksCompatibleWith(ResourceLock lock) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -134,7 +134,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 		if (testTask.getExecutionMode() == CONCURRENT && ForkJoinTask.getSurplusQueuedTaskCount() < parallelism) {
 			return exclusiveTask.fork();
 		}
-		exclusiveTask.exec();
+		exclusiveTask.execSync();
 		return completedFuture(null);
 	}
 
@@ -145,7 +145,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 	@Override
 	public void invokeAll(List<? extends TestTask> tasks) {
 		if (tasks.size() == 1) {
-			new ExclusiveTask(tasks.get(0)).exec();
+			new ExclusiveTask(tasks.get(0)).execSync();
 			return;
 		}
 		Deque<ExclusiveTask> nonConcurrentTasks = new LinkedList<>();
@@ -171,7 +171,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 
 	private void executeNonConcurrentTasks(Deque<ExclusiveTask> nonConcurrentTasks) {
 		for (ExclusiveTask task : nonConcurrentTasks) {
-			task.exec();
+			task.execSync();
 		}
 	}
 
@@ -220,6 +220,13 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 		 * Requires null completion value.
 		 */
 		protected final void setRawResult(Void mustBeNull) {
+		}
+
+		void execSync() {
+			boolean completed = exec();
+			if (!completed) {
+				throw new IllegalStateException("Task was deferred but should have been executed synchronously: " + testTask);
+			}
 		}
 
 		@SuppressWarnings("try")

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -273,7 +273,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 
 		@Override
 		public String toString() {
-			return "ExclusiveTask for " + testTask;
+			return "ExclusiveTask [" + testTask + "]";
 		}
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -97,4 +97,5 @@ class LockManager {
 				return new CompositeLock(locks);
 		}
 	}
+
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -60,7 +60,8 @@ class LockManager {
 		Lock lock = toLock(resource);
 		if (GLOBAL_READ.equals(resource)) {
 			return new SingleLock.GlobalReadLock(lock);
-		} else if (GLOBAL_READ_WRITE.equals(resource)) {
+		}
+		else if (GLOBAL_READ_WRITE.equals(resource)) {
 			return new SingleLock.GlobalReadWriteLock(lock);
 		}
 		return new SingleLock(lock);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -17,6 +17,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ;
 
 import java.util.Collection;
@@ -56,7 +57,13 @@ class LockManager {
 	}
 
 	ResourceLock getLockForResource(ExclusiveResource resource) {
-		return new SingleLock(toLock(resource), GLOBAL_READ.equals(resource));
+		Lock lock = toLock(resource);
+		if (GLOBAL_READ.equals(resource)) {
+			return new SingleLock.GlobalReadLock(lock);
+		} else if (GLOBAL_READ_WRITE.equals(resource)) {
+			return new SingleLock.GlobalReadWriteLock(lock);
+		}
+		return new SingleLock(lock);
 	}
 
 	private List<Lock> getDistinctSortedLocks(Collection<ExclusiveResource> resources) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -79,6 +79,11 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 		return taskContext.getExecutionAdvisor().getForcedExecutionMode(testDescriptor).orElse(node.getExecutionMode());
 	}
 
+	@Override
+	public String toString() {
+		return testDescriptor.toString();
+	}
+
 	void setParentContext(C parentContext) {
 		this.parentContext = parentContext;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -81,7 +81,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 
 	@Override
 	public String toString() {
-		return testDescriptor.toString();
+		return "NodeTestTask [" + testDescriptor + "]";
 	}
 
 	void setParentContext(C parentContext) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ResourceLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ResourceLock.java
@@ -43,4 +43,12 @@ public interface ResourceLock extends AutoCloseable {
 		release();
 	}
 
+	/**
+	 * {@return whether the given lock is compatible with this lock}
+	 * @param other the other lock to check for compatibility
+	 */
+	default boolean isCompatible(ResourceLock other) {
+		return other instanceof NopLock || this instanceof NopLock;
+	}
+
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ResourceLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ResourceLock.java
@@ -48,7 +48,7 @@ public interface ResourceLock extends AutoCloseable {
 	 * @param other the other lock to check for compatibility
 	 */
 	default boolean isCompatible(ResourceLock other) {
-		return other instanceof NopLock || this instanceof NopLock;
+		return this instanceof NopLock || other instanceof NopLock;
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
@@ -19,9 +19,11 @@ import java.util.concurrent.locks.Lock;
 class SingleLock implements ResourceLock {
 
 	private final Lock lock;
+	private final boolean isGlobalReadLock;
 
-	SingleLock(Lock lock) {
+	SingleLock(Lock lock, boolean isGlobalReadLock) {
 		this.lock = lock;
+		this.isGlobalReadLock = isGlobalReadLock;
 	}
 
 	// for tests only
@@ -60,4 +62,9 @@ class SingleLock implements ResourceLock {
 
 	}
 
+	@Override
+	public boolean isCompatible(ResourceLock other) {
+		return ResourceLock.super.isCompatible(other)
+				|| (other instanceof SingleLock && ((SingleLock) other).isGlobalReadLock && isGlobalReadLock);
+	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
@@ -64,6 +64,7 @@ class SingleLock implements ResourceLock {
 		GlobalReadLock(Lock lock) {
 			super(lock);
 		}
+
 		@Override
 		public boolean isCompatible(ResourceLock other) {
 			return !(other instanceof GlobalReadWriteLock);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
@@ -19,11 +19,9 @@ import java.util.concurrent.locks.Lock;
 class SingleLock implements ResourceLock {
 
 	private final Lock lock;
-	private final boolean isGlobalReadLock;
 
-	SingleLock(Lock lock, boolean isGlobalReadLock) {
+	SingleLock(Lock lock) {
 		this.lock = lock;
-		this.isGlobalReadLock = isGlobalReadLock;
 	}
 
 	// for tests only
@@ -62,9 +60,19 @@ class SingleLock implements ResourceLock {
 
 	}
 
-	@Override
-	public boolean isCompatible(ResourceLock other) {
-		return ResourceLock.super.isCompatible(other)
-				|| (other instanceof SingleLock && ((SingleLock) other).isGlobalReadLock && isGlobalReadLock);
+	static class GlobalReadLock extends SingleLock {
+		GlobalReadLock(Lock lock) {
+			super(lock);
+		}
+		@Override
+		public boolean isCompatible(ResourceLock other) {
+			return !(other instanceof GlobalReadWriteLock);
+		}
+	}
+
+	static class GlobalReadWriteLock extends SingleLock {
+		GlobalReadWriteLock(Lock lock) {
+			super(lock);
+		}
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinDeadLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinDeadLockTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.hierarchical;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.engine.Constants;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+public class ForkJoinDeadLockTests {
+
+	// https://github.com/junit-team/junit5/issues/3945
+	@Test
+	@Timeout(10)
+	void forkJoinExecutionDoesNotLeadToDeadLock() {
+		EngineTestKit.engine("junit-jupiter").selectors(selectClass(FirstTestCase.class),
+			selectClass(IsolatedTestCase.class), selectClass(Isolated2TestCase.class)) //
+				.configurationParameter(Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, "true") //
+				.configurationParameter(Constants.DEFAULT_PARALLEL_EXECUTION_MODE, "concurrent") //
+				.configurationParameter(Constants.DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME, "concurrent") //
+				.configurationParameter(Constants.PARALLEL_CONFIG_STRATEGY_PROPERTY_NAME, "fixed") //
+				.configurationParameter(Constants.PARALLEL_CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME, "3") //
+				.configurationParameter(Constants.PARALLEL_CONFIG_FIXED_PARALLELISM_PROPERTY_NAME, "3") //
+				.execute();
+	}
+
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	public static class FirstTestCase {
+		public static CountDownLatch countDownLatch = new CountDownLatch(2);
+
+		@BeforeAll
+		static void beforeAll() {
+			// System.out.println("forkJoinWorkerThread = " + Thread.currentThread());
+		}
+
+		@Test
+		void test1() throws InterruptedException {
+			// System.out.println("FirstTestCase.test1 Thread.currentThread() = " + Thread.currentThread());
+			await();
+		}
+
+		@Test
+		void test2() throws InterruptedException {
+			// System.out.println("FirstTestCase.test2 Thread.currentThread() = " + Thread.currentThread());
+			await();
+		}
+
+		private void await() throws InterruptedException {
+			countDownLatch.countDown();
+			countDownLatch.await();
+		}
+	}
+
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	@Isolated
+	public static class IsolatedTestCase {
+		@Test
+		void test1() {
+			// System.out.println("Isolated Thread.currentThread() = " + Thread.currentThread());
+		}
+	}
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	@Isolated
+	public static class Isolated2TestCase {
+		@Test
+		void test1() {
+			// System.out.println("Isolated2 Thread.currentThread() = " + Thread.currentThread());
+		}
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinDeadLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinDeadLockTests.java
@@ -33,7 +33,7 @@ public class ForkJoinDeadLockTests {
 	@Timeout(10)
 	void forkJoinExecutionDoesNotLeadToDeadLock() {
 		run(selectClass(FirstTestCase.class), selectClass(IsolatedTestCase.class),
-				selectClass(Isolated2TestCase.class));
+			selectClass(Isolated2TestCase.class));
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinDeadLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinDeadLockTests.java
@@ -13,8 +13,8 @@ package org.junit.platform.engine.support.hierarchical;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
-import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -24,34 +24,31 @@ import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.engine.Constants;
 import org.junit.platform.engine.discovery.ClassSelector;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
 // https://github.com/junit-team/junit5/issues/3945
+@Timeout(10)
 public class ForkJoinDeadLockTests {
 
 	@Test
-	@Timeout(10)
 	void forkJoinExecutionDoesNotLeadToDeadLock() {
-		run(selectClass(FirstTestCase.class), selectClass(IsolatedTestCase.class),
-			selectClass(Isolated2TestCase.class));
+		run(FirstTestCase.class, IsolatedTestCase.class, Isolated2TestCase.class);
 	}
 
 	@Test
-	@Timeout(10)
 	void nestedResourceLocksShouldStillWork() {
-		ClassSelector classSelector = selectClass(SharedResourceTestCase.class);
-		run(classSelector);
+		run(SharedResourceTestCase.class);
 	}
 
 	@Test
-	@Timeout(10)
 	void multiLevelLocks() {
-		ClassSelector classSelector = selectClass(ClassLevelTestCase.class);
-		run(classSelector);
+		run(ClassLevelTestCase.class);
 	}
 
-	private static void run(ClassSelector... classSelector) {
-		EngineTestKit.engine("junit-jupiter").selectors(classSelector) //
+	private static void run(Class<?>... classes) {
+		EngineTestKit.engine("junit-jupiter") //
+				.selectors(Arrays.stream(classes).map(DiscoverySelectors::selectClass).toArray(ClassSelector[]::new)) //
 				.configurationParameter(Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, "true") //
 				.configurationParameter(Constants.DEFAULT_PARALLEL_EXECUTION_MODE, "concurrent") //
 				.configurationParameter(Constants.DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME, "concurrent") //

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinDeadLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinDeadLockTests.java
@@ -147,8 +147,8 @@ public class ForkJoinDeadLockTests {
 		}
 	}
 
-	static class StartFinishLogger implements BeforeTestExecutionCallback, AfterTestExecutionCallback,
-			BeforeAllCallback, AfterAllCallback {
+	static class StartFinishLogger
+			implements BeforeTestExecutionCallback, AfterTestExecutionCallback, BeforeAllCallback, AfterAllCallback {
 
 		@Override
 		public void beforeAll(ExtensionContext context) {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -82,7 +82,8 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 					bothLeafTasksAreRunning.await();
 					try {
 						deferred.await();
-					} catch (InterruptedException e) {
+					}
+					catch (InterruptedException e) {
 						System.out.println("Interrupted while waiting for task to be deferred");
 					}
 				});

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -11,11 +11,25 @@
 package org.junit.platform.engine.support.hierarchical;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
+import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.CONCURRENT;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingConsumer;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.TaskEventListener;
+import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService.TestTask;
+import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
 
 class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 
@@ -33,4 +47,81 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 		assertThat(exception).rootCause().isInstanceOf(IllegalArgumentException.class);
 	}
 
+	@Test
+	void defersTasksWithIncompatibleLocks() throws Exception {
+		var configuration = new DefaultParallelExecutionConfiguration(2, 1, 2, 1, 1, __ -> false);
+
+		var lockManager = new LockManager();
+		var globalReadLock = lockManager.getLockForResource(GLOBAL_READ);
+		var globalReadWriteLock = lockManager.getLockForResource(GLOBAL_READ_WRITE);
+		var nopLock = NopLock.INSTANCE;
+
+		var threadNamesByTaskIdentifier = new ConcurrentHashMap<String, String>();
+		var deferred = new CountDownLatch(1);
+		var deferredTask = new AtomicReference<TestTask>();
+
+		TaskEventListener taskEventListener = testTask -> {
+			deferredTask.set(testTask);
+			deferred.countDown();
+		};
+
+		var isolatedTask = new DummyTestTask("isolatedTask", globalReadWriteLock,
+			t -> threadNamesByTaskIdentifier.put(t.identifier(), Thread.currentThread().getName()));
+
+		try (var pool = new ForkJoinPoolHierarchicalTestExecutorService(configuration, taskEventListener)) {
+
+			var bothLeafTasksAreRunning = new CountDownLatch(2);
+			var nestedTask = new DummyTestTask("nestedTask", globalReadLock, t -> {
+				threadNamesByTaskIdentifier.put(t.identifier(), Thread.currentThread().getName());
+				var leafTask1 = new DummyTestTask("leafTask1", nopLock, t1 -> {
+					threadNamesByTaskIdentifier.put(t1.identifier(), Thread.currentThread().getName());
+					bothLeafTasksAreRunning.countDown();
+					bothLeafTasksAreRunning.await();
+					pool.new ExclusiveTask(isolatedTask).fork();
+					deferred.await();
+				});
+				var leafTask2 = new DummyTestTask("leafTask2", nopLock, t2 -> {
+					threadNamesByTaskIdentifier.put(t2.identifier(), Thread.currentThread().getName());
+					bothLeafTasksAreRunning.countDown();
+					bothLeafTasksAreRunning.await();
+				});
+				pool.invokeAll(List.of(leafTask1, leafTask2));
+			});
+
+			pool.submit(nestedTask).get();
+		}
+
+		assertEquals(isolatedTask, deferredTask.get());
+		assertEquals(threadNamesByTaskIdentifier.get("nestedTask"), threadNamesByTaskIdentifier.get("leafTask2"));
+		assertNotEquals(threadNamesByTaskIdentifier.get("leafTask1"), threadNamesByTaskIdentifier.get("leafTask2"));
+		assertEquals(threadNamesByTaskIdentifier.get("leafTask1"), threadNamesByTaskIdentifier.get("isolatedTask"));
+	}
+
+	record DummyTestTask(String identifier, ResourceLock resourceLock, ThrowingConsumer<DummyTestTask> action)
+			implements TestTask {
+		@Override
+		public ExecutionMode getExecutionMode() {
+			return CONCURRENT;
+		}
+
+		@Override
+		public ResourceLock getResourceLock() {
+			return resourceLock;
+		}
+
+		@Override
+		public void execute() {
+			try {
+				action.accept(this);
+			}
+			catch (Throwable e) {
+				throw new RuntimeException("Action " + identifier + " failed", e);
+			}
+		}
+
+		@Override
+		public String toString() {
+			return identifier;
+		}
+	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.TaskEventListener;
@@ -48,8 +49,9 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 	}
 
 	@Test
+	@Timeout(5)
 	void defersTasksWithIncompatibleLocks() throws Exception {
-		var configuration = new DefaultParallelExecutionConfiguration(2, 1, 2, 1, 1, __ -> false);
+		var configuration = new DefaultParallelExecutionConfiguration(2, 2, 3, 1, 1, __ -> true);
 
 		var lockManager = new LockManager();
 		var globalReadLock = lockManager.getLockForResource(GLOBAL_READ);
@@ -94,7 +96,6 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 		assertEquals(isolatedTask, deferredTask.get());
 		assertEquals(threadNamesByTaskIdentifier.get("nestedTask"), threadNamesByTaskIdentifier.get("leafTask2"));
 		assertNotEquals(threadNamesByTaskIdentifier.get("leafTask1"), threadNamesByTaskIdentifier.get("leafTask2"));
-		assertEquals(threadNamesByTaskIdentifier.get("leafTask1"), threadNamesByTaskIdentifier.get("isolatedTask"));
 	}
 
 	record DummyTestTask(String identifier, ResourceLock resourceLock, ThrowingConsumer<DummyTestTask> action)

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
@@ -32,7 +32,7 @@ import org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode
  */
 class LockManagerTests {
 
-	private LockManager lockManager = new LockManager();
+	private final LockManager lockManager = new LockManager();
 
 	@Test
 	void returnsNopLockWithoutExclusiveResources() {
@@ -50,7 +50,7 @@ class LockManagerTests {
 		var locks = getLocks(resources, SingleLock.class);
 
 		assertThat(locks).hasSize(1);
-		assertThat(locks.get(0)).isInstanceOf(ReadLock.class);
+		assertThat(locks.getFirst()).isInstanceOf(ReadLock.class);
 	}
 
 	@Test
@@ -75,7 +75,7 @@ class LockManagerTests {
 
 		assertThat(locks1).hasSize(1);
 		assertThat(locks2).hasSize(1);
-		assertThat(locks1.get(0)).isSameAs(locks2.get(0));
+		assertThat(locks1.getFirst()).isSameAs(locks2.getFirst());
 	}
 
 	@Test
@@ -111,8 +111,26 @@ class LockManagerTests {
 		assertThat(locks.get(3)).isEqualTo(getSingleLock("foo", READ_WRITE));
 	}
 
-	private Lock getSingleLock(String globalResourceLockKey, LockMode read) {
-		return getLocks(Set.of(new ExclusiveResource(globalResourceLockKey, read)), SingleLock.class).get(0);
+	@Test
+	void usesSpecialClassForGlobalReadLock() {
+		var lock = lockManager.getLockForResources(List.of(ExclusiveResource.GLOBAL_READ));
+
+		assertThat(lock) //
+				.isInstanceOf(SingleLock.GlobalReadLock.class) //
+				.isSameAs(lockManager.getLockForResource(ExclusiveResource.GLOBAL_READ));
+	}
+
+	@Test
+	void usesSpecialClassForGlobalReadWriteLock() {
+		var lock = lockManager.getLockForResources(List.of(ExclusiveResource.GLOBAL_READ_WRITE));
+
+		assertThat(lock) //
+				.isInstanceOf(SingleLock.GlobalReadWriteLock.class) //
+				.isSameAs(lockManager.getLockForResource(ExclusiveResource.GLOBAL_READ_WRITE));
+	}
+
+	private Lock getSingleLock(String key, LockMode lockMode) {
+		return getLocks(Set.of(new ExclusiveResource(key, lockMode)), SingleLock.class).getFirst();
 	}
 
 	private List<Lock> getLocks(Collection<ExclusiveResource> resources, Class<? extends ResourceLock> type) {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.engine.support.hierarchical;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.jupiter.api.Test;
+
+class ResourceLockTests {
+
+	private final ReentrantLock reentrantLock = new ReentrantLock();
+
+	@Test
+	void singleResourceLocksThatBothHaveTheGlobalReadLockFlagAreCompatible() {
+		SingleLock lock1 = new SingleLock(reentrantLock, true);
+		SingleLock lock2 = new SingleLock(reentrantLock, true);
+		assertSymmetry(lock1, lock2);
+	}
+
+	@Test
+	void singleResourceLocksThatNotBothHaveTheGlobalReadLockFlagAreIncompatible() {
+		SingleLock lock1 = new SingleLock(reentrantLock, true);
+		SingleLock lock2 = new SingleLock(reentrantLock, false);
+		SingleLock lock3 = new SingleLock(reentrantLock, false);
+		assertSymmetryNotCompatible(lock1, lock2);
+		assertSymmetryNotCompatible(lock1, lock3);
+		assertSymmetryNotCompatible(lock2, lock3);
+	}
+
+	@Test
+	void nopLocksAreCompatibleWithEverything() {
+		ResourceLock nop = NopLock.INSTANCE;
+		SingleLock singleLockGR = new SingleLock(reentrantLock, true);
+		SingleLock singleLock = new SingleLock(reentrantLock, false);
+		CompositeLock compositeLock = new CompositeLock(List.of(reentrantLock));
+		assertSymmetry(nop, singleLockGR);
+		assertSymmetry(nop, singleLock);
+		assertSymmetry(nop, compositeLock);
+	}
+
+	@Test
+	void compositeLocksAreIncompatibleWithNonNopLocks() {
+		CompositeLock compositeLock = new CompositeLock(List.of(reentrantLock));
+		SingleLock singleLockGR = new SingleLock(reentrantLock, true);
+		SingleLock singleLock = new SingleLock(reentrantLock, false);
+		assertSymmetryNotCompatible(compositeLock, singleLockGR);
+		assertSymmetryNotCompatible(compositeLock, singleLock);
+		assertSymmetryNotCompatible(compositeLock, compositeLock);
+	}
+
+	void assertSymmetry(ResourceLock a, ResourceLock b) {
+		assertTrue(a.isCompatible(b));
+		assertTrue(b.isCompatible(a));
+	}
+
+	void assertSymmetryNotCompatible(ResourceLock a, ResourceLock b) {
+		assertFalse(a.isCompatible(b));
+		assertFalse(b.isCompatible(a));
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -24,16 +24,16 @@ class ResourceLockTests {
 
 	@Test
 	void singleResourceLocksThatBothHaveTheGlobalReadLockFlagAreCompatible() {
-		SingleLock lock1 = new SingleLock(reentrantLock, true);
-		SingleLock lock2 = new SingleLock(reentrantLock, true);
+		SingleLock lock1 = new SingleLock(reentrantLock);
+		SingleLock lock2 = new SingleLock(reentrantLock);
 		assertSymmetry(lock1, lock2);
 	}
 
 	@Test
 	void singleResourceLocksThatNotBothHaveTheGlobalReadLockFlagAreIncompatible() {
-		SingleLock lock1 = new SingleLock(reentrantLock, true);
-		SingleLock lock2 = new SingleLock(reentrantLock, false);
-		SingleLock lock3 = new SingleLock(reentrantLock, false);
+		SingleLock lock1 = new SingleLock(reentrantLock);
+		SingleLock lock2 = new SingleLock(reentrantLock);
+		SingleLock lock3 = new SingleLock(reentrantLock);
 		assertSymmetryNotCompatible(lock1, lock2);
 		assertSymmetryNotCompatible(lock1, lock3);
 		assertSymmetryNotCompatible(lock2, lock3);
@@ -42,8 +42,8 @@ class ResourceLockTests {
 	@Test
 	void nopLocksAreCompatibleWithEverything() {
 		ResourceLock nop = NopLock.INSTANCE;
-		SingleLock singleLockGR = new SingleLock(reentrantLock, true);
-		SingleLock singleLock = new SingleLock(reentrantLock, false);
+		SingleLock singleLockGR = new SingleLock(reentrantLock);
+		SingleLock singleLock = new SingleLock(reentrantLock);
 		CompositeLock compositeLock = new CompositeLock(List.of(reentrantLock));
 		assertSymmetry(nop, singleLockGR);
 		assertSymmetry(nop, singleLock);
@@ -53,8 +53,8 @@ class ResourceLockTests {
 	@Test
 	void compositeLocksAreIncompatibleWithNonNopLocks() {
 		CompositeLock compositeLock = new CompositeLock(List.of(reentrantLock));
-		SingleLock singleLockGR = new SingleLock(reentrantLock, true);
-		SingleLock singleLock = new SingleLock(reentrantLock, false);
+		SingleLock singleLockGR = new SingleLock(reentrantLock);
+		SingleLock singleLock = new SingleLock(reentrantLock);
 		assertSymmetryNotCompatible(compositeLock, singleLockGR);
 		assertSymmetryNotCompatible(compositeLock, singleLock);
 		assertSymmetryNotCompatible(compositeLock, compositeLock);

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/SingleLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/SingleLockTests.java
@@ -27,7 +27,7 @@ class SingleLockTests {
 	void acquire() throws Exception {
 		var lock = new ReentrantLock();
 
-		new SingleLock(lock).acquire();
+		new SingleLock(lock, true).acquire();
 
 		assertTrue(lock.isLocked());
 	}
@@ -37,7 +37,7 @@ class SingleLockTests {
 	void release() throws Exception {
 		var lock = new ReentrantLock();
 
-		new SingleLock(lock).acquire().close();
+		new SingleLock(lock, true).acquire().close();
 
 		assertFalse(lock.isLocked());
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/SingleLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/SingleLockTests.java
@@ -27,7 +27,7 @@ class SingleLockTests {
 	void acquire() throws Exception {
 		var lock = new ReentrantLock();
 
-		new SingleLock(lock, true).acquire();
+		new SingleLock(lock).acquire();
 
 		assertTrue(lock.isLocked());
 	}
@@ -37,7 +37,7 @@ class SingleLockTests {
 	void release() throws Exception {
 		var lock = new ReentrantLock();
 
-		new SingleLock(lock, true).acquire().close();
+		new SingleLock(lock).acquire().close();
 
 		assertFalse(lock.isLocked());
 	}


### PR DESCRIPTION
## Overview

fixes #3945

This PR actually fixes the problem that was attempted in #3936. 
That PR is still valid on its own, although it didn't fix the actual problem.
The release notes still apply for this as well.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
