### PR TITLE
Allow for work stealing when only holding read locks

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
@@ -87,7 +87,6 @@ class CompositeLock implements ResourceLock {
 	public String toString() {
 		return new ToStringBuilder(this) //
 				.append("resources", resources) //
-				.append("locks", locks) //
 				.toString();
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
@@ -27,11 +27,14 @@ class CompositeLock implements ResourceLock {
 
 	private final List<ExclusiveResource> resources;
 	private final List<Lock> locks;
+	private final boolean exclusive;
 
 	CompositeLock(List<ExclusiveResource> resources, List<Lock> locks) {
 		Preconditions.condition(resources.size() == locks.size(), "Resources and locks must have the same size");
 		this.resources = unmodifiableList(resources);
 		this.locks = Preconditions.notEmpty(locks, "Locks must not be empty");
+		this.exclusive = resources.stream().anyMatch(
+			resource -> resource.getLockMode() == ExclusiveResource.LockMode.READ_WRITE);
 	}
 
 	@Override
@@ -73,6 +76,11 @@ class CompositeLock implements ResourceLock {
 		for (int i = acquiredLocks.size() - 1; i >= 0; i--) {
 			acquiredLocks.get(i).unlock();
 		}
+	}
+
+	@Override
+	public boolean isExclusive() {
+		return exclusive;
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
@@ -10,12 +10,10 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static java.util.Collections.unmodifiableNavigableSet;
+import static java.util.Collections.unmodifiableList;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NavigableSet;
-import java.util.SortedSet;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.locks.Lock;
 
@@ -27,17 +25,17 @@ import org.junit.platform.commons.util.ToStringBuilder;
  */
 class CompositeLock implements ResourceLock {
 
-	private final SortedSet<ExclusiveResource> resources;
+	private final List<ExclusiveResource> resources;
 	private final List<Lock> locks;
 
-	CompositeLock(NavigableSet<ExclusiveResource> resources, List<Lock> locks) {
+	CompositeLock(List<ExclusiveResource> resources, List<Lock> locks) {
 		Preconditions.condition(resources.size() == locks.size(), "Resources and locks must have the same size");
-		this.resources = unmodifiableNavigableSet(resources);
+		this.resources = unmodifiableList(resources);
 		this.locks = Preconditions.notEmpty(locks, "Locks must not be empty");
 	}
 
 	@Override
-	public SortedSet<ExclusiveResource> getResources() {
+	public List<ExclusiveResource> getResources() {
 		return resources;
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
@@ -10,15 +10,12 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static java.util.Collections.unmodifiableNavigableSet;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.Comparator;
-import java.util.NavigableSet;
 import java.util.Objects;
-import java.util.TreeSet;
 import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apiguardian.api.API;
@@ -78,12 +75,6 @@ public class ExclusiveResource {
 	public ExclusiveResource(String key, LockMode lockMode) {
 		this.key = Preconditions.notBlank(key, "key must not be blank");
 		this.lockMode = Preconditions.notNull(lockMode, "lockMode must not be null");
-	}
-
-	static NavigableSet<ExclusiveResource> singleton(ExclusiveResource value) {
-		NavigableSet<ExclusiveResource> set = new TreeSet<>(COMPARATOR);
-		set.add(value);
-		return unmodifiableNavigableSet(set);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
@@ -10,9 +10,15 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import static java.util.Collections.unmodifiableNavigableSet;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.util.Comparator;
+import java.util.NavigableSet;
 import java.util.Objects;
+import java.util.TreeSet;
 import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apiguardian.api.API;
@@ -50,6 +56,14 @@ public class ExclusiveResource {
 	static final ExclusiveResource GLOBAL_READ = new ExclusiveResource(GLOBAL_KEY, LockMode.READ);
 	static final ExclusiveResource GLOBAL_READ_WRITE = new ExclusiveResource(GLOBAL_KEY, LockMode.READ_WRITE);
 
+	static final Comparator<ExclusiveResource> COMPARATOR //
+		= comparing(ExclusiveResource::getKey, globalKeyFirst().thenComparing(naturalOrder())) //
+				.thenComparing(ExclusiveResource::getLockMode);
+
+	private static Comparator<String> globalKeyFirst() {
+		return comparing(key -> !GLOBAL_KEY.equals(key));
+	}
+
 	private final String key;
 	private final LockMode lockMode;
 	private int hash;
@@ -64,6 +78,12 @@ public class ExclusiveResource {
 	public ExclusiveResource(String key, LockMode lockMode) {
 		this.key = Preconditions.notBlank(key, "key must not be blank");
 		this.lockMode = Preconditions.notNull(lockMode, "lockMode must not be null");
+	}
+
+	static NavigableSet<ExclusiveResource> singleton(ExclusiveResource value) {
+		NavigableSet<ExclusiveResource> set = new TreeSet<>(COMPARATOR);
+		set.add(value);
+		return unmodifiableNavigableSet(set);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -53,7 +53,9 @@ import org.junit.platform.engine.ConfigurationParameters;
 @API(status = STABLE, since = "1.10")
 public class ForkJoinPoolHierarchicalTestExecutorService implements HierarchicalTestExecutorService {
 
-	private final ForkJoinPool forkJoinPool;
+	// package-private for testing
+	final ForkJoinPool forkJoinPool;
+
 	private final TaskEventListener taskEventListener;
 	private final int parallelism;
 	private final ThreadLocal<ThreadLock> threadLocks = ThreadLocal.withInitial(ThreadLock::new);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -10,23 +10,25 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static java.util.Comparator.comparing;
-import static java.util.Comparator.naturalOrder;
+import static java.util.Collections.emptyNavigableSet;
+import static java.util.Collections.unmodifiableNavigableSet;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
-import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY;
+import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode.READ;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.singleton;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -40,14 +42,6 @@ import org.junit.platform.engine.support.hierarchical.SingleLock.GlobalReadWrite
  */
 class LockManager {
 
-	private static final Comparator<ExclusiveResource> COMPARATOR //
-		= comparing(ExclusiveResource::getKey, globalKeyFirst().thenComparing(naturalOrder())) //
-				.thenComparing(ExclusiveResource::getLockMode);
-
-	private static Comparator<String> globalKeyFirst() {
-		return comparing(key -> !GLOBAL_KEY.equals(key));
-	}
-
 	private final Map<String, ReadWriteLock> locksByKey = new ConcurrentHashMap<>();
 	private final GlobalReadLock globalReadLock;
 	private final GlobalReadWriteLock globalReadWriteLock;
@@ -58,57 +52,59 @@ class LockManager {
 	}
 
 	ResourceLock getLockForResources(Collection<ExclusiveResource> resources) {
-		return toResourceLock(toDistinctSortedLocks(resources));
+		return toResourceLock(toDistinctSortedResources(resources));
 	}
 
 	ResourceLock getLockForResource(ExclusiveResource resource) {
-		return toResourceLock(toLock(resource));
+		return toResourceLock(singleton(resource));
 	}
 
-	private List<Lock> toDistinctSortedLocks(Collection<ExclusiveResource> resources) {
+	private NavigableSet<ExclusiveResource> toDistinctSortedResources(Collection<ExclusiveResource> resources) {
 		if (resources.isEmpty()) {
-			return emptyList();
+			return emptyNavigableSet();
 		}
 		if (resources.size() == 1) {
-			return singletonList(toLock(getOnlyElement(resources)));
+			return singleton(getOnlyElement(resources));
 		}
 		// @formatter:off
 		Map<String, List<ExclusiveResource>> resourcesByKey = resources.stream()
-				.sorted(COMPARATOR)
+				.sorted(ExclusiveResource.COMPARATOR)
 				.distinct()
 				.collect(groupingBy(ExclusiveResource::getKey, LinkedHashMap::new, toList()));
 
-		return resourcesByKey.values().stream()
+		NavigableSet<ExclusiveResource> result = resourcesByKey.values().stream()
 				.map(resourcesWithSameKey -> resourcesWithSameKey.get(0))
-				.map(this::toLock)
-				.collect(toList());
+				.collect(toCollection(() -> new TreeSet<>(ExclusiveResource.COMPARATOR)));
 		// @formatter:on
+
+		return unmodifiableNavigableSet(result);
+	}
+
+	private ResourceLock toResourceLock(NavigableSet<ExclusiveResource> resources) {
+		switch (resources.size()) {
+			case 0:
+				return NopLock.INSTANCE;
+			case 1:
+				ExclusiveResource resource = getOnlyElement(resources);
+				if (GLOBAL_READ.equals(resource)) {
+					return globalReadLock;
+				}
+				if (GLOBAL_READ_WRITE.equals(resource)) {
+					return globalReadWriteLock;
+				}
+				return new SingleLock(resources, toLock(resource));
+			default:
+				return new CompositeLock(resources, toLocks(resources));
+		}
+	}
+
+	private List<Lock> toLocks(Set<ExclusiveResource> resources) {
+		return resources.stream().map(this::toLock).collect(toUnmodifiableList());
 	}
 
 	private Lock toLock(ExclusiveResource resource) {
 		ReadWriteLock lock = this.locksByKey.computeIfAbsent(resource.getKey(), key -> new ReentrantReadWriteLock());
 		return resource.getLockMode() == READ ? lock.readLock() : lock.writeLock();
-	}
-
-	private ResourceLock toResourceLock(List<Lock> locks) {
-		switch (locks.size()) {
-			case 0:
-				return NopLock.INSTANCE;
-			case 1:
-				return toResourceLock(locks.get(0));
-			default:
-				return new CompositeLock(locks);
-		}
-	}
-
-	private ResourceLock toResourceLock(Lock lock) {
-		if (lock == toLock(GLOBAL_READ)) {
-			return globalReadLock;
-		}
-		if (lock == toLock(GLOBAL_READ_WRITE)) {
-			return globalReadWriteLock;
-		}
-		return new SingleLock(lock);
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/LockManager.java
@@ -34,21 +34,18 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.junit.platform.engine.support.hierarchical.SingleLock.GlobalReadLock;
-import org.junit.platform.engine.support.hierarchical.SingleLock.GlobalReadWriteLock;
-
 /**
  * @since 1.3
  */
 class LockManager {
 
 	private final Map<String, ReadWriteLock> locksByKey = new ConcurrentHashMap<>();
-	private final GlobalReadLock globalReadLock;
-	private final GlobalReadWriteLock globalReadWriteLock;
+	private final SingleLock globalReadLock;
+	private final SingleLock globalReadWriteLock;
 
 	public LockManager() {
-		globalReadLock = new GlobalReadLock(toLock(GLOBAL_READ));
-		globalReadWriteLock = new GlobalReadWriteLock(toLock(GLOBAL_READ_WRITE));
+		globalReadLock = new SingleLock(GLOBAL_READ, toLock(GLOBAL_READ));
+		globalReadWriteLock = new SingleLock(GLOBAL_READ_WRITE, toLock(GLOBAL_READ_WRITE));
 	}
 
 	ResourceLock getLockForResources(Collection<ExclusiveResource> resources) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NopLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NopLock.java
@@ -44,6 +44,11 @@ class NopLock implements ResourceLock {
 	}
 
 	@Override
+	public boolean isExclusive() {
+		return false;
+	}
+
+	@Override
 	public String toString() {
 		return new ToStringBuilder(this).toString();
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NopLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NopLock.java
@@ -10,10 +10,9 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static java.util.Collections.unmodifiableNavigableSet;
+import static java.util.Collections.emptyList;
 
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.List;
 
 import org.junit.platform.commons.util.ToStringBuilder;
 
@@ -25,15 +24,13 @@ import org.junit.platform.commons.util.ToStringBuilder;
 class NopLock implements ResourceLock {
 
 	static final ResourceLock INSTANCE = new NopLock();
-	static final SortedSet<ExclusiveResource> RESOURCES = unmodifiableNavigableSet(
-		new TreeSet<>(ExclusiveResource.COMPARATOR));
 
 	private NopLock() {
 	}
 
 	@Override
-	public SortedSet<ExclusiveResource> getResources() {
-		return RESOURCES;
+	public List<ExclusiveResource> getResources() {
+		return emptyList();
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NopLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NopLock.java
@@ -10,6 +10,13 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import static java.util.Collections.unmodifiableNavigableSet;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.junit.platform.commons.util.ToStringBuilder;
+
 /**
  * No-op {@link ResourceLock} implementation.
  *
@@ -18,8 +25,15 @@ package org.junit.platform.engine.support.hierarchical;
 class NopLock implements ResourceLock {
 
 	static final ResourceLock INSTANCE = new NopLock();
+	static final SortedSet<ExclusiveResource> RESOURCES = unmodifiableNavigableSet(
+		new TreeSet<>(ExclusiveResource.COMPARATOR));
 
 	private NopLock() {
+	}
+
+	@Override
+	public SortedSet<ExclusiveResource> getResources() {
+		return RESOURCES;
 	}
 
 	@Override
@@ -32,4 +46,8 @@ class NopLock implements ResourceLock {
 		// nothing to do
 	}
 
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).toString();
+	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ResourceLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ResourceLock.java
@@ -75,6 +75,9 @@ public interface ResourceLock extends AutoCloseable {
 		// NodeTreeWalker will force all children to run in the same thread so that
 		// it should never attempt to steal work from another thread, and we shouldn't
 		// actually reach this point.
+		// The global read lock (which is always on direct children of the engine node)
+		// needs special treatment so that it is compatible with the first write lock
+		// (which may be on a test method).
 		boolean isGlobalReadLock = ownResources.size() == 1
 				&& ExclusiveResource.GLOBAL_READ.equals(ownResources.get(0));
 		if ((!isGlobalReadLock && other.isExclusive()) || this.isExclusive()) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ResourceLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ResourceLock.java
@@ -12,6 +12,8 @@ package org.junit.platform.engine.support.hierarchical;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.util.SortedSet;
+
 import org.apiguardian.api.API;
 
 /**
@@ -43,12 +45,18 @@ public interface ResourceLock extends AutoCloseable {
 		release();
 	}
 
+	SortedSet<ExclusiveResource> getResources();
+
 	/**
 	 * {@return whether the given lock is compatible with this lock}
 	 * @param other the other lock to check for compatibility
 	 */
 	default boolean isCompatible(ResourceLock other) {
-		return this instanceof NopLock || other instanceof NopLock;
+		if (this.getResources().isEmpty() || other.getResources().isEmpty()) {
+			return true;
+		}
+		return other.getResources().stream() //
+				.allMatch(it -> this.getResources().contains(it)
+						|| ExclusiveResource.COMPARATOR.compare(this.getResources().last(), it) < 0);
 	}
-
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
@@ -88,16 +88,4 @@ class SingleLock implements ResourceLock {
 		}
 
 	}
-
-	static class GlobalReadLock extends SingleLock {
-		GlobalReadLock(Lock lock) {
-			super(ExclusiveResource.GLOBAL_READ, lock);
-		}
-	}
-
-	static class GlobalReadWriteLock extends SingleLock {
-		GlobalReadWriteLock(Lock lock) {
-			super(ExclusiveResource.GLOBAL_READ_WRITE, lock);
-		}
-	}
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
@@ -62,7 +62,6 @@ class SingleLock implements ResourceLock {
 	public String toString() {
 		return new ToStringBuilder(this) //
 				.append("resource", getOnlyElement(resources)) //
-				.append("lock", lock) //
 				.toString();
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
@@ -10,16 +10,13 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static java.util.Collections.unmodifiableNavigableSet;
+import static java.util.Collections.singletonList;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
-import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.singleton;
 
-import java.util.NavigableSet;
-import java.util.SortedSet;
+import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.locks.Lock;
 
-import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ToStringBuilder;
 
 /**
@@ -27,21 +24,16 @@ import org.junit.platform.commons.util.ToStringBuilder;
  */
 class SingleLock implements ResourceLock {
 
-	private final SortedSet<ExclusiveResource> resources;
+	private final List<ExclusiveResource> resources;
 	private final Lock lock;
 
-	SingleLock(NavigableSet<ExclusiveResource> resources, Lock lock) {
-		Preconditions.condition(resources.size() == 1, "SingleLock must have exactly one resource");
-		this.resources = unmodifiableNavigableSet(resources);
+	SingleLock(ExclusiveResource resource, Lock lock) {
+		this.resources = singletonList(resource);
 		this.lock = lock;
 	}
 
-	SingleLock(ExclusiveResource resource, Lock lock) {
-		this(singleton(resource), lock);
-	}
-
 	@Override
-	public SortedSet<ExclusiveResource> getResources() {
+	public List<ExclusiveResource> getResources() {
 		return resources;
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/SingleLock.java
@@ -54,6 +54,11 @@ class SingleLock implements ResourceLock {
 	}
 
 	@Override
+	public boolean isExclusive() {
+		return resources.get(0).getLockMode() == ExclusiveResource.LockMode.READ_WRITE;
+	}
+
+	@Override
 	public String toString() {
 		return new ToStringBuilder(this) //
 				.append("resource", getOnlyElement(resources)) //

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/CompositeLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/CompositeLockTests.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
-import static java.util.stream.Collectors.toCollection;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -18,8 +17,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
-import java.util.NavigableSet;
-import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.IntStream;
@@ -95,10 +92,10 @@ class CompositeLockTests {
 		return lock;
 	}
 
-	private NavigableSet<ExclusiveResource> anyResources(int n) {
+	private List<ExclusiveResource> anyResources(int n) {
 		return IntStream.range(0, n) //
 				.mapToObj(j -> new ExclusiveResource("key" + j, LockMode.READ)) //
-				.collect(toCollection(() -> new TreeSet<>(ExclusiveResource.COMPARATOR)));
+				.toList();
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/CompositeLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/CompositeLockTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import static java.util.stream.Collectors.toCollection;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -17,11 +18,15 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.Lock;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode;
 
 /**
  * @since 1.3
@@ -34,7 +39,7 @@ class CompositeLockTests {
 		var lock1 = mock(Lock.class);
 		var lock2 = mock(Lock.class);
 
-		new CompositeLock(List.of(lock1, lock2)).acquire();
+		new CompositeLock(anyResources(2), List.of(lock1, lock2)).acquire();
 
 		var inOrder = inOrder(lock1, lock2);
 		inOrder.verify(lock1).lockInterruptibly();
@@ -47,7 +52,7 @@ class CompositeLockTests {
 		var lock1 = mock(Lock.class);
 		var lock2 = mock(Lock.class);
 
-		new CompositeLock(List.of(lock1, lock2)).acquire().close();
+		new CompositeLock(anyResources(2), List.of(lock1, lock2)).acquire().close();
 
 		var inOrder = inOrder(lock1, lock2);
 		inOrder.verify(lock2).unlock();
@@ -64,7 +69,7 @@ class CompositeLockTests {
 
 		var thread = new Thread(() -> {
 			try {
-				new CompositeLock(List.of(firstLock, secondLock, unavailableLock)).acquire();
+				new CompositeLock(anyResources(3), List.of(firstLock, secondLock, unavailableLock)).acquire();
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -88,6 +93,12 @@ class CompositeLockTests {
 			return null;
 		}).when(lock).lockInterruptibly();
 		return lock;
+	}
+
+	private NavigableSet<ExclusiveResource> anyResources(int n) {
+		return IntStream.range(0, n) //
+				.mapToObj(j -> new ExclusiveResource("key" + j, LockMode.READ)) //
+				.collect(toCollection(() -> new TreeSet<>(ExclusiveResource.COMPARATOR)));
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -24,7 +24,6 @@ import static org.junit.platform.engine.support.hierarchical.Node.ExecutionMode.
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -240,22 +239,5 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 		public String toString() {
 			return identifier;
 		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (obj == this)
-				return true;
-			if (obj == null || obj.getClass() != this.getClass())
-				return false;
-			var that = (DummyTestTask) obj;
-			return Objects.equals(this.identifier, that.identifier)
-					&& Objects.equals(this.resourceLock, that.resourceLock) && Objects.equals(this.action, that.action);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(identifier, resourceLock, action);
-		}
-
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -69,8 +69,24 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 				Set.of(new ExclusiveResource("a", LockMode.READ_WRITE)) //
 			), //
 			arguments(//
+				Set.of(new ExclusiveResource("a", LockMode.READ_WRITE)), //
+				Set.of(new ExclusiveResource("a", LockMode.READ_WRITE)) //
+			), //
+			arguments(//
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ_WRITE)), //
+				Set.of(GLOBAL_READ, new ExclusiveResource("b", LockMode.READ_WRITE)) //
+			), //
+			arguments(//
 				Set.of(new ExclusiveResource("b", LockMode.READ)), //
 				Set.of(new ExclusiveResource("a", LockMode.READ)) //
+			), //
+			arguments(//
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ_WRITE)), //
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)) //
+			), //
+			arguments(//
+				Set.of(GLOBAL_READ_WRITE), //
+				Set.of(GLOBAL_READ) //
 			)//
 		);
 	}
@@ -111,20 +127,20 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 	static List<Arguments> compatibleLockCombinations() {
 		return List.of(//
 			arguments(//
-				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)), //
-				Set.of(GLOBAL_READ, new ExclusiveResource("b", LockMode.READ)) //
+				Set.of(GLOBAL_READ), //
+				Set.of(new ExclusiveResource("a", LockMode.READ)) //
 			), //
 			arguments(//
-				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ_WRITE)), //
-				Set.of(GLOBAL_READ, new ExclusiveResource("b", LockMode.READ_WRITE)) //
-			), //
-			arguments(//
-				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ_WRITE)), //
+				Set.of(GLOBAL_READ), //
 				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)) //
 			), //
 			arguments(//
-				Set.of(GLOBAL_READ_WRITE), //
-				Set.of(GLOBAL_READ) //
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)), //
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)) //
+			), //
+			arguments(//
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)), //
+				Set.of(GLOBAL_READ, new ExclusiveResource("b", LockMode.READ)) //
 			)//
 		);
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -139,6 +139,14 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 			), //
 			arguments(//
 				Set.of(GLOBAL_READ), //
+				Set.of(new ExclusiveResource("a", LockMode.READ_WRITE)) //
+			), //
+			arguments(//
+				Set.of(GLOBAL_READ), //
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ_WRITE)) //
+			), //
+			arguments(//
+				Set.of(GLOBAL_READ), //
 				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)) //
 			), //
 			arguments(//

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -87,6 +87,13 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 			arguments(//
 				Set.of(GLOBAL_READ_WRITE), //
 				Set.of(GLOBAL_READ) //
+			), //
+			arguments(//
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ),
+					new ExclusiveResource("b", LockMode.READ), new ExclusiveResource("d", LockMode.READ)),
+				//
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ),
+					new ExclusiveResource("c", LockMode.READ)) //
 			)//
 		);
 	}
@@ -136,11 +143,17 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 			), //
 			arguments(//
 				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)), //
-				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)) //
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ),
+					new ExclusiveResource("b", LockMode.READ), new ExclusiveResource("c", LockMode.READ)) //
 			), //
 			arguments(//
 				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)), //
 				Set.of(GLOBAL_READ, new ExclusiveResource("b", LockMode.READ)) //
+			), //
+			arguments(//
+				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)), //
+				Set.of(new ExclusiveResource("a", LockMode.READ), new ExclusiveResource("b", LockMode.READ),
+					new ExclusiveResource("c", LockMode.READ)) //
 			)//
 		);
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorServiceTests.java
@@ -10,12 +10,14 @@
 
 package org.junit.platform.engine.support.hierarchical;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
@@ -25,13 +27,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingConsumer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,6 +48,9 @@ import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
 
 @Timeout(5)
 class ForkJoinPoolHierarchicalTestExecutorServiceTests {
+
+	DummyTaskFactory taskFactory = new DummyTaskFactory();
+	LockManager lockManager = new LockManager();
 
 	@Test
 	void exceptionsFromInvalidConfigurationAreNotSwallowed() {
@@ -91,7 +99,6 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 			arguments(//
 				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ),
 					new ExclusiveResource("b", LockMode.READ), new ExclusiveResource("d", LockMode.READ)),
-				//
 				Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ),
 					new ExclusiveResource("c", LockMode.READ)) //
 			)//
@@ -101,9 +108,8 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 	@ParameterizedTest
 	@MethodSource("incompatibleLockCombinations")
 	void defersTasksWithIncompatibleLocks(Set<ExclusiveResource> initialResources,
-			Set<ExclusiveResource> incompatibleResources) throws Exception {
+			Set<ExclusiveResource> incompatibleResources) throws Throwable {
 
-		var lockManager = new LockManager();
 		var initialLock = lockManager.getLockForResources(initialResources);
 		var incompatibleLock = lockManager.getLockForResources(incompatibleResources);
 
@@ -115,20 +121,14 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 			deferred.countDown();
 		};
 
-		var incompatibleTask = new DummyTestTask("incompatibleTask", incompatibleLock);
+		var incompatibleTask = taskFactory.create("incompatibleTask", incompatibleLock);
 
-		var tasks = runWithAttemptedWorkStealing(taskEventListener, incompatibleTask, initialLock, () -> {
-			try {
-				deferred.await();
-			}
-			catch (InterruptedException e) {
-				System.out.println("Interrupted while waiting for task to be deferred");
-			}
-		});
+		var tasks = runWithAttemptedWorkStealing(taskEventListener, incompatibleTask, initialLock,
+			() -> await(deferred, "Interrupted while waiting for task to be deferred"));
 
 		assertEquals(incompatibleTask, deferredTask.get());
-		assertEquals(tasks.get("nestedTask").threadName, tasks.get("leafTask2").threadName);
-		assertNotEquals(tasks.get("leafTask1").threadName, tasks.get("leafTask2").threadName);
+		assertEquals(tasks.get("nestedTask").threadName, tasks.get("leafTaskB").threadName);
+		assertNotEquals(tasks.get("leafTaskA").threadName, tasks.get("leafTaskB").threadName);
 	}
 
 	static List<Arguments> compatibleLockCombinations() {
@@ -169,67 +169,132 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 	@ParameterizedTest
 	@MethodSource("compatibleLockCombinations")
 	void canWorkStealTaskWithCompatibleLocks(Set<ExclusiveResource> initialResources,
-			Set<ExclusiveResource> compatibleResources) throws Exception {
+			Set<ExclusiveResource> compatibleResources) throws Throwable {
 
-		var lockManager = new LockManager();
 		var initialLock = lockManager.getLockForResources(initialResources);
 		var compatibleLock = lockManager.getLockForResources(compatibleResources);
 
 		var deferredTask = new AtomicReference<TestTask>();
 
 		var workStolen = new CountDownLatch(1);
-		var compatibleTask = new DummyTestTask("compatibleTask", compatibleLock, workStolen::countDown);
+		var compatibleTask = taskFactory.create("compatibleTask", compatibleLock, workStolen::countDown);
 
-		var tasks = runWithAttemptedWorkStealing(deferredTask::set, compatibleTask, initialLock, () -> {
-			try {
-				workStolen.await();
-			}
-			catch (InterruptedException e) {
-				System.out.println("Interrupted while waiting for work to be stolen");
-			}
-		});
+		var tasks = runWithAttemptedWorkStealing(deferredTask::set, compatibleTask, initialLock,
+			() -> await(workStolen, "Interrupted while waiting for work to be stolen"));
 
 		assertNull(deferredTask.get());
-		assertEquals(tasks.get("nestedTask").threadName, tasks.get("leafTask2").threadName);
-		assertNotEquals(tasks.get("leafTask1").threadName, tasks.get("leafTask2").threadName);
+		assertEquals(tasks.get("nestedTask").threadName, tasks.get("leafTaskB").threadName);
+		assertNotEquals(tasks.get("leafTaskA").threadName, tasks.get("leafTaskB").threadName);
 	}
 
-	private static Map<String, DummyTestTask> runWithAttemptedWorkStealing(TaskEventListener taskEventListener,
-			DummyTestTask taskToBeStolen, ResourceLock initialLock, Runnable waitAction)
-			throws InterruptedException, ExecutionException {
+	@Test
+	void defersTasksWithIncompatibleLocksOnMultipleLevels() throws Throwable {
 
-		var tasks = new HashMap<String, DummyTestTask>();
-		tasks.put(taskToBeStolen.identifier, taskToBeStolen);
+		var initialLock = lockManager.getLockForResources(
+			Set.of(GLOBAL_READ, new ExclusiveResource("a", LockMode.READ)));
+		var incompatibleLock1 = lockManager.getLockForResource(new ExclusiveResource("a", LockMode.READ_WRITE));
+		var compatibleLock1 = lockManager.getLockForResource(new ExclusiveResource("b", LockMode.READ));
+		var incompatibleLock2 = lockManager.getLockForResource(new ExclusiveResource("b", LockMode.READ_WRITE));
+
+		var deferred = new ConcurrentHashMap<TestTask, CountDownLatch>();
+		var deferredTasks = new CopyOnWriteArrayList<TestTask>();
+		TaskEventListener taskEventListener = testTask -> {
+			deferredTasks.add(testTask);
+			deferred.get(testTask).countDown();
+		};
+
+		var incompatibleTask1 = taskFactory.create("incompatibleTask1", incompatibleLock1);
+		deferred.put(incompatibleTask1, new CountDownLatch(1));
+
+		var incompatibleTask2 = taskFactory.create("incompatibleTask2", incompatibleLock2);
+		deferred.put(incompatibleTask2, new CountDownLatch(1));
+
+		var configuration = new DefaultParallelExecutionConfiguration(2, 2, 2, 2, 1, __1 -> true);
+
+		withForkJoinPoolHierarchicalTestExecutorService(configuration, taskEventListener, service -> {
+
+			var nestedTask2 = createNestedTaskWithTwoConcurrentLeafTasks(service, "2", compatibleLock1,
+				List.of(incompatibleTask2), //
+				() -> await(deferred.get(incompatibleTask2), incompatibleTask2.identifier + " to be deferred"));
+
+			var nestedTask1 = createNestedTaskWithTwoConcurrentLeafTasks(service, "1", initialLock,
+				List.of(incompatibleTask1, nestedTask2), //
+				() -> {
+					await(deferred.get(incompatibleTask1), incompatibleTask1.identifier + " to be deferred");
+					await(nestedTask2.started, nestedTask2.identifier + " to be started");
+				});
+
+			service.submit(nestedTask1).get();
+		});
+
+		assertThat(deferredTasks) //
+				.containsExactly(incompatibleTask1, incompatibleTask2, incompatibleTask1); // incompatibleTask1 may be deferred multiple times
+		assertThat(taskFactory.tasks) //
+				.hasSize(3 + 3 + 2) //
+				.values().extracting(it -> it.completion.isDone()).containsOnly(true);
+		assertThat(taskFactory.tasks) //
+				.values().extracting(it -> it.completion.isCompletedExceptionally()).containsOnly(false);
+	}
+
+	private Map<String, DummyTestTask> runWithAttemptedWorkStealing(TaskEventListener taskEventListener,
+			DummyTestTask taskToBeStolen, ResourceLock initialLock, Runnable waitAction) throws Throwable {
 
 		var configuration = new DefaultParallelExecutionConfiguration(2, 2, 2, 2, 1, __ -> true);
 
-		try (var pool = new ForkJoinPoolHierarchicalTestExecutorService(configuration, taskEventListener)) {
+		withForkJoinPoolHierarchicalTestExecutorService(configuration, taskEventListener, service -> {
 
-			var extraTask = pool.new ExclusiveTask(taskToBeStolen);
+			var nestedTask = createNestedTaskWithTwoConcurrentLeafTasks(service, "", initialLock,
+				List.of(taskToBeStolen), waitAction);
+
+			service.submit(nestedTask).get();
+		});
+
+		return taskFactory.tasks;
+	}
+
+	private DummyTestTask createNestedTaskWithTwoConcurrentLeafTasks(
+			ForkJoinPoolHierarchicalTestExecutorService service, String identifierSuffix, ResourceLock parentLock,
+			List<DummyTestTask> tasksToFork, Runnable waitAction) {
+
+		return taskFactory.create("nestedTask" + identifierSuffix, parentLock, () -> {
+
 			var bothLeafTasksAreRunning = new CountDownLatch(2);
-			var nestedTask = new DummyTestTask("nestedTask", initialLock, () -> {
-				var leafTask1 = new DummyTestTask("leafTask1", NopLock.INSTANCE, () -> {
-					extraTask.fork();
-					bothLeafTasksAreRunning.countDown();
-					bothLeafTasksAreRunning.await();
-					waitAction.run();
-				});
-				tasks.put(leafTask1.identifier, leafTask1);
-				var leafTask2 = new DummyTestTask("leafTask2", NopLock.INSTANCE, () -> {
-					bothLeafTasksAreRunning.countDown();
-					bothLeafTasksAreRunning.await();
-				});
-				tasks.put(leafTask2.identifier, leafTask2);
 
-				pool.invokeAll(List.of(leafTask1, leafTask2));
+			var leafTaskA = taskFactory.create("leafTaskA" + identifierSuffix, NopLock.INSTANCE, () -> {
+				tasksToFork.forEach(task -> service.new ExclusiveTask(task).fork());
+				bothLeafTasksAreRunning.countDown();
+				bothLeafTasksAreRunning.await();
+				waitAction.run();
 			});
-			tasks.put(nestedTask.identifier, nestedTask);
 
-			pool.submit(nestedTask).get();
-			extraTask.join();
+			var leafTaskB = taskFactory.create("leafTaskB" + identifierSuffix, NopLock.INSTANCE, () -> {
+				bothLeafTasksAreRunning.countDown();
+				bothLeafTasksAreRunning.await();
+			});
+
+			service.invokeAll(List.of(leafTaskA, leafTaskB));
+		});
+	}
+
+	private static void await(CountDownLatch latch, String message) {
+		try {
+			latch.await();
 		}
+		catch (InterruptedException e) {
+			System.out.println("Interrupted while waiting for " + message);
+		}
+	}
 
-		return tasks;
+	private void withForkJoinPoolHierarchicalTestExecutorService(ParallelExecutionConfiguration configuration,
+			TaskEventListener taskEventListener, ThrowingConsumer<ForkJoinPoolHierarchicalTestExecutorService> action)
+			throws Throwable {
+		try (var service = new ForkJoinPoolHierarchicalTestExecutorService(configuration, taskEventListener)) {
+
+			action.accept(service);
+
+			service.forkJoinPool.shutdown();
+			assertTrue(service.forkJoinPool.awaitTermination(5, SECONDS), "Pool did not terminate within timeout");
+		}
 	}
 
 	static final class DummyTestTask implements TestTask {
@@ -238,12 +303,9 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 		private final ResourceLock resourceLock;
 		private final Executable action;
 
-		private String threadName;
-
-		DummyTestTask(String identifier, ResourceLock resourceLock) {
-			this(identifier, resourceLock, () -> {
-			});
-		}
+		private volatile String threadName;
+		private final CountDownLatch started = new CountDownLatch(1);
+		private final CompletableFuture<Void> completion = new CompletableFuture<>();
 
 		DummyTestTask(String identifier, ResourceLock resourceLock, Executable action) {
 			this.identifier = identifier;
@@ -264,10 +326,13 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 		@Override
 		public void execute() {
 			threadName = Thread.currentThread().getName();
+			started.countDown();
 			try {
 				action.execute();
+				completion.complete(null);
 			}
 			catch (Throwable e) {
+				completion.completeExceptionally(e);
 				throw new RuntimeException("Action " + identifier + " failed", e);
 			}
 		}
@@ -275,6 +340,22 @@ class ForkJoinPoolHierarchicalTestExecutorServiceTests {
 		@Override
 		public String toString() {
 			return identifier;
+		}
+	}
+
+	static final class DummyTaskFactory {
+
+		final Map<String, DummyTestTask> tasks = new HashMap<>();
+
+		DummyTestTask create(String identifier, ResourceLock resourceLock) {
+			return create(identifier, resourceLock, () -> {
+			});
+		}
+
+		DummyTestTask create(String identifier, ResourceLock resourceLock, Executable action) {
+			DummyTestTask task = new DummyTestTask(identifier, resourceLock, action);
+			tasks.put(task.identifier, task);
+			return task;
 		}
 	}
 }

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/LockManagerTests.java
@@ -112,20 +112,20 @@ class LockManagerTests {
 	}
 
 	@Test
-	void usesSpecialClassForGlobalReadLock() {
+	void usesSingleInstanceForGlobalReadLock() {
 		var lock = lockManager.getLockForResources(List.of(ExclusiveResource.GLOBAL_READ));
 
 		assertThat(lock) //
-				.isInstanceOf(SingleLock.GlobalReadLock.class) //
+				.isInstanceOf(SingleLock.class) //
 				.isSameAs(lockManager.getLockForResource(ExclusiveResource.GLOBAL_READ));
 	}
 
 	@Test
-	void usesSpecialClassForGlobalReadWriteLock() {
+	void usesSingleInstanceForGlobalReadWriteLock() {
 		var lock = lockManager.getLockForResources(List.of(ExclusiveResource.GLOBAL_READ_WRITE));
 
 		assertThat(lock) //
-				.isInstanceOf(SingleLock.GlobalReadWriteLock.class) //
+				.isInstanceOf(SingleLock.class) //
 				.isSameAs(lockManager.getLockForResource(ExclusiveResource.GLOBAL_READ_WRITE));
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -33,7 +33,7 @@ class ResourceLockTests {
 	}
 
 	@Test
-	void readOnlySingleLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocks() {
+	void readOnlySingleLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocksOrViolateResourceIsolationGuarantees() {
 		ExclusiveResource bR = readOnlyResource("b");
 
 		assertCompatible(singleLock(bR), nopLock());

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
-import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.singleton;
 
 import java.util.List;
 import java.util.NavigableSet;
@@ -33,7 +32,7 @@ class ResourceLockTests {
 		assertTrue(nopLock.isCompatible(nopLock));
 		assertTrue(nopLock.isCompatible(NopLock.INSTANCE));
 		assertTrue(nopLock.isCompatible(new SingleLock(anyResource(), anyReentrantLock())));
-		assertTrue(nopLock.isCompatible(new CompositeLock(singleton(anyResource()), List.of(anyReentrantLock()))));
+		assertTrue(nopLock.isCompatible(new CompositeLock(List.of(anyResource()), List.of(anyReentrantLock()))));
 	}
 
 	@Test
@@ -51,14 +50,14 @@ class ResourceLockTests {
 		assertFalse(singleLock.isCompatible(new SingleLock(GLOBAL_READ, anyReentrantLock())));
 		assertFalse(singleLock.isCompatible(new SingleLock(GLOBAL_READ_WRITE, anyReentrantLock())));
 		assertTrue(singleLock.isCompatible(
-			new CompositeLock(allOf(resourceB, resource("C")), List.of(anyReentrantLock(), anyReentrantLock()))));
-		assertFalse(singleLock.isCompatible(new CompositeLock(allOf(resource("A1"), resource("A2"), resourceB),
+			new CompositeLock(List.of(resourceB, resource("C")), List.of(anyReentrantLock(), anyReentrantLock()))));
+		assertFalse(singleLock.isCompatible(new CompositeLock(List.of(resource("A1"), resource("A2"), resourceB),
 			List.of(anyReentrantLock(), anyReentrantLock(), anyReentrantLock()))));
 	}
 
 	@Test
 	void compositeLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocks() {
-		CompositeLock compositeLock = new CompositeLock(singleton(anyResource()), List.of(anyReentrantLock()));
+		CompositeLock compositeLock = new CompositeLock(List.of(anyResource()), List.of(anyReentrantLock()));
 
 		assertTrue(compositeLock.isCompatible(compositeLock));
 		assertTrue(compositeLock.isCompatible(NopLock.INSTANCE));

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -12,6 +12,8 @@ package org.junit.platform.engine.support.hierarchical;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.singleton;
 
 import java.util.List;
@@ -46,38 +48,12 @@ class ResourceLockTests {
 		assertFalse(singleLock.isCompatible(new SingleLock(resource("B", LockMode.READ_WRITE), anyReentrantLock())));
 		assertFalse(singleLock.isCompatible(new SingleLock(resource("A"), anyReentrantLock())));
 		assertTrue(singleLock.isCompatible(new SingleLock(resource("C"), anyReentrantLock())));
-		assertFalse(singleLock.isCompatible(new SingleLock.GlobalReadLock(anyReentrantLock())));
-		assertFalse(singleLock.isCompatible(new SingleLock.GlobalReadWriteLock(anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(new SingleLock(GLOBAL_READ, anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(new SingleLock(GLOBAL_READ_WRITE, anyReentrantLock())));
 		assertTrue(singleLock.isCompatible(
 			new CompositeLock(allOf(resourceB, resource("C")), List.of(anyReentrantLock(), anyReentrantLock()))));
 		assertFalse(singleLock.isCompatible(
 			new CompositeLock(allOf(resourceB, resource("A")), List.of(anyReentrantLock(), anyReentrantLock()))));
-	}
-
-	@Test
-	void globalReadLockIsCompatibleWithEverythingExceptGlobalReadWriteLock() {
-		var globalReadLock = new SingleLock.GlobalReadLock(anyReentrantLock());
-
-		assertTrue(globalReadLock.isCompatible(globalReadLock));
-		assertTrue(globalReadLock.isCompatible(NopLock.INSTANCE));
-		assertTrue(globalReadLock.isCompatible(new SingleLock(anyResource(), anyReentrantLock())));
-		assertTrue(globalReadLock.isCompatible(new SingleLock.GlobalReadLock(anyReentrantLock())));
-		assertFalse(globalReadLock.isCompatible(new SingleLock.GlobalReadWriteLock(anyReentrantLock())));
-		assertTrue(
-			globalReadLock.isCompatible(new CompositeLock(singleton(anyResource()), List.of(anyReentrantLock()))));
-	}
-
-	@Test
-	void globalReadWriteLockIsIncompatibleOtherLocksThatCanPotentiallyCauseDeadlocks() {
-		var globalReadWriteLock = new SingleLock.GlobalReadWriteLock(anyReentrantLock());
-
-		assertTrue(globalReadWriteLock.isCompatible(globalReadWriteLock));
-		assertTrue(globalReadWriteLock.isCompatible(NopLock.INSTANCE));
-		assertTrue(globalReadWriteLock.isCompatible(new SingleLock(anyResource(), anyReentrantLock())));
-		assertTrue(globalReadWriteLock.isCompatible(new SingleLock.GlobalReadLock(anyReentrantLock())));
-		assertTrue(globalReadWriteLock.isCompatible(new SingleLock.GlobalReadWriteLock(anyReentrantLock())));
-		assertTrue(
-			globalReadWriteLock.isCompatible(new CompositeLock(singleton(anyResource()), List.of(anyReentrantLock()))));
 	}
 
 	@Test
@@ -87,8 +63,8 @@ class ResourceLockTests {
 		assertTrue(compositeLock.isCompatible(compositeLock));
 		assertTrue(compositeLock.isCompatible(NopLock.INSTANCE));
 		assertTrue(compositeLock.isCompatible(new SingleLock(anyResource(), anyReentrantLock())));
-		assertFalse(compositeLock.isCompatible(new SingleLock.GlobalReadLock(anyReentrantLock())));
-		assertFalse(compositeLock.isCompatible(new SingleLock.GlobalReadWriteLock(anyReentrantLock())));
+		assertFalse(compositeLock.isCompatible(new SingleLock(GLOBAL_READ, anyReentrantLock())));
+		assertFalse(compositeLock.isCompatible(new SingleLock(GLOBAL_READ_WRITE, anyReentrantLock())));
 		assertTrue(compositeLock.isCompatible(compositeLock));
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -52,8 +52,8 @@ class ResourceLockTests {
 		assertFalse(singleLock.isCompatible(new SingleLock(GLOBAL_READ_WRITE, anyReentrantLock())));
 		assertTrue(singleLock.isCompatible(
 			new CompositeLock(allOf(resourceB, resource("C")), List.of(anyReentrantLock(), anyReentrantLock()))));
-		assertFalse(singleLock.isCompatible(
-			new CompositeLock(allOf(resourceB, resource("A")), List.of(anyReentrantLock(), anyReentrantLock()))));
+		assertFalse(singleLock.isCompatible(new CompositeLock(allOf(resource("A1"), resource("A2"), resourceB),
+			List.of(anyReentrantLock(), anyReentrantLock(), anyReentrantLock()))));
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -16,8 +16,6 @@ import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.G
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
 
 import java.util.List;
-import java.util.NavigableSet;
-import java.util.TreeSet;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.jupiter.api.Test;
@@ -36,7 +34,7 @@ class ResourceLockTests {
 	}
 
 	@Test
-	void singleLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocks() {
+	void readOnlySingleLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocks() {
 		ExclusiveResource resourceB = resource("B", LockMode.READ);
 		var singleLock = new SingleLock(resourceB, anyReentrantLock());
 
@@ -56,19 +54,70 @@ class ResourceLockTests {
 	}
 
 	@Test
-	void compositeLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocks() {
-		CompositeLock compositeLock = new CompositeLock(List.of(anyResource()), List.of(anyReentrantLock()));
+	void readWriteSingleLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocks() {
+		ExclusiveResource resourceB = resource("B", LockMode.READ_WRITE);
+		var singleLock = new SingleLock(resourceB, anyReentrantLock());
+
+		assertFalse(singleLock.isCompatible(singleLock));
+		assertTrue(singleLock.isCompatible(NopLock.INSTANCE));
+		assertFalse(singleLock.isCompatible(new SingleLock(resourceB, anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(new SingleLock(resourceB, anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(new SingleLock(resource("B", LockMode.READ), anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(new SingleLock(resource("A"), anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(new SingleLock(resource("C"), anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(new SingleLock(GLOBAL_READ, anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(new SingleLock(GLOBAL_READ_WRITE, anyReentrantLock())));
+		assertFalse(singleLock.isCompatible(
+			new CompositeLock(List.of(resourceB, resource("C")), List.of(anyReentrantLock(), anyReentrantLock()))));
+		assertFalse(singleLock.isCompatible(new CompositeLock(List.of(resource("A1"), resource("A2"), resourceB),
+			List.of(anyReentrantLock(), anyReentrantLock(), anyReentrantLock()))));
+	}
+
+	@Test
+	void globalReadLockIsCompatibleWithReadWriteLocksExceptForGlobalReadWriteLock() {
+		var globalReadLock = new SingleLock(GLOBAL_READ, anyReentrantLock());
+
+		assertTrue(globalReadLock.isCompatible(globalReadLock));
+		assertTrue(globalReadLock.isCompatible(NopLock.INSTANCE));
+		assertTrue(globalReadLock.isCompatible(new SingleLock(anyResource(LockMode.READ), anyReentrantLock())));
+		assertTrue(globalReadLock.isCompatible(new SingleLock(anyResource(LockMode.READ_WRITE), anyReentrantLock())));
+		assertFalse(globalReadLock.isCompatible(new SingleLock(GLOBAL_READ_WRITE, anyReentrantLock())));
+	}
+
+	@Test
+	void readOnlyCompositeLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocks() {
+		CompositeLock compositeLock = new CompositeLock(List.of(anyResource(LockMode.READ)),
+			List.of(anyReentrantLock()));
 
 		assertTrue(compositeLock.isCompatible(compositeLock));
 		assertTrue(compositeLock.isCompatible(NopLock.INSTANCE));
 		assertTrue(compositeLock.isCompatible(new SingleLock(anyResource(), anyReentrantLock())));
 		assertFalse(compositeLock.isCompatible(new SingleLock(GLOBAL_READ, anyReentrantLock())));
 		assertFalse(compositeLock.isCompatible(new SingleLock(GLOBAL_READ_WRITE, anyReentrantLock())));
-		assertTrue(compositeLock.isCompatible(compositeLock));
+		assertFalse(compositeLock.isCompatible(
+			new CompositeLock(List.of(anyResource(LockMode.READ_WRITE)), List.of(anyReentrantLock()))));
+	}
+
+	@Test
+	void readWriteCompositeLocksAreIncompatibleWithOtherLocksThatCanPotentiallyCauseDeadlocks() {
+		CompositeLock compositeLock = new CompositeLock(List.of(anyResource(LockMode.READ_WRITE)),
+			List.of(anyReentrantLock()));
+
+		assertFalse(compositeLock.isCompatible(compositeLock));
+		assertTrue(compositeLock.isCompatible(NopLock.INSTANCE));
+		assertFalse(compositeLock.isCompatible(new SingleLock(anyResource(), anyReentrantLock())));
+		assertFalse(compositeLock.isCompatible(new SingleLock(GLOBAL_READ, anyReentrantLock())));
+		assertFalse(compositeLock.isCompatible(new SingleLock(GLOBAL_READ_WRITE, anyReentrantLock())));
+		assertFalse(compositeLock.isCompatible(
+			new CompositeLock(List.of(anyResource(LockMode.READ)), List.of(anyReentrantLock()))));
 	}
 
 	private static ExclusiveResource anyResource() {
-		return resource("key", LockMode.READ);
+		return anyResource(LockMode.READ);
+	}
+
+	private static ExclusiveResource anyResource(LockMode lockMode) {
+		return resource("key", lockMode);
 	}
 
 	private static ExclusiveResource resource(String key) {
@@ -77,12 +126,6 @@ class ResourceLockTests {
 
 	private static ExclusiveResource resource(String key, LockMode lockMode) {
 		return new ExclusiveResource(key, lockMode);
-	}
-
-	private static NavigableSet<ExclusiveResource> allOf(ExclusiveResource... resources) {
-		var result = new TreeSet<>(ExclusiveResource.COMPARATOR);
-		result.addAll(List.of(resources));
-		return result;
 	}
 
 	private static ReentrantLock anyReentrantLock() {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -15,10 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ;
 import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_READ_WRITE;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode;
@@ -120,8 +120,7 @@ class ResourceLockTests {
 	}
 
 	private static CompositeLock compositeLock(ExclusiveResource... resources) {
-		return new CompositeLock(List.of(resources),
-			IntStream.range(0, resources.length).mapToObj(__ -> anyLock()).toList());
+		return new CompositeLock(List.of(resources), Arrays.stream(resources).map(__ -> anyLock()).toList());
 	}
 
 	private static ExclusiveResource anyReadOnlyResource() {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockTests.java
@@ -107,8 +107,8 @@ class ResourceLockTests {
 		assertTrue(first.isCompatible(second));
 	}
 
-	private static void assertIncompatible(ResourceLock singleLock, ResourceLock a) {
-		assertFalse(singleLock.isCompatible(a));
+	private static void assertIncompatible(ResourceLock first, ResourceLock second) {
+		assertFalse(first.isCompatible(second));
 	}
 
 	private static ResourceLock nopLock() {

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/SingleLockTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/SingleLockTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode;
 
 /**
  * @since 1.3
@@ -27,7 +28,7 @@ class SingleLockTests {
 	void acquire() throws Exception {
 		var lock = new ReentrantLock();
 
-		new SingleLock(lock).acquire();
+		new SingleLock(anyResource(), lock).acquire();
 
 		assertTrue(lock.isLocked());
 	}
@@ -37,9 +38,13 @@ class SingleLockTests {
 	void release() throws Exception {
 		var lock = new ReentrantLock();
 
-		new SingleLock(lock).acquire().close();
+		new SingleLock(anyResource(), lock).acquire().close();
 
 		assertFalse(lock.isLocked());
+	}
+
+	private static ExclusiveResource anyResource() {
+		return new ExclusiveResource("key", LockMode.READ);
 	}
 
 }


### PR DESCRIPTION
This allows tasks with only read locks to be stolen by threads that are
currently holding only read locks.