### PR TITLE
Add JUnit-specific metadata to open-test-reporting's HTML report

### DIFF
--- a/.github/actions/main-build/action.yml
+++ b/.github/actions/main-build/action.yml
@@ -19,5 +19,5 @@ runs:
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       if: ${{ always() }}
       with:
-        name: Open Test Reports (${{ github.job.name }})
+        name: Open Test Reports (${{ github.job }})
         path: '**/build/reports/open-test-report.html'

--- a/.github/actions/main-build/action.yml
+++ b/.github/actions/main-build/action.yml
@@ -19,5 +19,5 @@ runs:
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
       if: ${{ always() }}
       with:
-        name: Open Test Reports (${{ github.job }})
+        name: Open Test Reports (${{ github.job.name }})
         path: '**/build/reports/open-test-report.html'

--- a/.github/actions/main-build/action.yml
+++ b/.github/actions/main-build/action.yml
@@ -16,3 +16,8 @@ runs:
       with:
         arguments: ${{ inputs.arguments }}
         encryptionKey: ${{ inputs.encryptionKey }}
+    - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+      if: ${{ always() }}
+      with:
+        name: Open Test Reports (${{ github.job }})
+        path: '**/build/reports/open-test-report.html'

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}
         with:
-          name: Open Test Reports (${{ github.job.name }})
+          name: Open Test Reports (${{ github.job }})
           path: '**/build/reports/open-test-report.html'
   openj9:
     strategy:
@@ -110,5 +110,5 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}
         with:
-          name: Open Test Reports (${{ github.job.name }})
+          name: Open Test Reports (${{ github.job }})
           path: '**/build/reports/open-test-report.html'

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -102,3 +102,8 @@ jobs:
             -Dscan.tag.OpenJ9 \
             build \
             --configuration-cache
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        if: ${{ always() }}
+        with:
+          name: Open Test Reports (${{ github.job }})
+          path: '**/build/reports/open-test-report.html'

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}
         with:
-          name: Open Test Reports (${{ github.job }})
+          name: Open Test Reports (${{ github.job }} ${{ matrix.jdk.version }} (${{ matrix.jdk.release || matrix.jdk.type }}))
           path: '**/build/reports/open-test-report.html'
   openj9:
     strategy:

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}
         with:
-          name: Open Test Reports (${{ github.job }})
+          name: Open Test Reports (${{ github.job.name }})
           path: '**/build/reports/open-test-report.html'
   openj9:
     strategy:
@@ -110,5 +110,5 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}
         with:
-          name: Open Test Reports (${{ github.job }})
+          name: Open Test Reports (${{ github.job.name }})
           path: '**/build/reports/open-test-report.html'

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -66,6 +66,11 @@ jobs:
             -Dscan.tag.JDK_${{ matrix.jdk.version }} \
             build \
             --configuration-cache
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        if: ${{ always() }}
+        with:
+          name: Open Test Reports (${{ github.job }})
+          path: '**/build/reports/open-test-report.html'
   openj9:
     strategy:
       fail-fast: false

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -34,8 +34,3 @@ jobs:
       shell: bash
       run: |
         ./gradle/scripts/checkBuildReproducibility.sh
-    - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
-      if: ${{ always() }}
-      with:
-        name: Open Test Reports (${{ github.job }})
-        path: '**/build/reports/open-test-report.html'

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -34,3 +34,8 @@ jobs:
       shell: bash
       run: |
         ./gradle/scripts/checkBuildReproducibility.sh
+    - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+      if: ${{ always() }}
+      with:
+        name: Open Test Reports (${{ github.job }})
+        path: '**/build/reports/open-test-report.html'

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -38,6 +38,9 @@ JUnit repository on GitHub.
   `--select-file` and `--select-resource`.
 * `ConsoleLauncher` now accepts multiple values for all `--select` options.
 * Add `--select-unique-id` support to ConsoleLauncher.
+* The `junit-platform-reporting` module now contributes a section containing
+  JUnit-specific metadata about each test/container to the HTML report written by
+  open-test-reporting when added to the classpath/module path.
 
 
 [[release-notes-5.12.0-M1-junit-jupiter]]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ junit4Min = "4.12"
 ktlint = "1.4.1"
 log4j = "2.24.1"
 opentest4j = "1.3.0"
