### PR TITLE
Remove the workaround for updating Shadow 8.3.1

### DIFF
--- a/gradle/plugins/code-generator/src/main/kotlin/junitbuild/generator/GenerateJreRelatedSourceCode.kt
+++ b/gradle/plugins/code-generator/src/main/kotlin/junitbuild/generator/GenerateJreRelatedSourceCode.kt
@@ -45,7 +45,6 @@ abstract class GenerateJreRelatedSourceCode : DefaultTask() {
         val codeResolver = DirectoryCodeResolver(templateDir.toPath())
         val templateEngine =
             TemplateEngine.create(codeResolver, temporaryDir.toPath(), ContentType.Plain, javaClass.classLoader)
-        templateEngine.setCompileArgs("-proc:none")
 
         val templates = templateDir.walkTopDown()
             .filter { it.extension == "jte" }


### PR DESCRIPTION
## Overview

This has been handled by updating to Shadow 8.3.2

Follow up https://github.com/junit-team/junit5/pull/3969#issuecomment-2342918871.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
