### PR TITLE
Fix ExtensionContext on instance creation

### DIFF
--- a/documentation/src/test/java/example/TestInfoDemo.java
+++ b/documentation/src/test/java/example/TestInfoDemo.java
@@ -24,7 +24,8 @@ import org.junit.jupiter.api.TestInfo;
 class TestInfoDemo {
 
 	TestInfoDemo(TestInfo testInfo) {
-		assertEquals("TestInfo Demo", testInfo.getDisplayName());
+		String displayName = testInfo.getDisplayName();
+		assertTrue(displayName.equals("TEST 1") || displayName.equals("test2()"));
 	}
 
 	@BeforeEach

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -20,16 +20,13 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apiguardian.api.API;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
-import org.junit.jupiter.engine.extension.ExtensionRegistrar;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * {@link TestDescriptor} for tests based on Java classes.
@@ -74,9 +71,8 @@ public class ClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	@Override
 	protected TestInstances instantiateTestClass(JupiterEngineExecutionContext parentExecutionContext,
-			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext,
-			ThrowableCollector throwableCollector) {
-		return instantiateTestClass(Optional.empty(), registry, extensionContext);
+			ExtensionRegistry registry, JupiterEngineExecutionContext context) {
+		return instantiateTestClass(Optional.empty(), registry, context.getExtensionContext());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -21,16 +21,13 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apiguardian.api.API;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
-import org.junit.jupiter.engine.extension.ExtensionRegistrar;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * {@link TestDescriptor} for tests based on nested (but not static) Java classes.
@@ -77,14 +74,13 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	@Override
 	protected TestInstances instantiateTestClass(JupiterEngineExecutionContext parentExecutionContext,
-			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext,
-			ThrowableCollector throwableCollector) {
+			ExtensionRegistry registry, JupiterEngineExecutionContext context) {
 
 		// Extensions registered for nested classes and below are not to be used for instantiating and initializing outer classes
 		ExtensionRegistry extensionRegistryForOuterInstanceCreation = parentExecutionContext.getExtensionRegistry();
 		TestInstances outerInstances = parentExecutionContext.getTestInstancesProvider().getTestInstances(
-			extensionRegistryForOuterInstanceCreation, registrar, throwableCollector);
-		return instantiateTestClass(Optional.of(outerInstances), registry, extensionContext);
+			extensionRegistryForOuterInstanceCreation, context);
+		return instantiateTestClass(Optional.of(outerInstances), registry, context.getExtensionContext());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -101,19 +101,18 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 		MethodExtensionContext extensionContext = new MethodExtensionContext(context.getExtensionContext(),
 			context.getExecutionListener(), this, context.getConfiguration(), throwableCollector,
 			it -> new DefaultExecutableInvoker(it, registry));
-		throwableCollector.execute(() -> {
-			TestInstances testInstances = context.getTestInstancesProvider().getTestInstances(registry,
-				throwableCollector);
-			extensionContext.setTestInstances(testInstances);
-		});
-
 		// @formatter:off
-		return context.extend()
+		JupiterEngineExecutionContext newContext = context.extend()
 				.withExtensionRegistry(registry)
 				.withExtensionContext(extensionContext)
 				.withThrowableCollector(throwableCollector)
 				.build();
 		// @formatter:on
+		throwableCollector.execute(() -> {
+			TestInstances testInstances = newContext.getTestInstancesProvider().getTestInstances(newContext);
+			extensionContext.setTestInstances(testInstances);
+		});
+		return newContext;
 	}
 
 	protected MutableExtensionRegistry populateNewExtensionRegistry(JupiterEngineExecutionContext context) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/TestInstancesProvider.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/TestInstancesProvider.java
@@ -14,10 +14,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.TestInstances;
-import org.junit.jupiter.engine.extension.ExtensionRegistrar;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
-import org.junit.jupiter.engine.extension.MutableExtensionRegistry;
-import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 
 /**
  * @since 5.0
@@ -26,12 +23,10 @@ import org.junit.platform.engine.support.hierarchical.ThrowableCollector;
 @API(status = INTERNAL, since = "5.0")
 public interface TestInstancesProvider {
 
-	default TestInstances getTestInstances(MutableExtensionRegistry extensionRegistry,
-			ThrowableCollector throwableCollector) {
-		return getTestInstances(extensionRegistry, extensionRegistry, throwableCollector);
+	default TestInstances getTestInstances(JupiterEngineExecutionContext context) {
+		return getTestInstances(context.getExtensionRegistry(), context);
 	}
 
-	TestInstances getTestInstances(ExtensionRegistry extensionRegistry, ExtensionRegistrar extensionRegistrar,
-			ThrowableCollector throwableCollector);
+	TestInstances getTestInstances(ExtensionRegistry extensionRegistry, JupiterEngineExecutionContext executionContext);
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleTests.java
@@ -992,8 +992,7 @@ class TestInstanceLifecycleTests extends AbstractJupiterTestEngineTests {
 			trackLifecycle(context);
 			assertThat(context.getTestInstance()).isNotPresent();
 			assertNotNull(testInstance);
-			instanceMap.put(postProcessTestInstanceKey(context.getRequiredTestClass()),
-				DefaultTestInstances.of(testInstance));
+			instanceMap.put(postProcessTestInstanceKey(testInstance.getClass()), DefaultTestInstances.of(testInstance));
 		}
 
 		@Override

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ParameterResolverTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ParameterResolverTests.java
@@ -258,6 +258,8 @@ class ParameterResolverTests extends AbstractJupiterTestEngineTests {
 		void test() {
 			assertNotNull(this.outerTestInfo);
 			assertNotNull(this.outerCustomType);
+			assertEquals("test()", outerTestInfo.getDisplayName());
+			assertEquals(ConstructorInjectionTestCase.class, outerTestInfo.getTestClass().orElse(null));
 		}
 
 		@Nested
@@ -275,8 +277,13 @@ class ParameterResolverTests extends AbstractJupiterTestEngineTests {
 			void test() {
 				assertNotNull(outerTestInfo);
 				assertNotNull(outerCustomType);
+				assertEquals("test()", outerTestInfo.getDisplayName());
+				assertEquals(NestedTestCase.class, outerTestInfo.getTestClass().orElse(null));
+
 				assertNotNull(this.innerTestInfo);
 				assertNotNull(this.innerCustomType);
+				assertEquals("test()", innerTestInfo.getDisplayName());
+				assertEquals(NestedTestCase.class, innerTestInfo.getTestClass().orElse(null));
 			}
 		}
 	}
@@ -296,6 +303,9 @@ class ParameterResolverTests extends AbstractJupiterTestEngineTests {
 		void test() {
 			assertNotNull(this.outerTestInfo);
 			assertNotNull(this.outerCustomType);
+			assertEquals("test()", outerTestInfo.getDisplayName());
+			assertEquals(AnnotatedParameterConstructorInjectionTestCase.class,
+				outerTestInfo.getTestClass().orElse(null));
 		}
 
 		@Nested
@@ -314,8 +324,15 @@ class ParameterResolverTests extends AbstractJupiterTestEngineTests {
 			void test() {
 				assertNotNull(outerTestInfo);
 				assertNotNull(outerCustomType);
+				assertEquals("test()", outerTestInfo.getDisplayName());
+				assertEquals(AnnotatedConstructorParameterNestedTestCase.class,
+					outerTestInfo.getTestClass().orElse(null));
+
 				assertNotNull(this.innerTestInfo);
 				assertNotNull(this.innerCustomType);
+				assertEquals("test()", innerTestInfo.getDisplayName());
+				assertEquals(AnnotatedConstructorParameterNestedTestCase.class,
+					innerTestInfo.getTestClass().orElse(null));
 			}
 		}
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -404,20 +404,20 @@ class ParameterizedTestIntegrationTests {
 		assertThat(LifecycleTestCase.lifecycleEvents).containsExactly(
 			"beforeAll:ParameterizedTestIntegrationTests$LifecycleTestCase",
 				"providerMethod",
-					"constructor:ParameterizedTestIntegrationTests$LifecycleTestCase",
+					"constructor:LifecycleTestCase:[1] argument=foo",
 					"beforeEach:[1] argument=foo",
 						testMethods.get(0) + ":[1] argument=foo",
 					"afterEach:[1] argument=foo",
-					"constructor:ParameterizedTestIntegrationTests$LifecycleTestCase",
+					"constructor:LifecycleTestCase:[2] argument=bar",
 					"beforeEach:[2] argument=bar",
 						testMethods.get(0) + ":[2] argument=bar",
 					"afterEach:[2] argument=bar",
 				"providerMethod",
-					"constructor:ParameterizedTestIntegrationTests$LifecycleTestCase",
+					"constructor:LifecycleTestCase:[1] argument=foo",
 					"beforeEach:[1] argument=foo",
 						testMethods.get(1) + ":[1] argument=foo",
 					"afterEach:[1] argument=foo",
-					"constructor:ParameterizedTestIntegrationTests$LifecycleTestCase",
+					"constructor:LifecycleTestCase:[2] argument=bar",
 					"beforeEach:[2] argument=bar",
 						testMethods.get(1) + ":[2] argument=bar",
 					"afterEach:[2] argument=bar",
@@ -2009,7 +2009,7 @@ class ParameterizedTestIntegrationTests {
 		private static final Set<String> testMethods = new LinkedHashSet<>();
 
 		public LifecycleTestCase(TestInfo testInfo) {
-			lifecycleEvents.add("constructor:" + testInfo.getDisplayName());
+			lifecycleEvents.add("constructor:" + getClass().getSimpleName() + ":" + testInfo.getDisplayName());
 		}
 
 		@BeforeAll


### PR DESCRIPTION
## Overview

Resolve #3445. This PR moves the instance creation into the execution context of the test method. This affects the following callbacks:

* `TestInstancePreConstructCallback`
* `TestInstanceFactory`
* `ParameterResolver` (when resolving parameters for the constructor)
* `TestInstancePostProcessor`

Assuming the test is using `TestInstance.Lifecycle.PER_METHOD` (the default), these callbacks will now receive the `ExtensionContext` for the currently executed test method. This has the following effects:

* The callbacks can now access `ExtensionContext.getTestMethod()`
* `ExtensionContext.getTestClass()` and `TestInstanceFactoryContext.getTestClass()` are no-longer interchangeable
* `ExtensionContext.getTestClass()` now returns the (nested) class of the currently executed tests
* Instances of `CloseableResource` add to the store will now be closed at the end of the test execution

If the test is using `TestInstance.Lifecycle.PER_CLASS`, the behavior is unaltered.

Not sure if the change is considered API breaking. The previous behavior was rather unintuitive and not explicitly documented. However, the example at `TestInfoDemo` is no-longer valid and has been changed as part of the PR. I also think there is a good chance that there are extensions in the wild which rely on the previous behavior, since the behavior was in place for multiple years. I would therefore like to know how I should proceed with the PR.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
