### PR TITLE
Test and document XML report compatibility with Woodstox

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -9,9 +9,9 @@
         <value>
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />
-          <package name="javax" withSubpackages="true" static="false" />
-          <emptyLine />
           <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
           <emptyLine />
           <package name="jdk" withSubpackages="true" static="false" />
           <emptyLine />

--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/junit-platform-reporting.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/junit-platform-reporting.adoc
@@ -160,3 +160,13 @@ for JUnit 4 based test reports that was made popular by the Ant build system.
 
 The `LegacyXmlReportGeneratingListener` is used by the <<running-tests-console-launcher>>
 as well.
+
+[TIP]
+====
+The legacy XML format uses XML attributes for exception messages. The default XML writer
+in the JDK does not escape newlines, tabs, and carriage returns in attribute values.
+Therefore, if you have exception messages that contain these characters and want to
+process them with downstream tools, you should consider adding a STaX2 implementation
+such as link:https://github.com/FasterXML/woodstox[Woodstox] to your test runtime
+classpath or module path.
+====

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,6 +68,7 @@ univocity-parsers = { module = "com.sonofab1rd:univocity-parsers", version = "2.
 xmlunit-assertj = { module = "org.xmlunit:xmlunit-assertj3", version.ref = "xmlunit" }
 xmlunit-placeholders = { module = "org.xmlunit:xmlunit-placeholders", version.ref = "xmlunit" }
 testingAnnotations = { module = "com.gradle:develocity-testing-annotations", version = "2.0.1" }
+woodstox = { module = "com.fasterxml.woodstox:woodstox-core", version = "7.0.0" }
 
 # Only declared here so Dependabot knows when to update the referenced versions
 asciidoctorj-pdf = { module = "org.asciidoctor:asciidoctorj-pdf", version.ref = "asciidoctorj-pdf" }

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
@@ -228,27 +228,6 @@ class XmlReportWriterTests {
 				.contains("AssertionError: expected: <A> but was: <B&#0;>");
 	}
 
-	@Test
-	void doesNotReopenCDataWithinCDataContent() throws Exception {
-		var uniqueId = engineDescriptor.getUniqueId().append("test", "test");
-		engineDescriptor.addChild(new TestDescriptorStub(uniqueId, "test"));
-		var testPlan = TestPlan.from(Set.of(engineDescriptor), configParams, dummyOutputDirectoryProvider());
-
-		var reportData = new XmlReportData(testPlan, Clock.systemDefaultZone());
-		var assertionError = new AssertionError("<foo><![CDATA[bar]]></foo>");
-		reportData.markFinished(testPlan.getTestIdentifier(uniqueId), failed(assertionError));
-		Writer assertingWriter = new StringWriter() {
-
-			@SuppressWarnings("NullableProblems")
-			@Override
-			public void write(char[] buffer, int off, int len) {
-				assertThat(new String(buffer, off, len)).doesNotContain("]]><![CDATA[");
-			}
-		};
-
-		writeXmlReport(testPlan, reportData, assertingWriter);
-	}
-
 	@ParameterizedTest(name = "{index}")
 	@MethodSource("stringPairs")
 	void escapesIllegalChars(String input, String output) {

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/XmlReportWriterTests.java
@@ -21,6 +21,7 @@ import static org.junit.platform.launcher.LauncherConstants.STDERR_REPORT_ENTRY_
 import static org.junit.platform.launcher.LauncherConstants.STDOUT_REPORT_ENTRY_KEY;
 import static org.junit.platform.launcher.core.OutputDirectoryProviders.dummyOutputDirectoryProvider;
 import static org.junit.platform.reporting.legacy.xml.XmlReportAssertions.assertValidAccordingToJenkinsSchema;
+import static org.junit.platform.reporting.legacy.xml.XmlReportWriter.ILLEGAL_CHARACTER_REPLACEMENT;
 import static org.mockito.Mockito.mock;
 
 import java.io.StringReader;
@@ -220,29 +221,30 @@ class XmlReportWriterTests {
 
 		assertValidAccordingToJenkinsSchema(testsuite.document());
 		assertThat(testsuite.find("property").matchAttr("name", "foo\\.bar").attr("value")) //
-				.isEqualTo("&#1;");
+				.isEqualTo(String.valueOf(ILLEGAL_CHARACTER_REPLACEMENT));
 		var failure = testsuite.find("failure");
 		assertThat(failure.attr("message")) //
-				.isEqualTo("expected: <A> but was: <B&#0;>");
+				.isEqualTo("expected: <A> but was: <B" + ILLEGAL_CHARACTER_REPLACEMENT + ">");
 		assertThat(failure.text()) //
-				.contains("AssertionError: expected: <A> but was: <B&#0;>");
+				.contains("AssertionError: expected: <A> but was: <B" + ILLEGAL_CHARACTER_REPLACEMENT + ">");
 	}
 
-	@ParameterizedTest(name = "{index}")
+	@ParameterizedTest(name = "[{index}]")
 	@MethodSource("stringPairs")
-	void escapesIllegalChars(String input, String output) {
-		assertEquals(output, XmlReportWriter.escapeIllegalChars(input));
+	void replacesIllegalCharacters(String input, String output) {
+		assertEquals(output, XmlReportWriter.replaceIllegalCharacters(input));
 	}
 
 	static Stream<Arguments> stringPairs() {
 		return Stream.of( //
-			arguments("\0", "&#0;"), //
-			arguments("\1", "&#1;"), //
+			arguments("\0", String.valueOf(ILLEGAL_CHARACTER_REPLACEMENT)), //
+			arguments("\1", String.valueOf(ILLEGAL_CHARACTER_REPLACEMENT)), //
 			arguments("\t", "\t"), //
 			arguments("\r", "\r"), //
 			arguments("\n", "\n"), //
-			arguments("\u001f", "&#31;"), //
-			arguments("\u0020", "\u0020"), //
+			arguments("\u001f", String.valueOf(ILLEGAL_CHARACTER_REPLACEMENT)), //
+			arguments("✅", "✅"), //
+			arguments(" ", " "), //
 			arguments("foo!", "foo!"), //
 			arguments("\uD801\uDC00", "\uD801\uDC00") //
 		);


### PR DESCRIPTION
- **Fix IntelliJ package order config to be consistent with Spotless**
- **Add test task using Woodstox for XML serialization**
- **Delete duplicate test relying on implementation details**
- **Use Unicode replacement character for illegal characters**
- **Add test for Stax2 behavior**
- **Add tip regarding Woodstox to User Guide**

Resolves #4174.