### PR TITLE
Add workflow to verify reproducibility of binary release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
   verify_reproducibility:
     name: Verify artifacts are reproducible
     runs-on: ubuntu-24.04 # required to get a recent version of `jc`
+    permissions:
+      attestations: write # required for build provenance attestation
+      id-token: write # required for build provenance attestation
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -48,3 +51,7 @@ jobs:
             -Pmanifest.createdBy="${{ steps.referenceJar.outputs.createdBy }}" \
             :verifyArtifactsInStagingRepositoryAreReproducible \
             --remote-repo-url=${{ steps.stagingRepo.outputs.url }}
+      - name: Generate build provenance attestations
+        uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
+        with:
+          subject-path: build/repo/**/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: Version to be released (e.g. "5.12.0-M1")
+        required: true
+      stagingRepoId:
+        description: ID of the Nexus staging repository (e.g. "orgjunit-1159")
+        required: true
+
+permissions: read-all
+
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+jobs:
+
+  verify_reproducibility:
+    name: Verify artifacts are reproducible
+    runs-on: ubuntu-24.04 # required to get a recent version of `jc`
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 1
+          # TODO ref: "refs/tags/r${{ github.event.inputs.releaseVersion }}"
+      - name: Set staging repository URL
+        id: stagingRepo
+        run: echo "url=https://oss.sonatype.org/service/local/repositories/${{ github.event.inputs.stagingRepoId }}/content" > "$GITHUB_OUTPUT"
+      - name: Download reference JAR from staging repository
+        id: referenceJar
+        run: |
+          curl --silent --fail --location --output /tmp/reference.jar \
+            "${{ steps.stagingRepo.outputs.url }}/org/junit/jupiter/junit-jupiter-api/${{ github.event.inputs.releaseVersion }}/junit-jupiter-api-${{ github.event.inputs.releaseVersion }}.jar"
+          sudo apt-get update && sudo apt-get install --yes jc
+          unzip -c /tmp/reference.jar META-INF/MANIFEST.MF | jc --jar-manifest | jq '.[0]' > /tmp/manifest.json
+          echo "createdBy=$(jq --raw-output .Created_By /tmp/manifest.json)" >> "$GITHUB_OUTPUT"
+          echo "buildTimestamp=$(jq --raw-output .Build_Date /tmp/manifest.json) $(jq --raw-output .Build_Time /tmp/manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: Verify artifacts
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: |
+            --rerun-tasks \
+            -Pmanifest.buildTimestamp="${{ steps.referenceJar.outputs.buildTimestamp }}" \
+            -Pmanifest.createdBy="${{ steps.referenceJar.outputs.createdBy }}" \
+            :verifyArtifactsInStagingRepositoryAreReproducible \
+            --remote-repo-url=${{ steps.stagingRepo.outputs.url }}

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.temp-maven-repo.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.temp-maven-repo.gradle.kts
@@ -1,4 +1,5 @@
 import junitbuild.extensions.capitalized
+import junitbuild.release.VerifyBinaryArtifactsAreIdentical
 
 val tempRepoName by extra("temp")
 val tempRepoDir by extra {
@@ -12,6 +13,10 @@ val clearTempRepoDir by tasks.registering {
 	}
 }
 
+val verifyArtifactsInStagingRepositoryAreReproducible by tasks.registering(VerifyBinaryArtifactsAreIdentical::class) {
+	localRepoDir.set(tempRepoDir)
+}
+
 subprojects {
 	pluginManager.withPlugin("maven-publish") {
 		configure<PublishingExtension> {
@@ -22,10 +27,13 @@ subprojects {
 				}
 			}
 		}
-		tasks.withType<PublishToMavenRepository>()
+		val publishingTasks = tasks.withType<PublishToMavenRepository>()
 			.named { it.endsWith("To${tempRepoName.capitalized()}Repository") }
-			.configureEach {
-					dependsOn(clearTempRepoDir)
-			}
+		publishingTasks.configureEach {
+			dependsOn(clearTempRepoDir)
+		}
+		verifyArtifactsInStagingRepositoryAreReproducible {
+			dependsOn(publishingTasks)
+		}
 	}
 }

--- a/gradle/plugins/common/src/main/kotlin/junitbuild/release/VerifyBinaryArtifactsAreIdentical.kt
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild/release/VerifyBinaryArtifactsAreIdentical.kt
@@ -1,0 +1,80 @@
+package junitbuild.release
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+
+abstract class VerifyBinaryArtifactsAreIdentical : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val localRepoDir: DirectoryProperty
+
+    @get:Input
+    abstract val remoteRepoUrl: Property<String>
+
+    init {
+        // Depends on contents of remote repository
+        outputs.upToDateWhen { false }
+    }
+
+    @Suppress("unused")
+    @Option(
+        option = "remote-repo-url",
+        description = "The URL of the remote repository to compare the local repository against"
+    )
+    fun remoteRepo(url: String) {
+        remoteRepoUrl.set(url)
+    }
+
+    @TaskAction
+    fun execute() {
+        val localRootDir = localRepoDir.get().asFile
+        val baseUrl = remoteRepoUrl.get()
+        val mismatches = mutableListOf<Mismatch>()
+        var numChecks = 0
+        HttpClient.newHttpClient().use { httpClient ->
+            localRootDir.walk().forEach { file ->
+                if (file.isFile && file.name.endsWith(".jar.sha512") && !file.name.endsWith("-javadoc.jar.sha512")) {
+                    val localSha512 = file.readText()
+                    val relativeFile = file.relativeTo(localRootDir)
+                    val url = URI.create("${baseUrl}/${relativeFile.path}")
+                    logger.info("Checking {}...", url)
+                    val request = HttpRequest.newBuilder().GET().uri(url).build()
+                    val response = httpClient.send(request, BodyHandlers.ofString())
+                    val remoteSha512 = if (response.statusCode() == 200) response.body() else "status=${response.statusCode()}"
+                    if (localSha512 != remoteSha512) {
+                        mismatches.add(Mismatch(relativeFile, localSha512, remoteSha512))
+                    }
+                    numChecks++
+                }
+            }
+        }
+        require(numChecks > 0) {
+            "No files found to compare"
+        }
+        require(mismatches.isEmpty()) {
+            "The following files have different SHA-512 checksums in the local and remote repositories:\n\n" +
+                    mismatches.joinToString("\n\n") {
+                        """
+                            ${it.file}
+                            local:  ${it.localSha512}
+                            remote: ${it.remoteSha512}
+                        """.trimIndent()
+                    }
+        }
+    }
+
+    private data class Mismatch(val file: File, val localSha512: String, val remoteSha512: String)
+}


### PR DESCRIPTION
This workflow is supposed to be triggered manually _after_ release
artifacts have been uploaded to a staging repository and the
corresponding Git tag has been pushed to GitHub.

To ensure their integrity and reproducibility, the workflow rebuilds
all binary artifacts and verifies that their checksums are identical to
those in the staging repository.
