### PR TITLE
Automate post-release steps

### DIFF
--- a/.github/scripts/waitForMavenCentralSync.sh
+++ b/.github/scripts/waitForMavenCentralSync.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+URL_PATH=$1
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+"$SCRIPT_DIR"/waitForUrl.sh "https://repo1.maven.org/maven2/$URL_PATH"

--- a/.github/scripts/waitForUrl.sh
+++ b/.github/scripts/waitForUrl.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+URL=$1
+printf 'Waiting for %s' "$URL"
+until curl --output /dev/null --silent --location --head --fail "$URL"; do
+    printf '.'
+    sleep 5
+done
+echo ' OK'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,3 +132,27 @@ jobs:
           curl --silent --fail --location --output /tmp/junit-user-guide.pdf "${{ steps.pagesDeployment.outputs.pdfUrl }}"
           sudo apt-get update && sudo apt-get install --yes poppler-utils
           pdfinfo /tmp/junit-user-guide.pdf
+
+  close_github_milestone:
+    name: Close GitHub milestone
+    needs: release_staging_repo
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close milestone
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const openMilestones = await github.rest.issues.listMilestones({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open'
+            });
+            const [milestone] = openMilestones.data.filter(x => x.title === "${{ github.event.inputs.releaseVersion }}")
+            await github.rest.issues.updateMilestone({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                milestone_number: milestone.number,
+                state: 'closed'
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,41 @@ jobs:
           arguments: |
             releaseSonatypeStagingRepository \
             --staging-repository-id=${{ github.event.inputs.stagingRepoId }}
+
+  publish_documentation:
+    name: Publish documentation
+    needs: release_staging_repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 1
+          ref: "refs/tags/r${{ github.event.inputs.releaseVersion }}"
+      - name: Configure Git
+        run: |
+          git config --global user.name "JUnit Team"
+          git config --global user.email "team@junit.org"
+      - name: Build and publish documentation
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: |
+            --no-build-cache \
+            --no-configuration-cache \
+            clean \
+            gitPublishPush \
+            -Pdocumentation.replaceCurrentDocs=${{ contains(github.event.inputs.releaseVersion, '-') && 'false' || 'true' }}
+      - name: Wait for deployment to GitHub Pages
+        id: pagesDeployment
+        timeout-minutes: 20
+        run: |
+          URL="https://junit.org/junit5/docs/${{ github.event.inputs.releaseVersion }}/user-guide/junit-user-guide-${{ github.event.inputs.releaseVersion }}.pdf"
+          ./.github/scripts/waitForUrl.sh "$URL"
+          echo "pdfUrl=$URL" >> "$GITHUB_OUTPUT"
+      - name: Verify integrity of PDF version of User Guide
+        timeout-minutes: 15
+        run: |
+          curl --silent --fail --location --output /tmp/junit-user-guide.pdf "${{ steps.pagesDeployment.outputs.pdfUrl }}"
+          sudo apt-get update && sudo apt-get install --yes poppler-utils
+          pdfinfo /tmp/junit-user-guide.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,3 +211,28 @@ jobs:
           git switch main
           git merge --ff-only "r${{ github.event.inputs.releaseVersion }}"
           git push origin main
+
+  create_github_release:
+    name: Create GitHub release
+    needs: wait_for_maven_central
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const releaseVersion = "${{ github.event.inputs.releaseVersion }}";
+            const jupiterVersion = releaseVersion;
+            const vintageVersion = releaseVersion;
+            const platformVersion = "1." + releaseVersion.substring(2);
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `r${releaseVersion}`,
+              name: `JUnit ${releaseVersion}`,
+              generate_release_notes: true,
+              body: `JUnit ${jupiterVersion} = Platform ${platformVersion} + Jupiter ${jupiterVersion} + Vintage ${vintageVersion}\n\nSee [Release Notes](https://junit.org/junit5/docs/${releaseVersion}/release-notes/).`,
+              prerelease: releaseVersion.includes("-"),
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 1
-          # TODO ref: "refs/tags/r${{ github.event.inputs.releaseVersion }}"
+          ref: "refs/tags/r${{ github.event.inputs.releaseVersion }}"
       - name: Download reference JAR from staging repository
         id: referenceJar
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
         uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
         with:
           subject-path: build/repo/**/*.jar
+      - name: Upload local repository for later jobs
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        with:
+          name: local-maven-repository
+          path: build/repo
 
   verify_consumability:
     name: Verify artifacts are consumable
@@ -156,3 +161,18 @@ jobs:
                 milestone_number: milestone.number,
                 state: 'closed'
             });
