### PR TITLE
Add include matching on ClassNamePatternFilterUtils

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/Constants.java
@@ -91,7 +91,7 @@ public final class Constants {
 	 * @see #DEACTIVATE_CONDITIONS_PATTERN_PROPERTY_NAME
 	 * @see org.junit.jupiter.api.extension.ExecutionCondition
 	 */
-	public static final String DEACTIVATE_ALL_CONDITIONS_PATTERN = ClassNamePatternFilterUtils.DEACTIVATE_ALL_PATTERN;
+	public static final String DEACTIVATE_ALL_CONDITIONS_PATTERN = ClassNamePatternFilterUtils.ALL_PATTERN;
 
 	/**
 	 * Property name used to set the default display name generator class name: {@value}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
@@ -103,7 +103,7 @@ public class ClassNamePatternFilterUtils {
 	private static <T> Predicate<T> createPredicateFromPatterns(String patterns, Function<T, String> classNameProvider,
 			FilterType mode) {
 		if (ALL_PATTERN.equals(patterns)) {
-			return object -> mode == FilterType.INCLUDE;
+			return __ -> mode == FilterType.INCLUDE;
 		}
 
 		List<Pattern> patternList = convertToRegularExpressions(patterns);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
@@ -96,7 +96,7 @@ public class ClassNamePatternFilterUtils {
 				.filter(StringUtils::isNotBlank)
 				.map(String::trim)
 				.map(trimmedPatterns -> createPredicateFromPatterns(trimmedPatterns, classNameProvider, type))
-				.orElse(type == FilterType.EXCLUDE ? object -> true : object -> false);
+				.orElse(type == FilterType.EXCLUDE ? __ -> true : __ -> false);
 		// @formatter:on
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
@@ -41,7 +41,7 @@ public class ClassNamePatternFilterUtils {
 		/* no-op */
 	}
 
-	public static final String DEACTIVATE_ALL_PATTERN = "*";
+	public static final String ALL_PATTERN = "*";
 
 	/**
 	 * Create a {@link Predicate} that can be used to exclude (i.e., filter out)
@@ -51,7 +51,7 @@ public class ClassNamePatternFilterUtils {
 	 * @param patterns a comma-separated list of patterns
 	 */
 	public static <T> Predicate<T> excludeMatchingClasses(String patterns) {
-		return excludeMatchingClasses(patterns, object -> object.getClass().getName());
+		return matchingClasses(patterns, object -> object.getClass().getName(), FilterType.EXCLUDE);
 	}
 
 	/**
@@ -61,26 +61,57 @@ public class ClassNamePatternFilterUtils {
 	 * @param patterns a comma-separated list of patterns
 	 */
 	public static Predicate<String> excludeMatchingClassNames(String patterns) {
-		return excludeMatchingClasses(patterns, Function.identity());
+		return matchingClasses(patterns, Function.identity(), FilterType.EXCLUDE);
 	}
 
