### PR TITLE
Introduce from and to attributes on @EnumSource (#4185)

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -137,6 +137,8 @@ JUnit repository on GitHub.
   thread dump to `System.out` prior to interrupting a test thread due to a timeout.
 * `TestReporter` now allows publishing files for a test method or test class which can be
   used to include them in test reports, such as the Open Test Reporting format.
+* New `from` and `to` attributes added to `@EnumSource` to support range selection of
+  enum constants.
 
 
 [[release-notes-5.12.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1560,12 +1560,26 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_example_au
 ----
 
 The annotation provides an optional `names` attribute that lets you specify which
-constants shall be used, like in the following example. If omitted, all constants will be
-used.
+constants shall be used, like in the following example.
 
 [source,java,indent=0]
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_include_example]
+----
+
+In addition to `names`, you can use the `from` and `to` attributes to specify a range of
+constants. The range starts from the constant specified in the `from` attribute and
+includes all subsequent constants up to and including the one specified in the `to`
+attribute, based on the natural order of the enum constants.
+
+If `from` and `to` attributes are omitted, they default to the first and last constants
+in the enum type, respectively. If all `names`, `from`, and `to` attributes are omitted,
+all constants will be used. The following example demonstrates how to specify a range of
+constants.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_range_example]
 ----
 
 The `@EnumSource` annotation also provides an optional `mode` attribute that enables
@@ -1581,6 +1595,14 @@ include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_exclude_ex
 [source,java,indent=0]
 ----
 include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_regex_example]
