### PR TITLE
Include Git metadata in Open Test Report XML output

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -38,9 +38,11 @@ JUnit repository on GitHub.
   `--select-file` and `--select-resource`.
 * `ConsoleLauncher` now accepts multiple values for all `--select` options.
 * Add `--select-unique-id` support to ConsoleLauncher.
-* The `junit-platform-reporting` module now contributes a section containing
-  JUnit-specific metadata about each test/container to the HTML report written by
-  open-test-reporting when added to the classpath/module path.
+* The following improvements have been made to the open-test-reporting XML output:
+  - Information about the Git repository, the current branch, the commit hash, and the
+    current worktree status are now included in the XML report, if applicable.
+  - A section containing JUnit-specific metadata about each test/container to the HTML
+    report is now written by open-test-reporting when added to the classpath/module path
 
 
 [[release-notes-5.12.0-M1-junit-jupiter]]

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
@@ -216,7 +216,7 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 			process = Runtime.getRuntime().exec(args);
 		}
 		catch (IOException e) {
-			throw new RuntimeException(e);
+			throw new UncheckedIOException("Failed to start process", e);
 		}
 		return process;
 	}

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
@@ -11,6 +11,7 @@
 package org.junit.platform.reporting.open.xml;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 import static org.junit.platform.reporting.open.xml.JUnitFactory.legacyReportingName;
 import static org.junit.platform.reporting.open.xml.JUnitFactory.type;
 import static org.junit.platform.reporting.open.xml.JUnitFactory.uniqueId;
@@ -30,6 +31,10 @@ import static org.opentest4j.reporting.events.core.CoreFactory.tag;
 import static org.opentest4j.reporting.events.core.CoreFactory.tags;
 import static org.opentest4j.reporting.events.core.CoreFactory.uriSource;
 import static org.opentest4j.reporting.events.core.CoreFactory.userName;
+import static org.opentest4j.reporting.events.git.GitFactory.branch;
+import static org.opentest4j.reporting.events.git.GitFactory.commit;
+import static org.opentest4j.reporting.events.git.GitFactory.repository;
+import static org.opentest4j.reporting.events.git.GitFactory.status;
 import static org.opentest4j.reporting.events.java.JavaFactory.classSource;
 import static org.opentest4j.reporting.events.java.JavaFactory.classpathResourceSource;
 import static org.opentest4j.reporting.events.java.JavaFactory.fileEncoding;
@@ -42,18 +47,27 @@ import static org.opentest4j.reporting.events.root.RootFactory.finished;
 import static org.opentest4j.reporting.events.root.RootFactory.reported;
 import static org.opentest4j.reporting.events.root.RootFactory.started;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.StringUtils;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestExecutionResult;
@@ -74,6 +88,7 @@ import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.listeners.OutputDir;
 import org.opentest4j.reporting.events.api.DocumentWriter;
 import org.opentest4j.reporting.events.api.NamespaceRegistry;
+import org.opentest4j.reporting.events.core.Infrastructure;
 import org.opentest4j.reporting.events.core.Result;
 import org.opentest4j.reporting.events.core.Sources;
 import org.opentest4j.reporting.events.root.Events;
@@ -103,6 +118,7 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 		if (isEnabled(config)) {
 			NamespaceRegistry namespaceRegistry = NamespaceRegistry.builder(Namespace.REPORTING_CORE) //
 					.add("e", Namespace.REPORTING_EVENTS) //
+					.add("git", Namespace.REPORTING_GIT) //
 					.add("java", Namespace.REPORTING_JAVA) //
 					.add("junit", JUnitFactory.NAMESPACE,
 						"https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd") //
@@ -138,7 +154,90 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 					.append(javaVersion(System.getProperty("java.version"))) //
 					.append(fileEncoding(System.getProperty("file.encoding"))) //
 					.append(heapSize(), heapSize -> heapSize.withMax(Runtime.getRuntime().maxMemory()));
+
+			addGitInfo(infrastructure);
 		});
