### PR TITLE
Add `--select-unique-id` support to ConsoleLauncher

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -34,6 +34,7 @@ JUnit repository on GitHub.
 * Add support for passing line and column number to `ConsoleLauncher` via
   `--select-file` and `--select-resource`.
 * `ConsoleLauncher` now accepts multiple values for all `--select` options.
+* Add `--select-unique-id` support to ConsoleLauncher.
 
 
 [[release-notes-5.12.0-M1-junit-jupiter]]

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
@@ -17,6 +17,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectFile;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectModule;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUri;
 
 import java.net.URI;
@@ -34,6 +35,7 @@ import org.junit.platform.engine.discovery.IterationSelector;
 import org.junit.platform.engine.discovery.MethodSelector;
 import org.junit.platform.engine.discovery.ModuleSelector;
 import org.junit.platform.engine.discovery.PackageSelector;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.engine.discovery.UriSelector;
 
 import picocli.CommandLine.ITypeConverter;
@@ -110,6 +112,13 @@ class SelectorConverter {
 				IterationSelector.IdentifierParser.PREFIX, value);
 			return (IterationSelector) DiscoverySelectors.parse(identifier) //
 					.orElseThrow(() -> new PreconditionViolationException("Invalid format: Failed to parse selector"));
+		}
+	}
+
+	static class UniqueId implements ITypeConverter<UniqueIdSelector> {
+		@Override
+		public UniqueIdSelector convert(String value) {
+			return selectUniqueId(value);
 		}
 	}
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptions.java
@@ -35,6 +35,7 @@ import org.junit.platform.engine.discovery.IterationSelector;
 import org.junit.platform.engine.discovery.MethodSelector;
 import org.junit.platform.engine.discovery.ModuleSelector;
 import org.junit.platform.engine.discovery.PackageSelector;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.engine.discovery.UriSelector;
 
 /**
@@ -58,6 +59,7 @@ public class TestDiscoveryOptions {
 	private List<MethodSelector> selectedMethods = emptyList();
 	private List<ClasspathResourceSelector> selectedClasspathResources = emptyList();
 	private List<IterationSelector> selectedIterations = emptyList();
+	private List<UniqueIdSelector> selectedUniqueIds = emptyList();
 	private List<DiscoverySelectorIdentifier> selectorIdentifiers = emptyList();
 
 	private List<String> includedClassNamePatterns = singletonList(STANDARD_INCLUDE_PATTERN);
@@ -180,6 +182,14 @@ public class TestDiscoveryOptions {
 
 	public void setSelectedIterations(List<IterationSelector> selectedIterations) {
 		this.selectedIterations = selectedIterations;
+	}
+
+	public List<UniqueIdSelector> getSelectedUniqueIds() {
+		return selectedUniqueIds;
+	}
+
+	public void setSelectedUniqueId(List<UniqueIdSelector> selectedUniqueIds) {
+		this.selectedUniqueIds = selectedUniqueIds;
 	}
 
 	public List<DiscoverySelectorIdentifier> getSelectorIdentifiers() {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptionsMixin.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptionsMixin.java
@@ -27,6 +27,7 @@ import org.junit.platform.engine.discovery.IterationSelector;
 import org.junit.platform.engine.discovery.MethodSelector;
 import org.junit.platform.engine.discovery.ModuleSelector;
 import org.junit.platform.engine.discovery.PackageSelector;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.engine.discovery.UriSelector;
 
 import picocli.CommandLine;
@@ -146,6 +147,11 @@ class TestDiscoveryOptionsMixin {
 				"-select-iteration" }, arity = "1..*", hidden = true, converter = SelectorConverter.Iteration.class)
 		private final List<IterationSelector> selectedIterations2 = new ArrayList<>();
 
+		@Option(names = { "--select-unique-id",
+				"--uid" }, paramLabel = "UNIQUE-ID", arity = "1..*", converter = SelectorConverter.UniqueId.class, //
+				description = "Select a unique id for test discovery. This option can be repeated.")
+		private final List<UniqueIdSelector> selectedUniqueIds = new ArrayList<>();
+
 		@Option(names = "--select", paramLabel = "PREFIX:VALUE", arity = "1..*", converter = SelectorConverter.Identifier.class, //
 				description = "Select via a prefixed identifier (e.g. method:com.acme.Foo#m selects the m() method in the com.acme.Foo class). "
 						+ "This option can be repeated.")
@@ -168,6 +174,7 @@ class TestDiscoveryOptionsMixin {
 			result.setSelectedClasspathResources(
 				merge(this.selectedClasspathResources, this.selectedClasspathResources2));
 			result.setSelectedIterations(merge(this.selectedIterations, this.selectedIterations2));
+			result.setSelectedUniqueId(this.selectedUniqueIds);
 			result.setSelectorIdentifiers(this.selectorIdentifiers);
 		}
 	}
@@ -210,12 +217,12 @@ class TestDiscoveryOptionsMixin {
 		@Option(names = {
 				"--include-methodname" }, paramLabel = "PATTERN", arity = "1", description = "Provide a regular expression to include only methods whose fully qualified names without parameters match. " //
 						+ "When this option is repeated, all patterns will be combined using OR semantics.")
-		private List<String> includeMethodNamePatterns = new ArrayList<>();
+		private final List<String> includeMethodNamePatterns = new ArrayList<>();
 
 		@Option(names = {
 				"--exclude-methodname" }, paramLabel = "PATTERN", arity = "1", description = "Provide a regular expression to exclude those methods whose fully qualified names without parameters match. " //
 						+ "When this option is repeated, all patterns will be combined using OR semantics.")
-		private List<String> excludeMethodNamePatterns = new ArrayList<>();
+		private final List<String> excludeMethodNamePatterns = new ArrayList<>();
 
 		@Option(names = { "-t",
 				"--include-tag" }, paramLabel = "TAG", arity = "1", description = "Provide a tag or tag expression to include only tests whose tags match. "

--- a/platform-tests/src/test/java/org/junit/platform/console/options/CommandLineOptionsParsingTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/CommandLineOptionsParsingTests.java
@@ -26,6 +26,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectItera
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectModule;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUri;
 
 import java.io.File;
@@ -557,6 +558,24 @@ class CommandLineOptionsParsingTests {
 
 	@ParameterizedTest
 	@EnumSource
+	void parseValidUniqueIdSelectors(ArgsType type) {
+		// @formatter:off
+		assertAll(
+				() -> assertEquals(List.of(selectUniqueId("[engine:junit-jupiter]/[class:MyClass]/[method:myMethod]")), type.parseArgLine("--uid [engine:junit-jupiter]/[class:MyClass]/[method:myMethod]").discovery.getSelectedUniqueIds()),
+				() -> assertEquals(List.of(selectUniqueId("[engine:junit-jupiter]/[class:MyClass]/[method:myMethod]")), type.parseArgLine("--select-unique-id [engine:junit-jupiter]/[class:MyClass]/[method:myMethod]").discovery.getSelectedUniqueIds()),
+				() -> assertEquals(List.of(selectUniqueId("[engine:junit-jupiter]/[class:MyClass1]"), selectUniqueId("[engine:junit-jupiter]/[class:MyClass2]")), type.parseArgLine("--uid [engine:junit-jupiter]/[class:MyClass1] --uid [engine:junit-jupiter]/[class:MyClass2]").discovery.getSelectedUniqueIds()),
+				() -> assertEquals(List.of(selectUniqueId("[engine:junit-jupiter]/[class:MyClass1]"), selectUniqueId("[engine:junit-jupiter]/[class:MyClass2]")), type.parseArgLine("--uid [engine:junit-jupiter]/[class:MyClass1] [engine:junit-jupiter]/[class:MyClass2]").discovery.getSelectedUniqueIds())
+		);
+		// @formatter:on
+	}
+
+	@Test
+	void parseInvalidUniqueIdSelectors() {
+		assertOptionWithMissingRequiredArgumentThrowsException("--uid", "--select-unique-id");
+	}
+
+	@ParameterizedTest
+	@EnumSource
 	void parseClasspathScanningEntries(ArgsType type) {
 		var dir = Paths.get(".");
 		// @formatter:off
@@ -637,7 +656,8 @@ class CommandLineOptionsParsingTests {
 				() -> assertEquals(List.of(selectPackage("com.acme.foo")), parseIdentifiers(type,"--select package:com.acme.foo")),
 				() -> assertEquals(List.of(selectModule("com.acme.foo")), parseIdentifiers(type,"--select module:com.acme.foo")),
 				() -> assertEquals(List.of(selectDirectory("foo/bar")), parseIdentifiers(type,"--select directory:foo/bar")),
-				() -> assertEquals(List.of(selectFile("foo.txt"), selectUri("file:///foo.txt")), parseIdentifiers(type,"--select file:foo.txt --select uri:file:///foo.txt"))
+				() -> assertEquals(List.of(selectFile("foo.txt"), selectUri("file:///foo.txt")), parseIdentifiers(type,"--select file:foo.txt --select uri:file:///foo.txt")),
+				() -> assertEquals(List.of(selectUniqueId("[engine:junit-jupiter]/[class:MyClass]/[method:myMethod]")), parseIdentifiers(type,"--select uid:[engine:junit-jupiter]/[class:MyClass]/[method:myMethod]"))
 		);
 		// @formatter:on
 	}


### PR DESCRIPTION
## Overview

Resolves #3484 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
