### PR TITLE
Document that `AnnotationSupport.isAnnotated()` does not find repeatable annotations

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -871,7 +871,7 @@ and fields in a class or interface. Some of these methods search on implemented
 interfaces and within class hierarchies to find annotations.
 
 **Note:** `isAnnotated` method does not find repeatable annotations. To check for repeatable annotations,
-use the `findRepeatableAnnotations` method and verify that the returned list is not empty.
+use one of the `findRepeatableAnnotations()` methods and verify that the returned list is not empty.
 
 Consult the Javadoc for `{AnnotationSupport}` for further details.
 

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -868,12 +868,11 @@ order to align with the behavior of the JUnit Platform and JUnit Jupiter.
 These include methods to check whether an element is annotated or meta-annotated with a
 particular annotation, to search for specific annotations, and to find annotated methods
 and fields in a class or interface. Some of these methods search on implemented
-interfaces and within class hierarchies to find annotations.
+interfaces and within class hierarchies to find annotations. Consult the Javadoc for
+`{AnnotationSupport}` for further details.
 
 NOTE: The `isAnnotated()` methods do not find repeatable annotations. To check for repeatable annotations,
 use one of the `findRepeatableAnnotations()` methods and verify that the returned list is not empty.
-
-Consult the Javadoc for `{AnnotationSupport}` for further details.
 
 NOTE: See also: <<extensions-supported-utilities-search-semantics>>
 

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -868,8 +868,12 @@ order to align with the behavior of the JUnit Platform and JUnit Jupiter.
 These include methods to check whether an element is annotated or meta-annotated with a
 particular annotation, to search for specific annotations, and to find annotated methods
 and fields in a class or interface. Some of these methods search on implemented
-interfaces and within class hierarchies to find annotations. Consult the Javadoc for
-`{AnnotationSupport}` for further details.
+interfaces and within class hierarchies to find annotations.
+
+**Note:** `isAnnotated` method does not find repeatable annotations. To check for repeatable annotations,
+use the `findRepeatableAnnotations` method and verify that the returned list is not empty.
+
+Consult the Javadoc for `{AnnotationSupport}` for further details.
 
 NOTE: See also: <<extensions-supported-utilities-search-semantics>>
 

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -870,7 +870,7 @@ particular annotation, to search for specific annotations, and to find annotated
 and fields in a class or interface. Some of these methods search on implemented
 interfaces and within class hierarchies to find annotations.
 
-**Note:** `isAnnotated` method does not find repeatable annotations. To check for repeatable annotations,
+NOTE: The `isAnnotated()` methods do not find repeatable annotations. To check for repeatable annotations,
 use one of the `findRepeatableAnnotations()` methods and verify that the returned list is not empty.
 
 Consult the Javadoc for `{AnnotationSupport}` for further details.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/AnnotatedElementContext.java
@@ -55,6 +55,10 @@ public interface AnnotatedElementContext {
 	 * <em>present</em> or <em>meta-present</em> on the {@link AnnotatedElement} for
 	 * this context.
 	 *
+	 * <p><strong>Note:</strong> This method does not find repeatable annotations.
+	 * To check for repeatable annotations, use {@link #findRepeatableAnnotations(Class)}
+	 * and verify that the returned list is not empty.
+	 *
 	 * <h4>WARNING</h4>
 	 * <p>Favor the use of this method over directly invoking
 	 * {@link AnnotatedElement#isAnnotationPresent(Class)} due to a bug in {@code javac}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -80,7 +80,7 @@ public final class AnnotationSupport {
 	 * {@code element}.
 	 *
 	 * <p><strong>Note:</strong> This method does not find repeatable annotations.
-	 * To check for repeatable annotations, use {@link #findRepeatableAnnotations(Optional, Class)}
+	 * To check for repeatable annotations, use {@link #findRepeatableAnnotations(AnnotatedElement, Class)}
 	 * and verify that the returned list is not empty.
 	 *
 	 * @param element the element on which to search for the annotation; may be

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -54,6 +54,10 @@ public final class AnnotationSupport {
 	 * <em>present</em> or <em>meta-present</em> on the supplied optional
 	 * {@code element}.
 	 *
+	 * <p><strong>Note:</strong> This method does not find repeatable annotations.
+	 * To check for repeatable annotations, use {@link #findRepeatableAnnotations(Optional, Class)}
+	 * and verify that the returned list is not empty.
+	 *
 	 * @param element an {@link Optional} containing the element on which to
 	 * search for the annotation; may be {@code null} or <em>empty</em>
 	 * @param annotationType the annotation type to search for; never {@code null}
@@ -61,6 +65,7 @@ public final class AnnotationSupport {
 	 * @since 1.3
 	 * @see #isAnnotated(AnnotatedElement, Class)
 	 * @see #findAnnotation(Optional, Class)
+	 * @see #findRepeatableAnnotations(Optional, Class)
 	 */
 	@API(status = MAINTAINED, since = "1.3")
 	public static boolean isAnnotated(Optional<? extends AnnotatedElement> element,
@@ -74,12 +79,17 @@ public final class AnnotationSupport {
 	 * <em>present</em> or <em>meta-present</em> on the supplied
 	 * {@code element}.
 	 *
+	 * <p><strong>Note:</strong> This method does not find repeatable annotations.
+	 * To check for repeatable annotations, use {@link #findRepeatableAnnotations(Optional, Class)}
+	 * and verify that the returned list is not empty.
+	 *
 	 * @param element the element on which to search for the annotation; may be
 	 * {@code null}
 	 * @param annotationType the annotation type to search for; never {@code null}
 	 * @return {@code true} if the annotation is present or meta-present
 	 * @see #isAnnotated(Optional, Class)
 	 * @see #findAnnotation(AnnotatedElement, Class)
+	 * @see #findRepeatableAnnotations(Optional, Class)
 	 */
 	public static boolean isAnnotated(AnnotatedElement element, Class<? extends Annotation> annotationType) {
 		return AnnotationUtils.isAnnotated(element, annotationType);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -89,7 +89,7 @@ public final class AnnotationSupport {
 	 * @return {@code true} if the annotation is present or meta-present
 	 * @see #isAnnotated(Optional, Class)
 	 * @see #findAnnotation(AnnotatedElement, Class)
-	 * @see #findRepeatableAnnotations(Optional, Class)
+	 * @see #findRepeatableAnnotations(AnnotatedElement, Class)
 	 */
 	public static boolean isAnnotated(AnnotatedElement element, Class<? extends Annotation> annotationType) {
 		return AnnotationUtils.isAnnotated(element, annotationType);


### PR DESCRIPTION
Resolves: #4058 

## Overview

- Update the Javadoc for both `AnnotationSupport.isAnnotated()` variants to reflect this.
- Update the User Guide documentation for `AnnotationSupport` to reflect this, if applicable.
- Update the Javadoc for `AnnotatedElementContext.isAnnotated()` to reflect this.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).
