### PR TITLE
Configure toolchain repositories to avoid deprecation warning

### DIFF
--- a/platform-tooling-support-tests/projects/graalvm-starter/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/graalvm-starter/settings.gradle.kts
@@ -8,4 +8,8 @@ pluginManagement {
 	}
 }
 
+plugins {
+	id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "graalvm-starter"

--- a/platform-tooling-support-tests/projects/gradle-kotlin-extensions/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/gradle-kotlin-extensions/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "gradle-kotlin-extensions"

--- a/platform-tooling-support-tests/projects/gradle-missing-engine/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/gradle-missing-engine/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "gradle-missing-engine"

--- a/platform-tooling-support-tests/projects/gradle-starter/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/gradle-starter/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "gradle-starter"

--- a/platform-tooling-support-tests/projects/reflection-tests/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/reflection-tests/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "reflection-tests"

--- a/platform-tooling-support-tests/projects/vintage/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/vintage/settings.gradle.kts
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "vintage"


### PR DESCRIPTION
## Overview

When sample Gradle projects run from integration tests use a JDK provisioned via Gradle, toolchain repositories need to be defined to avoid a Gradle 9.0 deprecation warning.