### PR TITLE
Enable auto-flushing of output to fix `testfeed` details mode

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -18,6 +18,8 @@ JUnit repository on GitHub.
 
 * Fix support for disabling ANSI colors on the console when the `NO_COLOR` environment
   variable is available.
+* Enable auto-flushing of output in the `ConsoleLauncher` to fix issues with buffering,
+  in particular when using the `--details=testfeed` option.
 
 [[release-notes-5.12.0-M1-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/gradle/plugins/common/src/main/kotlin/junitbuild/exec/RunConsoleLauncher.kt
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild/exec/RunConsoleLauncher.kt
@@ -6,7 +6,13 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
@@ -16,7 +22,6 @@ import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.process.ExecOperations
 import trackOperationSystemAsInput
 import java.io.ByteArrayOutputStream
-import java.util.*
 import javax.inject.Inject
 
 @CacheableTask
@@ -95,6 +100,15 @@ abstract class RunConsoleLauncher @Inject constructor(private val execOperations
     )
     fun setDebug(enabled: Boolean) {
         debugging.set(enabled)
+    }
+
+    @Suppress("unused")
+    @Option(
+        option = "show-output",
+        description = "Show output"
+    )
+    fun setShowOutput(showOutput: Boolean) {
+        hideOutput.set(!showOutput)
     }
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -30,38 +30,23 @@ import org.junit.platform.console.tasks.ConsoleTestExecutor;
 public class ConsoleLauncher {
 
 	public static void main(String... args) {
-		CommandResult<?> result = run(null, null, args);
+		CommandResult<?> result = newCommandFacade().run(args);
 		System.exit(result.getExitCode());
 	}
 
 	@API(status = INTERNAL, since = "1.0")
 	public static CommandResult<?> run(PrintWriter out, PrintWriter err, String... args) {
-		ConsoleLauncher consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, out, err);
-		return consoleLauncher.run(args);
-	}
-
-	private final ConsoleTestExecutor.Factory consoleTestExecutorFactory;
-	private final PrintWriter out;
-	private final PrintWriter err;
-
-	ConsoleLauncher(ConsoleTestExecutor.Factory consoleTestExecutorFactory, PrintWriter out, PrintWriter err) {
-		this.consoleTestExecutorFactory = consoleTestExecutorFactory;
-		this.out = out;
-		this.err = err;
-	}
-
-	CommandResult<?> run(String... args) {
 		try {
-			return new CommandFacade(consoleTestExecutorFactory).run(out, err, args);
+			return newCommandFacade().run(args, out, err);
 		}
 		finally {
-			if (out != null) {
-				out.flush();
-			}
-			if (err != null) {
-				err.flush();
-			}
+			out.flush();
+			err.flush();
 		}
+	}
+
+	private static CommandFacade newCommandFacade() {
+		return new CommandFacade(ConsoleTestExecutor::new);
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -30,9 +30,7 @@ import org.junit.platform.console.tasks.ConsoleTestExecutor;
 public class ConsoleLauncher {
 
 	public static void main(String... args) {
-		PrintWriter out = new PrintWriter(System.out);
-		PrintWriter err = new PrintWriter(System.err);
-		CommandResult<?> result = run(out, err, args);
+		CommandResult<?> result = run(null, null, args);
 		System.exit(result.getExitCode());
 	}
 
@@ -57,8 +55,12 @@ public class ConsoleLauncher {
 			return new CommandFacade(consoleTestExecutorFactory).run(out, err, args);
 		}
 		finally {
-			out.flush();
-			err.flush();
+			if (out != null) {
+				out.flush();
+			}
+			if (err != null) {
+				err.flush();
+			}
 		}
 	}
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/ConsoleLauncher.java
@@ -36,13 +36,7 @@ public class ConsoleLauncher {
 
 	@API(status = INTERNAL, since = "1.0")
 	public static CommandResult<?> run(PrintWriter out, PrintWriter err, String... args) {
-		try {
-			return newCommandFacade().run(args, out, err);
-		}
-		finally {
-			out.flush();
-			err.flush();
-		}
+		return newCommandFacade().run(args, out, err);
 	}
 
 	private static CommandFacade newCommandFacade() {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandFacade.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandFacade.java
@@ -38,7 +38,13 @@ public class CommandFacade {
 	}
 
 	public CommandResult<?> run(String[] args, PrintWriter out, PrintWriter err) {
-		return run(args, Optional.of(new OutputStreamConfig(out, err)));
+		try {
+			return run(args, Optional.of(new OutputStreamConfig(out, err)));
+		}
+		finally {
+			out.flush();
+			err.flush();
+		}
 	}
 
 	private CommandResult<?> run(String[] args, Optional<OutputStreamConfig> outputStreamConfig) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandFacade.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandFacade.java
@@ -33,10 +33,18 @@ public class CommandFacade {
 		this.consoleTestExecutorFactory = consoleTestExecutorFactory;
 	}
 
-	public CommandResult<?> run(PrintWriter out, PrintWriter err, String[] args) {
+	public CommandResult<?> run(String[] args) {
+		return run(args, Optional.empty());
+	}
+
+	public CommandResult<?> run(String[] args, PrintWriter out, PrintWriter err) {
+		return run(args, Optional.of(new OutputConfig(out, err)));
+	}
+
+	private CommandResult<?> run(String[] args, Optional<OutputConfig> outputConfig) {
 		Optional<String> version = ManifestVersionProvider.getImplementationVersion();
 		System.setProperty("junit.docs.version",
 			version.map(it -> it.endsWith("-SNAPSHOT") ? "snapshot" : it).orElse("current"));
-		return new MainCommand(consoleTestExecutorFactory).run(out, err, args);
+		return new MainCommand(consoleTestExecutorFactory).run(args, outputConfig);
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandFacade.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/CommandFacade.java
@@ -38,13 +38,13 @@ public class CommandFacade {
 	}
 
 	public CommandResult<?> run(String[] args, PrintWriter out, PrintWriter err) {
-		return run(args, Optional.of(new OutputConfig(out, err)));
+		return run(args, Optional.of(new OutputStreamConfig(out, err)));
 	}
 
-	private CommandResult<?> run(String[] args, Optional<OutputConfig> outputConfig) {
+	private CommandResult<?> run(String[] args, Optional<OutputStreamConfig> outputStreamConfig) {
 		Optional<String> version = ManifestVersionProvider.getImplementationVersion();
 		System.setProperty("junit.docs.version",
 			version.map(it -> it.endsWith("-SNAPSHOT") ? "snapshot" : it).orElse("current"));
-		return new MainCommand(consoleTestExecutorFactory).run(args, outputConfig);
+		return new MainCommand(consoleTestExecutorFactory).run(args, outputStreamConfig);
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
@@ -144,10 +144,14 @@ class MainCommand implements Callable<Object>, IExitCodeGenerator {
 
 	private static CommandResult<Object> runCommand(PrintWriter out, PrintWriter err, String[] args,
 			CommandLine commandLine) {
-		int exitCode = BaseCommand.initialize(commandLine) //
-				.setOut(out) //
-				.setErr(err) //
-				.execute(args);
+		commandLine = BaseCommand.initialize(commandLine);
+		if (out != null) {
+			commandLine = commandLine.setOut(out);
+		}
+		if (err != null) {
+			commandLine = commandLine.setErr(err);
+		}
+		int exitCode = commandLine.execute(args);
 		return CommandResult.create(exitCode, getLikelyExecutedCommand(commandLine).getExecutionResult());
 	}
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
@@ -106,7 +106,7 @@ class MainCommand implements Callable<Object>, IExitCodeGenerator {
 		CommandResult<?> result = runCommand( //
 			new CommandLine(command), //
 			args.toArray(new String[0]), //
-			Optional.of(new OutputConfig(commandLine)) //
+			Optional.of(new OutputStreamConfig(commandLine)) //
 		);
 		this.commandResult = result;
 
@@ -131,18 +131,18 @@ class MainCommand implements Callable<Object>, IExitCodeGenerator {
 		err.flush();
 	}
 
-	CommandResult<?> run(String[] args, Optional<OutputConfig> outputConfig) {
+	CommandResult<?> run(String[] args, Optional<OutputStreamConfig> outputStreamConfig) {
 		CommandLine commandLine = new CommandLine(this) //
 				.addSubcommand(new DiscoverTestsCommand(consoleTestExecutorFactory)) //
 				.addSubcommand(new ExecuteTestsCommand(consoleTestExecutorFactory)) //
 				.addSubcommand(new ListTestEnginesCommand());
-		return runCommand(commandLine, args, outputConfig);
+		return runCommand(commandLine, args, outputStreamConfig);
 	}
 
 	private static CommandResult<Object> runCommand(CommandLine commandLine, String[] args,
-			Optional<OutputConfig> outputConfig) {
+			Optional<OutputStreamConfig> outputStreamConfig) {
 		BaseCommand.initialize(commandLine);
-		outputConfig.ifPresent(it -> it.applyTo(commandLine));
+		outputStreamConfig.ifPresent(it -> it.applyTo(commandLine));
 		int exitCode = commandLine.execute(args);
 		return CommandResult.create(exitCode, getLikelyExecutedCommand(commandLine).getExecutionResult());
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/MainCommand.java
@@ -139,7 +139,7 @@ class MainCommand implements Callable<Object>, IExitCodeGenerator {
 		return runCommand(commandLine, args, outputStreamConfig);
 	}
 
-	private static CommandResult<Object> runCommand(CommandLine commandLine, String[] args,
+	private static CommandResult<?> runCommand(CommandLine commandLine, String[] args,
 			Optional<OutputStreamConfig> outputStreamConfig) {
 		BaseCommand.initialize(commandLine);
 		outputStreamConfig.ifPresent(it -> it.applyTo(commandLine));

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/OutputConfig.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/OutputConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console.options;
+
+import java.io.PrintWriter;
+
+import picocli.CommandLine;
+
+class OutputConfig {
+
+	private final PrintWriter out;
+	private final PrintWriter err;
+
+	OutputConfig(CommandLine commandLine) {
+		this(commandLine.getOut(), commandLine.getErr());
+	}
+
+	OutputConfig(PrintWriter out, PrintWriter err) {
+		this.out = out;
+		this.err = err;
+	}
+
+	void applyTo(CommandLine commandLine) {
+		commandLine.setOut(out).setErr(err);
+	}
+}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/OutputStreamConfig.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/OutputStreamConfig.java
@@ -14,16 +14,16 @@ import java.io.PrintWriter;
 
 import picocli.CommandLine;
 
-class OutputConfig {
+class OutputStreamConfig {
 
 	private final PrintWriter out;
 	private final PrintWriter err;
 
-	OutputConfig(CommandLine commandLine) {
+	OutputStreamConfig(CommandLine commandLine) {
 		this(commandLine.getOut(), commandLine.getErr());
 	}
 
-	OutputConfig(PrintWriter out, PrintWriter err) {
+	OutputStreamConfig(PrintWriter out, PrintWriter err) {
 		this.out = out;
 		this.err = err;
 	}

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherTests.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.console.tasks.ConsoleTestExecutor;
 
 /**
  * @since 1.0
@@ -36,8 +35,7 @@ class ConsoleLauncherTests {
 	@EmptySource
 	@MethodSource("commandsWithEmptyOptionExitCodes")
 	void displayHelp(String command) {
-		var consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, printSink, printSink);
-		var exitCode = consoleLauncher.run(command, "--help").getExitCode();
+		var exitCode = ConsoleLauncher.run(printSink, printSink, command, "--help").getExitCode();
 
 		assertEquals(0, exitCode);
 		assertThat(output()).contains("--help");
@@ -47,8 +45,7 @@ class ConsoleLauncherTests {
 	@EmptySource
 	@MethodSource("commandsWithEmptyOptionExitCodes")
 	void displayVersion(String command) {
-		var consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, printSink, printSink);
-		var exitCode = consoleLauncher.run(command, "--version").getExitCode();
+		var exitCode = ConsoleLauncher.run(printSink, printSink, command, "--version").getExitCode();
 
 		assertEquals(0, exitCode);
 		assertThat(output()).contains("JUnit Platform Console Launcher");
@@ -57,8 +54,7 @@ class ConsoleLauncherTests {
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("commandsWithEmptyOptionExitCodes")
 	void displayBanner(String command) {
-		var consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, printSink, printSink);
-		consoleLauncher.run(command);
+		ConsoleLauncher.run(printSink, printSink, command);
 
 		assertThat(output()).contains("Thanks for using JUnit!");
 	}
@@ -66,8 +62,7 @@ class ConsoleLauncherTests {
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("commandsWithEmptyOptionExitCodes")
 	void disableBanner(String command, int expectedExitCode) {
-		var consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, printSink, printSink);
-		var exitCode = consoleLauncher.run(command, "--disable-banner").getExitCode();
+		var exitCode = ConsoleLauncher.run(printSink, printSink, command, "--disable-banner").getExitCode();
 
 		assertEquals(expectedExitCode, exitCode);
 		assertThat(output()).doesNotContain("Thanks for using JUnit!");
@@ -76,8 +71,7 @@ class ConsoleLauncherTests {
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("commandsWithEmptyOptionExitCodes")
 	void executeWithUnknownCommandLineOption(String command) {
-		var consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, printSink, printSink);
-		var exitCode = consoleLauncher.run(command, "--all").getExitCode();
+		var exitCode = ConsoleLauncher.run(printSink, printSink, command, "--all").getExitCode();
 
 		assertEquals(-1, exitCode);
 		assertThat(output()).contains("Unknown option: '--all'").contains("Usage:");
@@ -90,8 +84,7 @@ class ConsoleLauncherTests {
 	@ParameterizedTest(name = "{0}")
 	@MethodSource("commandsWithEmptyOptionExitCodes")
 	void executeWithoutCommandLineOptions(String command, int expectedExitCode) {
-		var consoleLauncher = new ConsoleLauncher(ConsoleTestExecutor::new, printSink, printSink);
-		var actualExitCode = consoleLauncher.run(command).getExitCode();
+		var actualExitCode = ConsoleLauncher.run(printSink, printSink, command).getExitCode();
 
 		assertEquals(expectedExitCode, actualExitCode);
 	}

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherWrapper.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherWrapper.java
@@ -17,6 +17,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Optional;
 
+import org.junit.platform.console.options.CommandFacade;
 import org.junit.platform.console.tasks.ConsoleTestExecutor;
 
 /**
@@ -26,16 +27,14 @@ class ConsoleLauncherWrapper {
 
 	private final StringWriter out = new StringWriter();
 	private final StringWriter err = new StringWriter();
-	private final ConsoleLauncher consoleLauncher;
+	private final ConsoleTestExecutor.Factory consoleTestExecutorFactory;
 
 	ConsoleLauncherWrapper() {
 		this(ConsoleTestExecutor::new);
 	}
 
 	private ConsoleLauncherWrapper(ConsoleTestExecutor.Factory consoleTestExecutorFactory) {
-		var outWriter = new PrintWriter(out, false);
-		var errWriter = new PrintWriter(err, false);
-		this.consoleLauncher = new ConsoleLauncher(consoleTestExecutorFactory, outWriter, errWriter);
+		this.consoleTestExecutorFactory = consoleTestExecutorFactory;
 	}
 
 	public ConsoleLauncherWrapperResult execute(String... args) {
@@ -47,7 +46,9 @@ class ConsoleLauncherWrapper {
 	}
 
 	public ConsoleLauncherWrapperResult execute(Optional<Integer> expectedCode, String... args) {
-		var result = consoleLauncher.run(args);
+		var outWriter = new PrintWriter(out, false);
+		var errWriter = new PrintWriter(err, false);
+		var result = new CommandFacade(consoleTestExecutorFactory).run(args, outWriter, errWriter);
 		var code = result.getExitCode();
 		var outText = out.toString();
 		var errText = err.toString();


### PR DESCRIPTION
## Overview

Prior to this PR, `ConsoleLauncher` created `PrintWriters` that wouldn't flush automatically when `println` is called which stopped the `testfeed` details mode from being useful. Moreover, it didn't initialized them with the right `Charsets`. Now, we rely on Picocli's initialization again which does both correctly.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
