### PR TITLE
Fail `@ParameterizedTest` if there are no registered `ArgumentProviders`

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -14,6 +14,7 @@ import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatio
 import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -74,8 +75,13 @@ class ParameterizedTestExtension implements TestTemplateInvocationContextProvide
 		ParameterizedTestNameFormatter formatter = createNameFormatter(extensionContext, methodContext);
 		AtomicLong invocationCount = new AtomicLong(0);
 
+		List<ArgumentsSource> argumentsSources = findRepeatableAnnotations(methodContext.method, ArgumentsSource.class);
+
+		Preconditions.notEmpty(argumentsSources,
+			"Configuration error: You must configure at least one arguments source for this @ParameterizedTest");
+
 		// @formatter:off
-		return findRepeatableAnnotations(methodContext.method, ArgumentsSource.class)
+		return argumentsSources
 				.stream()
 				.map(ArgumentsSource::value)
 				.map(clazz -> ParameterizedTestSpiInstantiator.instantiate(ArgumentsProvider.class, clazz, extensionContext))

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -146,14 +146,21 @@ class ParameterizedTestExtensionTests {
 
 	@Test
 	void doesNotThrowExceptionWhenParametrizedTestDoesNotRequireArguments() {
-		var extensionContextWithAnnotatedTestMethod = getExtensionContextReturningSingleMethod(
-			new TestCaseAllowNoArgumentsMethod());
+		var extensionContext = getExtensionContextReturningSingleMethod(new TestCaseAllowNoArgumentsMethod());
 
-		var stream = this.parameterizedTestExtension.provideTestTemplateInvocationContexts(
-			extensionContextWithAnnotatedTestMethod);
+		var stream = this.parameterizedTestExtension.provideTestTemplateInvocationContexts(extensionContext);
 		// cause the stream to be evaluated
 		stream.toArray();
 		stream.close();
+	}
+
+	@Test
+	void throwsExceptionWhenParameterizedTestHasNoArgumentsSource() {
+		var extensionContext = getExtensionContextReturningSingleMethod(new TestCaseWithNoArgumentsSource());
+
+		assertThrows(PreconditionViolationException.class,
+			() -> this.parameterizedTestExtension.provideTestTemplateInvocationContexts(extensionContext),
+			"Configuration error: You must configure at least one arguments source for this @ParameterizedTest");
 	}
 
 	@Test
@@ -323,8 +330,8 @@ class ParameterizedTestExtensionTests {
 
 	static class TestCaseWithAnnotatedMethod {
 
-		@SuppressWarnings("JUnitMalformedDeclaration")
 		@ParameterizedTest
+		@ArgumentsSource(ZeroArgumentsProvider.class)
 		void method() {
 		}
 	}
@@ -332,7 +339,24 @@ class ParameterizedTestExtensionTests {
 	static class TestCaseAllowNoArgumentsMethod {
 
 		@ParameterizedTest(allowZeroInvocations = true)
+		@ArgumentsSource(ZeroArgumentsProvider.class)
 		void method() {
+		}
+	}
+
+	static class TestCaseWithNoArgumentsSource {
+
+		@ParameterizedTest(allowZeroInvocations = true)
+		@SuppressWarnings("JUnitMalformedDeclaration")
+		void method() {
+		}
+	}
+
+	static class ZeroArgumentsProvider implements ArgumentsProvider {
+
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+			return Stream.empty();
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -457,7 +457,7 @@ class ParameterizedTestIntegrationTests {
 	}
 
 	@Test
-	void failsWhenArgumentsAreNotRequiredAndNoneProvided() {
+	void doesNotFailWhenArgumentsAreNotRequiredAndNoneProvided() {
 		var result = execute(ZeroArgumentsTestCase.class, "testThatDoesNotRequireArguments", String.class);
 		result.allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), event(container(ZeroArgumentsTestCase.class), started()),
@@ -465,6 +465,15 @@ class ParameterizedTestIntegrationTests {
 			event(container("testThatDoesNotRequireArguments"), finishedSuccessfully()),
 			event(container(ZeroArgumentsTestCase.class), finishedSuccessfully()),
 			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void failsWhenNoArgumentsSourceIsDeclared() {
+		var result = execute(ZeroArgumentsTestCase.class, "testThatHasNoArgumentsSource", String.class);
+		result.containerEvents().assertThatEvents() //
+				.haveExactly(1, //
+					event(displayName("testThatHasNoArgumentsSource(String)"), finishedWithFailure(message(
+						"Configuration error: You must configure at least one arguments source for this @ParameterizedTest"))));
 	}
 
 	private EngineExecutionResults execute(DiscoverySelector... selectors) {
@@ -2426,6 +2435,12 @@ class ParameterizedTestIntegrationTests {
 		@MethodSource("zeroArgumentsProvider")
 		void testThatDoesNotRequireArguments(String argument) {
 			fail("This test should not be executed, because no arguments are provided.");
+		}
+
+		@ParameterizedTest(allowZeroInvocations = true)
+		@SuppressWarnings("JUnitMalformedDeclaration")
+		void testThatHasNoArgumentsSource(String argument) {
+			fail("This test should not be executed, because no arguments source is declared.");
 		}
 
 		public static Stream<Arguments> zeroArgumentsProvider() {


### PR DESCRIPTION
## Overview

Resolves #4146 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