+
+  wait_for_maven_central:
+    name: Wait for sync to Maven Central
+    needs: release_staging_repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download local Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: local-maven-repository
+          path: build/repo
+      - name: Wait for sync to Maven Central
+        timeout-minutes: 30
+        run: |
+          find build/repo -name '*.pom' -printf './.github/scripts/waitForMavenCentralSync.sh %P\n' | sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,3 +176,38 @@ jobs:
         timeout-minutes: 30
         run: |
           find build/repo -name '*.pom' -printf './.github/scripts/waitForMavenCentralSync.sh %P\n' | sh
+
+  update_samples:
+    name: Update samples
+    needs: wait_for_maven_central
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out samples repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: junit-team/junit5-samples
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+      - name: Set up JDK
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: sbt/setup-sbt@v1
+      - name: Update JUnit dependencies in samples
+        run: java src/Updater.java ${{ github.event.inputs.releaseVersion }}
+      - name: Build samples
+        run: java src/Builder.java
+      - name: Create release branch
+        run: |
+          git config user.name "JUnit Team"
+          git config user.email "team@junit.org"
+          git switch -c "r${{ github.event.inputs.releaseVersion }}"
+          git commit -a -m "Use ${{ github.event.inputs.releaseVersion }}"
+          git push origin "r${{ github.event.inputs.releaseVersion }}"
+      - name: Update main branch (only for GA releases)
+        if: ${{ !contains(github.event.inputs.releaseVersion, '-') }}
+        run: |
+          git switch main
+          git merge --ff-only "r${{ github.event.inputs.releaseVersion }}"
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,21 @@ jobs:
         run: java src/StagingRepoInjector.java ${{ env.STAGING_REPO_URL }}
       - name: Build samples
         run: java src/Builder.java
+
+  release_staging_repo:
+    name: Release staging repository
+    needs: [verify_reproducibility, verify_consumability]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 1
+          ref: "refs/tags/r${{ github.event.inputs.releaseVersion }}"
+      - name: Release staging repository
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: |
+            releaseSonatypeStagingRepository \
+            --staging-repository-id=${{ github.event.inputs.stagingRepoId }}


### PR DESCRIPTION
- **Add job for releasing the staging repository**
- **Add job for publishing documentation**
- **Add job for closing the GitHub milestone of the release**
- **Add job for waiting for sync to Maven Central**
- **Add job for updating samples after sync to Maven Central was successful**
- **Add job for creating a GitHub release**

## New workflow

```
        ╭───────────────────────────────────╮ ╭─────────────────────────────────╮
        │ Verify artifacts are reproducible │ │ Verify artifacts are consumable │
        ╰───────────────────────────────────╯ ╰─────────────────────────────────╯
                                           ⬇
                             ╭────────────────────────────╮
                             │ Release staging repository │
                             ╰────────────────────────────╯
                                           ⬇
 ╭────────────────────────────────╮ ╭───────────────────────╮ ╭────────────────────────╮
 │ Wait for sync to Maven Central │ │ Publish documentation │ │ Close GitHub milestone │
 ╰────────────────────────────────╯ ╰───────────────────────╯ ╰────────────────────────╯
                                           ⬇
                      ╭────────────────╮ ╭───────────────────────╮
                      │ Update samples │ │ Create GitHub release │
                      ╰────────────────╯ ╰───────────────────────╯
```