### PR TITLE
Add tests for extension context scope supplied to InvocationInterceptor

### DIFF
--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/InvocationInterceptorTests.java
@@ -10,6 +10,8 @@
 
 package org.junit.jupiter.engine.extension;
 
+import static java.util.function.Function.identity;
+import static java.util.function.Predicate.isEqual;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -22,7 +24,10 @@ import static org.junit.platform.testkit.engine.TestExecutionResultConditions.me
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.EnumSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
@@ -30,9 +35,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.extension.DynamicTestInvocationContext;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,8 +50,6 @@ import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
@@ -130,28 +136,76 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 		}
 	}
 
-	@ParameterizedTest(name = "{0}")
-	@EnumSource(InvocationType.class)
-	void callsInterceptors(InvocationType invocationType) {
+	@TestFactory
+	Stream<DynamicTest> callsInterceptors() {
 		var results = executeTestsForClass(TestCaseWithThreeInterceptors.class);
 
 		results.testEvents().assertStatistics(stats -> stats.failed(0).succeeded(3));
 
-		assertThat(getEvents(results, EnumSet.of(invocationType)).distinct()) //
-				.containsExactly("before:foo", "before:bar", "before:baz", "test", "after:baz", "after:bar",
-					"after:foo");
+		return Arrays.stream(InvocationType.values()) //
+				.map(it -> dynamicTest(it.name(), () -> verifyEvents(results, it)));
 	}
 
-	private Stream<String> getEvents(EngineExecutionResults results, EnumSet<InvocationType> types) {
-		return results.allEvents().reportingEntryPublished() //
-				.map(event -> event.getPayload(ReportEntry.class).orElseThrow()) //
-				.map(ReportEntry::getKeyValuePairs) //
-				.filter(map -> map.keySet().stream().map(InvocationType::valueOf).anyMatch(types::contains)) //
-				.flatMap(map -> map.values().stream());
+	private void verifyEvents(EngineExecutionResults results, InvocationType invocationType) {
+		var beforeEvents = List.of("before:foo", "before:bar", "before:baz");
+		var testEvent = List.of("test");
+		var afterEvents = List.of("after:baz", "after:bar", "after:foo");
+		var allEvents = Stream.of(beforeEvents, testEvent, afterEvents).flatMap(Collection::stream).toList();
+		String testClassName = TestCaseWithThreeInterceptors.class.getName();
+
+		var expectedElements = switch (invocationType) {
+			case BEFORE_ALL, AFTER_ALL -> prefixed(allEvents, testClassName);
+			case CONSTRUCTOR -> concatStreams(
+				prefixed(allEvents, it -> it.endsWith(":bar") ? testClassName : "test(TestReporter)"),
+				prefixed(allEvents, it -> it.endsWith(":bar") ? testClassName : "testTemplate(TestReporter)[1]"),
+				prefixed(allEvents, it -> it.endsWith(":bar") ? testClassName : "testFactory(TestReporter)"));
+			case BEFORE_EACH, AFTER_EACH -> concatStreams(prefixed(allEvents, "test(TestReporter)"),
+				prefixed(allEvents, "testTemplate(TestReporter)[1]"), prefixed(allEvents, "testFactory(TestReporter)"));
+			case TEST_METHOD -> prefixed(allEvents, "test(TestReporter)");
+			case TEST_TEMPLATE_METHOD -> prefixed(allEvents, "testTemplate(TestReporter)[1]");
+			case TEST_FACTORY_METHOD -> prefixed(allEvents, "testFactory(TestReporter)");
+			case DYNAMIC_TEST -> concatStreams(prefixed(beforeEvents, "testFactory(TestReporter)[1]"),
+				prefixed(testEvent, "testFactory(TestReporter)"),
+				prefixed(afterEvents, "testFactory(TestReporter)[1]"));
+		};
+
+		assertThat(getEvents(results, invocationType)) //
+				.containsExactlyElementsOf(expectedElements.toList());
+	}
+
+	@SafeVarargs
+	@SuppressWarnings("varargs")
+	private static <T> Stream<T> concatStreams(Stream<T>... items) {
+		return Stream.of(items).flatMap(identity());
+	}
+
+	private static Stream<String> prefixed(List<String> values, String prefix) {
+		return prefixed(values, __ -> prefix);
+	}
+
+	private static Stream<String> prefixed(List<String> values, UnaryOperator<String> prefixGenerator) {
+		return values.stream() //
+				.map(it -> "[%s] %s".formatted(prefixGenerator.apply(it), it));
+	}
+
+	private Stream<String> getEvents(EngineExecutionResults results, InvocationType invocationType) {
+		return results.allEvents().reportingEntryPublished().stream() //
+				.flatMap(event -> {
+					var reportEntry = event.getPayload(ReportEntry.class).orElseThrow();
+					var keyValuePairs = reportEntry.getKeyValuePairs();
+					if (keyValuePairs.keySet().stream() //
+							.map(InvocationType::valueOf) //
+							.anyMatch(isEqual(invocationType))) {
+						return keyValuePairs.values().stream() //
+								.map(it -> "[%s] %s".formatted(event.getTestDescriptor().getLegacyReportingName(), it));
+					}
+					return Stream.empty();
+				});
 	}
 
 	@SuppressWarnings("JUnitMalformedDeclaration")
 	@ExtendWith({ FooInvocationInterceptor.class, BarInvocationInterceptor.class, BazInvocationInterceptor.class })
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	static class TestCaseWithThreeInterceptors {
 
 		public TestCaseWithThreeInterceptors(TestReporter reporter) {
@@ -169,16 +223,19 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 			publish(reporter, InvocationType.BEFORE_EACH);
 		}
 
+		@Order(1)
 		@Test
 		void test(TestReporter reporter) {
 			publish(reporter, InvocationType.TEST_METHOD);
 		}
 
+		@Order(2)
 		@RepeatedTest(1)
 		void testTemplate(TestReporter reporter) {
 			publish(reporter, InvocationType.TEST_TEMPLATE_METHOD);
 		}
 
+		@Order(3)
 		@TestFactory
 		DynamicTest testFactory(TestReporter reporter) {
 			publish(reporter, InvocationType.TEST_FACTORY_METHOD);
@@ -222,6 +279,11 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 
 		ReportingInvocationInterceptor(String name) {
 			this.name = name;
+		}
+
+		@Override
+		public ExtensionContextScope getTestInstantiationExtensionContextScope(ExtensionContext rootContext) {
+			return ExtensionContextScope.TEST_METHOD;
 		}
 
 		@Override
@@ -299,8 +361,8 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 			assertThat(invocationContext.getExecutable()).isNotNull();
 			assertThat(extensionContext.getUniqueId()).isNotBlank();
 			assertThat(extensionContext.getElement()).isEmpty();
-			assertThat(extensionContext.getParent().flatMap(ExtensionContext::getTestMethod)).contains(
-				testClass.getDeclaredMethod("testFactory", TestReporter.class));
+			assertThat(extensionContext.getParent().flatMap(ExtensionContext::getTestMethod)) //
+					.contains(testClass.getDeclaredMethod("testFactory", TestReporter.class));
 			reportAndProceed(invocation, extensionContext, InvocationType.DYNAMIC_TEST);
 		}
 
@@ -349,6 +411,12 @@ class InvocationInterceptorTests extends AbstractJupiterTestEngineTests {
 	static class BarInvocationInterceptor extends ReportingInvocationInterceptor {
 		BarInvocationInterceptor() {
 			super("bar");
+		}
+
+		@SuppressWarnings("deprecation")
+		@Override
+		public ExtensionContextScope getTestInstantiationExtensionContextScope(ExtensionContext rootContext) {
+			return ExtensionContextScope.DEFAULT;
 		}
 	}
 


### PR DESCRIPTION
## Overview

Check scope of supplied `ExtensionContext` in tests of `InvocationInterceptor`.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
