### PR TITLE
Adapt to API change in open-test-reporting

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -29,5 +29,6 @@ runs:
         -Pjunit.develocity.predictiveTestSelection.enabled=true \
         -Pjunit.develocity.predictiveTestSelection.selectRemainingTests=${{ github.event_name != 'pull_request' }} \
         "-Dscan.value.GitHub job=${{ github.job }}" \
+        --refresh-dependencies \
         javaToolchains \
         ${{ inputs.arguments }}

--- a/gradle/scripts/checkBuildReproducibility.sh
+++ b/gradle/scripts/checkBuildReproducibility.sh
@@ -12,6 +12,7 @@ function calculate_checksums() {
         --no-build-cache \
         -Porg.gradle.java.installations.auto-download=false \
         -Dscan.tag.Reproducibility \
+        --refresh-dependencies \
         clean \
         assemble
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
@@ -24,7 +24,6 @@ import org.opentest4j.reporting.schema.Namespace;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Contributor;
 import org.opentest4j.reporting.tooling.spi.htmlreport.KeyValuePairs;
 import org.opentest4j.reporting.tooling.spi.htmlreport.Section;
-import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -42,8 +41,8 @@ public class JUnitContributor implements Contributor {
 	}
 
 	@Override
-	public List<Section> contributeSectionsForTestNode(Element testNodeElement) {
-		return findChild(testNodeElement, Namespace.REPORTING_CORE, "metadata") //
+	public List<Section> contributeSectionsForTestNode(Context context) {
+		return findChild(context.element(), Namespace.REPORTING_CORE, "metadata") //
 				.map(metadata -> {
 					Map<String, String> table = new LinkedHashMap<>();
 					findChild(metadata, JUnitFactory.NAMESPACE, "type") //


### PR DESCRIPTION
## Overview

- **Adapt to API change in open-test-reporting**
- **Force checking for new snapshots on CI**

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [X] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [X] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
