### PR TITLE
Add JRE.JAVA_25

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -31,6 +31,8 @@ jobs:
         - version: 24
           type: ea
           release: leyden
+        - version: 25
+          type: ea
     name: "OpenJDK ${{ matrix.jdk.version }} (${{ matrix.jdk.release || matrix.jdk.type }})"
     runs-on: ubuntu-latest
     steps:

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.4.adoc
@@ -45,7 +45,7 @@ JUnit repository on GitHub.
 [[release-notes-5.11.4-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* JAVA_25 has been added to the JRE enum for use with JRE-based execution conditions.
+* `JAVA_25` has been added to the `JRE` enum for use with JRE-based execution conditions.
 
 
 [[release-notes-5.11.4-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.4.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.11.4.adoc
@@ -45,7 +45,7 @@ JUnit repository on GitHub.
 [[release-notes-5.11.4-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* JAVA_25 has been added to the JRE enum for use with JRE-based execution conditions.
 
 
 [[release-notes-5.11.4-junit-vintage]]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -118,7 +118,7 @@ JUnit repository on GitHub.
   thread dump to `System.out` prior to interrupting a test thread due to a timeout.
 * `TestReporter` now allows publishing files for a test method or test class which can be
   used to include them in test reports, such as the Open Test Reporting format.
-
+* JAVA_25 has been added to the JRE enum for use with JRE-based execution conditions.
 
 [[release-notes-5.12.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -118,7 +118,7 @@ JUnit repository on GitHub.
   thread dump to `System.out` prior to interrupting a test thread due to a timeout.
 * `TestReporter` now allows publishing files for a test method or test class which can be
   used to include them in test reports, such as the Open Test Reporting format.
-* JAVA_25 has been added to the JRE enum for use with JRE-based execution conditions.
+* `JAVA_25` has been added to the `JRE` enum for use with JRE-based execution conditions.
 
 [[release-notes-5.12.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/gradle/base/code-generator-model/src/main/resources/jre.yaml
+++ b/gradle/base/code-generator-model/src/main/resources/jre.yaml
@@ -29,4 +29,4 @@
 - version: 24
   since: '5.11'
 - version: 25
-  since: '5.12'
+  since: '5.11.4'

--- a/gradle/base/code-generator-model/src/main/resources/jre.yaml
+++ b/gradle/base/code-generator-model/src/main/resources/jre.yaml
@@ -28,3 +28,5 @@
   since: '5.11'
 - version: 24
   since: '5.11'
+- version: 25
+  since: '5.12'


### PR DESCRIPTION
## Overview

Add `JRE.JAVA_25` constant and JDK 25 CI build

Closes #4177

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
