### PR TITLE
Attribute non-test thread output to most recent test thread

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -52,6 +52,8 @@ JUnit repository on GitHub.
   - If <<../user-guide/index.adoc#running-tests-capturing-output, output capturing>> is
     enabled, the captured output written to `System.out` and `System.err` is now included
     in the XML report.
+* Output written to `System.out` and `System.err` from non-test threads is now attributed
+  to the most recent test or container that was started or has written output.
 * Introduced contracts for Kotlin-specific assertion methods.
 
 


### PR DESCRIPTION
When using frameworks or running external processes, test output is
often written on other threads than the test. When tests are executed
sequentially that output can be attributed unambiguously to the current
test. If tests are run in parallel, picking the right test to attribute
output to becomes much harder, though.
