### PR TITLE
Allow declaring exclusive resources for child nodes

### DIFF
--- a/documentation/src/docs/asciidoc/link-attributes.adoc
+++ b/documentation/src/docs/asciidoc/link-attributes.adoc
@@ -128,6 +128,7 @@ endif::[]
 :Execution:                                  {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/Execution.html[@Execution]
 :Isolated:                                   {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/Isolated.html[@Isolated]
 :ResourceLock:                               {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/ResourceLock.html[@ResourceLock]
+:ResourceLockTarget:                         {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/ResourceLockTarget.html[ResourceLockTarget]
 :ResourceLocksProvider:                      {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/ResourceLocksProvider.html[ResourceLocksProvider]
 :Resources:                                  {javadoc-root}/org.junit.jupiter.api/org/junit/jupiter/api/parallel/Resources.html[Resources]
 // Jupiter Extension APIs

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -90,7 +90,7 @@ JUnit repository on GitHub.
 * Allow determining "shared resources" at runtime via the new `@ResourceLock#providers`
   attribute that accepts implementations of `ResourceLocksProvider`.
 * Allow declaring "shared resources" for _direct_ child nodes via the new
-  `@ResourceLock(target = CHILDREN)` attribute. It may improve parallelization when
+  `@ResourceLock(target = CHILDREN)` attribute. This may improve parallelization when
   a test class declares a `READ` lock, but only a few methods hold a `READ_WRITE` lock.
 * Extensions that implement `TestInstancePreConstructCallback`, `TestInstanceFactory`,
   `TestInstancePostProcessor`, `ParameterResolver`, or `InvocationInterceptor` may

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -89,6 +89,9 @@ JUnit repository on GitHub.
   the absence of arguments is expected in some cases and should not cause a test failure.
 * Allow determining "shared resources" at runtime via the new `@ResourceLock#providers`
   attribute that accepts implementations of `ResourceLocksProvider`.
+* Allow declaring "shared resources" for _direct_ child nodes via the new
+  `@ResourceLock(target = CHILDREN)` attribute. It may improve parallelization when
+  a test class declares a `READ` lock, but only a few methods hold a `READ_WRITE` lock.
 * Extensions that implement `TestInstancePreConstructCallback`, `TestInstanceFactory`,
   `TestInstancePostProcessor`, `ParameterResolver`, or `InvocationInterceptor` may
   override the `getTestInstantiationExtensionContextScope()` method to enable receiving

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -3033,7 +3033,7 @@ Also, "static" shared resources can be declared for _direct_ child nodes via the
 attribute in the `{ResourceLock}` annotation, the attribute accepts a value from
 the `{ResourceLockTarget}` enum.
 
-Using the `target = CHILDREN` in a class-level `{ResourceLock}` annotation
+Specifying `target = CHILDREN` in a class-level `{ResourceLock}` annotation
 has the same semantics as adding an annotation with the same `value` and `mode`
 to each test method and nested test class declared in this class.
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -3035,15 +3035,15 @@ the `{ResourceLockTarget}` enum.
 
 Using the `target = CHILDREN` in a class-level `{ResourceLock}` annotation
 has the same semantics as adding an annotation with the same `value` and `mode`
-to each test method declared in this class.
+to each test method and nested test class declared in this class.
 
-It may improve parallelization when a test class declares a `READ` lock,
+This may improve parallelization when a test class declares a `READ` lock,
 but only a few methods hold a `READ_WRITE` lock.
 
 Tests in the following example would run in the `SAME_THREAD` if the `{ResourceLock}`
-doesn't have the `target = CHILDREN`. This is because the test class declares a `READ`
+didn't have `target = CHILDREN`. This is because the test class declares a `READ`
 shared resource, but one test method holds a `READ_WRITE` lock,
-which forces the `SAME_THREAD` execution mode for all the test methods.
+which would force the `SAME_THREAD` execution mode for all the test methods.
 
 [source,java]
 .Declaring shared resources for child nodes with `target` attribute

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2992,7 +2992,7 @@ Note that resources declared statically with `{ResourceLock}` annotation are com
 resources added dynamically by `{ResourceLocksProvider}` implementations.
 
 If the tests in the following example were run in parallel _without_ the use of
-{ResourceLock}, they would be _flaky_. Sometimes they would pass, and at other times they
+`{ResourceLock}`, they would be _flaky_. Sometimes they would pass, and at other times they
 would fail due to the inherent race condition of writing and then reading the same JVM
 System Property.
 
@@ -3027,6 +3027,28 @@ include::{testDir}/example/sharedresources/StaticSharedResourcesDemo.java[tags=u
 .Adding shared resources "dynamically" with `{ResourceLocksProvider}` implementation
 ----
 include::{testDir}/example/sharedresources/DynamicSharedResourcesDemo.java[tags=user_guide]
+----
+
+Also, "static" shared resources can be declared for _direct_ child nodes via the `target`
+attribute in the `{ResourceLock}` annotation, the attribute accepts a value from
+the `{ResourceLockTarget}` enum.
+
+Using the `target = CHILDREN` in a class-level `{ResourceLock}` annotation
+has the same semantics as adding an annotation with the same `value` and `mode`
+to each test method declared in this class.
+
+It may improve parallelization when a test class declares a `READ` lock,
+but only a few methods hold a `READ_WRITE` lock.
+
+Tests in the following example would run in the `SAME_THREAD` if the `{ResourceLock}`
+doesn't have the `target = CHILDREN`. This is because the test class declares a `READ`
+shared resource, but one test method holds a `READ_WRITE` lock,
+which forces the `SAME_THREAD` execution mode for all the test methods.
+
+[source,java]
+.Declaring shared resources for child nodes with `target` attribute
+----
+include::{testDir}/example/sharedresources/ChildrenSharedResourcesDemo.java[tags=user_guide]
 ----
 
 

--- a/documentation/src/test/java/example/sharedresources/ChildrenSharedResourcesDemo.java
+++ b/documentation/src/test/java/example/sharedresources/ChildrenSharedResourcesDemo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.sharedresources;
+
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
+import static org.junit.jupiter.api.parallel.ResourceLockTarget.CHILDREN;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+// tag::user_guide[]
+@Execution(CONCURRENT)
+@ResourceLock(value = "a", mode = READ, target = CHILDREN)
+public class ChildrenSharedResourcesDemo {
+
+	@ResourceLock(value = "a", mode = READ_WRITE)
+	@Test
+	void test1() throws InterruptedException {
+		Thread.sleep(2000L);
+	}
+
+	@Test
+	void test2() throws InterruptedException {
+		Thread.sleep(2000L);
+	}
+
+	@Test
+	void test3() throws InterruptedException {
+		Thread.sleep(2000L);
+	}
+
+	@Test
+	void test4() throws InterruptedException {
+		Thread.sleep(2000L);
+	}
+
+	@Test
+	void test5() throws InterruptedException {
+		Thread.sleep(2000L);
+	}
+
+}
+// end::user_guide[]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLock.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLock.java
@@ -46,11 +46,14 @@ import org.junit.jupiter.api.BeforeEach;
  *
  * <p>This annotation can be repeated to declare the use of multiple shared resources.
  *
+ * <p>Uniqueness of a shared resource is identified by both {@link #value()} and
+ * {@link #mode()}. Duplicated shared resources do not cause errors.
+ *
  * <p>Since JUnit Jupiter 5.4, this annotation is {@linkplain Inherited inherited}
  * within class hierarchies.
  *
  * <p>Since JUnit Jupiter 5.12, this annotation supports adding shared resources
- * dynamically at runtime via {@link ResourceLock#providers}.
+ * dynamically at runtime via {@link #providers}.
  *
  * <p>Resources declared "statically" using {@link #value()} and {@link #mode()}
  * are combined with "dynamic" resources added via {@link #providers()}.
@@ -58,9 +61,29 @@ import org.junit.jupiter.api.BeforeEach;
  * and resource "B" via a provider returning {@code new Lock("B")} will result
  * in two shared resources "A" and "B".
  *
+ * <p>Since JUnit Jupiter 5.12, this annotation supports declaring "static"
+ * shared resources for <em>direct</em> child nodes via the {@link #target()}
+ * attribute.
+ *
+ * <p>Using the {@link ResourceLockTarget#CHILDREN} in a class-level
+ * annotation has the same semantics as adding an annotation with the same
+ * {@link #value()} and {@link #mode()} to each test method declared
+ * in this class.
+ *
+ * <p>It may improve parallelization when a test class declares a
+ * {@link ResourceAccessMode#READ READ} lock, but only a few methods hold
+ * {@link ResourceAccessMode#READ_WRITE READ_WRITE} lock.
+ *
+ * <p>Note that the {@code target = CHILDREN} means that
+ * {@link #value()} and {@link #mode()} no longer apply to a node
+ * declaring the annotation. However, the {@link #providers()} attribute
+ * remains applicable, and the target of "dynamic" shared resources
+ * added via implementations of {@link ResourceLocksProvider} is not changed.
+ *
  * @see Isolated
  * @see Resources
  * @see ResourceAccessMode
+ * @see ResourceLockTarget
  * @see ResourceLocks
  * @see ResourceLocksProvider
  * @since 5.3
@@ -91,6 +114,20 @@ public @interface ResourceLock {
 	 * @see ResourceLocksProvider.Lock#getAccessMode()
 	 */
 	ResourceAccessMode mode() default ResourceAccessMode.READ_WRITE;
+
+	/**
+	 * The target of a resource created from {@link #value()} and {@link #mode()}.
+	 *
+	 * <p>Defaults to {@link ResourceLockTarget#SELF SELF}.
+	 *
+	 * <p>Note that using {@link ResourceLockTarget#CHILDREN} in
+	 * a method-level annotation results in an exception.
+	 *
+	 * @see ResourceLockTarget
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	ResourceLockTarget target() default ResourceLockTarget.SELF;
 
 	/**
 	 * An array of one or more classes implementing {@link ResourceLocksProvider}.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLock.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLock.java
@@ -67,10 +67,10 @@ import org.junit.jupiter.api.BeforeEach;
  *
  * <p>Using the {@link ResourceLockTarget#CHILDREN} in a class-level
  * annotation has the same semantics as adding an annotation with the same
- * {@link #value()} and {@link #mode()} to each test method declared
- * in this class.
+ * {@link #value()} and {@link #mode()} to each test method and nested test
+ * class declared in this class.
  *
- * <p>It may improve parallelization when a test class declares a
+ * <p>This may improve parallelization when a test class declares a
  * {@link ResourceAccessMode#READ READ} lock, but only a few methods hold
  * {@link ResourceAccessMode#READ_WRITE READ_WRITE} lock.
  *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLockTarget.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLockTarget.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api.parallel;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code ResourceLockTarget} is used to define the target of a shared resource.
+ *
+ * @since 5.12
+ * @see ResourceLock#target()
+ */
+@API(status = EXPERIMENTAL, since = "5.12")
+public enum ResourceLockTarget {
+
+	/**
+	 * Add a shared resource to the current node.
+	 */
+	SELF,
+
+	/**
+	 * Add a shared resource to the <em>direct</em> children of the current node.
+	 *
+	 * <p>Examples of "parent - child" relationship in the context of
+	 * {@link ResourceLockTarget}:
+	 * <ul>
+	 *     <li>a test class
+	 *     - test methods and nested test classes declared in the class.</li>
+	 *     <li>a nested test class
+	 *     - test methods declared in the nested class.</li>
+	 *     <li>a test method - considered to have no children.</li>
+	 * </ul>
+	 */
+	CHILDREN
+
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLockTarget.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLockTarget.java
@@ -37,8 +37,11 @@ public enum ResourceLockTarget {
 	 *     <li>a test class
 	 *     - test methods and nested test classes declared in the class.</li>
 	 *     <li>a nested test class
-	 *     - test methods declared in the nested class.</li>
-	 *     <li>a test method - considered to have no children.</li>
+	 *     - test methods and nested test classes declared in the nested class.
+	 *     </li>
+	 *     <li>a test method
+	 *     - considered to have no children. Using {@code CHILDREN} for
+	 *     a test method results in an exception.</li>
 	 * </ul>
 	 */
 	CHILDREN


### PR DESCRIPTION
Issue: #3102

## Overview

Allow declaring "shared resources" for _direct_ child nodes via the new `@ResourceLock(target = CHILDREN)` attribute.

Using the `@ResourceLock(target = CHILDREN)` in a class-level annotation has the same semantics as adding an annotation with the same `value` and `mode` to each test method and nested test class declared in this class.
 
This may improve parallelization when a test class declares a `READ` lock, but only a few methods hold a `READ_WRITE` lock.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