-openTestReporting = "0.1.0-M2"
+openTestReporting = "0.1.0-SNAPSHOT"
 surefire = "3.5.2"
 xmlunit = "2.10.0"
 
@@ -57,7 +57,8 @@ mockito = { module = "org.mockito:mockito-junit-jupiter", version = "5.14.2" }
 nohttp-checkstyle = { module = "io.spring.nohttp:nohttp-checkstyle", version = "0.0.11" }
 opentest4j = { module = "org.opentest4j:opentest4j", version.ref = "opentest4j" }
 openTestReporting-events = { module = "org.opentest4j.reporting:open-test-reporting-events", version.ref = "openTestReporting" }
-openTestReporting-tooling = { module = "org.opentest4j.reporting:open-test-reporting-tooling", version.ref = "openTestReporting" }
+openTestReporting-tooling-core = { module = "org.opentest4j.reporting:open-test-reporting-tooling-core", version.ref = "openTestReporting" }
+openTestReporting-tooling-spi = { module = "org.opentest4j.reporting:open-test-reporting-tooling-spi", version.ref = "openTestReporting" }
 picocli = { module = "info.picocli:picocli", version = "4.7.6" }
 slf4j-julBinding = { module = "org.slf4j:slf4j-jdk14", version = "2.0.16" }
 spock1 = { module = "org.spockframework:spock-core", version = "1.3-groovy-2.5" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ memoryfilesystem = { module = "com.github.marschall:memoryfilesystem", version =
 mockito = { module = "org.mockito:mockito-junit-jupiter", version = "5.14.2" }
 nohttp-checkstyle = { module = "io.spring.nohttp:nohttp-checkstyle", version = "0.0.11" }
 opentest4j = { module = "org.opentest4j:opentest4j", version.ref = "opentest4j" }
+openTestReporting-cli = { module = "org.opentest4j.reporting:open-test-reporting-cli", version.ref = "openTestReporting" }
 openTestReporting-events = { module = "org.opentest4j.reporting:open-test-reporting-events", version.ref = "openTestReporting" }
 openTestReporting-tooling-core = { module = "org.opentest4j.reporting:open-test-reporting-tooling-core", version.ref = "openTestReporting" }
 openTestReporting-tooling-spi = { module = "org.opentest4j.reporting:open-test-reporting-tooling-spi", version.ref = "openTestReporting" }

--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
 	shadowed(libs.apiguardian) {
 		because("downstream projects need it to avoid compiler warnings")
 	}
+
+	osgiVerification(libs.openTestReporting.tooling.spi)
 }
 
 val jupiterVersion = rootProject.version

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
 	osgiVerification(projects.junitJupiterEngine)
 	osgiVerification(projects.junitPlatformLauncher)
+	osgiVerification(libs.openTestReporting.tooling.spi)
 }
 
 tasks {

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
 	osgiVerification(projects.junitJupiterEngine)
 	osgiVerification(projects.junitPlatformLauncher)
+	osgiVerification(libs.openTestReporting.tooling.spi)
 
 	testFixturesApi(projects.junitJupiterApi)
 }

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 	api(projects.junitPlatformLauncher)
 
 	compileOnlyApi(libs.apiguardian)
+	compileOnlyApi(libs.openTestReporting.tooling.spi)
 
 	shadowed(libs.openTestReporting.events)
 
