### PR TITLE
Support `void` and `Void` class lookups in `ReflectionUtils`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -29,7 +29,8 @@ JUnit repository on GitHub.
 
 * Introduce `ReflectionSupport.makeAccessible(Field)` for third-party use rather than
   calling the internal `ReflectionUtils.makeAccessible(Field)` method directly.
-
+* Support both the primitive type `void` and the wrapper type `Void` in the internal
+  `ReflectionUtils` to allow String to Class conversion in parametrized tests
 
 [[release-notes-5.12.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -30,7 +30,8 @@ JUnit repository on GitHub.
 * Introduce `ReflectionSupport.makeAccessible(Field)` for third-party use rather than
   calling the internal `ReflectionUtils.makeAccessible(Field)` method directly.
 * Support both the primitive type `void` and the wrapper type `Void` in the internal
-  `ReflectionUtils` to allow String to Class conversion in parametrized tests
+  `ReflectionUtils` to support `String` to `Class` conversion in parameterized tests.
+
 
 [[release-notes-5.12.0-M1-junit-jupiter]]
 === JUnit Jupiter

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -225,7 +225,6 @@ public final class ReflectionUtils {
 			Long[].class,
 			Float[].class,
 			Double[].class,
-			Void[].class,
 			String[].class,
 
 			Boolean[][].class,
@@ -236,7 +235,6 @@ public final class ReflectionUtils {
 			Long[][].class,
 			Float[][].class,
 			Double[][].class,
-			Void[][].class,
 			String[][].class
 		);
 		// @formatter:on

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -186,6 +186,7 @@ public final class ReflectionUtils {
 			long.class,
 			float.class,
 			double.class,
+			void.class,
 
 			boolean[].class,
 			byte[].class,
@@ -213,6 +214,7 @@ public final class ReflectionUtils {
 			Long.class,
 			Float.class,
 			Double.class,
+			Void.class,
 			String.class,
 
 			Boolean[].class,
@@ -223,6 +225,7 @@ public final class ReflectionUtils {
 			Long[].class,
 			Float[].class,
 			Double[].class,
+			Void[].class,
 			String[].class,
 
 			Boolean[][].class,
@@ -233,6 +236,7 @@ public final class ReflectionUtils {
 			Long[][].class,
 			Float[][].class,
 			Double[][].class,
+			Void[][].class,
 			String[][].class
 		);
 		// @formatter:on
@@ -246,7 +250,7 @@ public final class ReflectionUtils {
 
 		classNameToTypeMap = Collections.unmodifiableMap(classNamesToTypes);
 
-		Map<Class<?>, Class<?>> primitivesToWrappers = new IdentityHashMap<>(8);
+		Map<Class<?>, Class<?>> primitivesToWrappers = new IdentityHashMap<>(9);
 
 		primitivesToWrappers.put(boolean.class, Boolean.class);
 		primitivesToWrappers.put(byte.class, Byte.class);
@@ -256,6 +260,7 @@ public final class ReflectionUtils {
 		primitivesToWrappers.put(long.class, Long.class);
 		primitivesToWrappers.put(float.class, Float.class);
 		primitivesToWrappers.put(double.class, Double.class);
+		primitivesToWrappers.put(void.class, Void.class);
 
 		primitiveToWrapperMap = Collections.unmodifiableMap(primitivesToWrappers);
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.params.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +45,6 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -356,17 +354,6 @@ class DefaultArgumentConverterTests {
 	void convertsStringToUUID() {
 		var uuid = "d043e930-7b3b-48e3-bdbe-5a3ccfb833db";
 		assertConverts(uuid, UUID.class, UUID.fromString(uuid));
-	}
-
-	@Nested
-	class IntegrationTests {
-
-		@ParameterizedTest
-		@ValueSource(strings = { "boolean", "byte", "char", "short", "int", "long", "float", "double", "void" })
-		void convertsStringToPrimitiveClass(Class<?> clazz) {
-			assertTrue(clazz.isPrimitive());
-		}
-
 	}
 
 	// -------------------------------------------------------------------------

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.params.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +46,7 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -132,7 +134,7 @@ class DefaultArgumentConverterTests {
 
 	@ParameterizedTest(name = "[{index}] {0}")
 	@ValueSource(classes = { char.class, boolean.class, short.class, byte.class, int.class, long.class, float.class,
-			double.class })
+			double.class, void.class })
 	void throwsExceptionForNullToPrimitiveTypeConversion(Class<?> type) {
 		assertThatExceptionOfType(ArgumentConversionException.class) //
 				.isThrownBy(() -> convert(null, type)) //
@@ -261,8 +263,10 @@ class DefaultArgumentConverterTests {
 	@Test
 	void convertsStringToClass() {
 		assertConverts("java.lang.Integer", Class.class, Integer.class);
+		assertConverts("java.lang.Void", Class.class, Void.class);
 		assertConverts("java.lang.Thread$State", Class.class, State.class);
 		assertConverts("byte", Class.class, byte.class);
+		assertConverts("void", Class.class, void.class);
 		assertConverts("char[]", Class.class, char[].class);
 		assertConverts("java.lang.Long[][]", Class.class, Long[][].class);
 		assertConverts("[[[I", Class.class, int[][][].class);
@@ -352,6 +356,17 @@ class DefaultArgumentConverterTests {
 	void convertsStringToUUID() {
 		var uuid = "d043e930-7b3b-48e3-bdbe-5a3ccfb833db";
 		assertConverts(uuid, UUID.class, UUID.fromString(uuid));
+	}
+
+	@Nested
+	class IntegrationTests {
+
+		@ParameterizedTest
+		@ValueSource(strings = { "boolean", "byte", "char", "short", "int", "long", "float", "double", "void" })
+		void convertsStringToPrimitiveClass(Class<?> clazz) {
+			assertTrue(clazz.isPrimitive());
+		}
+
 	}
 
 	// -------------------------------------------------------------------------

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -559,6 +559,7 @@ class ReflectionUtilsTests {
 			// Wrappers to Primitives
 			assertTrue(ReflectionUtils.isAssignableTo(Integer.class, int.class));
 			assertTrue(ReflectionUtils.isAssignableTo(Boolean.class, boolean.class));
+			assertTrue(ReflectionUtils.isAssignableTo(Void.class, void.class));
 
 			// Widening Conversions from Wrappers to Primitives
 			assertTrue(ReflectionUtils.isAssignableTo(Integer.class, long.class));
@@ -759,6 +760,7 @@ class ReflectionUtilsTests {
 		@Test
 		void tryToLoadClass() {
 			assertThat(ReflectionUtils.tryToLoadClass(Integer.class.getName())).isEqualTo(success(Integer.class));
+			assertThat(ReflectionUtils.tryToLoadClass(Void.class.getName())).isEqualTo(success(Void.class));
 		}
 
 		@Test
@@ -770,6 +772,7 @@ class ReflectionUtilsTests {
 		@Test
 		void tryToLoadClassForPrimitive() {
 			assertThat(ReflectionUtils.tryToLoadClass(int.class.getName())).isEqualTo(success(int.class));
+			assertThat(ReflectionUtils.tryToLoadClass(void.class.getName())).isEqualTo(success(void.class));
 		}
 
 		@Test


### PR DESCRIPTION
Fix #4048.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
