### PR TITLE
Fix package name comparison on Java 8

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.3.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.3.adoc
@@ -16,7 +16,8 @@ on GitHub.
 [[release-notes-5.11.3-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Fixed a regression in method search algorithms introduced in 5.11.0 when classes reside
+  in the default package and using a Java 8 runtime.
 
 [[release-notes-5.11.3-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -29,6 +29,7 @@ tasks.jar {
 
 tasks.codeCoverageClassesJar {
 	exclude("org/junit/platform/commons/util/ModuleUtils.class")
+	exclude("org/junit/platform/commons/util/PackageNameUtils.class")
 }
 
 eclipse {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageNameUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/PackageNameUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static org.junit.platform.commons.util.PackageUtils.DEFAULT_PACKAGE_NAME;
+
+/**
+ * Collection of utilities for working with package names.
+ *
+ * <h2>DISCLAIMER</h2>
+ *
+ * <p>These utilities are intended solely for usage within the JUnit framework
+ * itself. <strong>Any usage by external parties is not supported.</strong>
+ * Use at your own risk!
+ *
+ * @since 1.11.3
+ */
+class PackageNameUtils {
+
+	static String getPackageName(Class<?> clazz) {
+		Package p = clazz.getPackage();
+		if (p != null) {
+			return p.getName();
+		}
+		String className = clazz.getName();
+		int index = className.lastIndexOf('.');
+		return index == -1 ? DEFAULT_PACKAGE_NAME : className.substring(0, index);
+	}
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -19,6 +19,7 @@ import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
+import static org.junit.platform.commons.util.PackageNameUtils.getPackageName;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.BOTTOM_UP;
 import static org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode.TOP_DOWN;
 
@@ -1903,8 +1904,7 @@ public final class ReflectionUtils {
 	}
 
 	private static boolean declaredInSamePackage(Method m1, Method m2) {
-		return PackageNameUtils.getPackageName(m1.getDeclaringClass()).equals(
-			PackageNameUtils.getPackageName(m2.getDeclaringClass()));
+		return getPackageName(m1.getDeclaringClass()).equals(getPackageName(m2.getDeclaringClass()));
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -1903,7 +1903,8 @@ public final class ReflectionUtils {
 	}
 
 	private static boolean declaredInSamePackage(Method m1, Method m2) {
-		return m1.getDeclaringClass().getPackage().getName().equals(m2.getDeclaringClass().getPackage().getName());
+		return PackageNameUtils.getPackageName(m1.getDeclaringClass()).equals(
+			PackageNameUtils.getPackageName(m2.getDeclaringClass()));
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java9/org/junit/platform/commons/util/PackageNameUtils.java
+++ b/junit-platform-commons/src/main/java9/org/junit/platform/commons/util/PackageNameUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+/**
+ * Collection of utilities for working with package names.
+ *
+ * <h2>DISCLAIMER</h2>
+ *
+ * <p>These utilities are intended solely for usage within the JUnit framework
+ * itself. <strong>Any usage by external parties is not supported.</strong>
+ * Use at your own risk!
+ *
+ * @since 1.11.3
+ */
+class PackageNameUtils {
+
+	static String getPackageName(Class<?> clazz) {
+		return clazz.getPackageName();
+	}
+
+}

--- a/platform-tooling-support-tests/projects/vintage/src/test/java/DefaultPackageTest.java
+++ b/platform-tooling-support-tests/projects/vintage/src/test/java/DefaultPackageTest.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2015-2024 the original author or authors.
  *
@@ -7,24 +8,15 @@
  *
  * https://www.eclipse.org/legal/epl-v20.html
  */
+import com.example.vintage.VintageTest;
 
-package com.example.vintage;
+import org.junit.Ignore;
 
-import static org.junit.Assert.*;
-
-import org.junit.Test;
-
-public class VintageTest {
+/**
+ * Reproducer for https://github.com/junit-team/junit5/issues/4076
+ */
+@Ignore
+public class DefaultPackageTest extends VintageTest {
 	void packagePrivateMethod() {
-	}
-
-	@Test
-	public void success() {
-		// pass
-	}
-
-	@Test
-	public void failure() {
-		fail("expected to fail");
 	}
 }


### PR DESCRIPTION
## Overview

- **Add reproducer for #4076**
- **Handle Class.getPackage() returning `null` for default package on Java 8**

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