-	private static <T> Predicate<T> excludeMatchingClasses(String patterns, Function<T, String> classNameGetter) {
+	/**
+	 * Create a {@link Predicate} that can be used to include (i.e., filter in)
+	 * objects of type {@code T} whose fully qualified class names match any of
+	 * the supplied patterns.
+	 *
+	 * @param patterns a comma-separated list of patterns
+	 */
+	public static <T> Predicate<T> includeMatchingClasses(String patterns) {
+		return matchingClasses(patterns, object -> object.getClass().getName(), FilterType.INCLUDE);
+	}
+
+	/**
+	 * Create a {@link Predicate} that can be used to include (i.e., filter in)
+	 * fully qualified class names matching any of the supplied patterns.
+	 *
+	 * @param patterns a comma-separated list of patterns
+	 */
+	public static Predicate<String> includeMatchingClassNames(String patterns) {
+		return matchingClasses(patterns, Function.identity(), FilterType.INCLUDE);
+	}
+
+	private enum FilterType {
+		INCLUDE, EXCLUDE
+	}
+
+	private static <T> Predicate<T> matchingClasses(String patterns, Function<T, String> classNameProvider,
+			FilterType type) {
 		// @formatter:off
 		return Optional.ofNullable(patterns)
 				.filter(StringUtils::isNotBlank)
 				.map(String::trim)
-				.map(trimmedPatterns -> createPredicateFromPatterns(trimmedPatterns, classNameGetter))
-				.orElse(object -> true);
+				.map(trimmedPatterns -> createPredicateFromPatterns(trimmedPatterns, classNameProvider, type))
+				.orElse(type == FilterType.EXCLUDE ? object -> true : object -> false);
 		// @formatter:on
 	}
 
-	private static <T> Predicate<T> createPredicateFromPatterns(String patterns,
-			Function<T, String> classNameProvider) {
-		if (DEACTIVATE_ALL_PATTERN.equals(patterns)) {
-			return object -> false;
+	private static <T> Predicate<T> createPredicateFromPatterns(String patterns, Function<T, String> classNameProvider,
+			FilterType mode) {
+		if (ALL_PATTERN.equals(patterns)) {
+			return object -> mode == FilterType.INCLUDE;
 		}
+
 		List<Pattern> patternList = convertToRegularExpressions(patterns);
-		return object -> patternList.stream().noneMatch(it -> it.matcher(classNameProvider.apply(object)).matches());
+		return object -> {
+			boolean isMatchingAnyPattern = patternList.stream().anyMatch(
+				pattern -> pattern.matcher(classNameProvider.apply(object)).matches());
+			return (mode == FilterType.INCLUDE) == isMatchingAnyPattern;
+		};
 	}
 
 	private static List<Pattern> convertToRegularExpressions(String patterns) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -146,7 +146,7 @@ public class LauncherConstants {
 	 * @see #DEACTIVATE_LISTENERS_PATTERN_PROPERTY_NAME
 	 * @see org.junit.platform.launcher.TestExecutionListener
 	 */
-	public static final String DEACTIVATE_ALL_LISTENERS_PATTERN = ClassNamePatternFilterUtils.DEACTIVATE_ALL_PATTERN;
+	public static final String DEACTIVATE_ALL_LISTENERS_PATTERN = ClassNamePatternFilterUtils.ALL_PATTERN;
 
 	/**
 	 * Property name used to enable support for

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ClassNamePatternFilterUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ClassNamePatternFilterUtilsTests.java
@@ -169,4 +169,155 @@ class ClassNamePatternFilterUtilsTests {
 				.isEmpty();
 	}
 
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.jupiter.*",
+			"org.junit.platform.*.NonExistentClass",
+			"*.NonExistentClass*",
+			"*NonExistentClass*",
+			"AExecutionConditionClass, BExecutionConditionClass"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void neverIncludedConditions(String pattern) {
+		List<? extends ExecutionCondition> executionConditions = List.of(new AExecutionConditionClass(),
+			new BExecutionConditionClass());
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClasses(pattern)) //
+				.isEmpty();
+	}
+
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.platform.*",
+			"*.platform.*",
+			"*",
+			"*AExecutionConditionClass, *BExecutionConditionClass",
+			"*ExecutionConditionClass"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void alwaysIncludedConditions(String pattern) {
+		List<? extends ExecutionCondition> executionConditions = List.of(new AExecutionConditionClass(),
+			new BExecutionConditionClass());
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClasses(pattern)) //
+				.hasSize(2);
+	}
+
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.jupiter.*",
+			"org.junit.platform.*.NonExistentClass",
+			"*.NonExistentClass*",
+			"*NonExistentClass*",
+			"ATestExecutionListenerClass, BTestExecutionListenerClass"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void neverIncludedListeners(String pattern) {
+		List<? extends TestExecutionListener> executionConditions = List.of(new ATestExecutionListenerClass(),
+			new BTestExecutionListenerClass());
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClasses(pattern)) //
+				.isEmpty();
+	}
+
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.platform.*",
+			"*.platform.*",
+			"*",
+			"*ATestExecutionListenerClass, *BTestExecutionListenerClass",
+			"*TestExecutionListenerClass"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void alwaysIncludedListeners(String pattern) {
+		List<? extends TestExecutionListener> executionConditions = List.of(new ATestExecutionListenerClass(),
+			new BTestExecutionListenerClass());
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClasses(pattern)) //
+				.hasSize(2);
+	}
+
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.jupiter.*",
+			"org.junit.platform.*.NonExistentClass",
+			"*.NonExistentClass*",
+			"*NonExistentClass*",
+			"AVanillaEmpty, BVanillaEmpty"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void neverIncludedClass(String pattern) {
+		var executionConditions = List.of(new AVanillaEmpty(), new BVanillaEmpty());
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClasses(pattern)) //
+				.isEmpty();
+	}
+
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.platform.*",
+			"*.platform.*",
+			"*",
+			"*AVanillaEmpty, *BVanillaEmpty",
+			"*VanillaEmpty"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void alwaysIncludedClass(String pattern) {
+		var executionConditions = List.of(new AVanillaEmpty(), new BVanillaEmpty());
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClasses(pattern)) //
+				.hasSize(2);
+	}
+
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.jupiter.*",
+			"org.junit.platform.*.NonExistentClass",
+			"*.NonExistentClass*",
+			"*NonExistentClass*",
+			"AVanillaEmpty, BVanillaEmpty"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void neverIncludedClassName(String pattern) {
+		var executionConditions = List.of("org.junit.platform.commons.util.classes.AVanillaEmpty",
+			"org.junit.platform.commons.util.classes.BVanillaEmpty");
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClassNames(pattern)) //
+				.isEmpty();
+	}
+
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.platform.*",
+			"*.platform.*",
+			"*",
+			"*AVanillaEmpty, *BVanillaEmpty",
+			"*VanillaEmpty"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void alwaysIncludedClassName(String pattern) {
+		var executionConditions = List.of("org.junit.platform.commons.util.classes.AVanillaEmpty",
+			"org.junit.platform.commons.util.classes.BVanillaEmpty");
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClassNames(pattern)) //
+				.hasSize(2);
+	}
+
+	//@formatter:off
+	@ValueSource(strings = {
+			"org.junit.platform.*",
+			"*.platform.*",
+			"*",
+			"*AVanillaEmpty, *BVanillaEmpty",
+			"*VanillaEmpty"
+	})
+	//@formatter:on
+	@ParameterizedTest
+	void includeAndExcludeSame(String pattern) {
+		var executionConditions = List.of("org.junit.platform.commons.util.classes.AVanillaEmpty",
+			"org.junit.platform.commons.util.classes.BVanillaEmpty");
+		assertThat(executionConditions).filteredOn(ClassNamePatternFilterUtils.includeMatchingClassNames(pattern)) //
+				.hasSize(2);
+	}
+
 }


### PR DESCRIPTION
Issue: #3717

## Overview

I've already worked on this in my personal repository, and since there’s a large amount of code changes, I decided to split it into two PRs.

https://github.com/YongGoose/junit5/commit/a2ef07f02a0fd7e4980931bd2ea2f390f53962fa
I plan to proceed in the following two ways.

1. Add an include method to ClassNamePatternFilterUtils.
2. Implement include and exclude filtering when calling registerAutoDetectedExtensions in MutableExtensionRegistry.
- https://github.com/junit-team/junit5/pull/4115
The link above is the PR for the first step.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
