### PR TITLE
Add support for passing line and column number to ConsoleLauncher via `--select-file` and `--select-resource`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -18,6 +18,8 @@ JUnit repository on GitHub.
 
 * Fix support for disabling ANSI colors on the console when the `NO_COLOR` environment
   variable is available.
+* Add support for passing line and column number to ConsoleLauncher via `--select-file`
+  and `--select-resource`.
 
 [[release-notes-5.12.0-M1-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -18,8 +18,6 @@ JUnit repository on GitHub.
 
 * Fix support for disabling ANSI colors on the console when the `NO_COLOR` environment
   variable is available.
-* Add support for passing line and column number to ConsoleLauncher via `--select-file`
-  and `--select-resource`.
 
 [[release-notes-5.12.0-M1-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes
@@ -33,6 +31,8 @@ JUnit repository on GitHub.
   calling the internal `ReflectionUtils.makeAccessible(Field)` method directly.
 * Support both the primitive type `void` and the wrapper type `Void` in the internal
   `ReflectionUtils` to allow `String` to `Class` conversion in parameterized tests.
+* Add support for passing line and column number to `ConsoleLauncher` via
+  `--select-file` and `--select-resource`.
 
 
 [[release-notes-5.12.0-M1-junit-jupiter]]

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ResourceUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ResourceUtils.java
@@ -8,19 +8,21 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.platform.engine.support.descriptor;
+package org.junit.platform.commons.util;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.net.URI;
 
-import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.commons.util.StringUtils;
+import org.apiguardian.api.API;
 
 /**
  * Collection of static utility methods for working with resources.
  *
- * @since 1.3
+ * @since 1.3 (originally in org.junit.platform.engine.support.descriptor)
  */
-final class ResourceUtils {
+@API(status = INTERNAL, since = "1.12")
+public final class ResourceUtils {
 
 	private ResourceUtils() {
 		/* no-op */
@@ -33,8 +35,10 @@ final class ResourceUtils {
 	 * @param uri the {@code URI} from which to strip the query component
 	 * @return a new {@code URI} with the query component removed, or the
 	 * original {@code URI} unmodified if it does not have a query component
+	 *
+	 * @since 1.3
 	 */
-	static URI stripQueryComponent(URI uri) {
+	public static URI stripQueryComponent(URI uri) {
 		Preconditions.notNull(uri, "URI must not be null");
 
 		if (StringUtils.isBlank(uri.getQuery())) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
@@ -22,7 +22,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUri;
 import java.net.URI;
 
 import org.junit.platform.commons.PreconditionViolationException;
-import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.commons.util.ResourceUtils;
 import org.junit.platform.engine.DiscoverySelectorIdentifier;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.ClasspathResourceSelector;
@@ -58,7 +58,7 @@ class SelectorConverter {
 		@Override
 		public FileSelector convert(String value) {
 			URI uri = URI.create(value);
-			String path = stripQueryComponent(uri).getPath();
+			String path = ResourceUtils.stripQueryComponent(uri).getPath();
 			FilePosition filePosition = FilePosition.fromQuery(uri.getQuery()).orElse(null);
 			return selectFile(path, filePosition);
 		}
@@ -97,7 +97,7 @@ class SelectorConverter {
 		@Override
 		public ClasspathResourceSelector convert(String value) {
 			URI uri = URI.create(value);
-			String path = stripQueryComponent(uri).getPath();
+			String path = ResourceUtils.stripQueryComponent(uri).getPath();
 			FilePosition filePosition = FilePosition.fromQuery(uri.getQuery()).orElse(null);
 			return selectClasspathResource(path, filePosition);
 		}
@@ -120,12 +120,4 @@ class SelectorConverter {
 		}
 	}
 
-	private static URI stripQueryComponent(URI uri) {
-		if (StringUtils.isBlank(uri.getQuery())) {
-			return uri;
-		}
-
-		String uriAsString = uri.toString();
-		return URI.create(uriAsString.substring(0, uriAsString.indexOf('?')));
-	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
@@ -19,12 +19,16 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectModul
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUri;
 
+import java.net.URI;
+
 import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.DiscoverySelectorIdentifier;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.ClasspathResourceSelector;
 import org.junit.platform.engine.discovery.DirectorySelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.engine.discovery.FilePosition;
 import org.junit.platform.engine.discovery.FileSelector;
 import org.junit.platform.engine.discovery.IterationSelector;
 import org.junit.platform.engine.discovery.MethodSelector;
@@ -53,8 +57,12 @@ class SelectorConverter {
 	static class File implements ITypeConverter<FileSelector> {
 		@Override
 		public FileSelector convert(String value) {
-			return selectFile(value);
+			URI uri = URI.create(value);
+			String path = stripQueryComponent(uri).getPath();
+			FilePosition filePosition = FilePosition.fromQuery(uri.getQuery()).orElse(null);
+			return selectFile(path, filePosition);
 		}
+
 	}
 
 	static class Directory implements ITypeConverter<DirectorySelector> {
@@ -88,7 +96,10 @@ class SelectorConverter {
 	static class ClasspathResource implements ITypeConverter<ClasspathResourceSelector> {
 		@Override
 		public ClasspathResourceSelector convert(String value) {
-			return selectClasspathResource(value);
+			URI uri = URI.create(value);
+			String path = stripQueryComponent(uri).getPath();
+			FilePosition filePosition = FilePosition.fromQuery(uri.getQuery()).orElse(null);
+			return selectClasspathResource(path, filePosition);
 		}
 	}
 
@@ -109,4 +120,12 @@ class SelectorConverter {
 		}
 	}
 
+	private static URI stripQueryComponent(URI uri) {
+		if (StringUtils.isBlank(uri.getQuery())) {
+			return uri;
+		}
+
+		String uriAsString = uri.toString();
+		return URI.create(uriAsString.substring(0, uriAsString.indexOf('?')));
+	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptionsMixin.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptionsMixin.java
@@ -76,7 +76,10 @@ class TestDiscoveryOptionsMixin {
 		private final List<UriSelector> selectedUris2 = new ArrayList<>();
 
 		@Option(names = { "-f",
-				"--select-file" }, paramLabel = "FILE", arity = "1", converter = SelectorConverter.File.class, description = "Select a file for test discovery. This option can be repeated.")
+				"--select-file" }, paramLabel = "FILE", arity = "1", converter = SelectorConverter.File.class, //
+				description = "Select a file for test discovery. "
+						+ "The line and column numbers can be provided as URI query parameters (e.g. foo.txt?line=12&column=34). "
+						+ "This option can be repeated.")
 		private final List<FileSelector> selectedFiles = new ArrayList<>();
 
 		@Option(names = { "--f", "-select-file" }, arity = "1", hidden = true, converter = SelectorConverter.File.class)
@@ -123,7 +126,10 @@ class TestDiscoveryOptionsMixin {
 		private final List<MethodSelector> selectedMethods2 = new ArrayList<>();
 
 		@Option(names = { "-r",
-				"--select-resource" }, paramLabel = "RESOURCE", arity = "1", converter = SelectorConverter.ClasspathResource.class, description = "Select a classpath resource for test discovery. This option can be repeated.")
+				"--select-resource" }, paramLabel = "RESOURCE", arity = "1", converter = SelectorConverter.ClasspathResource.class, //
+				description = "Select a classpath resource for test discovery. "
+						+ "The line and column numbers can be provided as URI query parameters (e.g. foo.csv?line=12&column=34). "
+						+ "This option can be repeated.")
 		private final List<ClasspathResourceSelector> selectedClasspathResources = new ArrayList<>();
 
 		@Option(names = { "--r",

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ResourceUtils;
 import org.junit.platform.commons.util.ToStringBuilder;
 import org.junit.platform.engine.TestSource;
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
@@ -20,6 +20,7 @@ import java.nio.file.Paths;
 import org.apiguardian.api.API;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ResourceUtils;
 import org.junit.platform.engine.TestSource;
 
 /**

--- a/platform-tests/src/test/java/org/junit/platform/console/options/CommandLineOptionsParsingTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/CommandLineOptionsParsingTests.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.engine.discovery.FilePosition;
 
 /**
  * @since 1.10
@@ -382,7 +383,9 @@ class CommandLineOptionsParsingTests {
 				() -> assertEquals(List.of(selectFile("foo.txt")), type.parseArgLine("-select-file=foo.txt").discovery.getSelectedFiles()),
 				() -> assertEquals(List.of(selectFile("foo.txt")), type.parseArgLine("--select-file foo.txt").discovery.getSelectedFiles()),
 				() -> assertEquals(List.of(selectFile("foo.txt")), type.parseArgLine("--select-file=foo.txt").discovery.getSelectedFiles()),
-				() -> assertEquals(List.of(selectFile("foo.txt"), selectFile("bar.csv")), type.parseArgLine("-f foo.txt -f bar.csv").discovery.getSelectedFiles())
+				() -> assertEquals(List.of(selectFile("foo.txt"), selectFile("bar.csv")), type.parseArgLine("-f foo.txt -f bar.csv").discovery.getSelectedFiles()),
+				() -> assertEquals(List.of(selectFile("foo.txt", FilePosition.from(5))), type.parseArgLine("-f foo.txt?line=5").discovery.getSelectedFiles()),
+				() -> assertEquals(List.of(selectFile("foo.txt", FilePosition.from(12, 34))), type.parseArgLine("-f foo.txt?line=12&column=34").discovery.getSelectedFiles())
 		);
 		// @formatter:on
 	}
@@ -509,7 +512,9 @@ class CommandLineOptionsParsingTests {
 				() -> assertEquals(List.of(selectClasspathResource("/foo.csv")), type.parseArgLine("-select-resource=/foo.csv").discovery.getSelectedClasspathResources()),
 				() -> assertEquals(List.of(selectClasspathResource("/foo.csv")), type.parseArgLine("--select-resource /foo.csv").discovery.getSelectedClasspathResources()),
 				() -> assertEquals(List.of(selectClasspathResource("/foo.csv")), type.parseArgLine("--select-resource=/foo.csv").discovery.getSelectedClasspathResources()),
-				() -> assertEquals(List.of(selectClasspathResource("/foo.csv"), selectClasspathResource("bar.json")), type.parseArgLine("-r /foo.csv -r bar.json").discovery.getSelectedClasspathResources())
+				() -> assertEquals(List.of(selectClasspathResource("/foo.csv"), selectClasspathResource("bar.json")), type.parseArgLine("-r /foo.csv -r bar.json").discovery.getSelectedClasspathResources()),
+				() -> assertEquals(List.of(selectClasspathResource("/foo.csv", FilePosition.from(5))), type.parseArgLine("-r /foo.csv?line=5").discovery.getSelectedClasspathResources()),
+				() -> assertEquals(List.of(selectClasspathResource("/foo.csv", FilePosition.from(12, 34))), type.parseArgLine("-r /foo.csv?line=12&column=34").discovery.getSelectedClasspathResources())
 		);
 		// @formatter:on
 	}


### PR DESCRIPTION
## Overview

Resolves #3483 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
