### PR TITLE
Introduce configuration parameter for default extension context scope

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstantiationAwareExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstantiationAwareExtension.java
@@ -106,10 +106,16 @@ public interface TestInstantiationAwareExtension extends Extension {
 
 		/**
 		 * The extension should receive an {@link ExtensionContext} scoped to
-		 * the test class.
+		 * in the <em>default</em> scope.
+		 *
+		 * <p>The default scope is determined by the configuration parameter
+		 * {@link #DEFAULT_SCOPE_PROPERTY_NAME}. If not specified, extensions
+		 * will receive an {@link ExtensionContext} scoped to the test class.
 		 *
 		 * @deprecated This behavior will be removed from future versions of
 		 * JUnit and {@link #TEST_METHOD} will become the default.
+		 *
+		 * @see #DEFAULT_SCOPE_PROPERTY_NAME
 		 */
 		@API(status = DEPRECATED, since = "5.12") //
 		@Deprecated
@@ -120,7 +126,19 @@ public interface TestInstantiationAwareExtension extends Extension {
 		 * the test method, unless the
 		 * {@link TestInstance.Lifecycle#PER_CLASS PER_CLASS} lifecycle is used.
 		 */
-		TEST_METHOD
+		TEST_METHOD;
+
+		/**
+		 * Property name used to set the default extension context scope: {@value}
+		 *
+		 * <h4>Supported Values</h4>
+		 *
+		 * <p>Supported values include names of enum constants defined in this
+		 * class, ignoring case.
+		 *
+		 * @see #DEFAULT
+		 */
+		public static final String DEFAULT_SCOPE_PROPERTY_NAME = "junit.jupiter.extensions.testInstantiation.extensionContextScope.default";
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.TestInstantiationAwareExtension.ExtensionContextScope;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
@@ -368,6 +369,16 @@ public final class Constants {
 	 */
 	@API(status = EXPERIMENTAL, since = "5.10")
 	public static final String DEFAULT_TEMP_DIR_FACTORY_PROPERTY_NAME = TempDir.DEFAULT_FACTORY_PROPERTY_NAME;
+
+	/**
+	 * Property name used to set the default extension context scope for
+	 * extensions that participate in test instantiation: {@value}
+	 *
+	 * @since 5.12
+	 * @see org.junit.jupiter.api.extension.TestInstantiationAwareExtension
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	public static final String DEFAULT_TEST_CLASS_INSTANCE_CONSTRUCTION_EXTENSION_CONTEXT_SCOPE_PROPERTY_NAME = ExtensionContextScope.DEFAULT_SCOPE_PROPERTY_NAME;
 
 	private Constants() {
 		/* no-op */

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.TestInstantiationAwareExtension.ExtensionContextScope;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDirFactory;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -58,71 +59,77 @@ public class CachingJupiterConfiguration implements JupiterConfiguration {
 	@Override
 	public boolean isParallelExecutionEnabled() {
 		return (boolean) cache.computeIfAbsent(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME,
-			key -> delegate.isParallelExecutionEnabled());
+			__ -> delegate.isParallelExecutionEnabled());
 	}
 
 	@Override
 	public boolean isExtensionAutoDetectionEnabled() {
 		return (boolean) cache.computeIfAbsent(EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME,
-			key -> delegate.isExtensionAutoDetectionEnabled());
+			__ -> delegate.isExtensionAutoDetectionEnabled());
 	}
 
 	@Override
 	public ExecutionMode getDefaultExecutionMode() {
 		return (ExecutionMode) cache.computeIfAbsent(DEFAULT_EXECUTION_MODE_PROPERTY_NAME,
-			key -> delegate.getDefaultExecutionMode());
+			__ -> delegate.getDefaultExecutionMode());
 	}
 
 	@Override
 	public ExecutionMode getDefaultClassesExecutionMode() {
 		return (ExecutionMode) cache.computeIfAbsent(DEFAULT_CLASSES_EXECUTION_MODE_PROPERTY_NAME,
-			key -> delegate.getDefaultClassesExecutionMode());
+			__ -> delegate.getDefaultClassesExecutionMode());
 	}
 
 	@Override
 	public TestInstance.Lifecycle getDefaultTestInstanceLifecycle() {
 		return (TestInstance.Lifecycle) cache.computeIfAbsent(DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME,
-			key -> delegate.getDefaultTestInstanceLifecycle());
+			__ -> delegate.getDefaultTestInstanceLifecycle());
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public Predicate<ExecutionCondition> getExecutionConditionFilter() {
 		return (Predicate<ExecutionCondition>) cache.computeIfAbsent(DEACTIVATE_CONDITIONS_PATTERN_PROPERTY_NAME,
-			key -> delegate.getExecutionConditionFilter());
+			__ -> delegate.getExecutionConditionFilter());
 	}
 
 	@Override
 	public DisplayNameGenerator getDefaultDisplayNameGenerator() {
 		return (DisplayNameGenerator) cache.computeIfAbsent(DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME,
-			key -> delegate.getDefaultDisplayNameGenerator());
+			__ -> delegate.getDefaultDisplayNameGenerator());
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public Optional<MethodOrderer> getDefaultTestMethodOrderer() {
 		return (Optional<MethodOrderer>) cache.computeIfAbsent(DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME,
-			key -> delegate.getDefaultTestMethodOrderer());
+			__ -> delegate.getDefaultTestMethodOrderer());
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public Optional<ClassOrderer> getDefaultTestClassOrderer() {
 		return (Optional<ClassOrderer>) cache.computeIfAbsent(DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME,
-			key -> delegate.getDefaultTestClassOrderer());
+			__ -> delegate.getDefaultTestClassOrderer());
 	}
 
 	@Override
 	public CleanupMode getDefaultTempDirCleanupMode() {
 		return (CleanupMode) cache.computeIfAbsent(DEFAULT_CLEANUP_MODE_PROPERTY_NAME,
-			key -> delegate.getDefaultTempDirCleanupMode());
+			__ -> delegate.getDefaultTempDirCleanupMode());
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public Supplier<TempDirFactory> getDefaultTempDirFactorySupplier() {
 		return (Supplier<TempDirFactory>) cache.computeIfAbsent(DEFAULT_FACTORY_PROPERTY_NAME,
-			key -> delegate.getDefaultTempDirFactorySupplier());
+			__ -> delegate.getDefaultTempDirFactorySupplier());
 	}
 
