### PR TITLE
Allow `DisplayNameGenerator` to access runtime enclosing type for `@Nested`

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -91,7 +91,8 @@ public interface DisplayNameGenerator {
 	 * @return the display name for the nested class; never blank
 	 */
 	default String generateDisplayNameForNestedClass(Class<?> nestedClass) {
-		throw new UnsupportedOperationException("Implement generateDisplayNameForNestedClass(List<Class<?>>, Class<?>) instead");
+		throw new UnsupportedOperationException(
+			"Implement generateDisplayNameForNestedClass(List<Class<?>>, Class<?>) instead");
 	}
 
 	/**
@@ -121,7 +122,8 @@ public interface DisplayNameGenerator {
 	 * @return the display name for the test; never blank
 	 */
 	default String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
-		throw new UnsupportedOperationException("Implement generateDisplayNameForMethod(List<Class<?>>, Class<?>, Method) instead");
+		throw new UnsupportedOperationException(
+			"Implement generateDisplayNameForMethod(List<Class<?>>, Class<?>, Method) instead");
 	}
 
 	/**
@@ -285,9 +287,11 @@ public interface DisplayNameGenerator {
 		}
 
 		@Override
-		public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass, Method testMethod) {
+		public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+				Method testMethod) {
 			return getSentenceBeginning(enclosingInstanceTypes, testClass) + getFragmentSeparator(testClass)
-					+ getGeneratorFor(testClass).generateDisplayNameForMethod(enclosingInstanceTypes, testClass, testMethod);
+					+ getGeneratorFor(testClass).generateDisplayNameForMethod(enclosingInstanceTypes, testClass,
+						testMethod);
 		}
 
 		private String getSentenceBeginning(List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
@@ -319,10 +323,13 @@ public interface DisplayNameGenerator {
 					.filter(IndicativeSentences.class::equals)//
 					.isPresent();
 
-			String prefix = (buildPrefix ? getSentenceBeginning(enclosingInstanceTypes, enclosingInstanceType) + getFragmentSeparator(testClass) : "");
+			String prefix = (buildPrefix
+					? getSentenceBeginning(enclosingInstanceTypes, enclosingInstanceType)
+							+ getFragmentSeparator(testClass)
+					: "");
 
 			return prefix + displayName.orElseGet(
-					() -> getGeneratorFor(testClass).generateDisplayNameForNestedClass(testClass));
+				() -> getGeneratorFor(testClass).generateDisplayNameForNestedClass(testClass));
 		}
 
 		/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -14,6 +14,7 @@ import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatio
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -95,6 +96,12 @@ final class DisplayNameUtils {
 			createDisplayNameSupplierForMethod(testClass, testMethod, configuration));
 	}
 
+	static String determineDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass, Method testMethod,
+			JupiterConfiguration configuration) {
+		return determineDisplayName(testMethod,
+				createDisplayNameSupplierForMethod(enclosingInstanceTypes, testClass, testMethod, configuration));
+	}
+
 	static Supplier<String> createDisplayNameSupplierForClass(Class<?> testClass, JupiterConfiguration configuration) {
 		return createDisplayNameSupplier(testClass, configuration,
 			generator -> generator.generateDisplayNameForClass(testClass));
@@ -106,10 +113,22 @@ final class DisplayNameUtils {
 			generator -> generator.generateDisplayNameForNestedClass(testClass));
 	}
 
+	static Supplier<String> createDisplayNameSupplierForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			JupiterConfiguration configuration) {
+		return createDisplayNameSupplier(testClass, configuration,
+				generator -> generator.generateDisplayNameForNestedClass(enclosingInstanceTypes, testClass));
+	}
+
 	private static Supplier<String> createDisplayNameSupplierForMethod(Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
 		return createDisplayNameSupplier(testClass, configuration,
 			generator -> generator.generateDisplayNameForMethod(testClass, testMethod));
+	}
+
+	private static Supplier<String> createDisplayNameSupplierForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass, Method testMethod,
+			JupiterConfiguration configuration) {
+		return createDisplayNameSupplier(testClass, configuration,
+				generator -> generator.generateDisplayNameForMethod(enclosingInstanceTypes, testClass, testMethod));
 	}
 
 	private static Supplier<String> createDisplayNameSupplier(Class<?> testClass, JupiterConfiguration configuration,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -96,10 +96,10 @@ final class DisplayNameUtils {
 			createDisplayNameSupplierForMethod(testClass, testMethod, configuration));
 	}
 
-	static String determineDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass, Method testMethod,
-			JupiterConfiguration configuration) {
+	static String determineDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			Method testMethod, JupiterConfiguration configuration) {
 		return determineDisplayName(testMethod,
-				createDisplayNameSupplierForMethod(enclosingInstanceTypes, testClass, testMethod, configuration));
+			createDisplayNameSupplierForMethod(enclosingInstanceTypes, testClass, testMethod, configuration));
 	}
 
 	static Supplier<String> createDisplayNameSupplierForClass(Class<?> testClass, JupiterConfiguration configuration) {
@@ -113,10 +113,10 @@ final class DisplayNameUtils {
 			generator -> generator.generateDisplayNameForNestedClass(testClass));
 	}
 
-	static Supplier<String> createDisplayNameSupplierForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
-			JupiterConfiguration configuration) {
+	static Supplier<String> createDisplayNameSupplierForNestedClass(List<Class<?>> enclosingInstanceTypes,
+			Class<?> testClass, JupiterConfiguration configuration) {
 		return createDisplayNameSupplier(testClass, configuration,
-				generator -> generator.generateDisplayNameForNestedClass(enclosingInstanceTypes, testClass));
+			generator -> generator.generateDisplayNameForNestedClass(enclosingInstanceTypes, testClass));
 	}
 
 	private static Supplier<String> createDisplayNameSupplierForMethod(Class<?> testClass, Method testMethod,
@@ -125,10 +125,10 @@ final class DisplayNameUtils {
 			generator -> generator.generateDisplayNameForMethod(testClass, testMethod));
 	}
 
-	private static Supplier<String> createDisplayNameSupplierForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass, Method testMethod,
-			JupiterConfiguration configuration) {
+	private static Supplier<String> createDisplayNameSupplierForMethod(List<Class<?>> enclosingInstanceTypes,
+			Class<?> testClass, Method testMethod, JupiterConfiguration configuration) {
 		return createDisplayNameSupplier(testClass, configuration,
-				generator -> generator.generateDisplayNameForMethod(enclosingInstanceTypes, testClass, testMethod));
+			generator -> generator.generateDisplayNameForMethod(enclosingInstanceTypes, testClass, testMethod));
 	}
 
 	private static Supplier<String> createDisplayNameSupplier(Class<?> testClass, JupiterConfiguration configuration,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -65,7 +65,7 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor im
 	MethodBasedTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
 			Method testMethod, JupiterConfiguration configuration) {
 		this(uniqueId, determineDisplayNameForMethod(enclosingInstanceTypes, testClass, testMethod, configuration),
-				testClass, testMethod, configuration);
+			testClass, testMethod, configuration);
 	}
 
 	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -62,6 +62,12 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor im
 			configuration);
 	}
 
+	MethodBasedTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			Method testMethod, JupiterConfiguration configuration) {
+		this(uniqueId, determineDisplayNameForMethod(enclosingInstanceTypes, testClass, testMethod, configuration),
+				testClass, testMethod, configuration);
+	}
+
 	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
 		super(uniqueId, displayName, MethodSource.from(testClass, testMethod), configuration);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -50,8 +50,10 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 		super(uniqueId, testClass, createDisplayNameSupplierForNestedClass(testClass, configuration), configuration);
 	}
 
-	public NestedClassTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes, Class<?> testClass, JupiterConfiguration configuration) {
-		super(uniqueId, testClass, createDisplayNameSupplierForNestedClass(enclosingInstanceTypes, testClass, configuration), configuration);
+	public NestedClassTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			JupiterConfiguration configuration) {
+		super(uniqueId, testClass,
+			createDisplayNameSupplierForNestedClass(enclosingInstanceTypes, testClass, configuration), configuration);
 	}
 
 	// --- TestDescriptor ------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -50,6 +50,10 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 		super(uniqueId, testClass, createDisplayNameSupplierForNestedClass(testClass, configuration), configuration);
 	}
 
+	public NestedClassTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes, Class<?> testClass, JupiterConfiguration configuration) {
+		super(uniqueId, testClass, createDisplayNameSupplierForNestedClass(enclosingInstanceTypes, testClass, configuration), configuration);
+	}
+
 	// --- TestDescriptor ------------------------------------------------------
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -18,6 +18,7 @@ import static org.junit.platform.engine.support.descriptor.ClasspathResourceSour
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -65,6 +66,11 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 	public TestFactoryTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
 		super(uniqueId, testClass, testMethod, configuration);
+	}
+
+	public TestFactoryTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			Method testMethod, JupiterConfiguration configuration) {
+		super(uniqueId, enclosingInstanceTypes, testClass, testMethod, configuration);
 	}
 
 	// --- Filterable ----------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.
 import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -77,6 +78,12 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 	public TestMethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
 		super(uniqueId, testClass, testMethod, configuration);
+		this.interceptorCall = defaultInterceptorCall;
+	}
+
+	public TestMethodTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			Method testMethod, JupiterConfiguration configuration) {
+		super(uniqueId, enclosingInstanceTypes, testClass, testMethod, configuration);
 		this.interceptorCall = defaultInterceptorCall;
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -50,6 +50,11 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 		super(uniqueId, testClass, templateMethod, configuration);
 	}
 
+	public TestTemplateTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			Method templateMethod, JupiterConfiguration configuration) {
+		super(uniqueId, enclosingInstanceTypes, testClass, templateMethod, configuration);
+	}
+
 	// --- Filterable ----------------------------------------------------------
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
@@ -82,8 +82,9 @@ class ClassSelectorResolver implements SelectorResolver {
 	@Override
 	public Resolution resolve(NestedClassSelector selector, Context context) {
 		if (isNestedTestClass.test(selector.getNestedClass())) {
-			return toResolution(context.addToParent(() -> selectClass(selector.getEnclosingClasses()),
-				parent -> Optional.of(newNestedClassTestDescriptor(parent, selector.getEnclosingClasses(), selector.getNestedClass()))));
+			return toResolution(
+				context.addToParent(() -> selectClass(selector.getEnclosingClasses()), parent -> Optional.of(
+					newNestedClassTestDescriptor(parent, selector.getEnclosingClasses(), selector.getNestedClass()))));
 		}
 		return unresolved();
 	}
@@ -127,10 +128,11 @@ class ClassSelectorResolver implements SelectorResolver {
 			configuration);
 	}
 
-	private NestedClassTestDescriptor newNestedClassTestDescriptor(TestDescriptor parent, List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
+	private NestedClassTestDescriptor newNestedClassTestDescriptor(TestDescriptor parent,
+			List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
 		return new NestedClassTestDescriptor(
-				parent.getUniqueId().append(NestedClassTestDescriptor.SEGMENT_TYPE, testClass.getSimpleName()), enclosingInstanceTypes, testClass,
-				configuration);
+			parent.getUniqueId().append(NestedClassTestDescriptor.SEGMENT_TYPE, testClass.getSimpleName()),
+			enclosingInstanceTypes, testClass, configuration);
 	}
 
 	private Resolution toResolution(Optional<? extends ClassBasedTestDescriptor> testDescriptor) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
@@ -83,7 +83,7 @@ class ClassSelectorResolver implements SelectorResolver {
 	public Resolution resolve(NestedClassSelector selector, Context context) {
 		if (isNestedTestClass.test(selector.getNestedClass())) {
 			return toResolution(context.addToParent(() -> selectClass(selector.getEnclosingClasses()),
-				parent -> Optional.of(newNestedClassTestDescriptor(parent, selector.getNestedClass()))));
+				parent -> Optional.of(newNestedClassTestDescriptor(parent, selector.getEnclosingClasses(), selector.getNestedClass()))));
 		}
 		return unresolved();
 	}
@@ -125,6 +125,12 @@ class ClassSelectorResolver implements SelectorResolver {
 		return new NestedClassTestDescriptor(
 			parent.getUniqueId().append(NestedClassTestDescriptor.SEGMENT_TYPE, testClass.getSimpleName()), testClass,
 			configuration);
+	}
+
+	private NestedClassTestDescriptor newNestedClassTestDescriptor(TestDescriptor parent, List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
+		return new NestedClassTestDescriptor(
+				parent.getUniqueId().append(NestedClassTestDescriptor.SEGMENT_TYPE, testClass.getSimpleName()), enclosingInstanceTypes, testClass,
+				configuration);
 	}
 
 	private Resolution toResolution(Optional<? extends ClassBasedTestDescriptor> testDescriptor) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
@@ -169,6 +169,12 @@ class MethodSelectorResolver implements SelectorResolver {
 					JupiterConfiguration configuration) {
 				return new TestMethodTestDescriptor(uniqueId, testClass, method, configuration);
 			}
+
+			@Override
+			protected TestDescriptor createTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes,
+					Class<?> testClass, Method method, JupiterConfiguration configuration) {
+				return new TestMethodTestDescriptor(uniqueId, enclosingInstanceTypes, testClass, method, configuration);
+			}
 		},
 
 		TEST_FACTORY(new IsTestFactoryMethod(), TestFactoryTestDescriptor.SEGMENT_TYPE,
@@ -179,6 +185,12 @@ class MethodSelectorResolver implements SelectorResolver {
 					JupiterConfiguration configuration) {
 				return new TestFactoryTestDescriptor(uniqueId, testClass, method, configuration);
 			}
+
+			@Override
+			protected TestDescriptor createTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes,
+					Class<?> testClass, Method method, JupiterConfiguration configuration) {
+				return new TestFactoryTestDescriptor(uniqueId, enclosingInstanceTypes, testClass, method, configuration);
+			}
 		},
 
 		TEST_TEMPLATE(new IsTestTemplateMethod(), TestTemplateTestDescriptor.SEGMENT_TYPE,
@@ -187,6 +199,12 @@ class MethodSelectorResolver implements SelectorResolver {
 			protected TestDescriptor createTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method method,
 					JupiterConfiguration configuration) {
 				return new TestTemplateTestDescriptor(uniqueId, testClass, method, configuration);
+			}
+
+			@Override
+			protected TestDescriptor createTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes,
+					Class<?> testClass, Method method, JupiterConfiguration configuration) {
+				return new TestTemplateTestDescriptor(uniqueId, enclosingInstanceTypes, testClass, method, configuration);
 			}
 		};
 
@@ -207,7 +225,7 @@ class MethodSelectorResolver implements SelectorResolver {
 			}
 			return context.addToParent(() -> selectClass(enclosingClasses, testClass), //
 				parent -> Optional.of(
-					createTestDescriptor(createUniqueId(method, parent), testClass, method, configuration)));
+					createTestDescriptor(createUniqueId(method, parent), enclosingClasses, testClass, method, configuration)));
 		}
 
 		private DiscoverySelector selectClass(List<Class<?>> enclosingClasses, Class<?> testClass) {
@@ -245,6 +263,9 @@ class MethodSelectorResolver implements SelectorResolver {
 
 		protected abstract TestDescriptor createTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method method,
 				JupiterConfiguration configuration);
+
+		protected abstract TestDescriptor createTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes,
+				Class<?> testClass, Method method, JupiterConfiguration configuration);
 
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
@@ -189,7 +189,8 @@ class MethodSelectorResolver implements SelectorResolver {
 			@Override
 			protected TestDescriptor createTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes,
 					Class<?> testClass, Method method, JupiterConfiguration configuration) {
-				return new TestFactoryTestDescriptor(uniqueId, enclosingInstanceTypes, testClass, method, configuration);
+				return new TestFactoryTestDescriptor(uniqueId, enclosingInstanceTypes, testClass, method,
+					configuration);
 			}
 		},
 
@@ -204,7 +205,8 @@ class MethodSelectorResolver implements SelectorResolver {
 			@Override
 			protected TestDescriptor createTestDescriptor(UniqueId uniqueId, List<Class<?>> enclosingInstanceTypes,
 					Class<?> testClass, Method method, JupiterConfiguration configuration) {
-				return new TestTemplateTestDescriptor(uniqueId, enclosingInstanceTypes, testClass, method, configuration);
+				return new TestTemplateTestDescriptor(uniqueId, enclosingInstanceTypes, testClass, method,
+					configuration);
 			}
 		};
 
@@ -224,8 +226,8 @@ class MethodSelectorResolver implements SelectorResolver {
 				return Optional.empty();
 			}
 			return context.addToParent(() -> selectClass(enclosingClasses, testClass), //
-				parent -> Optional.of(
-					createTestDescriptor(createUniqueId(method, parent), enclosingClasses, testClass, method, configuration)));
+				parent -> Optional.of(createTestDescriptor(createUniqueId(method, parent), enclosingClasses, testClass,
+					method, configuration)));
 		}
 
 		private DiscoverySelector selectClass(List<Class<?>> enclosingClasses, Class<?> testClass) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AbstractBaseTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AbstractBaseTests.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
 package org.junit.jupiter.api;
 
 @IndicativeSentencesGeneration

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AbstractBaseTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AbstractBaseTests.java
@@ -1,0 +1,13 @@
+package org.junit.jupiter.api;
+
+@IndicativeSentencesGeneration
+abstract class AbstractBaseTests {
+
+	@Nested
+	class NestedTests {
+
+		@Test
+		void test() {
+		}
+	}
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/ScenarioOneTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/ScenarioOneTests.java
@@ -1,0 +1,4 @@
+package org.junit.jupiter.api;
+
+public class ScenarioOneTests extends AbstractBaseTests {
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/ScenarioOneTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/ScenarioOneTests.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
 package org.junit.jupiter.api;
 
 public class ScenarioOneTests extends AbstractBaseTests {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/ScenarioTwoTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/ScenarioTwoTests.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
 package org.junit.jupiter.api;
 
 public class ScenarioTwoTests extends AbstractBaseTests {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/ScenarioTwoTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/ScenarioTwoTests.java
@@ -1,0 +1,4 @@
+package org.junit.jupiter.api;
+
+public class ScenarioTwoTests extends AbstractBaseTests {
+}


### PR DESCRIPTION
This PR is supposed to resolve the Issue: #4130

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [X] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
