### PR TITLE
Allow nullable Java Time parameters

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -47,7 +47,7 @@ JUnit repository on GitHub.
 [[release-notes-5.12.0-M1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* Add support for null-values in Java Time parameters using the `nullable`-attribute in `JavaTimeConversionPattern`.
 
 
 [[release-notes-5.12.0-M1-junit-vintage]]

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeArgumentConverter.java
@@ -52,7 +52,11 @@ class JavaTimeArgumentConverter extends AnnotationBasedArgumentConverter<JavaTim
 	@Override
 	protected Object convert(Object input, Class<?> targetClass, JavaTimeConversionPattern annotation) {
 		if (input == null) {
-			throw new ArgumentConversionException("Cannot convert null to " + targetClass.getName());
+			if (annotation.nullable()) {
+				return null;
+			}
+			throw new ArgumentConversionException(
+				"Cannot convert null to " + targetClass.getName() + ", consider setting 'nullable = true'");
 		}
 		TemporalQuery<?> temporalQuery = TEMPORAL_QUERIES.get(targetClass);
 		if (temporalQuery == null) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeConversionPattern.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeConversionPattern.java
@@ -45,4 +45,9 @@ public @interface JavaTimeConversionPattern {
 	 */
 	String value();
 
+	/**
+	 * Whether this Java Time parameter may be null or not.
+	 */
+	boolean nullable() default false;
+
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/JavaTimeArgumentConverterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/JavaTimeArgumentConverterTests.java
@@ -110,10 +110,29 @@ class JavaTimeArgumentConverterTests {
 		assertThat(exception).hasMessage("Cannot convert to java.lang.Integer: 2017");
 	}
 
+	@Test
+	void throwsExceptionOnNullParameterWithoutNullable() {
+		var exception = assertThrows(ArgumentConversionException.class,
+			() -> convert(null, "dd.MM.yyyy", LocalDate.class));
+
+		assertThat(exception).hasMessage(
+			"Cannot convert null to java.time.LocalDate, consider setting 'nullable = true'");
+	}
+
+	@Test
+	void convertsNullableParameter() {
+		assertThat(convert(null, "dd.MM.yyyy", true, LocalDate.class)).isEqualTo(null);
+	}
+
 	private Object convert(Object input, String pattern, Class<?> targetClass) {
+		return convert(input, pattern, false, targetClass);
+	}
+
+	private Object convert(Object input, String pattern, boolean nullable, Class<?> targetClass) {
 		var converter = new JavaTimeArgumentConverter();
 		var annotation = mock(JavaTimeConversionPattern.class);
 		when(annotation.value()).thenReturn(pattern);
+		when(annotation.nullable()).thenReturn(nullable);
 
 		return converter.convert(input, targetClass, annotation);
 	}


### PR DESCRIPTION
Issue: #4010

## Overview

Added the attribute `nullable` to the `JavaTimeConversionPattern` annotation to allow null-values in Java Time parameters.

If `nullable` is not set, the `ArgumentConversionException` will contain a hint mentioning the new option.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