+----
+
+You can also combine `mode` with the `from`, `to` and `names` attributes to define a
+range of constants while excluding specific values from that range as shown below.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=EnumSource_range_exclude_example]
 ----
 
 [[writing-tests-parameterized-tests-sources-MethodSource]]

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -174,7 +174,7 @@ class ParameterizedTestDemo {
 
 	// tag::EnumSource_range_exclude_example[]
 	@ParameterizedTest
-	@EnumSource(mode = EXCLUDE, from = "HOURS", to = "DAYS", names = { "HALF_DAYS" })
+	@EnumSource(from = "HOURS", to = "DAYS", mode = EXCLUDE, names = { "HALF_DAYS" })
 	void testWithEnumSourceRangeExclude(ChronoUnit unit) {
 		assertTrue(EnumSet.of(ChronoUnit.HOURS, ChronoUnit.DAYS).contains(unit));
 		assertFalse(EnumSet.of(ChronoUnit.HALF_DAYS).contains(unit));

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -148,6 +148,14 @@ class ParameterizedTestDemo {
 	}
 	// end::EnumSource_include_example[]
 
+	// tag::EnumSource_range_example[]
+	@ParameterizedTest
+	@EnumSource(from = "HOURS", to = "DAYS")
+	void testWithEnumSourceRange(ChronoUnit unit) {
+		assertTrue(EnumSet.of(ChronoUnit.HOURS, ChronoUnit.HALF_DAYS, ChronoUnit.DAYS).contains(unit));
+	}
+	// end::EnumSource_range_example[]
+
 	// tag::EnumSource_exclude_example[]
 	@ParameterizedTest
 	@EnumSource(mode = EXCLUDE, names = { "ERAS", "FOREVER" })
@@ -163,6 +171,15 @@ class ParameterizedTestDemo {
 		assertTrue(unit.name().endsWith("DAYS"));
 	}
 	// end::EnumSource_regex_example[]
+
+	// tag::EnumSource_range_exclude_example[]
+	@ParameterizedTest
+	@EnumSource(mode = EXCLUDE, from = "HOURS", to = "DAYS", names = { "HALF_DAYS" })
+	void testWithEnumSourceRangeExclude(ChronoUnit unit) {
+		assertTrue(EnumSet.of(ChronoUnit.HOURS, ChronoUnit.DAYS).contains(unit));
+		assertFalse(EnumSet.of(ChronoUnit.HALF_DAYS).contains(unit));
+	}
+	// end::EnumSource_range_exclude_example[]
 
 	// tag::simple_MethodSource_example[]
 	@ParameterizedTest

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumArgumentsProvider.java
@@ -43,7 +43,13 @@ class EnumArgumentsProvider extends AnnotationBasedArgumentsProvider<EnumSource>
 
 	private <E extends Enum<E>> Set<? extends E> getEnumConstants(ExtensionContext context, EnumSource enumSource) {
 		Class<E> enumClass = determineEnumClass(context, enumSource);
-		return EnumSet.allOf(enumClass);
+		E[] constants = enumClass.getEnumConstants();
+		if (constants.length == 0) {
+			return EnumSet.noneOf(enumClass);
+		}
+		E from = enumSource.from().isEmpty() ? constants[0] : Enum.valueOf(enumClass, enumSource.from());
+		E to = enumSource.to().isEmpty() ? constants[constants.length - 1] : Enum.valueOf(enumClass, enumSource.to());
+		return EnumSet.range(from, to);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumArgumentsProvider.java
@@ -45,10 +45,16 @@ class EnumArgumentsProvider extends AnnotationBasedArgumentsProvider<EnumSource>
 		Class<E> enumClass = determineEnumClass(context, enumSource);
 		E[] constants = enumClass.getEnumConstants();
 		if (constants.length == 0) {
+			Preconditions.condition(enumSource.from().isEmpty() && enumSource.to().isEmpty(),
+				"No enum constant in " + enumClass.getSimpleName() + ", but 'from' or 'to' is not empty.");
 			return EnumSet.noneOf(enumClass);
 		}
 		E from = enumSource.from().isEmpty() ? constants[0] : Enum.valueOf(enumClass, enumSource.from());
 		E to = enumSource.to().isEmpty() ? constants[constants.length - 1] : Enum.valueOf(enumClass, enumSource.to());
+		Preconditions.condition(from.compareTo(to) <= 0,
+			() -> String.format(
+				"Invalid enum range: 'from' (%s) must come before 'to' (%s) in the natural order of enum constants.",
+				from, to));
 		return EnumSet.range(from, to);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -99,7 +99,10 @@ public @interface EnumSource {
 	 * @see #names
 	 * @see #to
 	 * @see #mode
+	 *
+	 * @since 5.12
 	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
 	String from() default "";
 
 	/**
@@ -112,11 +115,18 @@ public @interface EnumSource {
 	 * @see #names
 	 * @see #from
 	 * @see #mode
+	 *
+	 * @since 5.12
 	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
 	String to() default "";
 
 	/**
 	 * The enum constant selection mode.
+	 *
+	 * <p>The mode only applies to the {@link #names} attribute and does not change
+	 * the behavior of {@link #from} and {@link #to}, which always define a range
+	 * based on the natural order of the enum constants.
 	 *
 	 * <p>Defaults to {@link Mode#INCLUDE INCLUDE}.
 	 *
@@ -126,6 +136,8 @@ public @interface EnumSource {
 	 * @see Mode#MATCH_ANY
 	 * @see Mode#MATCH_NONE
 	 * @see #names
+	 * @see #from
+	 * @see #to
 	 */
 	Mode mode() default Mode.INCLUDE;
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -40,8 +40,8 @@ import org.junit.platform.commons.util.Preconditions;
  * attribute. Otherwise, the declared type of the first parameter of the
  * {@code @ParameterizedTest} method is used.
  *
- * <p>The set of enum constants can be restricted via the {@link #names} and
- * {@link #mode} attributes.
+ * <p>The set of enum constants can be restricted via the {@link #names},
+ * {@link #from}, {@link #to} and {@link #mode} attributes.
  *
  * @since 5.0
  * @see org.junit.jupiter.params.provider.ArgumentsSource
@@ -63,6 +63,8 @@ public @interface EnumSource {
 	 * first parameter of the {@code @ParameterizedTest} method is used.
 	 *
 	 * @see #names
+	 * @see #from
+	 * @see #to
 	 * @see #mode
 	 */
 	Class<? extends Enum<?>> value() default NullEnum.class;
@@ -71,15 +73,47 @@ public @interface EnumSource {
 	 * The names of enum constants to provide, or regular expressions to select
 	 * the names of enum constants to provide.
 	 *
-	 * <p>If no names or regular expressions are specified, all enum constants
-	 * declared in the specified {@linkplain #value enum type} will be provided.
+	 * <p>If no names or regular expressions are specified, and neither {@link #from}
+	 * nor {@link #to} are specified, all enum constants declared in the specified
+	 * {@linkplain #value enum type} will be provided.
+	 *
+	 * <p>If {@link #from} or {@link #to} are specified, the elements in names must
+	 * fall within the range defined by {@link #from} and {@link #to}.
 	 *
 	 * <p>The {@link #mode} determines how the names are interpreted.
 	 *
 	 * @see #value
+	 * @see #from
+	 * @see #to
 	 * @see #mode
 	 */
 	String[] names() default {};
+
+	/**
+	 * The starting enum constant of the range to be included.
+	 *
+	 * <p>Defaults to an empty string, where the range starts from the first enum
+	 * constant of the specified {@linkplain #value enum type}.
+	 *
+	 * @see #value
+	 * @see #names
+	 * @see #to
+	 * @see #mode
+	 */
+	String from() default "";
+
+	/**
+	 * The ending enum constant of the range to be included.
+	 *
+	 * <p>Defaults to an empty string, where the range ends at the last enum
+	 * constant of the specified {@linkplain #value enum type}.
+	 *
+	 * @see #value
+	 * @see #names
+	 * @see #from
+	 * @see #mode
+	 */
+	String to() default "";
 
 	/**
 	 * The enum constant selection mode.

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
@@ -164,6 +164,20 @@ class EnumArgumentsProviderTests {
 		assertThat(exception).hasMessageContaining("No enum constant");
 	}
 
+	@Test
+	void invalidRangeOrderIsDetected() {
+		Exception exception = assertThrows(PreconditionViolationException.class,
+			() -> provideArguments(EnumWithFourConstants.class, "BAR", "FOO", Mode.INCLUDE).findAny());
+		assertThat(exception).hasMessageContaining("Invalid enum range");
+	}
+
+	@Test
+	void invalidRangeIsDetectedWhenEnumWithNoConstantIsProvided() {
+		Exception exception = assertThrows(PreconditionViolationException.class,
+			() -> provideArguments(EnumWithNoConstant.class, "BAR", "FOO", Mode.INCLUDE).findAny());
+		assertThat(exception).hasMessageContaining("No enum constant");
+	}
+
 	static class TestCase {
 		void methodWithCorrectParameter(EnumWithFourConstants parameter) {
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
@@ -58,21 +58,21 @@ class EnumArgumentsProviderTests {
 
 	@Test
 	void duplicateConstantNameIsDetected() {
-		Exception exception = assertThrows(PreconditionViolationException.class,
+		var exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(EnumWithFourConstants.class, "FOO", "BAR", "FOO").findAny());
 		assertThat(exception).hasMessageContaining("Duplicate enum constant name(s) found");
 	}
 
 	@Test
 	void invalidConstantNameIsDetected() {
-		Exception exception = assertThrows(PreconditionViolationException.class,
+		var exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(EnumWithFourConstants.class, "FO0", "B4R").findAny());
 		assertThat(exception).hasMessageContaining("Invalid enum constant name(s) in");
 	}
 
 	@Test
 	void invalidPatternIsDetected() {
-		Exception exception = assertThrows(PreconditionViolationException.class,
+		var exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(EnumWithFourConstants.class, Mode.MATCH_ALL, "(", ")").findAny());
 		assertThat(exception).hasMessageContaining("Pattern compilation failed");
 	}
@@ -93,7 +93,7 @@ class EnumArgumentsProviderTests {
 		when(extensionContext.getRequiredTestMethod()).thenReturn(
 			TestCase.class.getDeclaredMethod("methodWithIncorrectParameter", Object.class));
 
-		Exception exception = assertThrows(PreconditionViolationException.class,
+		var exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(NullEnum.class).findAny());
 		assertThat(exception).hasMessageStartingWith("First parameter must reference an Enum type");
 	}
@@ -103,7 +103,7 @@ class EnumArgumentsProviderTests {
 		when(extensionContext.getRequiredTestMethod()).thenReturn(
 			TestCase.class.getDeclaredMethod("methodWithoutParameters"));
 
-		Exception exception = assertThrows(PreconditionViolationException.class,
+		var exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(NullEnum.class).findAny());
 		assertThat(exception).hasMessageStartingWith("Test method must declare at least one parameter");
 	}
@@ -145,35 +145,35 @@ class EnumArgumentsProviderTests {
 
 	@Test
 	void invalidConstantNameIsDetectedInRange() {
-		Exception exception = assertThrows(PreconditionViolationException.class,
+		var exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(EnumWithFourConstants.class, "FOO", "BAZ", Mode.EXCLUDE, "QUX").findAny());
 		assertThat(exception).hasMessageContaining("Invalid enum constant name(s) in");
 	}
 
 	@Test
 	void invalidStartingRangeIsDetected() {
-		Exception exception = assertThrows(IllegalArgumentException.class,
+		var exception = assertThrows(IllegalArgumentException.class,
 			() -> provideArguments(EnumWithFourConstants.class, "B4R", "", Mode.INCLUDE).findAny());
 		assertThat(exception).hasMessageContaining("No enum constant");
 	}
 
 	@Test
 	void invalidEndingRangeIsDetected() {
-		Exception exception = assertThrows(IllegalArgumentException.class,
+		var exception = assertThrows(IllegalArgumentException.class,
 			() -> provideArguments(EnumWithFourConstants.class, "", "B4R", Mode.INCLUDE).findAny());
 		assertThat(exception).hasMessageContaining("No enum constant");
 	}
 
 	@Test
 	void invalidRangeOrderIsDetected() {
-		Exception exception = assertThrows(PreconditionViolationException.class,
+		var exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(EnumWithFourConstants.class, "BAR", "FOO", Mode.INCLUDE).findAny());
 		assertThat(exception).hasMessageContaining("Invalid enum range");
 	}
 
 	@Test
 	void invalidRangeIsDetectedWhenEnumWithNoConstantIsProvided() {
-		Exception exception = assertThrows(PreconditionViolationException.class,
+		var exception = assertThrows(PreconditionViolationException.class,
 			() -> provideArguments(EnumWithNoConstant.class, "BAR", "FOO", Mode.INCLUDE).findAny());
 		assertThat(exception).hasMessageContaining("No enum constant");
 	}
@@ -207,11 +207,11 @@ class EnumArgumentsProviderTests {
 	private <E extends Enum<E>> Stream<Object[]> provideArguments(Class<E> enumClass, String from, String to, Mode mode,
 			String... names) {
 		var annotation = mock(EnumSource.class);
-		when(annotation.value()).thenAnswer(invocation -> enumClass);
-		when(annotation.from()).thenAnswer(invocation -> from);
-		when(annotation.to()).thenAnswer(invocation -> to);
-		when(annotation.mode()).thenAnswer(invocation -> mode);
-		when(annotation.names()).thenAnswer(invocation -> names);
+		when(annotation.value()).thenAnswer(__ -> enumClass);
+		when(annotation.from()).thenReturn(from);
+		when(annotation.to()).thenReturn(to);
+		when(annotation.mode()).thenReturn(mode);
+		when(annotation.names()).thenReturn(names);
 		when(annotation.toString()).thenReturn(
 			String.format("@EnumSource(value=%s.class, from=%s, to=%s, mode=%s, names=%s)", enumClass.getSimpleName(),
 				from, to, mode, Arrays.toString(names)));


### PR DESCRIPTION
Resolves #4185.

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
