### PR TITLE
Avoid multiple class-level annotation lookups

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -10,16 +10,19 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import static java.util.Collections.emptyList;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.DisplayNameUtils.createDisplayNameSupplierForClass;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
+import org.junit.jupiter.api.parallel.ResourceLocksProvider;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistrar;
@@ -57,6 +60,11 @@ public class ClassTestDescriptor extends ClassBasedTestDescriptor {
 		return new LinkedHashSet<>(this.tags);
 	}
 
+	@Override
+	public List<Class<?>> getEnclosingTestClasses() {
+		return emptyList();
+	}
+
 	// --- Node ----------------------------------------------------------------
 
 	@Override
@@ -70,6 +78,11 @@ public class ClassTestDescriptor extends ClassBasedTestDescriptor {
 			ExtensionRegistry registry, ExtensionRegistrar registrar, ExtensionContext extensionContext,
 			ThrowableCollector throwableCollector) {
 		return instantiateTestClass(Optional.empty(), registry, extensionContext);
+	}
+
+	@Override
+	public Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider) {
+		return provider.provideForClass(getTestClass());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExclusiveResourceCollector.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExclusiveResourceCollector.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
+import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocksProvider;
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
+
+/**
+ * @since 5.12
+ */
+abstract class ExclusiveResourceCollector {
+
+	private static final ExclusiveResourceCollector NO_EXCLUSIVE_RESOURCES = new ExclusiveResourceCollector() {
+
+		@Override
+		Stream<ExclusiveResource> getAllExclusiveResources(
+				Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> providerToLocks) {
+			return Stream.empty();
+		}
+
+		@Override
+		public Stream<ExclusiveResource> getStaticResources() {
+			return Stream.empty();
+		}
+
+		@Override
+		Stream<ExclusiveResource> getDynamicResources(
+				Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> providerToLocks) {
+			return Stream.empty();
+		}
+	};
+
+	Stream<ExclusiveResource> getAllExclusiveResources(
+			Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> providerToLocks) {
+		return Stream.concat(getStaticResources(), getDynamicResources(providerToLocks));
+	}
+
+	abstract Stream<ExclusiveResource> getStaticResources();
+
+	abstract Stream<ExclusiveResource> getDynamicResources(
+			Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> providerToLocks);
+
+	static ExclusiveResourceCollector from(AnnotatedElement element) {
+		List<ResourceLock> annotations = findRepeatableAnnotations(element, ResourceLock.class);
+		return annotations.isEmpty() ? NO_EXCLUSIVE_RESOURCES : new DefaultExclusiveResourceCollector(annotations);
+	}
+
+	private static class DefaultExclusiveResourceCollector extends ExclusiveResourceCollector {
+
+		private final List<ResourceLock> annotations;
+		private List<ResourceLocksProvider> providers;
+
+		DefaultExclusiveResourceCollector(List<ResourceLock> annotations) {
+			this.annotations = annotations;
+		}
+
+		@Override
+		public Stream<ExclusiveResource> getStaticResources() {
+			return annotations.stream() //
+					.filter(annotation -> StringUtils.isNotBlank(annotation.value())) //
+					.map(annotation -> new ExclusiveResource(annotation.value(), toLockMode(annotation.mode())));
+		}
+
+		@Override
+		Stream<ExclusiveResource> getDynamicResources(
+				Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> providerToLocks) {
+			List<ResourceLocksProvider> providers = getProviders();
+			if (providers.isEmpty()) {
+				return Stream.empty();
+			}
+			return providers.stream() //
+					.map(providerToLocks) //
+					.flatMap(Collection::stream) //
+					.map(lock -> new ExclusiveResource(lock.getKey(), toLockMode(lock.getAccessMode())));
+		}
+
+		private List<ResourceLocksProvider> getProviders() {
+			if (this.providers == null) {
+				this.providers = annotations.stream() //
+						.flatMap(annotation -> Stream.of(annotation.providers()).map(ReflectionUtils::newInstance)) //
+						.collect(toUnmodifiableList());
+			}
+			return providers;
+		}
+
+		private static ExclusiveResource.LockMode toLockMode(ResourceAccessMode mode) {
+			switch (mode) {
+				case READ:
+					return ExclusiveResource.LockMode.READ;
+				case READ_WRITE:
+					return ExclusiveResource.LockMode.READ_WRITE;
+			}
+			throw new JUnitException("Unknown ResourceAccessMode: " + mode);
+		}
+	}
+}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestWatcher;
+import org.junit.jupiter.api.parallel.ResourceLocksProvider;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.execution.JupiterEngineExecutionContext;
 import org.junit.platform.commons.logging.Logger;
@@ -36,7 +37,6 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.MethodSource;
-import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
 
 /**
  * Base class for {@link TestDescriptor TestDescriptors} based on Java methods.
@@ -44,7 +44,7 @@ import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
  * @since 5.0
  */
 @API(status = INTERNAL, since = "5.0")
-public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
+public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor implements ResourceLockAware {
 
 	private static final Logger logger = LoggerFactory.getLogger(MethodBasedTestDescriptor.class);
 
@@ -80,13 +80,14 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor {
 	}
 
 	@Override
-	public Set<ExclusiveResource> getExclusiveResources() {
-		// @formatter:off
-		return getExclusiveResourcesFromAnnotations(
-				getTestMethod(),
-				provider -> provider.provideForMethod(getTestClass(), getTestMethod())
-		);
-		// @formatter:on
+	public ExclusiveResourceCollector getExclusiveResourceCollector() {
+		// There's no need to cache this as this method should only be called once
+		return ExclusiveResourceCollector.from(getTestMethod());
+	}
+
+	@Override
+	public Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider) {
+		return provider.provideForMethod(getTestClass(), getTestMethod());
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ResourceLockAware.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ResourceLockAware.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.descriptor;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.parallel.ResourceLocksProvider;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
+
+/**
+ * @since 5.12
+ */
+interface ResourceLockAware extends TestDescriptor {
+
+	default Stream<ExclusiveResource> determineExclusiveResources() {
+
+		Deque<ResourceLockAware> ancestors = new ArrayDeque<>();
+		TestDescriptor parent = this.getParent().orElse(null);
+		while (parent instanceof ResourceLockAware) {
+			ancestors.addFirst((ResourceLockAware) parent);
+			parent = parent.getParent().orElse(null);
+		}
+
+		if (ancestors.isEmpty()) {
+			return determineOwnExclusiveResources();
+		}
+
+		Stream<ExclusiveResource> ancestorDynamicResources = ancestors.stream() //
+				.map(ResourceLockAware::getExclusiveResourceCollector) //
+				.flatMap(collector -> collector.getDynamicResources(this::evaluateResourceLocksProvider));
+
+		return Stream.concat(ancestorDynamicResources, determineOwnExclusiveResources());
+	}
+
+	default Stream<ExclusiveResource> determineOwnExclusiveResources() {
+		return this.getExclusiveResourceCollector().getAllExclusiveResources(this::evaluateResourceLocksProvider);
+	}
+
+	ExclusiveResourceCollector getExclusiveResourceCollector();
+
+	Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider);
+
+}

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ResourceLocksProviderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/ResourceLocksProviderTests.java
@@ -77,6 +77,7 @@ class ResourceLocksProviderTests {
 
 	// -------------------------------------------------------------------------
 
+	@SuppressWarnings("JUnitMalformedDeclaration")
 	@ResourceLock(providers = ClassLevelProviderTestCase.Provider.class)
 	static class ClassLevelProviderTestCase {
 
@@ -150,6 +151,7 @@ class ResourceLocksProviderTests {
 		}
 	}
 
+	@SuppressWarnings("JUnitMalformedDeclaration")
 	static class NestedClassLevelProviderTestCase {
 
 		@Test
@@ -202,6 +204,7 @@ class ResourceLocksProviderTests {
 		}
 	}
 
+	@SuppressWarnings("JUnitMalformedDeclaration")
 	static class MethodLevelProviderTestCase {
 
 		@Test
@@ -249,6 +252,7 @@ class ResourceLocksProviderTests {
 		}
 	}
 
+	@SuppressWarnings("JUnitMalformedDeclaration")
 	static class MethodLevelProviderInNestedClassTestCase {
 
 		@Test


### PR DESCRIPTION
## Overview

Instead of looking up annotations on the declaring and all enclosing
classes for each test method, each `ResourceLockAware` test descriptor
now delegates to the `ExclusiveResourceCollector` of its ancestors which
cache the class-level annotations and `ResourceLocksProvider` instances.

Resolves #2677.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