@@ -22,7 +23,7 @@ dependencies {
 
 tasks {
 	shadowJar {
-		relocate("org.opentest4j.reporting", "org.junit.platform.reporting.shadow.org.opentest4j.reporting")
+		relocate("org.opentest4j.reporting.events", "org.junit.platform.reporting.shadow.org.opentest4j.reporting.events")
 		from(projectDir) {
 			include("LICENSE-open-test-reporting.md")
 			into("META-INF")

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -24,7 +24,10 @@ dependencies {
 
 tasks {
 	shadowJar {
-		relocate("org.opentest4j.reporting.events", "org.junit.platform.reporting.shadow.org.opentest4j.reporting.events")
+		listOf("events", "schema").forEach { name ->
+			val packageName = "org.opentest4j.reporting.${name}"
+			relocate(packageName, "org.junit.platform.reporting.shadow.${packageName}")
+		}
 		from(projectDir) {
 			include("LICENSE-open-test-reporting.md")
 			into("META-INF")

--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("junitbuild.java-library-conventions")
 	id("junitbuild.shadow-conventions")
+	`java-test-fixtures`
 }
 
 description = "JUnit Platform Reporting"
@@ -15,6 +16,8 @@ dependencies {
 
 	osgiVerification(projects.junitJupiterEngine)
 	osgiVerification(projects.junitPlatformLauncher)
+
+	testFixturesApi(projects.junitJupiterApi)
 }
 
 tasks {

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.reporting.open.xml;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apiguardian.api.API;
+import org.opentest4j.reporting.schema.Namespace;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Contributor;
+import org.opentest4j.reporting.tooling.spi.htmlreport.KeyValuePairs;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Section;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+@API(status = INTERNAL, since = "1.12")
+public class JUnitContributor implements Contributor {
+
+	public JUnitContributor() {
+	}
+
+	@Override
+	public List<Section> contributeSectionsForTestNode(Element testNodeElement) {
+		return findChild(testNodeElement, Namespace.REPORTING_CORE, "metadata") //
+				.map(metadata -> {
+					Map<String, String> table = new LinkedHashMap<>();
+					findChild(metadata, JUnitFactory.NAMESPACE, "type") //
+							.map(Node::getTextContent) //
+							.ifPresent(value -> table.put("Type", value));
+					findChild(metadata, JUnitFactory.NAMESPACE, "uniqueId") //
+							.map(Node::getTextContent) //
+							.ifPresent(value -> table.put("Unique ID", value));
+					findChild(metadata, JUnitFactory.NAMESPACE, "legacyReportingName") //
+							.map(Node::getTextContent) //
+							.ifPresent(value -> table.put("Legacy reporting name", value));
+					return table;
+				}) //
+				.filter(table -> !table.isEmpty()) //
+				.map(table -> singletonList(Section.builder() //
+						.title("JUnit metadata") //
+						.order(15) //
+						.addBlock(KeyValuePairs.builder().content(table).build()) //
+						.build())) //
+				.orElse(emptyList());
+	}
+
+	private static Optional<Node> findChild(Node parent, Namespace namespace, String localName) {
+		NodeList children = parent.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node child = children.item(i);
+			if (localName.equals(child.getLocalName()) && namespace.getUri().equals(child.getNamespaceURI())) {
+				return Optional.of(child);
+			}
+		}
+		return Optional.empty();
+	}
+}

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
@@ -28,6 +28,12 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+/**
+ * Contributes a section containing JUnit-specific metadata for each test node
+ * to the open-test-reporting HTML report.
+ *
+ * @since 1.12
+ */
 @SuppressWarnings("exports") // we don't want to export 'org.opentest4j.reporting.tooling.spi' transitively
 @API(status = INTERNAL, since = "1.12")
 public class JUnitContributor implements Contributor {

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
@@ -28,6 +28,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+@SuppressWarnings("exports") // we don't want to export 'org.opentest4j.reporting.tooling.spi' transitively
 @API(status = INTERNAL, since = "1.12")
 public class JUnitContributor implements Contributor {
 

--- a/junit-platform-reporting/src/main/resources/META-INF/services/org.opentest4j.reporting.tooling.spi.htmlreport.Contributor
+++ b/junit-platform-reporting/src/main/resources/META-INF/services/org.opentest4j.reporting.tooling.spi.htmlreport.Contributor
@@ -1,0 +1,1 @@
+org.junit.platform.reporting.open.xml.JUnitContributor

--- a/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
+++ b/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
@@ -14,11 +14,12 @@
  * @since 1.4
  */
 module org.junit.platform.reporting {
-	requires java.xml;
+	requires transitive java.xml;
 	requires static transitive org.apiguardian.api;
 	requires org.junit.platform.commons;
 	requires transitive org.junit.platform.engine;
 	requires transitive org.junit.platform.launcher;
+	requires static transitive org.opentest4j.reporting.tooling.spi;
 
 	// exports org.junit.platform.reporting; empty package
 	exports org.junit.platform.reporting.legacy;
@@ -27,4 +28,7 @@ module org.junit.platform.reporting {
 
 	provides org.junit.platform.launcher.TestExecutionListener
 			with org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener;
+
+	provides org.opentest4j.reporting.tooling.spi.htmlreport.Contributor
+			with org.junit.platform.reporting.open.xml.JUnitContributor;
 }

--- a/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
+++ b/junit-platform-reporting/src/module/org.junit.platform.reporting/module-info.java
@@ -14,12 +14,12 @@
  * @since 1.4
  */
 module org.junit.platform.reporting {
-	requires transitive java.xml;
+	requires java.xml;
 	requires static transitive org.apiguardian.api;
 	requires org.junit.platform.commons;
 	requires transitive org.junit.platform.engine;
 	requires transitive org.junit.platform.launcher;
-	requires static transitive org.opentest4j.reporting.tooling.spi;
+	requires org.opentest4j.reporting.tooling.spi;
 
 	// exports org.junit.platform.reporting; empty package
 	exports org.junit.platform.reporting.legacy;

--- a/junit-platform-reporting/src/testFixtures/java/org/junit/platform/reporting/open/xml/OpenTestReportGenerationSystemPropertyOverride.java
+++ b/junit-platform-reporting/src/testFixtures/java/org/junit/platform/reporting/open/xml/OpenTestReportGenerationSystemPropertyOverride.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.reporting.open.xml;
+
+import static org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener.ENABLED_PROPERTY_NAME;
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class OpenTestReportGenerationSystemPropertyOverride
+		implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+	@Override
+	public void beforeTestExecution(ExtensionContext context) {
+		var oldValue = System.clearProperty(ENABLED_PROPERTY_NAME);
+		getStore(context).put(ENABLED_PROPERTY_NAME, oldValue);
+	}
+
+	@Override
+	public void afterTestExecution(ExtensionContext context) {
+		var oldValue = getStore(context).get(ENABLED_PROPERTY_NAME, String.class);
+		if (oldValue == null) {
+			System.clearProperty(ENABLED_PROPERTY_NAME);
+		}
+		else {
+			System.setProperty(ENABLED_PROPERTY_NAME, oldValue);
+		}
+	}
+
+	private static ExtensionContext.Store getStore(ExtensionContext context) {
+		return context.getStore(
+			ExtensionContext.Namespace.create(OpenTestReportGenerationSystemPropertyOverride.class));
+	}
+}

--- a/junit-platform-reporting/src/testFixtures/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/junit-platform-reporting/src/testFixtures/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.junit.platform.reporting.open.xml.OpenTestReportGenerationSystemPropertyOverride

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 	testImplementation(libs.picocli)
 	testImplementation(libs.bundles.xmlunit)
 	testImplementation(testFixtures(projects.junitJupiterApi))
+	testImplementation(testFixtures(projects.junitPlatformReporting))
 
 	// --- Test run-time dependencies ---------------------------------------------
 	testRuntimeOnly(projects.junitVintageEngine)

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 		exclude(group = "org.junit.vintage")
 	}
 	testImplementation(libs.joox)
-	testImplementation(libs.openTestReporting.tooling)
+	testImplementation(libs.openTestReporting.tooling.core)
 	testImplementation(libs.picocli)
 	testImplementation(libs.bundles.xmlunit)
 	testImplementation(testFixtures(projects.junitJupiterApi))

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
@@ -248,7 +248,7 @@ class XmlReportWriterTests {
 		writeXmlReport(testPlan, reportData, assertingWriter);
 	}
 
-	@ParameterizedTest
+	@ParameterizedTest(name = "{index}")
 	@MethodSource("stringPairs")
 	void escapesIllegalChars(String input, String output) {
 		assertEquals(output, XmlReportWriter.escapeIllegalChars(input));

--- a/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/JUnitContributorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/JUnitContributorTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.reporting.open.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opentest4j.reporting.tooling.core.htmlreport.DefaultHtmlReportWriter;
+
+public class JUnitContributorTests {
+
+	@Test
+	void contributesJUnitSpecificMetadata(@TempDir Path tempDir) throws Exception {
+		var xmlFile = Files.writeString(tempDir.resolve("report.xml"),
+			"""
+					<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.1.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.1.0"
+					          xmlns:junit="https://schemas.junit.org/open-test-reporting" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+					          xsi:schemaLocation="https://schemas.junit.org/open-test-reporting https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd">
+					    <e:started id="1" name="dummy" time="2024-11-10T16:31:35.000Z">
+					        <metadata>
+					            <junit:uniqueId>[engine:dummy]</junit:uniqueId>
+					            <junit:legacyReportingName>dummy</junit:legacyReportingName>
+					            <junit:type>CONTAINER</junit:type>
+					        </metadata>
+					    </e:started>
+					    <e:started id="2" name="method" parentId="1" time="2024-11-10T16:31:35.001Z">
+					        <metadata>
+					            <junit:uniqueId>[engine:dummy]/[test:method]</junit:uniqueId>
+					            <junit:legacyReportingName>method()</junit:legacyReportingName>
+					            <junit:type>TEST</junit:type>
+					        </metadata>
+					    </e:started>
+					    <e:finished id="2" time="2024-11-10T16:31:35.002Z">
+					        <result status="SUCCESSFUL"/>
+					    </e:finished>
+					    <e:finished id="1" time="2024-11-10T16:31:35.003Z">
+					        <result status="SUCCESSFUL"/>
+					    </e:finished>
+					</e:events>
+					""");
+		var htmlReport = tempDir.resolve("report.html");
+
+		new DefaultHtmlReportWriter().writeHtmlReport(List.of(xmlFile), htmlReport);
+
+		assertThat(htmlReport).content() //
+				.contains("JUnit metadata") //
+				.contains("Type").contains("CONTAINER") //
+				.contains("Unique ID").contains("[engine:dummy]") //
+				.contains("Legacy reporting name").contains("dummy") //
+				.contains("Type").contains("TEST") //
+				.contains("Unique ID").contains("[engine:dummy]/[test:method]") //
+				.contains("Legacy reporting name").contains("method()");
+	}
+}

--- a/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
@@ -33,8 +33,8 @@ import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.hierarchical.DemoHierarchicalTestEngine;
-import org.opentest4j.reporting.tooling.validator.DefaultValidator;
-import org.opentest4j.reporting.tooling.validator.ValidationResult;
+import org.opentest4j.reporting.tooling.core.validator.DefaultValidator;
+import org.opentest4j.reporting.tooling.core.validator.ValidationResult;
 import org.xmlunit.assertj3.XmlAssert;
 import org.xmlunit.placeholder.PlaceholderDifferenceEvaluator;
 

--- a/platform-tests/src/test/resources/junit-platform.properties
+++ b/platform-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled=true

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
 	thirdPartyJars(libs.apiguardian)
 	thirdPartyJars(libs.hamcrest)
 	thirdPartyJars(libs.opentest4j)
+	thirdPartyJars(libs.openTestReporting.tooling.spi)
 	thirdPartyJars(libs.jimfs)
 
 	antJars(platform(projects.junitBom))

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-reporting.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-reporting.expected.txt
@@ -8,4 +8,6 @@ requires org.apiguardian.api static transitive
 requires org.junit.platform.commons
 requires org.junit.platform.engine transitive
 requires org.junit.platform.launcher transitive
+requires org.opentest4j.reporting.tooling.spi
 provides org.junit.platform.launcher.TestExecutionListener with org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener
+provides org.opentest4j.reporting.tooling.spi.htmlreport.Contributor with org.junit.platform.reporting.open.xml.JUnitContributor

--- a/platform-tooling-support-tests/projects/maven-starter/pom.xml
+++ b/platform-tooling-support-tests/projects/maven-starter/pom.xml
@@ -89,6 +89,16 @@
                 <enabled>true</enabled>
             </releases>
         </repository>
+        <repository>
+            <id>sonatype-oss-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
     </repositories>
 
 </project>

--- a/platform-tooling-support-tests/projects/multi-release-jar/default/pom.xml
+++ b/platform-tooling-support-tests/projects/multi-release-jar/default/pom.xml
@@ -68,6 +68,16 @@
                 <enabled>true</enabled>
             </releases>
         </repository>
+        <repository>
+            <id>sonatype-oss-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
     </repositories>
 
 </project>

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ArchUnitTests.java
@@ -56,6 +56,11 @@ class ArchUnitTests {
 
 	@SuppressWarnings("unused")
 	@ArchTest
+	private final ArchRule allClassesAreInJUnitPackage = classes() //
+			.should().haveNameMatching("org\\.junit\\..+");
+
+	@SuppressWarnings("unused")
+	@ArchTest
 	private final ArchRule allPublicTopLevelTypesHaveApiAnnotations = classes() //
 			.that(have(modifier(PUBLIC))) //
 			.and(TOP_LEVEL_CLASSES) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JarDescribeModuleTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JarDescribeModuleTests.java
@@ -20,7 +20,6 @@ import java.lang.module.ModuleFinder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.stream.Collectors;
 
 import de.sormuras.bartholdy.jdk.Jar;
 
@@ -62,7 +61,7 @@ class JarDescribeModuleTests {
 			result.getOutputLines("out").forEach(System.err::println);
 			fail("No such file: " + expected);
 		}
-		var expectedLines = Files.lines(expected).map(Helper::replaceVersionPlaceholders).collect(Collectors.toList());
+		var expectedLines = Files.lines(expected).map(Helper::replaceVersionPlaceholders).toList();
 		var origin = Path.of("projects", "jar-describe-module", module + ".expected.txt").toUri();
 		assertLinesMatch(expectedLines, result.getOutputLines("out"), () -> String.format("%s\nError", origin));
 	}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ModularUserGuideTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ModularUserGuideTests.java
@@ -86,6 +86,7 @@ class ModularUserGuideTests {
 		ThirdPartyJars.copy(lib, "org.apiguardian", "apiguardian-api");
 		ThirdPartyJars.copy(lib, "org.hamcrest", "hamcrest");
 		ThirdPartyJars.copy(lib, "org.opentest4j", "opentest4j");
+		ThirdPartyJars.copy(lib, "org.opentest4j.reporting", "open-test-reporting-tooling-spi");
 		ThirdPartyJars.copy(lib, "com.google.jimfs", "jimfs");
 		ThirdPartyJars.copy(lib, "com.google.guava", "guava");
 		Helper.loadAllJUnitModules(lib);

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/StandaloneTests.java
@@ -118,7 +118,10 @@ class StandaloneTests {
 		var junitJars = Stream.of("junit-platform-console", "junit-platform-reporting", "junit-platform-engine",
 			"junit-platform-launcher", "junit-platform-commons") //
 				.map(MavenRepo::jar);
-		var thirdPartyJars = Stream.of(ThirdPartyJars.find("org.opentest4j", "opentest4j"));
+		var thirdPartyJars = Stream.of( //
+			ThirdPartyJars.find("org.opentest4j", "opentest4j"), //
+			ThirdPartyJars.find("org.opentest4j.reporting", "open-test-reporting-tooling-spi") //
+		);
 		var modulePath = Stream.concat(junitJars, thirdPartyJars) //
 				.map(String::valueOf) //
 				.collect(joining(File.pathSeparator));

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ToolProviderTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ToolProviderTests.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.spi.ToolProvider;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -98,7 +97,7 @@ class ToolProviderTests {
 				.map(ModuleReference::descriptor) //
 				.map(ModuleDescriptor::toNameAndVersion) //
 				.sorted() //
-				.collect(Collectors.toList());
+				.toList();
 		// modules.forEach(System.out::println);
 
 		var bootLayer = ModuleLayer.boot();
@@ -140,7 +139,7 @@ class ToolProviderTests {
 			">> USAGE >>", //
 			"Launches the JUnit Platform for test discovery and execution.", //
 			">> OPTIONS >>"), //
-			out.toString().lines().collect(Collectors.toList())), //
+			out.toString().lines().toList()), //
 			() -> assertEquals("", err.toString()), //
 			() -> assertEquals(0, code, "Expected exit of 0, but got: " + code) //
 		);

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ToolProviderTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ToolProviderTests.java
@@ -69,6 +69,7 @@ class ToolProviderTests {
 			}
 			ThirdPartyJars.copy(lib, "org.apiguardian", "apiguardian-api");
 			ThirdPartyJars.copy(lib, "org.opentest4j", "opentest4j");
+			ThirdPartyJars.copy(lib, "org.opentest4j.reporting", "open-test-reporting-tooling-spi");
 		}
 		catch (Exception e) {
 			throw new AssertionError("Preparing local library folder failed", e);


### PR DESCRIPTION
## Overview

When creating the event-based XML report, the `OpenTestReportGeneratingListener` includes JUnit-specific metadata: type, unique ID, and legacy reporting name. This PR implements open-test-reporting's `Contributor` SPI to include that data in the new HTML report of open-test-reporting.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
