### PR TITLE
Add constructor injection support for ParameterizedTest SPIs

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -50,6 +50,10 @@ JUnit repository on GitHub.
 * In a `@ParameterizedTest` method, a `null` value can now be supplied for Java Date/Time
   types such as `LocalDate` if the new `nullable` attribute in
   `@JavaTimeConversionPattern` is set to `true`.
+* `ArgumentsProvider` (declared via `@ArgumentsSource`), `ArgumentConverter` (declared via
+  `@ConvertWith`), and `ArgumentsAggregator` (declared via `@AggregateWith`)
+  implementations can now use constructor injection from registered `ParameterResolver`
+  extensions.
 
 
 [[release-notes-5.12.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1984,6 +1984,15 @@ If you wish to implement a custom `ArgumentsProvider` that also consumes an anno
 (like built-in providers such as `{ValueArgumentsProvider}` or `{CsvArgumentsProvider}`),
 you have the possibility to extend the `{AnnotationBasedArgumentsProvider}` class.
 
+Moreover, `ArgumentsProvider` implementations may declare constructor parameters in case
+they need to be resolved by a registered `ParameterResolver` as demonstrated in the
+following example.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=ArgumentsProviderWithConstructorInjection_example]
+----
+
 [[writing-tests-parameterized-repeatable-sources]]
 ===== Multiple sources using repeatable annotations
 Repeatable annotations provide a convenient way to specify multiple sources from

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -348,6 +348,29 @@ class ParameterizedTestDemo {
 	}
 	// end::ArgumentsProvider_example[]
 
+	@ParameterizedTest
+	@ArgumentsSource(MyArgumentsProviderWithConstructorInjection.class)
+	void testWithArgumentsSourceWithConstructorInjection(String argument) {
+		assertNotNull(argument);
+	}
+
+	static
+	// tag::ArgumentsProviderWithConstructorInjection_example[]
+	public class MyArgumentsProviderWithConstructorInjection implements ArgumentsProvider {
+
+		private final TestInfo testInfo;
+
+		public MyArgumentsProviderWithConstructorInjection(TestInfo testInfo) {
+			this.testInfo = testInfo;
+		}
+
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+			return Stream.of(Arguments.of(testInfo.getDisplayName()));
+		}
+	}
+	// end::ArgumentsProviderWithConstructorInjection_example[]
+
 	// tag::ParameterResolver_example[]
 	@BeforeEach
 	void beforeEach(TestInfo testInfo) {

--- a/junit-jupiter-params/src/jmh/java/org/junit/jupiter/params/ParameterizedTestNameFormatterBenchmarks.java
+++ b/junit-jupiter-params/src/jmh/java/org/junit/jupiter/params/ParameterizedTestNameFormatterBenchmarks.java
@@ -47,7 +47,8 @@ public class ParameterizedTestNameFormatterBenchmarks {
 		var formatter = new ParameterizedTestNameFormatter(
 			ParameterizedTest.DISPLAY_NAME_PLACEHOLDER + " " + ParameterizedTest.DEFAULT_DISPLAY_NAME + " ({0})",
 			"displayName",
-			new ParameterizedTestMethodContext(TestCase.class.getDeclaredMethod("parameterizedTest", int.class)), 512);
+			new ParameterizedTestMethodContext(TestCase.class.getDeclaredMethod("parameterizedTest", int.class), null),
+			512);
 		for (int i = 0; i < argumentsList.size(); i++) {
 			Arguments arguments = argumentsList.get(i);
 			blackhole.consume(formatter.format(i, arguments, arguments.get()));

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestMethodContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestMethodContext.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.converter.DefaultArgumentConverter;
 import org.junit.jupiter.params.support.AnnotationConsumerInitializer;
 import org.junit.platform.commons.support.AnnotationSupport;
-import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.commons.util.StringUtils;
 
 /**
@@ -200,7 +199,7 @@ class ParameterizedTestMethodContext {
 				try { // @formatter:off
 					return AnnotationSupport.findAnnotation(parameterContext.getParameter(), AggregateWith.class)
 							.map(AggregateWith::value)
-							.map(clazz -> (ArgumentsAggregator) ReflectionSupport.newInstance(clazz))
+							.map(clazz -> ParameterizedTestSpiInstantiator.instantiate(ArgumentsAggregator.class, clazz, extensionContext))
 							.map(Aggregator::new)
 							.orElse(Aggregator.DEFAULT);
 				} // @formatter:on

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestSpiInstantiator.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestSpiInstantiator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params;
+
+import static org.junit.platform.commons.util.CollectionUtils.getFirstElement;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.commons.support.ModifierSupport;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+/**
+ * @since 5.12
+ */
+class ParameterizedTestSpiInstantiator {
+
+	static <T> T instantiate(Class<T> spiClass, Class<? extends T> clazz, ExtensionContext extensionContext) {
+		return extensionContext.getExecutableInvoker().invoke(findConstructor(spiClass, clazz));
+	}
+
+	/**
+	 * Find the "best" constructor for the supplied class.
+	 *
+	 * <p>For backward compatibility, it first checks for a default constructor
+	 * which takes precedence over any other constructor. If no default
+	 * constructor is found, it checks for a single constructor and returns it.
+	 */
+	@SuppressWarnings("unchecked")
+	private static <T> Constructor<? extends T> findConstructor(Class<T> spiClass, Class<? extends T> clazz) {
+		Optional<Constructor<?>> defaultConstructor = getFirstElement(
+			ReflectionUtils.findConstructors(clazz, it -> it.getParameterCount() == 0));
+		if (defaultConstructor.isPresent()) {
+			return (Constructor<? extends T>) defaultConstructor.get();
+		}
+		if (ModifierSupport.isNotStatic(clazz)) {
+			String message = String.format("The %s [%s] must be either a top-level class or a static nested class",
+				spiClass.getSimpleName(), clazz.getName());
+			throw new JUnitException(message);
+		}
+		try {
+			return ReflectionUtils.getDeclaredConstructor(clazz);
+		}
+		catch (PreconditionViolationException ex) {
+			String message = String.format(
+				"Failed to find constructor for %s [%s]. "
+						+ "Please ensure that a no-argument or a single constructor exists.",
+				spiClass.getSimpleName(), clazz.getName());
+			throw new JUnitException(message);
+		}
+	}
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAggregator.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAggregator.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
 
 /**
  * {@code ArgumentsAggregator} is an abstraction for the aggregation of arguments
@@ -33,10 +34,11 @@ import org.junit.jupiter.api.extension.ParameterContext;
  * in a CSV file into a domain object such as a {@code Person}, {@code Address},
  * {@code Order}, etc.
  *
- * <p>Implementations must provide a no-args constructor and should not make any
- * assumptions regarding when they are instantiated or how often they are called.
- * Since instances may potentially be cached and called from different threads,
- * they should be thread-safe and designed to be used as singletons.
+ * <p>Implementations must provide a no-args constructor or a single unambiguous
+ * constructor to use {@linkplain ParameterResolver parameter resolution}. They
+ * should not make any assumptions regarding when they are instantiated or how
+ * often they are called. Since instances may potentially be cached and called
+ * from different threads, they should be thread-safe.
  *
  * @since 5.2
  * @see AggregateWith

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ArgumentConverter.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
 
 /**
  * {@code ArgumentConverter} is an abstraction that allows an input object to
@@ -24,10 +25,11 @@ import org.junit.jupiter.api.extension.ParameterContext;
  * method with the help of a
  * {@link org.junit.jupiter.params.converter.ConvertWith @ConvertWith} annotation.
  *
- * <p>Implementations must provide a no-args constructor and should not make any
- * assumptions regarding when they are instantiated or how often they are called.
- * Since instances may potentially be cached and called from different threads,
- * they should be thread-safe and designed to be used as singletons.
+ * <p>Implementations must provide a no-args constructor or a single unambiguous
+ * constructor to use {@linkplain ParameterResolver parameter resolution}. They
+ * should not make any assumptions regarding when they are instantiated or how
+ * often they are called. Since instances may potentially be cached and called
+ * from different threads, they should be thread-safe.
  *
  * <p>Extend {@link SimpleArgumentConverter} if your implementation only needs
  * to know the target type and does not need access to the {@link ParameterContext}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsProvider.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
 
 /**
  * An {@code ArgumentsProvider} is responsible for {@linkplain #provideArguments
@@ -25,7 +26,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * <p>An {@code ArgumentsProvider} can be registered via the
  * {@link ArgumentsSource @ArgumentsSource} annotation.
  *
- * <p>Implementations must provide a no-args constructor.
+ * <p>Implementations must provide a no-args constructor or a single unambiguous
+ * constructor to use {@linkplain ParameterResolver parameter resolution}.
  *
  * @since 5.0
  * @see org.junit.jupiter.params.ParameterizedTest

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -1218,6 +1218,13 @@ class ParameterizedTestIntegrationTests {
 					.testEvents() //
 					.assertStatistics(it -> it.succeeded(1));
 		}
+
+		@Test
+		void injectsParametersIntoArgumentConverterConstructor() {
+			execute(SpiParameterInjectionTestCase.class, "argumentConverterWithConstructorParameter", String.class) //
+					.testEvents() //
+					.assertStatistics(it -> it.succeeded(1));
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -2162,11 +2169,26 @@ class ParameterizedTestIntegrationTests {
 			assertEquals("resolved value", argument);
 		}
 
+		@ParameterizedTest
+		@ValueSource(strings = "value")
+		void argumentConverterWithConstructorParameter(
+				@ConvertWith(ArgumentConverterWithConstructorParameter.class) String argument) {
+			assertEquals("resolved value", argument);
+		}
+
 		record ArgumentsProviderWithConstructorParameter(String value) implements ArgumentsProvider {
 
 			@Override
 			public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
 				return Stream.of(arguments(value));
+			}
+		}
+
+		record ArgumentConverterWithConstructorParameter(String value) implements ArgumentConverter {
+
+			@Override
+			public Object convert(Object source, ParameterContext context) throws ArgumentConversionException {
+				return value;
 			}
 		}
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -1225,6 +1225,13 @@ class ParameterizedTestIntegrationTests {
 					.testEvents() //
 					.assertStatistics(it -> it.succeeded(1));
 		}
+
+		@Test
+		void injectsParametersIntoArgumentsAggregatorConstructor() {
+			execute(SpiParameterInjectionTestCase.class, "argumentsAggregatorWithConstructorParameter", String.class) //
+					.testEvents() //
+					.assertStatistics(it -> it.succeeded(1));
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -2176,6 +2183,13 @@ class ParameterizedTestIntegrationTests {
 			assertEquals("resolved value", argument);
 		}
 
+		@ParameterizedTest
+		@ValueSource(strings = "value")
+		void argumentsAggregatorWithConstructorParameter(
+				@AggregateWith(ArgumentsAggregatorWithConstructorParameter.class) String argument) {
+			assertEquals("resolved value", argument);
+		}
+
 		record ArgumentsProviderWithConstructorParameter(String value) implements ArgumentsProvider {
 
 			@Override
@@ -2188,6 +2202,15 @@ class ParameterizedTestIntegrationTests {
 
 			@Override
 			public Object convert(Object source, ParameterContext context) throws ArgumentConversionException {
+				return value;
+			}
+		}
+
+		record ArgumentsAggregatorWithConstructorParameter(String value) implements ArgumentsAggregator {
+
+			@Override
+			public Object aggregateArguments(ArgumentsAccessor accessor, ParameterContext context)
+					throws ArgumentsAggregationException {
 				return value;
 			}
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestMethodContextTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestMethodContextTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.params;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -33,13 +34,13 @@ class ParameterizedTestMethodContextTests {
 	@ValueSource(strings = { "onePrimitive", "twoPrimitives", "twoAggregators", "twoAggregatorsWithTestInfoAtTheEnd",
 			"mixedMode" })
 	void validSignatures(String name) {
-		assertTrue(new ParameterizedTestMethodContext(method(name)).hasPotentiallyValidSignature());
+		assertTrue(new ParameterizedTestMethodContext(method(name), mock()).hasPotentiallyValidSignature());
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { "twoAggregatorsWithPrimitiveInTheMiddle", "twoAggregatorsWithTestInfoInTheMiddle" })
 	void invalidSignatures(String name) {
-		assertFalse(new ParameterizedTestMethodContext(method(name)).hasPotentiallyValidSignature());
+		assertFalse(new ParameterizedTestMethodContext(method(name), mock()).hasPotentiallyValidSignature());
 	}
 
 	private Method method(String name) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -330,8 +330,8 @@ class ParameterizedTestNameFormatterTests {
 	}
 
 	private static ParameterizedTestNameFormatter formatter(String pattern, String displayName, Method method) {
-		return new ParameterizedTestNameFormatter(pattern, displayName, new ParameterizedTestMethodContext(method),
-			512);
+		return new ParameterizedTestNameFormatter(pattern, displayName,
+			new ParameterizedTestMethodContext(method, mock()), 512);
 	}
 
 	private static String format(ParameterizedTestNameFormatter formatter, int invocationIndex, Arguments arguments) {


### PR DESCRIPTION
## Overview

- **Allow ArgumentsProvider implementations to use constructor injection**
- **Allow ArgumentConverter implementations to use constructor injection**
- **Allow ArgumentsAggregator implementations to use constructor injection**
- **Document constructor injection support in release notes**

Resolves #4018.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
