### PR TITLE
Add constructor injection support for `TempDir`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -62,6 +62,7 @@ JUnit repository on GitHub.
   `ExtensionContext` while instantiating the test instance.
   The behavior enabled by the annotation is expected to eventually become the default in
   future versions of JUnit Jupiter.
+* `@TempDir` is now supported on test class constructors.
 
 
 [[release-notes-5.12.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -3003,7 +3003,8 @@ The built-in `{TempDirectory}` extension is used to create and clean up a tempor
 directory for an individual test or all tests in a test class. It is registered by
 default. To use it, annotate a non-final, unassigned field of type `java.nio.file.Path` or
 `java.io.File` with `{TempDir}` or add a parameter of type `java.nio.file.Path` or
-`java.io.File` annotated with `@TempDir` to a lifecycle method or test method.
+`java.io.File` annotated with `@TempDir` to a test class constructor, lifecycle method, or
+test method.
 
 For example, the following test declares a parameter annotated with `@TempDir` for a
 single test method, creates and writes to a file in the temporary directory, and checks
@@ -3028,14 +3029,10 @@ entire test class or method (depending on which level the annotation is used), y
 the `junit.jupiter.tempdir.scope` configuration parameter to `per_context`. However,
 please note that this option is deprecated and will be removed in a future release.
 
-`@TempDir` is not supported on constructor parameters. If you wish to retain a single
-reference to a temp directory across lifecycle methods and the current test method, please
-use field injection by annotating an instance field with `@TempDir`.
-
 The following example stores a _shared_ temporary directory in a `static` field. This
 allows the same `sharedTempDir` to be used in all lifecycle methods and test methods of
-the test class. For better isolation, you should use an instance field so that each test
-method uses a separate directory.
+the test class. For better isolation, you should use an instance field or constructor
+injection so that each test method uses a separate directory.
 
 [source,java,indent=0]
 .A test class that shares a temporary directory across test methods

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -22,7 +22,6 @@ import static org.junit.platform.commons.support.ReflectionSupport.makeAccessibl
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Parameter;
 import java.nio.file.DirectoryNotEmptyException;
@@ -45,12 +44,12 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.extension.AnnotatedElementContext;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.EnableTestScopedConstructorContext;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
@@ -78,6 +77,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  * @see TempDir
  * @see Files#createTempDirectory
  */
+@EnableTestScopedConstructorContext
 class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterResolver {
 
 	static final Namespace NAMESPACE = Namespace.create(TempDirectory.class);
@@ -161,12 +161,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 	 */
 	@Override
 	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		boolean annotated = parameterContext.isAnnotated(TempDir.class);
-		if (annotated && parameterContext.getDeclaringExecutable() instanceof Constructor) {
-			throw new ParameterResolutionException(
-				"@TempDir is not supported on constructor parameters. Please use field injection instead.");
-		}
-		return annotated;
+		return parameterContext.isAnnotated(TempDir.class);
 	}
 
 	/**


### PR DESCRIPTION
## Overview

This was made possible by lifting the `ParameterResolver` limitation for
accessing the test-scoped `ExtensionContext` for test class constructors
in #3445.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
