### PR TITLE
Pass enclosing instance types to DisplayNameGenerators

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -86,7 +86,7 @@ JUnit repository on GitHub.
 * Provide _runtime_ enclosing types of `@Nested` test classes and contained test methods
   to `DisplayNameGenerator` implementations. Prior to this change, such generators were
   only able to access the enclosing class in which `@Nested` was declared, but they could
-  not access the concrete type of the enclosing instance.
+  not access the concrete runtime type of the enclosing instance.
 
 [[release-notes-5.12.0-M1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-M1.adoc
@@ -83,7 +83,10 @@ JUnit repository on GitHub.
 [[release-notes-5.12.0-M1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Provide _runtime_ enclosing types of `@Nested` test classes and contained test methods
+  to `DisplayNameGenerator` implementations. Prior to this change, such generators were
+  only able to access the enclosing class in which `@Nested` was declared, but they could
+  not access the concrete type of the enclosing instance.
 
 [[release-notes-5.12.0-M1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -117,8 +117,8 @@ public interface DisplayNameGenerator {
 	 * class is inherited from a superclass.
 	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
-	 * instances of {@code clazz}, ordered from outermost to innermost,
-	 * excluding {@code class}; never {@code null}
+	 * instances for the test class, ordered from outermost to innermost,
+	 * excluding {@code nestedClass}; never {@code null}
 	 * @param nestedClass the class to generate a name for; never {@code null}
 	 * @return the display name for the nested class; never blank
 	 * @since 5.12
@@ -165,8 +165,8 @@ public interface DisplayNameGenerator {
 	 * method is inherited from a superclass.
 	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
-	 * instances of {@code clazz}, ordered from outermost to innermost,
-	 * excluding {@code class}; never {@code null}
+	 * instances for the test class, ordered from outermost to innermost,
+	 * excluding {@code testClass}; never {@code null}
 	 * @param testClass the class the test method is invoked on; never {@code null}
 	 * @param testMethod method to generate a display name for; never {@code null}
 	 * @return the display name for the test; never blank

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -150,7 +150,10 @@ public interface DisplayNameGenerator {
 	 *
 	 * <p>If it returns {@code null}, the default display name generator will be used instead.
 	 *
-	 * @implNote The class instance supplied as {@code testClass} may differ from
+	 * @implNote The classes supplied as {@code enclosingInstanceTypes} may differ
+	 * from the classes returned from invocations of {@link Class#getEnclosingClass()}
+	 * &mdash; for example, when a nested test class is inherited from a superclass.
+	 * Similarly, the class instance supplied as {@code testClass} may differ from
 	 * the class returned by {@code testMethod.getDeclaringClass()} &mdash; for
 	 * example, when a test method is inherited from a superclass.
 	 *

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -118,7 +118,8 @@ public interface DisplayNameGenerator {
 	 * class is inherited from a superclass.
 	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
-	 * instances; never {@code null}
+	 * instances of {@code clazz}, ordered from outermost to innermost,
+	 * excluding {@code class}; never {@code null}
 	 * @param nestedClass the class to generate a name for; never {@code null}
 	 * @return the display name for the nested class; never blank
 	 * @since 5.12
@@ -165,7 +166,8 @@ public interface DisplayNameGenerator {
 	 * method is inherited from a superclass.
 	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
-	 * instances; never {@code null}
+	 * instances of {@code clazz}, ordered from outermost to innermost,
+	 * excluding {@code class}; never {@code null}
 	 * @param testClass the class the test method is invoked on; never {@code null}
 	 * @param testMethod method to generate a display name for; never {@code null}
 	 * @return the display name for the test; never blank

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -97,10 +97,9 @@ public interface DisplayNameGenerator {
 	 * @return the display name for the nested class; never blank
 	 * @deprecated in favor of {@link #generateDisplayNameForNestedClass(List, Class)}
 	 */
-	@SuppressWarnings("DeprecatedIsStillUsed")
 	@API(status = DEPRECATED, since = "5.12")
 	@Deprecated
-	default String generateDisplayNameForNestedClass(@SuppressWarnings("unused") Class<?> nestedClass) {
+	default String generateDisplayNameForNestedClass(Class<?> nestedClass) {
 		throw new UnsupportedOperationException(
 			"Implement generateDisplayNameForNestedClass(List<Class<?>>, Class<?>) instead");
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -112,6 +112,11 @@ public interface DisplayNameGenerator {
 	 * <p>If this method returns {@code null}, the default display name
 	 * generator will be used instead.
 	 *
+	 * @implNote The classes supplied as {@code enclosingInstanceTypes} may
+	 * differ from the classes returned from invocations of
+	 * {@link Class#getEnclosingClass()} &mdash; for example, when a nested test
+	 * class is inherited from a superclass.
+	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
 	 * instances; never {@code null}
 	 * @param nestedClass the class to generate a name for; never {@code null}
@@ -151,12 +156,13 @@ public interface DisplayNameGenerator {
 	 * <p>If this method returns {@code null}, the default display name
 	 * generator will be used instead.
 	 *
-	 * @implNote The classes supplied as {@code enclosingInstanceTypes} may differ
-	 * from the classes returned from invocations of {@link Class#getEnclosingClass()}
-	 * &mdash; for example, when a nested test class is inherited from a superclass.
-	 * Similarly, the class instance supplied as {@code testClass} may differ from
-	 * the class returned by {@code testMethod.getDeclaringClass()} &mdash; for
-	 * example, when a test method is inherited from a superclass.
+	 * @implNote The classes supplied as {@code enclosingInstanceTypes} may
+	 * differ from the classes returned from invocations of
+	 * {@link Class#getEnclosingClass()} &mdash; for example, when a nested test
+	 * class is inherited from a superclass. Similarly, the class instance
+	 * supplied as {@code testClass} may differ from the class returned by
+	 * {@code testMethod.getDeclaringClass()} &mdash; for example, when a test
+	 * method is inherited from a superclass.
 	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
 	 * instances; never {@code null}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -10,11 +10,14 @@
 
 package org.junit.jupiter.api;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.support.ModifierSupport.isStatic;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -82,14 +85,41 @@ public interface DisplayNameGenerator {
 	String generateDisplayNameForClass(Class<?> testClass);
 
 	/**
-	 * Generate a display name for the given {@link Nested @Nested} inner test class.
+	 * Generate a display name for the given {@link Nested @Nested} inner test
+	 * class.
 	 *
-	 * <p>If it returns {@code null}, the default display name generator will be used instead.
+	 * <p>If it returns {@code null}, the default display name generator will be
+	 * used instead.
 	 *
 	 * @param nestedClass the class to generate a name for; never {@code null}
 	 * @return the display name for the nested class; never blank
+	 * @deprecated in favor of {@link #generateDisplayNameForNestedClass(List, Class)}
 	 */
-	String generateDisplayNameForNestedClass(Class<?> nestedClass);
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@API(status = DEPRECATED, since = "5.12")
+	@Deprecated
+	default String generateDisplayNameForNestedClass(@SuppressWarnings("unused") Class<?> nestedClass) {
+		throw new UnsupportedOperationException(
+			"Implement generateDisplayNameForNestedClass(List<Class<?>>, Class<?>) instead");
+	}
+
+	/**
+	 * Generate a display name for the given {@link Nested @Nested} inner test
+	 * class.
+	 *
+	 * <p>If it returns {@code null}, the default display name generator will be
+	 * used instead.
+	 *
+	 * @param enclosingInstanceTypes the runtime types of the enclosing
+	 * instances; never {@code null}
+	 * @param nestedClass the class to generate a name for; never {@code null}
+	 * @return the display name for the nested class; never blank
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	default String generateDisplayNameForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
+		return generateDisplayNameForNestedClass(nestedClass);
+	}
 
 	/**
 	 * Generate a display name for the given method.
@@ -103,8 +133,38 @@ public interface DisplayNameGenerator {
 	 * @param testClass the class the test method is invoked on; never {@code null}
 	 * @param testMethod method to generate a display name for; never {@code null}
 	 * @return the display name for the test; never blank
+	 * @deprecated in favor of {@link #generateDisplayNameForMethod(List, Class, Method)}
 	 */
-	String generateDisplayNameForMethod(Class<?> testClass, Method testMethod);
+	@SuppressWarnings("DeprecatedIsStillUsed")
+	@API(status = DEPRECATED, since = "5.12")
+	@Deprecated
+	default String generateDisplayNameForMethod(@SuppressWarnings("unused") Class<?> testClass,
+			@SuppressWarnings("unused") Method testMethod) {
+		throw new UnsupportedOperationException(
+			"Implement generateDisplayNameForMethod(List<Class<?>>, Class<?>, Method) instead");
+	}
+
+	/**
+	 * Generate a display name for the given method.
+	 *
+	 * <p>If it returns {@code null}, the default display name generator will be used instead.
+	 *
+	 * @implNote The class instance supplied as {@code testClass} may differ from
+	 * the class returned by {@code testMethod.getDeclaringClass()} &mdash; for
+	 * example, when a test method is inherited from a superclass.
+	 *
+	 * @param enclosingInstanceTypes the runtime types of the enclosing
+	 * instances; never {@code null}
+	 * @param testClass the class the test method is invoked on; never {@code null}
+	 * @param testMethod method to generate a display name for; never {@code null}
+	 * @return the display name for the test; never blank
+	 * @since 5.12
+	 */
+	@API(status = EXPERIMENTAL, since = "5.12")
+	default String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			Method testMethod) {
+		return generateDisplayNameForMethod(testClass, testMethod);
+	}
 
 	/**
 	 * Generate a string representation of the formal parameters of the supplied
@@ -142,12 +202,13 @@ public interface DisplayNameGenerator {
 		}
 
 		@Override
-		public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+		public String generateDisplayNameForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
 			return nestedClass.getSimpleName();
 		}
 
 		@Override
-		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+		public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+				Method testMethod) {
 			return testMethod.getName() + parameterTypesAsString(testMethod);
 		}
 	}
@@ -168,7 +229,8 @@ public interface DisplayNameGenerator {
 		}
 
 		@Override
-		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+		public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+				Method testMethod) {
 			String displayName = testMethod.getName();
 			if (hasParameters(testMethod)) {
 				displayName += ' ' + parameterTypesAsString(testMethod);
@@ -202,13 +264,15 @@ public interface DisplayNameGenerator {
 		}
 
 		@Override
-		public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
-			return replaceUnderscores(super.generateDisplayNameForNestedClass(nestedClass));
+		public String generateDisplayNameForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
+			return replaceUnderscores(super.generateDisplayNameForNestedClass(enclosingInstanceTypes, nestedClass));
 		}
 
 		@Override
-		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
-			return replaceUnderscores(super.generateDisplayNameForMethod(testClass, testMethod));
+		public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+				Method testMethod) {
+			return replaceUnderscores(
+				super.generateDisplayNameForMethod(enclosingInstanceTypes, testClass, testMethod));
 		}
 
 		private static String replaceUnderscores(String name) {
@@ -243,17 +307,21 @@ public interface DisplayNameGenerator {
 		}
 
 		@Override
-		public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
-			return getSentenceBeginning(nestedClass);
+		public String generateDisplayNameForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
+			return getSentenceBeginning(enclosingInstanceTypes, nestedClass);
 		}
 
 		@Override
-		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
-			return getSentenceBeginning(testClass) + getFragmentSeparator(testClass)
-					+ getGeneratorFor(testClass).generateDisplayNameForMethod(testClass, testMethod);
+		public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+				Method testMethod) {
+			// TODO Pass enclosingInstanceTypes to getSentenceBeginning()
+			return getSentenceBeginning(enclosingInstanceTypes, testClass) + getFragmentSeparator(testClass)
+					+ getGeneratorFor(testClass).generateDisplayNameForMethod(enclosingInstanceTypes, testClass,
+						testMethod);
 		}
 
-		private String getSentenceBeginning(Class<?> testClass) {
+		private String getSentenceBeginning(List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
+			// TODO Use last element of enclosingInstanceTypes and remove it for later calls
 			Class<?> enclosingClass = testClass.getEnclosingClass();
 			boolean topLevelTestClass = (enclosingClass == null || isStatic(testClass));
 			Optional<String> displayName = findAnnotation(testClass, DisplayName.class)//
@@ -280,10 +348,12 @@ public interface DisplayNameGenerator {
 					.filter(IndicativeSentences.class::equals)//
 					.isPresent();
 
-			String prefix = (buildPrefix ? getSentenceBeginning(enclosingClass) + getFragmentSeparator(testClass) : "");
+			String prefix = (buildPrefix
+					? getSentenceBeginning(enclosingInstanceTypes, enclosingClass) + getFragmentSeparator(testClass)
+					: "");
 
 			return prefix + displayName.orElseGet(
-				() -> getGeneratorFor(testClass).generateDisplayNameForNestedClass(testClass));
+				() -> getGeneratorFor(testClass).generateDisplayNameForNestedClass(enclosingInstanceTypes, testClass));
 		}
 
 		/**
@@ -349,6 +419,7 @@ public interface DisplayNameGenerator {
 				SearchOption.INCLUDE_ENCLOSING_CLASSES);
 		}
 
+		@SuppressWarnings("SameParameterValue")
 		private static Predicate<Class<?>> not(Class<?> clazz) {
 			return ((Predicate<Class<?>>) clazz::equals).negate();
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -136,11 +136,9 @@ public interface DisplayNameGenerator {
 	 * @return the display name for the test; never blank
 	 * @deprecated in favor of {@link #generateDisplayNameForMethod(List, Class, Method)}
 	 */
-	@SuppressWarnings("DeprecatedIsStillUsed")
 	@API(status = DEPRECATED, since = "5.12")
 	@Deprecated
-	default String generateDisplayNameForMethod(@SuppressWarnings("unused") Class<?> testClass,
-			@SuppressWarnings("unused") Method testMethod) {
+	default String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
 		throw new UnsupportedOperationException(
 			"Implement generateDisplayNameForMethod(List<Class<?>>, Class<?>, Method) instead");
 	}
@@ -426,7 +424,6 @@ public interface DisplayNameGenerator {
 				SearchOption.INCLUDE_ENCLOSING_CLASSES);
 		}
 
-		@SuppressWarnings("SameParameterValue")
 		private static Predicate<Class<?>> not(Class<?> clazz) {
 			return ((Predicate<Class<?>>) clazz::equals).negate();
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -78,7 +78,8 @@ public interface DisplayNameGenerator {
 	/**
 	 * Generate a display name for the given top-level or {@code static} nested test class.
 	 *
-	 * <p>If it returns {@code null}, the default display name generator will be used instead.
+	 * <p>If this method returns {@code null}, the default display name
+	 * generator will be used instead.
 	 *
 	 * @param testClass the class to generate a name for; never {@code null}
 	 * @return the display name for the class; never blank
@@ -89,8 +90,8 @@ public interface DisplayNameGenerator {
 	 * Generate a display name for the given {@link Nested @Nested} inner test
 	 * class.
 	 *
-	 * <p>If it returns {@code null}, the default display name generator will be
-	 * used instead.
+	 * <p>If this method returns {@code null}, the default display name
+	 * generator will be used instead.
 	 *
 	 * @param nestedClass the class to generate a name for; never {@code null}
 	 * @return the display name for the nested class; never blank
@@ -108,8 +109,8 @@ public interface DisplayNameGenerator {
 	 * Generate a display name for the given {@link Nested @Nested} inner test
 	 * class.
 	 *
-	 * <p>If it returns {@code null}, the default display name generator will be
-	 * used instead.
+	 * <p>If this method returns {@code null}, the default display name
+	 * generator will be used instead.
 	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
 	 * instances; never {@code null}
@@ -125,7 +126,8 @@ public interface DisplayNameGenerator {
 	/**
 	 * Generate a display name for the given method.
 	 *
-	 * <p>If it returns {@code null}, the default display name generator will be used instead.
+	 * <p>If this method returns {@code null}, the default display name
+	 * generator will be used instead.
 	 *
 	 * @implNote The class instance supplied as {@code testClass} may differ from
 	 * the class returned by {@code testMethod.getDeclaringClass()} &mdash; for
@@ -146,7 +148,8 @@ public interface DisplayNameGenerator {
 	/**
 	 * Generate a display name for the given method.
 	 *
-	 * <p>If it returns {@code null}, the default display name generator will be used instead.
+	 * <p>If this method returns {@code null}, the default display name
+	 * generator will be used instead.
 	 *
 	 * @implNote The classes supplied as {@code enclosingInstanceTypes} may differ
 	 * from the classes returned from invocations of {@link Class#getEnclosingClass()}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import static java.util.Collections.emptyList;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 
 import java.lang.reflect.AnnotatedElement;
@@ -96,20 +97,22 @@ final class DisplayNameUtils {
 	}
 
 	static Supplier<String> createDisplayNameSupplierForClass(Class<?> testClass, JupiterConfiguration configuration) {
+		// TODO Compute enclosing test classes
 		return createDisplayNameSupplier(testClass, configuration,
 			generator -> generator.generateDisplayNameForClass(testClass));
 	}
 
 	static Supplier<String> createDisplayNameSupplierForNestedClass(Class<?> testClass,
 			JupiterConfiguration configuration) {
+		// TODO Compute enclosing test classes
 		return createDisplayNameSupplier(testClass, configuration,
-			generator -> generator.generateDisplayNameForNestedClass(testClass));
+			generator -> generator.generateDisplayNameForNestedClass(emptyList(), testClass));
 	}
 
 	private static Supplier<String> createDisplayNameSupplierForMethod(Class<?> testClass, Method testMethod,
 			JupiterConfiguration configuration) {
 		return createDisplayNameSupplier(testClass, configuration,
-			generator -> generator.generateDisplayNameForMethod(testClass, testMethod));
+			generator -> generator.generateDisplayNameForMethod(emptyList(), testClass, testMethod));
 	}
 
 	private static Supplier<String> createDisplayNameSupplier(Class<?> testClass, JupiterConfiguration configuration,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -10,11 +10,11 @@
 
 package org.junit.jupiter.engine.descriptor;
 
-import static java.util.Collections.emptyList;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -90,29 +90,27 @@ final class DisplayNameUtils {
 		return displayNameSupplier.get();
 	}
 
-	static String determineDisplayNameForMethod(Class<?> testClass, Method testMethod,
-			JupiterConfiguration configuration) {
+	static String determineDisplayNameForMethod(Supplier<List<Class<?>>> enclosingInstanceTypes, Class<?> testClass,
+			Method testMethod, JupiterConfiguration configuration) {
 		return determineDisplayName(testMethod,
-			createDisplayNameSupplierForMethod(testClass, testMethod, configuration));
+			createDisplayNameSupplierForMethod(enclosingInstanceTypes, testClass, testMethod, configuration));
 	}
 
 	static Supplier<String> createDisplayNameSupplierForClass(Class<?> testClass, JupiterConfiguration configuration) {
-		// TODO Compute enclosing test classes
 		return createDisplayNameSupplier(testClass, configuration,
 			generator -> generator.generateDisplayNameForClass(testClass));
 	}
 
-	static Supplier<String> createDisplayNameSupplierForNestedClass(Class<?> testClass,
-			JupiterConfiguration configuration) {
-		// TODO Compute enclosing test classes
+	static Supplier<String> createDisplayNameSupplierForNestedClass(Supplier<List<Class<?>>> enclosingInstanceTypes,
+			Class<?> testClass, JupiterConfiguration configuration) {
 		return createDisplayNameSupplier(testClass, configuration,
-			generator -> generator.generateDisplayNameForNestedClass(emptyList(), testClass));
+			generator -> generator.generateDisplayNameForNestedClass(enclosingInstanceTypes.get(), testClass));
 	}
 
-	private static Supplier<String> createDisplayNameSupplierForMethod(Class<?> testClass, Method testMethod,
-			JupiterConfiguration configuration) {
+	private static Supplier<String> createDisplayNameSupplierForMethod(Supplier<List<Class<?>>> enclosingInstanceTypes,
+			Class<?> testClass, Method testMethod, JupiterConfiguration configuration) {
 		return createDisplayNameSupplier(testClass, configuration,
-			generator -> generator.generateDisplayNameForMethod(emptyList(), testClass, testMethod));
+			generator -> generator.generateDisplayNameForMethod(enclosingInstanceTypes.get(), testClass, testMethod));
 	}
 
 	private static Supplier<String> createDisplayNameSupplier(Class<?> testClass, JupiterConfiguration configuration,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -59,9 +60,9 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor im
 	private final Set<TestTag> tags;
 
 	MethodBasedTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod,
-			JupiterConfiguration configuration) {
-		this(uniqueId, determineDisplayNameForMethod(testClass, testMethod, configuration), testClass, testMethod,
-			configuration);
+			Supplier<List<Class<?>>> enclosingInstanceTypes, JupiterConfiguration configuration) {
+		this(uniqueId, determineDisplayNameForMethod(enclosingInstanceTypes, testClass, testMethod, configuration),
+			testClass, testMethod, configuration);
 	}
 
 	MethodBasedTestDescriptor(UniqueId uniqueId, String displayName, Class<?> testClass, Method testMethod,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.TestInstances;
@@ -46,8 +47,10 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	public static final String SEGMENT_TYPE = "nested-class";
 
-	public NestedClassTestDescriptor(UniqueId uniqueId, Class<?> testClass, JupiterConfiguration configuration) {
-		super(uniqueId, testClass, createDisplayNameSupplierForNestedClass(testClass, configuration), configuration);
+	public NestedClassTestDescriptor(UniqueId uniqueId, Class<?> testClass,
+			Supplier<List<Class<?>>> enclosingInstanceTypes, JupiterConfiguration configuration) {
+		super(uniqueId, testClass,
+			createDisplayNameSupplierForNestedClass(enclosingInstanceTypes, testClass, configuration), configuration);
 	}
 
 	// --- TestDescriptor ------------------------------------------------------
@@ -62,7 +65,11 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	@Override
 	public List<Class<?>> getEnclosingTestClasses() {
-		TestDescriptor parent = getParent().orElse(null);
+		return getEnclosingTestClasses(getParent().orElse(null));
+	}
+
+	@API(status = INTERNAL, since = "5.12")
+	public static List<Class<?>> getEnclosingTestClasses(TestDescriptor parent) {
 		if (parent instanceof ClassBasedTestDescriptor) {
 			ClassBasedTestDescriptor parentClassDescriptor = (ClassBasedTestDescriptor) parent;
 			List<Class<?>> result = new ArrayList<>(parentClassDescriptor.getEnclosingTestClasses());

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -18,6 +18,7 @@ import static org.junit.platform.engine.support.descriptor.ClasspathResourceSour
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -63,8 +64,8 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 	private final DynamicDescendantFilter dynamicDescendantFilter = new DynamicDescendantFilter();
 
 	public TestFactoryTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod,
-			JupiterConfiguration configuration) {
-		super(uniqueId, testClass, testMethod, configuration);
+			Supplier<List<Class<?>>> enclosingInstanceTypes, JupiterConfiguration configuration) {
+		super(uniqueId, testClass, testMethod, enclosingInstanceTypes, configuration);
 	}
 
 	// --- Filterable ----------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -17,6 +17,8 @@ import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.
 import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
 
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -75,8 +77,8 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 	private final ReflectiveInterceptorCall<Method, Void> interceptorCall;
 
 	public TestMethodTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method testMethod,
-			JupiterConfiguration configuration) {
-		super(uniqueId, testClass, testMethod, configuration);
+			Supplier<List<Class<?>>> enclosingInstanceTypes, JupiterConfiguration configuration) {
+		super(uniqueId, testClass, testMethod, enclosingInstanceTypes, configuration);
 		this.interceptorCall = defaultInterceptorCall;
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
@@ -46,8 +47,8 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 	private final DynamicDescendantFilter dynamicDescendantFilter = new DynamicDescendantFilter();
 
 	public TestTemplateTestDescriptor(UniqueId uniqueId, Class<?> testClass, Method templateMethod,
-			JupiterConfiguration configuration) {
-		super(uniqueId, testClass, templateMethod, configuration);
+			Supplier<List<Class<?>>> enclosingInstanceTypes, JupiterConfiguration configuration) {
+		super(uniqueId, testClass, templateMethod, enclosingInstanceTypes, configuration);
 	}
 
 	// --- Filterable ----------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.discovery;
 
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toCollection;
+import static org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor.getEnclosingTestClasses;
 import static org.junit.jupiter.engine.discovery.predicates.IsTestClassWithTests.isTestOrTestFactoryOrTestTemplateMethod;
 import static org.junit.platform.commons.support.HierarchyTraversalMode.TOP_DOWN;
 import static org.junit.platform.commons.support.ReflectionSupport.findMethods;
@@ -122,9 +123,9 @@ class ClassSelectorResolver implements SelectorResolver {
 	}
 
 	private NestedClassTestDescriptor newNestedClassTestDescriptor(TestDescriptor parent, Class<?> testClass) {
-		return new NestedClassTestDescriptor(
-			parent.getUniqueId().append(NestedClassTestDescriptor.SEGMENT_TYPE, testClass.getSimpleName()), testClass,
-			configuration);
+		UniqueId uniqueId = parent.getUniqueId().append(NestedClassTestDescriptor.SEGMENT_TYPE,
+			testClass.getSimpleName());
+		return new NestedClassTestDescriptor(uniqueId, testClass, () -> getEnclosingTestClasses(parent), configuration);
 	}
 
 	private Resolution toResolution(Optional<? extends ClassBasedTestDescriptor> testDescriptor) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -198,6 +198,23 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 		);
 	}
 
+	@Test
+	void indicativeSentencesRuntimeEnclosingType() {
+		check(IndicativeSentencesRuntimeEnclosingTypeScenarioOneTestCase.class, //
+			"CONTAINER: Scenario 1", //
+			"CONTAINER: Scenario 1 -> Level 1", //
+			"CONTAINER: Scenario 1 -> Level 1 -> Level 2", //
+			"TEST: Scenario 1 -> Level 1 -> Level 2 -> this is a test"//
+		);
+
+		check(IndicativeSentencesRuntimeEnclosingTypeScenarioTwoTestCase.class, //
+			"CONTAINER: Scenario 2", //
+			"CONTAINER: Scenario 2 -> Level 1", //
+			"CONTAINER: Scenario 2 -> Level 1 -> Level 2", //
+			"TEST: Scenario 2 -> Level 1 -> Level 2 -> this is a test"//
+		);
+	}
+
 	private void check(Class<?> testClass, String... expectedDisplayNames) {
 		var request = request().selectors(selectClass(testClass)).build();
 		var descriptors = discoverTests(request).getDescendants();

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -20,6 +20,7 @@ import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.r
 
 import java.lang.reflect.Method;
 import java.util.EmptyStackException;
+import java.util.List;
 import java.util.Stack;
 
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
@@ -217,12 +218,13 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Override
-		public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+		public String generateDisplayNameForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
 			return "nn";
 		}
 
 		@Override
-		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+		public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+				Method testMethod) {
 			return "nn";
 		}
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeScenarioOneTestCase.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeScenarioOneTestCase.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+@DisplayName("Scenario 1")
+class IndicativeSentencesRuntimeEnclosingTypeScenarioOneTestCase
+		extends IndicativeSentencesRuntimeEnclosingTypeTestCase {
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeScenarioOneTestCase.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeScenarioOneTestCase.java
@@ -10,6 +10,9 @@
 
 package org.junit.jupiter.api;
 
+/**
+ * @since 5.12
+ */
 @DisplayName("Scenario 1")
 class IndicativeSentencesRuntimeEnclosingTypeScenarioOneTestCase
 		extends IndicativeSentencesRuntimeEnclosingTypeTestCase {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeScenarioTwoTestCase.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeScenarioTwoTestCase.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+@DisplayName("Scenario 2")
+class IndicativeSentencesRuntimeEnclosingTypeScenarioTwoTestCase
+		extends IndicativeSentencesRuntimeEnclosingTypeTestCase {
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeScenarioTwoTestCase.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeScenarioTwoTestCase.java
@@ -10,6 +10,9 @@
 
 package org.junit.jupiter.api;
 
+/**
+ * @since 5.12
+ */
 @DisplayName("Scenario 2")
 class IndicativeSentencesRuntimeEnclosingTypeScenarioTwoTestCase
 		extends IndicativeSentencesRuntimeEnclosingTypeTestCase {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeTestCase.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeTestCase.java
@@ -13,7 +13,7 @@ package org.junit.jupiter.api;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 
 /**
- * @since 5.8
+ * @since 5.12
  */
 @DisplayName("Base Scenario")
 @IndicativeSentencesGeneration(separator = " -> ", generator = ReplaceUnderscores.class)

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeTestCase.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/IndicativeSentencesRuntimeEnclosingTypeTestCase.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.api;
+
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+/**
+ * @since 5.8
+ */
+@DisplayName("Base Scenario")
+@IndicativeSentencesGeneration(separator = " -> ", generator = ReplaceUnderscores.class)
+abstract class IndicativeSentencesRuntimeEnclosingTypeTestCase {
+
+	@Nested
+	class Level_1 {
+
+		@Nested
+		class Level_2 {
+
+			@Test
+			void this_is_a_test() {
+			}
+		}
+	}
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/parallel/ResourceLockAnnotationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/parallel/ResourceLockAnnotationTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -255,7 +256,7 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 
 	private Set<ExclusiveResource> getMethodResources(Class<?> testClass) {
 		var descriptor = new TestMethodTestDescriptor( //
-			uniqueId, testClass, getDeclaredTestMethod(testClass), configuration //
+			uniqueId, testClass, getDeclaredTestMethod(testClass), List::of, configuration //
 		);
 		descriptor.setParent(getClassTestDescriptor(testClass));
 		return descriptor.getExclusiveResources();
@@ -271,7 +272,7 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	private Set<ExclusiveResource> getNestedClassResources(Class<?> testClass) {
-		var descriptor = new NestedClassTestDescriptor(uniqueId, testClass, configuration);
+		var descriptor = new NestedClassTestDescriptor(uniqueId, testClass, List::of, configuration);
 		descriptor.setParent(getClassTestDescriptor(testClass.getEnclosingClass()));
 		return descriptor.getExclusiveResources();
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/CustomDisplayNameGenerator.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/CustomDisplayNameGenerator.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.descriptor;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayNameGenerator;
 
@@ -22,12 +23,13 @@ public class CustomDisplayNameGenerator implements DisplayNameGenerator {
 	}
 
 	@Override
-	public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+	public String generateDisplayNameForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
 		return "nested-class-display-name";
 	}
 
 	@Override
-	public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+	public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+			Method testMethod) {
 		return "method-display-name";
 	}
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/DisplayNameUtilsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/DisplayNameUtilsTests.java
@@ -71,7 +71,7 @@ class DisplayNameUtilsTests {
 		@Nested
 		class ClassDisplayNameSupplierTests {
 
-			private JupiterConfiguration configuration = mock();
+			private final JupiterConfiguration configuration = mock();
 
 			@Test
 			void shouldGetDisplayNameFromDisplayNameGenerationAnnotation() {
@@ -116,12 +116,12 @@ class DisplayNameUtilsTests {
 	@Nested
 	class NestedClassDisplayNameTests {
 
-		private JupiterConfiguration configuration = mock();
+		private final JupiterConfiguration configuration = mock();
 
 		@Test
 		void shouldGetDisplayNameFromDisplayNameGenerationAnnotation() {
 			when(configuration.getDefaultDisplayNameGenerator()).thenReturn(new CustomDisplayNameGenerator());
-			Supplier<String> displayName = DisplayNameUtils.createDisplayNameSupplierForNestedClass(
+			Supplier<String> displayName = DisplayNameUtils.createDisplayNameSupplierForNestedClass(List::of,
 				StandardDisplayNameTestCase.class, configuration);
 
 			assertThat(displayName.get()).isEqualTo(StandardDisplayNameTestCase.class.getSimpleName());
@@ -130,7 +130,7 @@ class DisplayNameUtilsTests {
 		@Test
 		void shouldGetDisplayNameFromDefaultDisplayNameGenerator() {
 			when(configuration.getDefaultDisplayNameGenerator()).thenReturn(new CustomDisplayNameGenerator());
-			Supplier<String> displayName = DisplayNameUtils.createDisplayNameSupplierForNestedClass(
+			Supplier<String> displayName = DisplayNameUtils.createDisplayNameSupplierForNestedClass(List::of,
 				NestedTestCase.class, configuration);
 
 			assertThat(displayName.get()).isEqualTo("nested-class-display-name");
@@ -139,7 +139,7 @@ class DisplayNameUtilsTests {
 		@Test
 		void shouldFallbackOnDefaultDisplayNameGeneratorWhenNullIsGenerated() {
 			when(configuration.getDefaultDisplayNameGenerator()).thenReturn(new CustomDisplayNameGenerator());
-			Supplier<String> displayName = DisplayNameUtils.createDisplayNameSupplierForNestedClass(
+			Supplier<String> displayName = DisplayNameUtils.createDisplayNameSupplierForNestedClass(List::of,
 				NullDisplayNameTestCase.NestedTestCase.class, configuration);
 
 			assertThat(displayName.get()).isEqualTo("nested-class-display-name");
@@ -149,14 +149,14 @@ class DisplayNameUtilsTests {
 	@Nested
 	class MethodDisplayNameTests {
 
-		private JupiterConfiguration configuration = mock();
+		private final JupiterConfiguration configuration = mock();
 
 		@Test
 		void shouldGetDisplayNameFromDisplayNameGenerationAnnotation() throws Exception {
 			when(configuration.getDefaultDisplayNameGenerator()).thenReturn(new CustomDisplayNameGenerator());
 			Method method = MyTestCase.class.getDeclaredMethod("test1");
-			String displayName = DisplayNameUtils.determineDisplayNameForMethod(StandardDisplayNameTestCase.class,
-				method, configuration);
+			String displayName = DisplayNameUtils.determineDisplayNameForMethod(List::of,
+				StandardDisplayNameTestCase.class, method, configuration);
 
 			assertThat(displayName).isEqualTo("test1()");
 		}
@@ -166,8 +166,8 @@ class DisplayNameUtilsTests {
 			Method method = MyTestCase.class.getDeclaredMethod("test1");
 			when(configuration.getDefaultDisplayNameGenerator()).thenReturn(new CustomDisplayNameGenerator());
 
-			String displayName = DisplayNameUtils.determineDisplayNameForMethod(NotDisplayNameTestCase.class, method,
-				configuration);
+			String displayName = DisplayNameUtils.determineDisplayNameForMethod(List::of, NotDisplayNameTestCase.class,
+				method, configuration);
 
 			assertThat(displayName).isEqualTo("method-display-name");
 		}
@@ -177,8 +177,8 @@ class DisplayNameUtilsTests {
 			Method method = NullDisplayNameTestCase.class.getDeclaredMethod("test");
 			when(configuration.getDefaultDisplayNameGenerator()).thenReturn(new CustomDisplayNameGenerator());
 
-			String displayName = DisplayNameUtils.determineDisplayNameForMethod(NullDisplayNameTestCase.class, method,
-				configuration);
+			String displayName = DisplayNameUtils.determineDisplayNameForMethod(List::of, NullDisplayNameTestCase.class,
+				method, configuration);
 
 			assertThat(displayName).isEqualTo("method-display-name");
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/DisplayNameUtilsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/DisplayNameUtilsTests.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -238,12 +239,13 @@ class DisplayNameUtilsTests {
 		}
 
 		@Override
-		public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+		public String generateDisplayNameForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
 			return null;
 		}
 
 		@Override
-		public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+		public String generateDisplayNameForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+				Method testMethod) {
 			return null;
 		}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
@@ -418,7 +418,7 @@ public class ExtensionContextTests {
 			named("method", (JupiterConfiguration configuration) -> {
 				var method = ReflectionSupport.findMethod(testClass, "extensionContextFactories").orElseThrow();
 				var methodUniqueId = UniqueId.parse("[engine:junit-jupiter]/[class:MyClass]/[method:myMethod]");
-				var methodTestDescriptor = new TestMethodTestDescriptor(methodUniqueId, testClass, method,
+				var methodTestDescriptor = new TestMethodTestDescriptor(methodUniqueId, testClass, method, List::of,
 					configuration);
 				return new MethodExtensionContext(null, null, methodTestDescriptor, configuration, extensionRegistry,
 					null);
@@ -428,7 +428,7 @@ public class ExtensionContextTests {
 
 	private NestedClassTestDescriptor nestedClassDescriptor() {
 		return new NestedClassTestDescriptor(UniqueId.root("nested-class", "NestedClass"), OuterClass.NestedClass.class,
-			configuration);
+			List::of, configuration);
 	}
 
 	private ClassTestDescriptor outerClassDescriptor(TestDescriptor child) {
@@ -443,7 +443,7 @@ public class ExtensionContextTests {
 	private TestMethodTestDescriptor methodDescriptor() {
 		try {
 			return new TestMethodTestDescriptor(UniqueId.root("method", "aMethod"), OuterClass.class,
-				OuterClass.class.getDeclaredMethod("aMethod"), configuration);
+				OuterClass.class.getDeclaredMethod("aMethod"), List::of, configuration);
 		}
 		catch (NoSuchMethodException e) {
 			throw new RuntimeException(e);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
@@ -113,7 +113,7 @@ class JupiterTestDescriptorTests {
 	void constructFromMethod() throws Exception {
 		Class<?> testClass = TestCase.class;
 		Method testMethod = testClass.getDeclaredMethod("test");
-		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, testClass, testMethod,
+		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, testClass, testMethod, List::of,
 			configuration);
 
 		assertEquals(uniqueId, descriptor.getUniqueId());
@@ -127,7 +127,7 @@ class JupiterTestDescriptorTests {
 		JupiterTestDescriptor classDescriptor = new ClassTestDescriptor(uniqueId, TestCase.class, configuration);
 		Method testMethod = TestCase.class.getDeclaredMethod("foo");
 		TestMethodTestDescriptor methodDescriptor = new TestMethodTestDescriptor(uniqueId, TestCase.class, testMethod,
-			configuration);
+			List::of, configuration);
 		classDescriptor.addChild(methodDescriptor);
 
 		assertEquals(testMethod, methodDescriptor.getTestMethod());
@@ -143,7 +143,7 @@ class JupiterTestDescriptorTests {
 	void constructFromMethodWithCustomTestAnnotation() throws Exception {
 		Method testMethod = TestCase.class.getDeclaredMethod("customTestAnnotation");
 		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, TestCase.class, testMethod,
-			configuration);
+			List::of, configuration);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("custom name", descriptor.getDisplayName(), "display name:");
@@ -155,7 +155,7 @@ class JupiterTestDescriptorTests {
 	void constructFromMethodWithParameters() throws Exception {
 		Method testMethod = TestCase.class.getDeclaredMethod("test", String.class, BigDecimal.class);
 		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, TestCase.class, testMethod,
-			configuration);
+			List::of, configuration);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("test(String, BigDecimal)", descriptor.getDisplayName(), "display name");
@@ -166,7 +166,7 @@ class JupiterTestDescriptorTests {
 	void constructFromMethodWithPrimitiveArrayParameter() throws Exception {
 		Method testMethod = TestCase.class.getDeclaredMethod("test", int[].class);
 		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, TestCase.class, testMethod,
-			configuration);
+			List::of, configuration);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("test(int[])", descriptor.getDisplayName(), "display name");
@@ -177,7 +177,7 @@ class JupiterTestDescriptorTests {
 	void constructFromMethodWithObjectArrayParameter() throws Exception {
 		Method testMethod = TestCase.class.getDeclaredMethod("test", String[].class);
 		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, TestCase.class, testMethod,
-			configuration);
+			List::of, configuration);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("test(String[])", descriptor.getDisplayName(), "display name");
@@ -188,7 +188,7 @@ class JupiterTestDescriptorTests {
 	void constructFromMethodWithMultidimensionalPrimitiveArrayParameter() throws Exception {
 		Method testMethod = TestCase.class.getDeclaredMethod("test", int[][][][][].class);
 		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, TestCase.class, testMethod,
-			configuration);
+			List::of, configuration);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("test(int[][][][][])", descriptor.getDisplayName(), "display name");
@@ -199,7 +199,7 @@ class JupiterTestDescriptorTests {
 	void constructFromMethodWithMultidimensionalObjectArrayParameter() throws Exception {
 		Method testMethod = TestCase.class.getDeclaredMethod("test", String[][][][][].class);
 		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, TestCase.class, testMethod,
-			configuration);
+			List::of, configuration);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 		assertEquals("test(String[][][][][])", descriptor.getDisplayName(), "display name");
@@ -210,7 +210,7 @@ class JupiterTestDescriptorTests {
 	void constructFromInheritedMethod() throws Exception {
 		Method testMethod = ConcreteTestCase.class.getMethod("theTest");
 		TestMethodTestDescriptor descriptor = new TestMethodTestDescriptor(uniqueId, ConcreteTestCase.class, testMethod,
-			configuration);
+			List::of, configuration);
 
 		assertEquals(testMethod, descriptor.getTestMethod());
 
@@ -230,7 +230,7 @@ class JupiterTestDescriptorTests {
 		assertEquals("class-display-name", descriptor.getDisplayName());
 		assertEquals(getClass().getName(), descriptor.getLegacyReportingName());
 
-		descriptor = new NestedClassTestDescriptor(uniqueId, NestedTestCase.class, configuration);
+		descriptor = new NestedClassTestDescriptor(uniqueId, NestedTestCase.class, List::of, configuration);
 		assertEquals("nested-class-display-name", descriptor.getDisplayName());
 		assertEquals(NestedTestCase.class.getName(), descriptor.getLegacyReportingName());
 
@@ -249,7 +249,7 @@ class JupiterTestDescriptorTests {
 		assertEquals(getClass().getSimpleName(), descriptor.getDisplayName());
 		assertEquals(getClass().getName(), descriptor.getLegacyReportingName());
 
-		descriptor = new NestedClassTestDescriptor(uniqueId, NestedTestCase.class, configuration);
+		descriptor = new NestedClassTestDescriptor(uniqueId, NestedTestCase.class, List::of, configuration);
 		assertEquals(NestedTestCase.class.getSimpleName(), descriptor.getDisplayName());
 		assertEquals(NestedTestCase.class.getName(), descriptor.getLegacyReportingName());
 
@@ -269,7 +269,7 @@ class JupiterTestDescriptorTests {
 		ClassBasedTestDescriptor parentDescriptor = new ClassTestDescriptor(uniqueId, StaticTestCase.class,
 			configuration);
 		ClassBasedTestDescriptor nestedDescriptor = new NestedClassTestDescriptor(uniqueId, NestedTestCase.class,
-			configuration);
+			List::of, configuration);
 		assertThat(parentDescriptor.getEnclosingTestClasses()).isEmpty();
 		assertThat(nestedDescriptor.getEnclosingTestClasses()).isEmpty();
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptorTests.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -147,7 +148,7 @@ class TestFactoryTestDescriptorTests {
 
 			Method testMethod = CustomStreamTestCase.class.getDeclaredMethod("customStream");
 			descriptor = new TestFactoryTestDescriptor(UniqueId.forEngine("engine"), CustomStreamTestCase.class,
-				testMethod, jupiterConfiguration);
+				testMethod, List::of, jupiterConfiguration);
 			when(extensionContext.getTestMethod()).thenReturn(Optional.of(testMethod));
 		}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptorTests.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class TestTemplateInvocationTestDescriptorTests {
 		JupiterConfiguration configuration = mock();
 		when(configuration.getDefaultDisplayNameGenerator()).thenReturn(new DisplayNameGenerator.Standard());
 		TestTemplateTestDescriptor parent = new TestTemplateTestDescriptor(UniqueId.root("segment", "template"),
-			testClass, testTemplateMethod, configuration);
+			testClass, testTemplateMethod, List::of, configuration);
 		TestTemplateInvocationContext invocationContext = mock();
 		when(invocationContext.getDisplayName(anyInt())).thenReturn("invocation");
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptorTests.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -45,7 +46,7 @@ class TestTemplateTestDescriptorTests {
 
 		TestTemplateTestDescriptor testDescriptor = new TestTemplateTestDescriptor(
 			parentUniqueId.append("tmp", "testTemplate()"), MyTestCase.class,
-			MyTestCase.class.getDeclaredMethod("testTemplate"), jupiterConfiguration);
+			MyTestCase.class.getDeclaredMethod("testTemplate"), List::of, jupiterConfiguration);
 		parent.addChild(testDescriptor);
 
 		assertThat(testDescriptor.getTags()).containsExactlyInAnyOrder(TestTag.create("foo"), TestTag.create("bar"),
@@ -63,7 +64,7 @@ class TestTemplateTestDescriptorTests {
 
 		TestTemplateTestDescriptor testDescriptor = new TestTemplateTestDescriptor(
 			parentUniqueId.append("tmp", "testTemplate()"), MyTestCase.class,
-			MyTestCase.class.getDeclaredMethod("testTemplate"), jupiterConfiguration);
+			MyTestCase.class.getDeclaredMethod("testTemplate"), List::of, jupiterConfiguration);
 		parent.addChild(testDescriptor);
 
 		assertThat(testDescriptor.getDisplayName()).isEqualTo("method-display-name");
@@ -80,7 +81,7 @@ class TestTemplateTestDescriptorTests {
 
 		TestTemplateTestDescriptor testDescriptor = new TestTemplateTestDescriptor(
 			parentUniqueId.append("tmp", "testTemplate()"), MyTestCase.class,
-			MyTestCase.class.getDeclaredMethod("testTemplate"), jupiterConfiguration);
+			MyTestCase.class.getDeclaredMethod("testTemplate"), List::of, jupiterConfiguration);
 		parent.addChild(testDescriptor);
 
 		assertThat(testDescriptor.getDisplayName()).isEqualTo("testTemplate()");


### PR DESCRIPTION
## Overview

Resolves #4130.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
