### PR TITLE
Fix test to allow Git origin URLs starting with `git@`

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -75,9 +76,9 @@ public class OpenTestReportGeneratingListenerTests {
 				        <java:javaVersion>${xmlunit.ignore}</java:javaVersion>
 				        <java:fileEncoding>${xmlunit.ignore}</java:fileEncoding>
 				        <java:heapSize max="${xmlunit.isNumber}"/>
-				        <git:repository originUrl="${xmlunit.matchesRegex(https://.+)}"/>
+				        <git:repository originUrl="${xmlunit.matchesRegex#(git@|https://).+#}"/>
 				        <git:branch>${xmlunit.ignore}</git:branch>
-				        <git:commit>${xmlunit.matchesRegex([0-9a-f]{40})}</git:commit>
+				        <git:commit>${xmlunit.matchesRegex#[0-9a-f]{40}#}</git:commit>
 				        <git:status clean="${xmlunit.ignore}">${xmlunit.ignore}</git:status>
 				    </infrastructure>
 				    <e:started id="1" name="dummy" time="${xmlunit.isDateTime}">
@@ -104,7 +105,7 @@ public class OpenTestReportGeneratingListenerTests {
 				    <e:finished id="2" time="${xmlunit.isDateTime}">
 				        <result status="FAILED">
 				            <java:throwable assertionError="true" type="org.opentest4j.AssertionFailedError">
-				                ${xmlunit.matchesRegex(org\\.opentest4j\\.AssertionFailedError: failure message)}
+				                ${xmlunit.matchesRegex#org\\.opentest4j\\.AssertionFailedError: failure message#}
 				            </java:throwable>
 				        </result>
 				    </e:finished>
@@ -115,7 +116,8 @@ public class OpenTestReportGeneratingListenerTests {
 				""";
 
 		XmlAssert.assertThat(xmlFile).and(expected) //
-				.withDifferenceEvaluator(new PlaceholderDifferenceEvaluator()) //
+				.withDifferenceEvaluator(new PlaceholderDifferenceEvaluator(Pattern.quote("${"), Pattern.quote("}"),
+					Pattern.quote("#"), Pattern.quote("#"), ",")) //
 				.ignoreWhitespace() //
 				.areIdentical();
 	}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/XmlAssertions.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/XmlAssertions.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 import org.xmlunit.assertj3.XmlAssert;
 import org.xmlunit.placeholder.PlaceholderDifferenceEvaluator;
@@ -46,9 +47,9 @@ class XmlAssertions {
 				            <java:javaVersion>${xmlunit.ignore}</java:javaVersion>
 				            <java:fileEncoding>${xmlunit.ignore}</java:fileEncoding>
 				            <java:heapSize max="${xmlunit.isNumber}"/>
-				            <git:repository originUrl="${xmlunit.matchesRegex(https://.+)}"/>
+				            <git:repository originUrl="${xmlunit.matchesRegex#(git@|https://).+#}"/>
 				            <git:branch>${xmlunit.ignore}</git:branch>
-				            <git:commit>${xmlunit.matchesRegex([0-9a-f]{40})}</git:commit>
+				            <git:commit>${xmlunit.matchesRegex#[0-9a-f]{40}#}</git:commit>
 				            <git:status clean="${xmlunit.ignore}">${xmlunit.ignore}</git:status>
 				          </infrastructure>
 				          <e:started id="1" name="JUnit Jupiter" time="${xmlunit.isDateTime}">
@@ -156,7 +157,8 @@ class XmlAssertions {
 				""";
 
 		XmlAssert.assertThat(xmlFile).and(expected) //
-				.withDifferenceEvaluator(new PlaceholderDifferenceEvaluator()) //
+				.withDifferenceEvaluator(new PlaceholderDifferenceEvaluator(Pattern.quote("${"), Pattern.quote("}"),
+					Pattern.quote("#"), Pattern.quote("#"), ",")) //
 				.ignoreWhitespace() //
 				.areIdentical();
 	}


### PR DESCRIPTION
## Overview

fix test to allow git origin urls starting with "git@"

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
