### PR TITLE
Remove custom array handling already covered by `Class.forName()`

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -126,21 +126,6 @@ public final class ReflectionUtils {
 		BOTTOM_UP
 	}
 
-	// Pattern: "[Ljava.lang.String;", "[[[[Ljava.lang.String;", etc.
-	private static final Pattern VM_INTERNAL_OBJECT_ARRAY_PATTERN = Pattern.compile("^(\\[+)L(.+);$");
-
-	/**
-	 * Pattern: "[x", "[[[[x", etc., where x is Z, B, C, D, F, I, J, S, etc.
-	 *
-	 * <p>The pattern intentionally captures the last bracket with the
-	 * capital letter so that the combination can be looked up via
-	 * {@link #classNameToTypeMap}. For example, the last matched group
-	 * will contain {@code "[I"} instead of {@code "I"}.
-	 *
-	 * @see Class#getName()
-	 */
-	private static final Pattern VM_INTERNAL_PRIMITIVE_ARRAY_PATTERN = Pattern.compile("^(\\[+)(\\[[ZBCDFIJS])$");
-
 	// Pattern: "java.lang.String[]", "int[]", "int[][][][]", etc.
 	// ?> => non-capturing atomic group
 	// ++ => possessive quantifier
@@ -856,32 +841,8 @@ public final class ReflectionUtils {
 		}
 
 		return Try.call(() -> {
-			Matcher matcher;
-
-			// Primitive arrays such as "[I", "[[[[D", etc.
-			matcher = VM_INTERNAL_PRIMITIVE_ARRAY_PATTERN.matcher(trimmedName);
-			if (matcher.matches()) {
-				String brackets = matcher.group(1);
-				String componentTypeName = matcher.group(2);
-				// Calculate dimensions by counting brackets.
-				int dimensions = brackets.length();
-
-				return loadArrayType(classLoader, componentTypeName, dimensions);
-			}
-
-			// Object arrays such as "[Ljava.lang.String;", "[[[[Ljava.lang.String;", etc.
-			matcher = VM_INTERNAL_OBJECT_ARRAY_PATTERN.matcher(trimmedName);
-			if (matcher.matches()) {
-				String brackets = matcher.group(1);
-				String componentTypeName = matcher.group(2);
-				// Calculate dimensions by counting brackets.
-				int dimensions = brackets.length();
-
-				return loadArrayType(classLoader, componentTypeName, dimensions);
-			}
-
 			// Arrays such as "java.lang.String[]", "int[]", "int[][][][]", etc.
-			matcher = SOURCE_CODE_SYNTAX_ARRAY_PATTERN.matcher(trimmedName);
+			Matcher matcher = SOURCE_CODE_SYNTAX_ARRAY_PATTERN.matcher(trimmedName);
 			if (matcher.matches()) {
 				String componentTypeName = matcher.group(1);
 				String bracketPairs = matcher.group(2);


### PR DESCRIPTION
## Overview

`Class.forName()` from `java.base/java.lang` has built-in support for array type names matching:

- _Primitive arrays such as "[I", "[[[[D", etc._ and
- _Object arrays such as "[Ljava.lang.String;", etc._

This pull request deletes the redundant implementation from JUnit's internal `ReflectionUtils` helper.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
