### PR TITLE
Fix global read-write lock handling when not declared on top level

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.2.adoc
@@ -16,7 +16,9 @@ on GitHub.
 [[release-notes-5.11.2-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Fix regression in parallel execution that was introduced in 5.10.4/5.11.1 regarding
+  global read-write locks. When such a lock was declared on descendants of top-level nodes
+  in the test tree, such as Cucumber scenarios, test execution failed.
 
 [[release-notes-5.11.2-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeExecutionAdvisor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeExecutionAdvisor.java
@@ -33,6 +33,10 @@ class NodeExecutionAdvisor {
 		resourceLocksByTestDescriptor.put(testDescriptor, resourceLock);
 	}
 
+	void removeResourceLock(TestDescriptor testDescriptor) {
+		resourceLocksByTestDescriptor.remove(testDescriptor);
+	}
+
 	Optional<ExecutionMode> getForcedExecutionMode(TestDescriptor testDescriptor) {
 		return testDescriptor.getParent().flatMap(this::lookupExecutionModeForcedByAncestor);
 	}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
@@ -282,7 +282,7 @@ class ParallelExecutionIntegrationTests {
 
 	@ParameterizedTest
 	@ValueSource(classes = { IsolatedMethodFirstTestCase.class, IsolatedMethodLastTestCase.class })
-	void canRunTestsIsolatedFromEachOtherWhenDeclaredOnFirstMethod(Class<?> testClass) {
+	void canRunTestsIsolatedFromEachOtherWhenDeclaredOnMethodLevel(Class<?> testClass) {
 		List<Event> events = executeConcurrentlySuccessfully(1, testClass).list();
 
 		assertThat(ThreadReporter.getThreadNames(events)).hasSize(1);

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 import static org.junit.jupiter.engine.Constants.DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.DEFAULT_PARALLEL_EXECUTION_MODE;
 import static org.junit.jupiter.engine.Constants.PARALLEL_CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.engine.Constants.PARALLEL_CONFIG_FIXED_PARALLELI
 import static org.junit.jupiter.engine.Constants.PARALLEL_CONFIG_STRATEGY_PROPERTY_NAME;
 import static org.junit.jupiter.engine.Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.GLOBAL_KEY;
 import static org.junit.platform.testkit.engine.EventConditions.container;
 import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
@@ -65,6 +67,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
@@ -73,6 +77,7 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
 import org.junit.platform.testkit.engine.Event;
+import org.junit.platform.testkit.engine.Events;
 
 /**
  * @since 1.3
@@ -82,7 +87,7 @@ class ParallelExecutionIntegrationTests {
 
 	@Test
 	void successfulParallelTest(TestReporter reporter) {
-		var events = executeConcurrently(3, SuccessfulParallelTestCase.class);
+		var events = executeConcurrentlySuccessfully(3, SuccessfulParallelTestCase.class).list();
 
 		var startedTimestamps = getTimestampsFor(events, event(test(), started()));
 		var finishedTimestamps = getTimestampsFor(events, event(test(), finishedSuccessfully()));
@@ -98,13 +103,13 @@ class ParallelExecutionIntegrationTests {
 
 	@Test
 	void failingTestWithoutLock() {
-		var events = executeConcurrently(3, FailingWithoutLockTestCase.class);
+		var events = executeConcurrently(3, FailingWithoutLockTestCase.class).list();
 		assertThat(events.stream().filter(event(test(), finishedWithFailure())::matches)).hasSize(2);
 	}
 
 	@Test
 	void successfulTestWithMethodLock() {
-		var events = executeConcurrently(3, SuccessfulWithMethodLockTestCase.class);
+		var events = executeConcurrentlySuccessfully(3, SuccessfulWithMethodLockTestCase.class).list();
 
 		assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(3);
 		assertThat(ThreadReporter.getThreadNames(events)).hasSize(3);
@@ -112,7 +117,7 @@ class ParallelExecutionIntegrationTests {
 
 	@Test
 	void successfulTestWithClassLock() {
-		var events = executeConcurrently(3, SuccessfulWithClassLockTestCase.class);
+		var events = executeConcurrentlySuccessfully(3, SuccessfulWithClassLockTestCase.class).list();
 
 		assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(3);
 		assertThat(ThreadReporter.getThreadNames(events)).hasSize(1);
@@ -120,7 +125,7 @@ class ParallelExecutionIntegrationTests {
 
 	@Test
 	void testCaseWithFactory() {
-		var events = executeConcurrently(3, TestCaseWithTestFactory.class);
+		var events = executeConcurrentlySuccessfully(3, TestCaseWithTestFactory.class).list();
 
 		assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(3);
 		assertThat(ThreadReporter.getThreadNames(events)).hasSize(1);
@@ -133,7 +138,7 @@ class ParallelExecutionIntegrationTests {
 		var smilingLoader = new URLClassLoader("(-:", new URL[0], ClassLoader.getSystemClassLoader());
 		currentThread.setContextClassLoader(smilingLoader);
 		try {
-			var events = executeConcurrently(3, SuccessfulWithMethodLockTestCase.class);
+			var events = executeConcurrentlySuccessfully(3, SuccessfulWithMethodLockTestCase.class).list();
 
 			assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(3);
 			assertThat(ThreadReporter.getThreadNames(events)).hasSize(3);
@@ -146,7 +151,8 @@ class ParallelExecutionIntegrationTests {
 
 	@RepeatedTest(10)
 	void mixingClassAndMethodLevelLocks() {
-		var events = executeConcurrently(4, TestCaseWithSortedLocks.class, TestCaseWithUnsortedLocks.class);
+		var events = executeConcurrentlySuccessfully(4, TestCaseWithSortedLocks.class,
+			TestCaseWithUnsortedLocks.class).list();
 
 		assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(6);
 		assertThat(ThreadReporter.getThreadNames(events).count()).isLessThanOrEqualTo(2);
@@ -154,7 +160,7 @@ class ParallelExecutionIntegrationTests {
 
 	@RepeatedTest(10)
 	void locksOnNestedTests() {
-		var events = executeConcurrently(3, TestCaseWithNestedLocks.class);
+		var events = executeConcurrentlySuccessfully(3, TestCaseWithNestedLocks.class).list();
 
 		assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(6);
 		assertThat(ThreadReporter.getThreadNames(events)).hasSize(1);
@@ -162,7 +168,7 @@ class ParallelExecutionIntegrationTests {
 
 	@Test
 	void afterHooksAreCalledAfterConcurrentDynamicTestsAreFinished() {
-		var events = executeConcurrently(3, ConcurrentDynamicTestCase.class);
+		var events = executeConcurrentlySuccessfully(3, ConcurrentDynamicTestCase.class).list();
 
 		assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(1);
 		var timestampedEvents = ConcurrentDynamicTestCase.events;
@@ -175,14 +181,14 @@ class ParallelExecutionIntegrationTests {
 	 */
 	@Test
 	void threadInterruptedByUserCode() {
-		var events = executeConcurrently(3, InterruptedThreadTestCase.class);
+		var events = executeConcurrentlySuccessfully(3, InterruptedThreadTestCase.class).list();
 
 		assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(4);
 	}
 
 	@Test
 	void executesTestTemplatesWithResourceLocksInSameThread() {
-		var events = executeConcurrently(2, ConcurrentTemplateTestCase.class);
+		var events = executeConcurrentlySuccessfully(2, ConcurrentTemplateTestCase.class).list();
 
 		assertThat(events.stream().filter(event(test(), finishedSuccessfully())::matches)).hasSize(10);
 		assertThat(ThreadReporter.getThreadNames(events)).hasSize(1);
@@ -228,30 +234,22 @@ class ParallelExecutionIntegrationTests {
 
 	@Test
 	void canRunTestsIsolatedFromEachOther() {
-		var events = executeConcurrently(2, IsolatedTestCase.class);
-
-		assertThat(events.stream().filter(event(test(), finishedWithFailure())::matches)).isEmpty();
+		executeConcurrentlySuccessfully(2, IsolatedTestCase.class);
 	}
 
 	@Test
 	void canRunTestsIsolatedFromEachOtherWithNestedCases() {
-		var events = executeConcurrently(4, NestedIsolatedTestCase.class);
-
-		assertThat(events.stream().filter(event(test(), finishedWithFailure())::matches)).isEmpty();
+		executeConcurrentlySuccessfully(4, NestedIsolatedTestCase.class);
 	}
 
 	@Test
 	void canRunTestsIsolatedFromEachOtherAcrossClasses() {
-		var events = executeConcurrently(4, IndependentClasses.A.class, IndependentClasses.B.class);
-
-		assertThat(events.stream().filter(event(test(), finishedWithFailure())::matches)).isEmpty();
+		executeConcurrentlySuccessfully(4, IndependentClasses.A.class, IndependentClasses.B.class);
 	}
 
 	@RepeatedTest(10)
 	void canRunTestsIsolatedFromEachOtherAcrossClassesWithOtherResourceLocks() {
-		var events = executeConcurrently(4, IndependentClasses.B.class, IndependentClasses.C.class);
-
-		assertThat(events.stream().filter(event(test(), finishedWithFailure())::matches)).isEmpty();
+		executeConcurrentlySuccessfully(4, IndependentClasses.B.class, IndependentClasses.C.class);
 	}
 
 	@Test
@@ -262,9 +260,8 @@ class ParallelExecutionIntegrationTests {
 		);
 		Class<?>[] testClasses = { IsolatedTestCase.class, SuccessfulParallelTestCase.class };
 		var events = executeWithFixedParallelism(3, configParams, testClasses) //
-				.allEvents();
-
-		assertThat(events.stream().filter(event(test(), finishedWithFailure())::matches)).isEmpty();
+				.allEvents() //
+				.assertStatistics(it -> it.failed(0));
 
 		List<Event> parallelTestMethodEvents = events.reportingEntryPublished() //
 				.filter(e -> e.getTestDescriptor().getSource() //
@@ -281,6 +278,14 @@ class ParallelExecutionIntegrationTests {
 		var isolatedClassStart = getOnlyElement(
 			getTimestampsFor(events.list(), event(container(IsolatedTestCase.class), started())));
 		assertThat(isolatedClassStart).isAfterOrEqualTo(parallelClassFinish);
+	}
+
+	@ParameterizedTest
+	@ValueSource(classes = { IsolatedMethodFirstTestCase.class, IsolatedMethodLastTestCase.class })
+	void canRunTestsIsolatedFromEachOtherWhenDeclaredOnFirstMethod(Class<?> testClass) {
+		List<Event> events = executeConcurrentlySuccessfully(1, testClass).list();
+
+		assertThat(ThreadReporter.getThreadNames(events)).hasSize(1);
 	}
 
 	@Isolated("testing")
@@ -355,6 +360,56 @@ class ParallelExecutionIntegrationTests {
 		}
 	}
 
+	@ExtendWith(ThreadReporter.class)
+	static class IsolatedMethodFirstTestCase {
+
+		static AtomicInteger sharedResource;
+		static CountDownLatch countDownLatch;
+
+		@BeforeAll
+		static void initialize() {
+			sharedResource = new AtomicInteger();
+			countDownLatch = new CountDownLatch(2);
+		}
+
+		@Test
+		@ResourceLock(value = GLOBAL_KEY, mode = READ_WRITE) // effectively @Isolated
+		void test1() throws InterruptedException {
+			incrementBlockAndCheck(sharedResource, countDownLatch);
+		}
+
+		@Test
+		@ResourceLock(value = "b", mode = READ_WRITE)
+		void test2() throws InterruptedException {
+			incrementBlockAndCheck(sharedResource, countDownLatch);
+		}
+	}
+
+	@ExtendWith(ThreadReporter.class)
+	static class IsolatedMethodLastTestCase {
+
+		static AtomicInteger sharedResource;
+		static CountDownLatch countDownLatch;
+
+		@BeforeAll
+		static void initialize() {
+			sharedResource = new AtomicInteger();
+			countDownLatch = new CountDownLatch(2);
+		}
+
+		@Test
+		@ResourceLock(value = "b", mode = READ_WRITE)
+		void test1() throws InterruptedException {
+			incrementBlockAndCheck(sharedResource, countDownLatch);
+		}
+
+		@Test
+		@ResourceLock(value = GLOBAL_KEY, mode = READ_WRITE) // effectively @Isolated
+		void test2() throws InterruptedException {
+			incrementBlockAndCheck(sharedResource, countDownLatch);
+		}
+	}
+
 	static class IndependentClasses {
 		static AtomicInteger sharedResource = new AtomicInteger();
 		static CountDownLatch countDownLatch = new CountDownLatch(4);
@@ -416,11 +471,21 @@ class ParallelExecutionIntegrationTests {
 		// @formatter:on
 	}
 
-	private List<Event> executeConcurrently(int parallelism, Class<?>... testClasses) {
+	private Events executeConcurrentlySuccessfully(int parallelism, Class<?>... testClasses) {
+		var events = executeConcurrently(parallelism, testClasses);
+		try {
+			return events.assertStatistics(it -> it.failed(0));
+		}
+		catch (AssertionError error) {
+			events.debug();
+			throw error;
+		}
+	}
+
+	private Events executeConcurrently(int parallelism, Class<?>... testClasses) {
 		Map<String, String> configParams = Map.of(DEFAULT_PARALLEL_EXECUTION_MODE, "concurrent");
 		return executeWithFixedParallelism(parallelism, configParams, testClasses) //
-				.allEvents() //
-				.list();
+				.allEvents();
 	}
 
 	private EngineExecutionResults executeWithFixedParallelism(int parallelism, Map<String, String> configParams,


### PR DESCRIPTION
## Overview

Prior to this change additional locks were not cleared from siblings 
when discovering the global read-write lock on a test descriptor which 
led to incompatible locks and caused test execution to fail.

Fixes #4027.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