+	}
+
+	private static void addGitInfo(Infrastructure infrastructure) {
+		boolean gitInstalled = exec("git", "--version").isPresent();
+		if (gitInstalled) {
+			exec("git", "config", "--get", "remote.origin.url") //
+					.filter(StringUtils::isNotBlank) //
+					.ifPresent(
+						gitUrl -> infrastructure.append(repository(), repository -> repository.withOriginUrl(gitUrl)));
+			exec("git", "rev-parse", "--abbrev-ref", "HEAD") //
+					.filter(StringUtils::isNotBlank) //
+					.ifPresent(branch -> infrastructure.append(branch(branch)));
+			exec("git", "rev-parse", "--verify", "HEAD") //
+					.filter(StringUtils::isNotBlank) //
+					.ifPresent(gitCommitHash -> infrastructure.append(commit(gitCommitHash)));
+			exec("git", "status", "--porcelain") //
+					.ifPresent(statusOutput -> infrastructure.append(status(statusOutput),
+						status -> status.withClean(statusOutput.isEmpty())));
+		}
+	}
+
+	static Optional<String> exec(String... args) {
+
+		Process process = startProcess(args);
+
+		try (Reader out = newBufferedReader(process.getInputStream());
+				Reader err = newBufferedReader(process.getErrorStream())) {
+
+			StringBuilder output = new StringBuilder();
+			readAllChars(out, (chars, numChars) -> output.append(chars, 0, numChars));
+
+			readAllChars(err, (__, ___) -> {
+				// ignore
+			});
+
+			boolean terminated = process.waitFor(10, TimeUnit.SECONDS);
+			return terminated && process.exitValue() == 0 ? Optional.of(trimAtEnd(output)) : Optional.empty();
+		}
+		catch (InterruptedException e) {
+			throw ExceptionUtils.throwAsUncheckedException(e);
+		}
+		catch (IOException ignore) {
+			return Optional.empty();
+		}
+		finally {
+			process.destroyForcibly();
+		}
+	}
+
+	private static BufferedReader newBufferedReader(InputStream stream) {
+		return new BufferedReader(new InputStreamReader(stream, Charset.defaultCharset()));
+	}
+
+	private static Process startProcess(String[] args) {
+		Process process;
+		try {
+			process = Runtime.getRuntime().exec(args);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+		return process;
+	}
+
+	private static void readAllChars(Reader reader, BiConsumer<char[], Integer> consumer) throws IOException {
+		char[] buffer = new char[1024];
+		int numChars;
+		while ((numChars = reader.read(buffer)) != -1) {
+			consumer.accept(buffer, numChars);
+		}
+	}
+
+	private static String trimAtEnd(StringBuilder value) {
+		int endIndex = value.length();
+		for (int i = value.length() - 1; i >= 0; i--) {
+			if (Character.isWhitespace(value.charAt(i))) {
+				endIndex--;
+				break;
+			}
+		}
+		return value.substring(0, endIndex);
 	}
 
 	@Override
@@ -160,7 +259,7 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 		reportStarted(testIdentifier, id);
 		eventsFileWriter.append(finished(id, Instant.now()), //
 			finished -> finished.append(result(Result.Status.SKIPPED), result -> {
-				if (StringUtils.isNotBlank(reason)) {
+				if (isNotBlank(reason)) {
 					result.append(reason(reason));
 				}
 			}));

--- a/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
@@ -64,8 +64,11 @@ public class OpenTestReportGeneratingListenerTests {
 		assertThat(validate(xmlFile)).isEmpty();
 
 		var expected = """
-				<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.1.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.1.0"
-				          xmlns:junit="https://schemas.junit.org/open-test-reporting" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.1.0"
+				          xmlns:git="https://schemas.opentest4j.org/reporting/git/0.1.0"
+				          xmlns:java="https://schemas.opentest4j.org/reporting/java/0.1.0"
+				          xmlns:junit="https://schemas.junit.org/open-test-reporting"
+				          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 				          xsi:schemaLocation="https://schemas.junit.org/open-test-reporting https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd">
 				    <infrastructure>
 				        <hostName>${xmlunit.ignore}</hostName>
@@ -75,6 +78,10 @@ public class OpenTestReportGeneratingListenerTests {
 				        <java:javaVersion>${xmlunit.ignore}</java:javaVersion>
 				        <java:fileEncoding>${xmlunit.ignore}</java:fileEncoding>
 				        <java:heapSize max="${xmlunit.isNumber}"/>
+				        <git:repository originUrl="${xmlunit.matchesRegex(https://.+)}"/>
+				        <git:branch>${xmlunit.ignore}</git:branch>
+				        <git:commit>${xmlunit.matchesRegex([0-9a-f]{40})}</git:commit>
+				        <git:status clean="${xmlunit.ignore}">${xmlunit.ignore}</git:status>
 				    </infrastructure>
 				    <e:started id="1" name="dummy" time="${xmlunit.isDateTime}">
 				        <metadata>

--- a/platform-tooling-support-tests/projects/java-versions/pom.xml
+++ b/platform-tooling-support-tests/projects/java-versions/pom.xml
@@ -53,9 +53,11 @@
             <url>file://${maven.repo}</url>
             <snapshots>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </snapshots>
             <releases>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
     </repositories>

--- a/platform-tooling-support-tests/projects/maven-starter/pom.xml
+++ b/platform-tooling-support-tests/projects/maven-starter/pom.xml
@@ -84,9 +84,11 @@
             <url>file://${maven.repo}</url>
             <snapshots>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </snapshots>
             <releases>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
         <repository>

--- a/platform-tooling-support-tests/projects/maven-starter/pom.xml
+++ b/platform-tooling-support-tests/projects/maven-starter/pom.xml
@@ -90,8 +90,8 @@
             </releases>
         </repository>
         <repository>
-            <id>sonatype-oss-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>snapshots-repo</id>
+            <url>${snapshot.repo.url}</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/platform-tooling-support-tests/projects/maven-surefire-compatibility/pom.xml
+++ b/platform-tooling-support-tests/projects/maven-surefire-compatibility/pom.xml
@@ -60,9 +60,11 @@
             <url>file://${maven.repo}</url>
             <snapshots>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </snapshots>
             <releases>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
     </repositories>

--- a/platform-tooling-support-tests/projects/multi-release-jar/default/pom.xml
+++ b/platform-tooling-support-tests/projects/multi-release-jar/default/pom.xml
@@ -63,9 +63,11 @@
             <url>file://${maven.repo}</url>
             <snapshots>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </snapshots>
             <releases>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
         <repository>

--- a/platform-tooling-support-tests/projects/multi-release-jar/default/pom.xml
+++ b/platform-tooling-support-tests/projects/multi-release-jar/default/pom.xml
@@ -69,8 +69,8 @@
             </releases>
         </repository>
         <repository>
-            <id>sonatype-oss-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>snapshots-repo</id>
+            <url>${snapshot.repo.url}</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/platform-tooling-support-tests/projects/vintage/pom.xml
+++ b/platform-tooling-support-tests/projects/vintage/pom.xml
@@ -54,9 +54,11 @@
             <url>file://${maven.repo}</url>
             <snapshots>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </snapshots>
             <releases>
                 <enabled>true</enabled>
+                <checksumPolicy>ignore</checksumPolicy>
             </releases>
         </repository>
     </repositories>

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GlobalResource.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GlobalResource.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.platform.commons.support.ReflectionSupport.streamFields;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.commons.util.Preconditions;
+
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RUNTIME)
+@ExtendWith(GlobalResource.Extension.class)
+public @interface GlobalResource {
+
+	class Extension implements ParameterResolver, TestInstancePostProcessor {
+
+		@Override
+		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			return parameterContext.isAnnotated(GlobalResource.class);
+		}
+
+		@Override
+		public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			Class<?> type = parameterContext.getParameter().getType();
+			return getOrCreateResource(extensionContext, type).get();
+		}
+
+		@Override
+		public void postProcessTestInstance(Object testInstance, ExtensionContext extensionContext) {
+			streamFields(testInstance.getClass(), field -> AnnotationSupport.isAnnotated(field, GlobalResource.class),
+				HierarchyTraversalMode.BOTTOM_UP) //
+						.forEach(field -> {
+							try {
+								field.set(testInstance, getOrCreateResource(extensionContext, field.getType()).get());
+							}
+							catch (IllegalAccessException e) {
+								throw new RuntimeException("Failed to inject resource into field: " + field, e);
+							}
+						});
+		}
+
+		@SuppressWarnings("unchecked")
+		private <T> Resource<T> getOrCreateResource(ExtensionContext extensionContext, Class<T> type) {
+			return extensionContext.getRoot().getStore(Namespace.GLOBAL) //
+					.getOrComputeIfAbsent(type, Resource::new, Resource.class);
+		}
+	}
+
+	class Resource<T> implements CloseableResource {
+
+		private final T value;
+
+		private Resource(Class<T> type) {
+			Preconditions.condition(AutoCloseable.class.isAssignableFrom(type),
+				() -> "Resource type must implement AutoCloseable: " + type.getName());
+			this.value = ReflectionSupport.newInstance(type);
+		}
+
+		private T get() {
+			return value;
+		}
+
+		@Override
+		public void close() throws Throwable {
+			((AutoCloseable) value).close();
+		}
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
@@ -27,15 +27,14 @@ import org.junit.jupiter.api.Test;
 import platform.tooling.support.Helper;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
-import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 /**
  * @since 1.4
  */
 class JavaVersionsTests {
 
-	@LocalMavenRepo
-	Directory localMavenRepo;
+	@GlobalResource
+	LocalMavenRepo localMavenRepo;
 
 	@Test
 	void java_8() {

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JavaVersionsTests.java
@@ -27,11 +27,15 @@ import org.junit.jupiter.api.Test;
 import platform.tooling.support.Helper;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
+import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 /**
  * @since 1.4
  */
 class JavaVersionsTests {
+
+	@LocalMavenRepo
+	Directory localMavenRepo;
 
 	@Test
 	void java_8() {
@@ -54,7 +58,7 @@ class JavaVersionsTests {
 				.setTool(Request.maven()) //
 				.setProject(Projects.JAVA_VERSIONS) //
 				.setWorkspace("java-versions-" + version) //
-				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments(localMavenRepo.toCliArgument(), "-Dmaven.repo=" + MavenRepo.dir()) //
 				.addArguments("--update-snapshots", "--batch-mode", "verify") //
 				.setTimeout(TOOL_TIMEOUT) //
 				.setJavaHome(javaHome);

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java
@@ -10,103 +10,41 @@
 
 package platform.tooling.support.tests;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.junit.platform.commons.support.ReflectionSupport.streamFields;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
-import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
-import org.junit.jupiter.api.extension.TestInstancePostProcessor;
-import org.junit.platform.commons.support.AnnotationSupport;
-import org.junit.platform.commons.support.HierarchyTraversalMode;
-import org.junit.platform.commons.util.Preconditions;
+public class LocalMavenRepo implements AutoCloseable {
 
-@Target({ ElementType.PARAMETER, ElementType.FIELD })
-@Retention(RUNTIME)
-@ExtendWith(LocalMavenRepo.Extension.class)
-public @interface LocalMavenRepo {
+	private final Path tempDir;
 
-	class Extension implements ParameterResolver, TestInstancePostProcessor {
-
-		@Override
-		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-				throws ParameterResolutionException {
-			return parameterContext.isAnnotated(LocalMavenRepo.class);
+	public LocalMavenRepo() {
+		try {
+			tempDir = Files.createTempDirectory("local-maven-repo-");
 		}
-
-		@Override
-		public Directory resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-				throws ParameterResolutionException {
-			Preconditions.condition(Directory.class.equals(parameterContext.getParameter().getType()),
-				() -> "Parameter must be of type " + Directory.class + ": " + parameterContext.getParameter());
-			return getOrCreateDirectory(extensionContext);
-		}
-
-		@Override
-		public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
-			streamFields(testInstance.getClass(), field -> AnnotationSupport.isAnnotated(field, LocalMavenRepo.class),
-				HierarchyTraversalMode.BOTTOM_UP) //
-						.forEach(field -> {
-							Preconditions.condition(Directory.class.equals(field.getType()),
-								() -> "Field must be of type " + Directory.class + ": " + field);
-							try {
-								field.set(testInstance, getOrCreateDirectory(context));
-							}
-							catch (IllegalAccessException e) {
-								throw new RuntimeException(e);
-							}
-						});
-		}
-
-		private Directory getOrCreateDirectory(ExtensionContext extensionContext) {
-			return extensionContext.getRoot().getStore(Namespace.GLOBAL) //
-					.getOrComputeIfAbsent(Directory.class, __ -> new Directory(), Directory.class);
+		catch (IOException e) {
+			throw new RuntimeException(e);
 		}
 	}
 
-	class Directory implements CloseableResource {
+	public String toCliArgument() {
+		return "-Dmaven.repo.local=" + tempDir;
+	}
 
-		private final Path tempDir;
-
-		private Directory() {
-			try {
-				tempDir = Files.createTempDirectory("local-maven-repo-");
-			}
-			catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		public String toCliArgument() {
-			return "-Dmaven.repo.local=" + tempDir;
-		}
-
-		@Override
-		public void close() throws Throwable {
-			try (var files = Files.walk(tempDir)) {
-				files.sorted(Comparator.<Path> naturalOrder().reversed()) //
-						.forEach(path -> {
-							try {
-								Files.delete(path);
-							}
-							catch (IOException e) {
-								throw new UncheckedIOException(e);
-							}
-						});
-			}
+	@Override
+	public void close() throws IOException {
+		try (var files = Files.walk(tempDir)) {
+			files.sorted(Comparator.<Path> naturalOrder().reversed()) //
+					.forEach(path -> {
+						try {
+							Files.delete(path);
+						}
+						catch (IOException e) {
+							throw new UncheckedIOException(e);
+						}
+					});
 		}
 	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/LocalMavenRepo.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.platform.commons.support.ReflectionSupport.streamFields;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.util.Preconditions;
+
+@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RUNTIME)
+@ExtendWith(LocalMavenRepo.Extension.class)
+public @interface LocalMavenRepo {
+
+	class Extension implements ParameterResolver, TestInstancePostProcessor {
+
+		@Override
+		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			return parameterContext.isAnnotated(LocalMavenRepo.class);
+		}
+
+		@Override
+		public Directory resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+				throws ParameterResolutionException {
+			Preconditions.condition(Directory.class.equals(parameterContext.getParameter().getType()),
+				() -> "Parameter must be of type " + Directory.class + ": " + parameterContext.getParameter());
+			return getOrCreateDirectory(extensionContext);
+		}
+
+		@Override
+		public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+			streamFields(testInstance.getClass(), field -> AnnotationSupport.isAnnotated(field, LocalMavenRepo.class),
+				HierarchyTraversalMode.BOTTOM_UP) //
+						.forEach(field -> {
+							Preconditions.condition(Directory.class.equals(field.getType()),
+								() -> "Field must be of type " + Directory.class + ": " + field);
+							try {
+								field.set(testInstance, getOrCreateDirectory(context));
+							}
+							catch (IllegalAccessException e) {
+								throw new RuntimeException(e);
+							}
+						});
+		}
+
+		private Directory getOrCreateDirectory(ExtensionContext extensionContext) {
+			return extensionContext.getRoot().getStore(Namespace.GLOBAL) //
+					.getOrComputeIfAbsent(Directory.class, __ -> new Directory(), Directory.class);
+		}
+	}
+
+	class Directory implements CloseableResource {
+
+		private final Path tempDir;
+
+		private Directory() {
+			try {
+				tempDir = Files.createTempDirectory("local-maven-repo-");
+			}
+			catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		public String toCliArgument() {
+			return "-Dmaven.repo.local=" + tempDir;
+		}
+
+		@Override
+		public void close() throws Throwable {
+			try (var files = Files.walk(tempDir)) {
+				files.sorted(Comparator.<Path> naturalOrder().reversed()) //
+						.forEach(path -> {
+							try {
+								Files.delete(path);
+							}
+							catch (IOException e) {
+								throw new UncheckedIOException(e);
+							}
+						});
+			}
+		}
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenRepoProxy.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenRepoProxy.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static java.net.http.HttpRequest.BodyPublishers.noBody;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+public class MavenRepoProxy implements AutoCloseable {
+
+	// Forbid downloading JUnit artifacts since we want to use the local ones
+	private static final List<String> FORBIDDEN_PATHS = List.of("/org/junit");
+
+	private static final List<String> RESTRICTED_HEADER_NAMES = List.of("Connection", "Host");
+
+	private final HttpServer httpServer;
+	private final HttpClient httpClient;
+
+	@SuppressWarnings("unused")
+	public MavenRepoProxy() throws IOException {
+		this(0);
+	}
+
+	@SuppressWarnings("unused")
+	public MavenRepoProxy(int port) throws IOException {
+		this("https://oss.sonatype.org/content/repositories/snapshots", port);
+	}
+
+	private MavenRepoProxy(String proxiedUrl, int port) throws IOException {
+		httpClient = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.ALWAYS).build();
+		httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), port), 0);
+		httpServer.createContext("/", exchange -> {
+			try (exchange) {
+				switch (exchange.getRequestMethod()) {
+					case "HEAD":
+					case "GET":
+						if (FORBIDDEN_PATHS.stream().anyMatch(
+							it -> exchange.getRequestURI().getPath().startsWith(it))) {
+							exchange.sendResponseHeaders(404, 0);
+							break;
+						}
+						var request = mapRequest(proxiedUrl, exchange);
+						try {
+							var response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+							mapResponse(response, exchange);
+						}
+						catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
+						}
+						break;
+					default:
+						exchange.sendResponseHeaders(405, -1);
+				}
+			}
+			catch (Exception e) {
+				e.printStackTrace();
+			}
+		});
+		httpServer.start();
+	}
+
+	URI getBaseUri() {
+		var address = httpServer.getAddress();
+		return URI.create("http://" + address.getAddress().getHostName() + ":" + address.getPort());
+	}
+
+	private static void mapResponse(HttpResponse<InputStream> response, HttpExchange exchange) throws IOException {
+		exchange.sendResponseHeaders(response.statusCode(),
+			response.headers().firstValueAsLong("Content-Length").orElse(0));
+		response.headers().map().forEach((key, values) -> exchange.getResponseHeaders().put(key, values));
+		try (InputStream body = response.body()) {
+			body.transferTo(exchange.getResponseBody());
+		}
+	}
+
+	private static HttpRequest mapRequest(String proxiedUrl, HttpExchange exchange) {
+		var request = HttpRequest.newBuilder().method(exchange.getRequestMethod(), noBody()) //
+				.uri(URI.create(proxiedUrl + exchange.getRequestURI().getPath()));
+		exchange.getRequestHeaders().entrySet().stream() //
+				.filter(entry -> RESTRICTED_HEADER_NAMES.stream().noneMatch(it -> it.equalsIgnoreCase(entry.getKey()))) //
+				.forEach(entry -> entry.getValue() //
+						.forEach(value -> request.header(entry.getKey(), value)));
+		return request.build();
+	}
+
+	@Override
+	public void close() {
+		assertAll( //
+			() -> assertDoesNotThrow(() -> httpServer.stop(0)), //
+			() -> assertDoesNotThrow(httpClient::close) //
+		);
+	}
+
+	@SuppressWarnings("unused")
+	public static void main(String[] args) throws Exception {
+		try (var proxy = new MavenRepoProxy(12345)) {
+			System.out.println("Started proxy: " + proxy.getBaseUri());
+			while (!Thread.interrupted()) {
+				Thread.onSpinWait();
+			}
+		}
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
@@ -33,6 +33,9 @@ class MavenStarterTests {
 	@GlobalResource
 	LocalMavenRepo localMavenRepo;
 
+	@GlobalResource
+	MavenRepoProxy mavenRepoProxy;
+
 	@ResourceLock(Projects.MAVEN_STARTER)
 	@Test
 	void verifyMavenStarterProject() {
@@ -40,6 +43,7 @@ class MavenStarterTests {
 				.setTool(Request.maven()) //
 				.setProject(Projects.MAVEN_STARTER) //
 				.addArguments(localMavenRepo.toCliArgument(), "-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments("-Dsnapshot.repo.url=" + mavenRepoProxy.getBaseUri()) //
 				.addArguments("--update-snapshots", "--batch-mode", "verify") //
 				.setTimeout(TOOL_TIMEOUT) //
 				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
@@ -24,16 +24,18 @@ import org.opentest4j.TestAbortedException;
 import platform.tooling.support.Helper;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
-import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 /**
  * @since 1.3
  */
 class MavenStarterTests {
 
+	@GlobalResource
+	LocalMavenRepo localMavenRepo;
+
 	@ResourceLock(Projects.MAVEN_STARTER)
 	@Test
-	void verifyMavenStarterProject(@LocalMavenRepo Directory localMavenRepo) {
+	void verifyMavenStarterProject() {
 		var request = Request.builder() //
 				.setTool(Request.maven()) //
 				.setProject(Projects.MAVEN_STARTER) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
@@ -24,6 +24,7 @@ import org.opentest4j.TestAbortedException;
 import platform.tooling.support.Helper;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
+import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 /**
  * @since 1.3
@@ -32,11 +33,11 @@ class MavenStarterTests {
 
 	@ResourceLock(Projects.MAVEN_STARTER)
 	@Test
-	void verifyMavenStarterProject() {
+	void verifyMavenStarterProject(@LocalMavenRepo Directory localMavenRepo) {
 		var request = Request.builder() //
 				.setTool(Request.maven()) //
 				.setProject(Projects.MAVEN_STARTER) //
-				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments(localMavenRepo.toCliArgument(), "-Dmaven.repo=" + MavenRepo.dir()) //
 				.addArguments("--update-snapshots", "--batch-mode", "verify") //
 				.setTimeout(TOOL_TIMEOUT) //
 				.setJavaHome(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenSurefireCompatibilityTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenSurefireCompatibilityTests.java
@@ -27,15 +27,14 @@ import org.opentest4j.TestAbortedException;
 import platform.tooling.support.Helper;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
-import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 /**
  * @since 1.9.2
  */
 class MavenSurefireCompatibilityTests {
 
-	@LocalMavenRepo
-	Directory localMavenRepo;
+	@GlobalResource
+	LocalMavenRepo localMavenRepo;
 
 	@ResourceLock(Projects.MAVEN_SUREFIRE_COMPATIBILITY)
 	@ParameterizedTest

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenSurefireCompatibilityTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenSurefireCompatibilityTests.java
@@ -27,11 +27,15 @@ import org.opentest4j.TestAbortedException;
 import platform.tooling.support.Helper;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
+import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 /**
  * @since 1.9.2
  */
 class MavenSurefireCompatibilityTests {
+
+	@LocalMavenRepo
+	Directory localMavenRepo;
 
 	@ResourceLock(Projects.MAVEN_SUREFIRE_COMPATIBILITY)
 	@ParameterizedTest
@@ -44,7 +48,7 @@ class MavenSurefireCompatibilityTests {
 		var request = Request.builder() //
 				.setTool(Request.maven()) //
 				.setProject(Projects.MAVEN_SUREFIRE_COMPATIBILITY) //
-				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments(localMavenRepo.toCliArgument(), "-Dmaven.repo=" + MavenRepo.dir()) //
 				.addArguments("-Dsurefire.version=" + surefireVersion) //
 				.addArguments("--update-snapshots", "--batch-mode", "test") //
 				.addArguments(extraArgs) //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
@@ -37,6 +37,9 @@ class MultiReleaseJarTests {
 	@GlobalResource
 	LocalMavenRepo localMavenRepo;
 
+	@GlobalResource
+	MavenRepoProxy mavenRepoProxy;
+
 	@ResourceLock(Projects.MULTI_RELEASE_JAR)
 	@Test
 	void checkDefault() throws Exception {
@@ -92,6 +95,7 @@ class MultiReleaseJarTests {
 				.setTool(Request.maven()) //
 				.setProject(Projects.MULTI_RELEASE_JAR) //
 				.addArguments(localMavenRepo.toCliArgument(), "-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments("-Dsnapshot.repo.url=" + mavenRepoProxy.getBaseUri()) //
 				.addArguments("--update-snapshots", "--show-version", "--errors", "--batch-mode", "--file", variant,
 					"test") //
 				.setTimeout(TOOL_TIMEOUT);

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
@@ -28,11 +28,15 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
+import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 /**
  * @since 1.4
  */
 class MultiReleaseJarTests {
+
+	@LocalMavenRepo
+	Directory localMavenRepo;
 
 	@ResourceLock(Projects.MULTI_RELEASE_JAR)
 	@Test
@@ -88,7 +92,7 @@ class MultiReleaseJarTests {
 		var builder = Request.builder() //
 				.setTool(Request.maven()) //
 				.setProject(Projects.MULTI_RELEASE_JAR) //
-				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments(localMavenRepo.toCliArgument(), "-Dmaven.repo=" + MavenRepo.dir()) //
 				.addArguments("--update-snapshots", "--show-version", "--errors", "--batch-mode", "--file", variant,
 					"test") //
 				.setTimeout(TOOL_TIMEOUT);

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MultiReleaseJarTests.java
@@ -28,15 +28,14 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
-import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 /**
  * @since 1.4
  */
 class MultiReleaseJarTests {
 
-	@LocalMavenRepo
-	Directory localMavenRepo;
+	@GlobalResource
+	LocalMavenRepo localMavenRepo;
 
 	@ResourceLock(Projects.MULTI_RELEASE_JAR)
 	@Test

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageMavenIntegrationTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageMavenIntegrationTests.java
@@ -24,12 +24,11 @@ import org.opentest4j.TestAbortedException;
 import platform.tooling.support.Helper;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
-import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 class VintageMavenIntegrationTests {
 
-	@LocalMavenRepo
-	Directory localMavenRepo;
+	@GlobalResource
+	LocalMavenRepo localMavenRepo;
 
 	@Test
 	void unsupportedVersion() {

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageMavenIntegrationTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/VintageMavenIntegrationTests.java
@@ -24,8 +24,12 @@ import org.opentest4j.TestAbortedException;
 import platform.tooling.support.Helper;
 import platform.tooling.support.MavenRepo;
 import platform.tooling.support.Request;
+import platform.tooling.support.tests.LocalMavenRepo.Directory;
 
 class VintageMavenIntegrationTests {
+
+	@LocalMavenRepo
+	Directory localMavenRepo;
 
 	@Test
 	void unsupportedVersion() {
@@ -61,7 +65,7 @@ class VintageMavenIntegrationTests {
 				.setProject(Projects.VINTAGE) //
 				.setWorkspace("vintage-maven-" + version) //
 				.addArguments("clean", "test", "--update-snapshots", "--batch-mode") //
-				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments(localMavenRepo.toCliArgument(), "-Dmaven.repo=" + MavenRepo.dir()) //
 				.addArguments("-Djunit4Version=" + version) //
 				.setTimeout(TOOL_TIMEOUT) //
 				.build() //

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/XmlAssertions.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/XmlAssertions.java
@@ -34,7 +34,8 @@ class XmlAssertions {
 
 	private static void verifyContent(Path xmlFile) {
 		var expected = """
-				        <e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.1.0" xmlns:java="https://schemas.opentest4j.org/reporting/java/0.1.0"
+				        <e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.1.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.1.0" xmlns:git="https://schemas.opentest4j.org/reporting/git/0.1.0"
+				                  xmlns:java="https://schemas.opentest4j.org/reporting/java/0.1.0"
 				                  xmlns:junit="https://schemas.junit.org/open-test-reporting" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 				                  xsi:schemaLocation="https://schemas.junit.org/open-test-reporting https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd">
 				          <infrastructure>
@@ -45,6 +46,10 @@ class XmlAssertions {
 				            <java:javaVersion>${xmlunit.ignore}</java:javaVersion>
 				            <java:fileEncoding>${xmlunit.ignore}</java:fileEncoding>
 				            <java:heapSize max="${xmlunit.isNumber}"/>
+				            <git:repository originUrl="${xmlunit.matchesRegex(https://.+)}"/>
+				            <git:branch>${xmlunit.ignore}</git:branch>
+				            <git:commit>${xmlunit.matchesRegex([0-9a-f]{40})}</git:commit>
+				            <git:status clean="${xmlunit.ignore}">${xmlunit.ignore}</git:status>
 				          </infrastructure>
 				          <e:started id="1" name="JUnit Jupiter" time="${xmlunit.isDateTime}">
 				            <metadata>


### PR DESCRIPTION
## Overview

Write Git metadata (introduced in https://github.com/ota4j-team/open-test-reporting/pull/180) to infrastructure section of Open Test Report XML output.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