+	@Override
+	public ExtensionContextScope getDefaultTestInstantiationExtensionContextScope() {
+		return (ExtensionContextScope) cache.computeIfAbsent(
+			DEFAULT_TEST_INSTANTIATION_EXTENSION_CONTEXT_SCOPE_PROPERTY_NAME,
+			__ -> delegate.getDefaultTestInstantiationExtensionContextScope());
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.TestInstantiationAwareExtension.ExtensionContextScope;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDirFactory;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -61,6 +62,9 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 
 	private static final InstantiatingConfigurationParameterConverter<TempDirFactory> tempDirFactoryConverter = //
 		new InstantiatingConfigurationParameterConverter<>(TempDirFactory.class, "temp dir factory");
+
+	private static final EnumConfigurationParameterConverter<ExtensionContextScope> extensionContextScopeConverter = //
+		new EnumConfigurationParameterConverter<>(ExtensionContextScope.class, "extension context scope");
 
 	private final ConfigurationParameters configurationParameters;
 
@@ -141,4 +145,10 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 		return () -> supplier.get().orElse(TempDirFactory.Standard.INSTANCE);
 	}
 
+	@SuppressWarnings("deprecation")
+	@Override
+	public ExtensionContextScope getDefaultTestInstantiationExtensionContextScope() {
+		return extensionContextScopeConverter.get(configurationParameters,
+			DEFAULT_TEST_INSTANTIATION_EXTENSION_CONTEXT_SCOPE_PROPERTY_NAME, ExtensionContextScope.DEFAULT);
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.TestInstantiationAwareExtension.ExtensionContextScope;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDirFactory;
 import org.junit.jupiter.api.parallel.Execution;
@@ -42,7 +43,8 @@ public interface JupiterConfiguration {
 	String DEFAULT_TEST_INSTANCE_LIFECYCLE_PROPERTY_NAME = TestInstance.Lifecycle.DEFAULT_LIFECYCLE_PROPERTY_NAME;
 	String DEFAULT_DISPLAY_NAME_GENERATOR_PROPERTY_NAME = DisplayNameGenerator.DEFAULT_GENERATOR_PROPERTY_NAME;
 	String DEFAULT_TEST_METHOD_ORDER_PROPERTY_NAME = MethodOrderer.DEFAULT_ORDER_PROPERTY_NAME;
-	String DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME = ClassOrderer.DEFAULT_ORDER_PROPERTY_NAME;
+	String DEFAULT_TEST_CLASS_ORDER_PROPERTY_NAME = ClassOrderer.DEFAULT_ORDER_PROPERTY_NAME;;
+	String DEFAULT_TEST_INSTANTIATION_EXTENSION_CONTEXT_SCOPE_PROPERTY_NAME = ExtensionContextScope.DEFAULT_SCOPE_PROPERTY_NAME;
 
 	Optional<String> getRawConfigurationParameter(String key);
 
@@ -69,5 +71,7 @@ public interface JupiterConfiguration {
 	CleanupMode getDefaultTempDirCleanupMode();
 
 	Supplier<TempDirFactory> getDefaultTempDirFactorySupplier();
+
+	ExtensionContextScope getDefaultTestInstantiationExtensionContextScope();
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -288,7 +288,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor imp
 			JupiterEngineExecutionContext context) {
 
 		ExtensionContextSupplier extensionContext = ExtensionContextSupplier.create(context.getExtensionContext(),
-			ourExtensionContext);
+			ourExtensionContext, configuration);
 		TestInstances instances = instantiateTestClass(parentExecutionContext, extensionContext, registry, context);
 		context.getThrowableCollector().execute(() -> {
 			invokeTestInstancePostProcessors(instances.getInnermostInstance(), registry, extensionContext);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -287,7 +287,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor imp
 			ClassExtensionContext ourExtensionContext, ExtensionRegistry registry,
 			JupiterEngineExecutionContext context) {
 
-		ExtensionContextSupplier extensionContext = new ExtensionContextSupplier(context.getExtensionContext(),
+		ExtensionContextSupplier extensionContext = ExtensionContextSupplier.create(context.getExtensionContext(),
 			ourExtensionContext);
 		TestInstances instances = instantiateTestClass(parentExecutionContext, extensionContext, registry, context);
 		context.getThrowableCollector().execute(() -> {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionContextSupplier.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ExtensionContextSupplier.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.extension.TestInstantiationAwareExtension.Ex
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstantiationAwareExtension;
+import org.junit.jupiter.engine.config.JupiterConfiguration;
 
 /**
  * Container of two instances of {@link ExtensionContext} to simplify the legacy for
@@ -29,8 +30,9 @@ import org.junit.jupiter.api.extension.TestInstantiationAwareExtension;
 public interface ExtensionContextSupplier {
 
 	static ExtensionContextSupplier create(ExtensionContext currentExtensionContext,
-			ExtensionContext legacyExtensionContext) {
-		if (currentExtensionContext == legacyExtensionContext) {
+			ExtensionContext legacyExtensionContext, JupiterConfiguration configuration) {
+		if (currentExtensionContext == legacyExtensionContext
+				|| configuration.getDefaultTestInstantiationExtensionContextScope() == TEST_METHOD) {
 			return __ -> currentExtensionContext;
 		}
 		return new ScopeBasedExtensionContextSupplier(currentExtensionContext, legacyExtensionContext);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -83,8 +83,7 @@ public class ParameterResolutionUtils {
 	 */
 	public static Object[] resolveParameters(Executable executable, Optional<Object> target,
 			Optional<Object> outerInstance, ExtensionContext extensionContext, ExtensionRegistry extensionRegistry) {
-		ExtensionContextSupplier context = new ExtensionContextSupplier(extensionContext, extensionContext);
-		return resolveParameters(executable, target, outerInstance, context, extensionRegistry);
+		return resolveParameters(executable, target, outerInstance, __ -> extensionContext, extensionRegistry);
 	}
 
 	public static Object[] resolveParameters(Executable executable, Optional<Object> target,

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvokerTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvokerTests.java
@@ -31,9 +31,8 @@ class InterceptingExecutableInvokerTests extends AbstractExecutableInvokerTests 
 
 	@Override
 	<T> T invokeConstructor(Constructor<T> constructor, Object outerInstance) {
-		ExtensionContextSupplier context = ExtensionContextSupplier.create(extensionContext, extensionContext);
-		return newInvoker().invoke(constructor, Optional.ofNullable(outerInstance), context, extensionRegistry,
-			passthroughInterceptor());
+		return newInvoker().invoke(constructor, Optional.ofNullable(outerInstance), __ -> extensionContext,
+			extensionRegistry, passthroughInterceptor());
 	}
 
 	private InterceptingExecutableInvoker newInvoker() {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvokerTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvokerTests.java
@@ -31,7 +31,7 @@ class InterceptingExecutableInvokerTests extends AbstractExecutableInvokerTests 
 
 	@Override
 	<T> T invokeConstructor(Constructor<T> constructor, Object outerInstance) {
-		ExtensionContextSupplier context = new ExtensionContextSupplier(extensionContext, extensionContext);
+		ExtensionContextSupplier context = ExtensionContextSupplier.create(extensionContext, extensionContext);
 		return newInvoker().invoke(constructor, Optional.ofNullable(outerInstance), context, extensionRegistry,
 			passthroughInterceptor());
 	}


### PR DESCRIPTION
## Overview

The new `junit.jupiter.extensions.testClassInstanceConstruction.extensionContextScope.default` configuration parameters allows to change the default extension context scope introduced in #4062 to allow checking for compatibility issues of existing extensions without having to change their implementation.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
