### PR TITLE
Reduce stack utilization of TestTemplateTestDescriptor::execute

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -101,12 +101,11 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 			context.getExtensionRegistry());
 		AtomicInteger invocationIndex = new AtomicInteger();
 		// @formatter:off
-		providers.stream()
-				.flatMap(provider -> provider.provideTestTemplateInvocationContexts(extensionContext))
-				.map(invocationContext -> createInvocationTestDescriptor(invocationContext, invocationIndex.incrementAndGet()))
-				.filter(Optional::isPresent)
-				.map(Optional::get)
-				.forEach(invocationTestDescriptor -> execute(dynamicTestExecutor, invocationTestDescriptor));
+		for (TestTemplateInvocationContextProvider provider : providers) {
+			provider.provideTestTemplateInvocationContexts(extensionContext)
+				.forEach(invocationContext -> createInvocationTestDescriptor(invocationContext, invocationIndex.incrementAndGet())
+					.ifPresent(invocationTestDescriptor -> execute(dynamicTestExecutor, invocationTestDescriptor)));
+		}
 		// @formatter:on
 		validateWasAtLeastInvokedOnce(invocationIndex.get(), providers);
 		return context;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -101,7 +101,6 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 		List<TestTemplateInvocationContextProvider> providers = validateProviders(extensionContext,
 			context.getExtensionRegistry());
 		AtomicInteger invocationIndex = new AtomicInteger();
-		// @formatter:off
 		for (TestTemplateInvocationContextProvider provider : providers) {
 			try (Stream<TestTemplateInvocationContext> stream = provider.provideTestTemplateInvocationContexts(
 				extensionContext)) {
@@ -110,7 +109,6 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 						invocationTestDescriptor -> execute(dynamicTestExecutor, invocationTestDescriptor)));
 			}
 		}
-		// @formatter:on
 		validateWasAtLeastInvokedOnce(invocationIndex.get(), providers);
 		return context;
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -102,9 +103,12 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 		AtomicInteger invocationIndex = new AtomicInteger();
 		// @formatter:off
 		for (TestTemplateInvocationContextProvider provider : providers) {
-			provider.provideTestTemplateInvocationContexts(extensionContext)
-				.forEach(invocationContext -> createInvocationTestDescriptor(invocationContext, invocationIndex.incrementAndGet())
-					.ifPresent(invocationTestDescriptor -> execute(dynamicTestExecutor, invocationTestDescriptor)));
+			try (Stream<TestTemplateInvocationContext> stream = provider.provideTestTemplateInvocationContexts(
+				extensionContext)) {
+				stream.forEach(invocationContext -> createInvocationTestDescriptor(invocationContext,
+					invocationIndex.incrementAndGet()).ifPresent(
+						invocationTestDescriptor -> execute(dynamicTestExecutor, invocationTestDescriptor)));
+			}
 		}
 		// @formatter:on
 		validateWasAtLeastInvokedOnce(invocationIndex.get(), providers);


### PR DESCRIPTION
## Overview

Fixes issue #4020

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc -- no method declarations changed
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling -- refactoring only change, I believe no new tests are necessary
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html) -- no public APIs changed
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes) -- should I write something there, or the change is minor and doesn't worth mentioning?
