### PR TITLE
Rename requireArguments to allowZeroInvocations

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -85,7 +85,7 @@ JUnit repository on GitHub.
 * Extensions based on `TestTemplateInvocationContextProvider` can now allow returning zero
   invocation contexts by overriding the new `mayReturnZeroTestTemplateInvocationContexts`
   method.
-* The new `@ParameterizedTest(requireArguments = false)` attribute allows to specify that
+* The new `@ParameterizedTest(allowZeroInvocations = true)` attribute allows to specify that
   the absence of arguments is expected in some cases and should not cause a test failure.
 * Allow determining "shared resources" at runtime via the new `@ResourceLock#providers`
   attribute that accepts implementations of `ResourceLocksProvider`.

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -304,7 +304,7 @@ public @interface ParameterizedTest {
 	 * @since 5.12
 	 */
 	@API(status = EXPERIMENTAL, since = "5.12")
-	boolean requireArguments() default true;
+	boolean allowZeroInvocations() default false;
 
 	/**
 	 * Configure how the number of arguments provided by an {@link ArgumentsSource} are validated.

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -293,13 +293,13 @@ public @interface ParameterizedTest {
 	boolean autoCloseArguments() default true;
 
 	/**
-	 * Configure whether at least one set of arguments is required for this
+	 * Configure whether zero invocations are allowed for this
 	 * parameterized test.
 	 *
-	 * <p>Set this attribute to {@code false} if the absence of arguments is
+	 * <p>Set this attribute to {@code true} if the absence of arguments is
 	 * expected in some cases and should not cause a test failure.
 	 *
-	 * <p>Defaults to {@code true}.
+	 * <p>Defaults to {@code false}.
 	 *
 	 * @since 5.12
 	 */

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -86,7 +86,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 					return createInvocationContext(formatter, methodContext, arguments, invocationCount.intValue());
 				})
 				.onClose(() ->
-						Preconditions.condition(invocationCount.get() > 0 || !methodContext.annotation.requireArguments(),
+						Preconditions.condition(invocationCount.get() > 0 || methodContext.annotation.allowZeroInvocations(),
 								"Configuration error: You must configure at least one set of arguments for this @ParameterizedTest"));
 		// @formatter:on
 	}
@@ -94,7 +94,7 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 	@Override
 	public boolean mayReturnZeroTestTemplateInvocationContexts(ExtensionContext extensionContext) {
 		ParameterizedTestMethodContext methodContext = getMethodContext(extensionContext);
-		return !methodContext.annotation.requireArguments();
+		return methodContext.annotation.allowZeroInvocations();
 	}
 
 	private ParameterizedTestMethodContext getMethodContext(ExtensionContext extensionContext) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -325,7 +325,7 @@ class ParameterizedTestExtensionTests {
 
 	static class TestCaseAllowNoArgumentsMethod {
 
-		@ParameterizedTest(requireArguments = false)
+		@ParameterizedTest(allowZeroInvocations = true)
 		void method() {
 		}
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -2422,7 +2422,7 @@ class ParameterizedTestIntegrationTests {
 			fail("This test should not be executed, because no arguments are provided.");
 		}
 
-		@ParameterizedTest(requireArguments = false)
+		@ParameterizedTest(allowZeroInvocations = true)
 		@MethodSource("zeroArgumentsProvider")
 		void testThatDoesNotRequireArguments(String argument) {
 			fail("This test should not be executed, because no arguments are provided.");


### PR DESCRIPTION
## Overview

This is supposed to resolve the Issue #4137

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
