### PR TITLE
Provide runtime enclosing instance types to ResourceLocksProviders

### DIFF
--- a/documentation/src/test/java/example/sharedresources/DynamicSharedResourcesDemo.java
+++ b/documentation/src/test/java/example/sharedresources/DynamicSharedResourcesDemo.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -68,7 +69,8 @@ class DynamicSharedResourcesDemo {
 	static class Provider implements ResourceLocksProvider {
 
 		@Override
-		public Set<Lock> provideForMethod(Class<?> testClass, Method testMethod) {
+		public Set<Lock> provideForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+				Method testMethod) {
 			ResourceAccessMode mode = testMethod.getName().startsWith("canSet") ? READ_WRITE : READ;
 			return Collections.singleton(new Lock(SYSTEM_PROPERTIES, mode));
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
@@ -62,7 +62,7 @@ public interface ResourceLocksProvider {
 
 	/**
 	 * Add shared resources for a
-	 * {@linkplain org.junit.jupiter.api.Nested @Nested} test class.
+	 * {@link org.junit.jupiter.api.Nested @Nested} test class.
 	 *
 	 * <p>Invoked in case:
 	 * <ul>

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
@@ -14,6 +14,7 @@ import static java.util.Collections.emptySet;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -43,7 +44,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 public interface ResourceLocksProvider {
 
 	/**
-	 * Add shared resources to a test class.
+	 * Add shared resources for a test class.
 	 *
 	 * <p>Invoked in case a test class or its parent class is annotated with
 	 * {@code @ResourceLock(providers)}.
@@ -60,8 +61,8 @@ public interface ResourceLocksProvider {
 	}
 
 	/**
-	 * Add shared resources to a {@linkplain org.junit.jupiter.api.Nested @Nested}
-	 * test class.
+	 * Add shared resources for a
+	 * {@linkplain org.junit.jupiter.api.Nested @Nested} test class.
 	 *
 	 * <p>Invoked in case:
 	 * <ul>
@@ -75,16 +76,18 @@ public interface ResourceLocksProvider {
 	 * the same semantics as annotating a nested test class with an analogous
 	 * {@code @ResourceLock(value, mode)} declaration.
 	 *
+	 * @param enclosingInstanceTypes the runtime types of the enclosing
+	 * instances; never {@code null}
 	 * @param testClass a nested test class for which to add shared resources
 	 * @return a set of {@link Lock}; may be empty
 	 * @see org.junit.jupiter.api.Nested @Nested
 	 */
-	default Set<Lock> provideForNestedClass(Class<?> testClass) {
+	default Set<Lock> provideForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
 		return emptySet();
 	}
 
 	/**
-	 * Add shared resources to a test method.
+	 * Add shared resources for a test method.
 	 *
 	 * <p>Invoked in case:
 	 * <ul>
@@ -97,13 +100,15 @@ public interface ResourceLocksProvider {
 	 * has the same semantics as annotating a test method
 	 * with analogous {@code @ResourceLock(value, mode)}.
 	 *
+	 * @param enclosingInstanceTypes the runtime types of the enclosing
+	 * instances; never {@code null}
 	 * @param testClass the test class or {@link org.junit.jupiter.api.Nested @Nested}
 	 * test class that contains the {@code testMethod}
 	 * @param testMethod a test method for which to add shared resources
 	 * @return a set of {@link Lock}; may be empty
 	 * @see org.junit.jupiter.api.Nested @Nested
 	 */
-	default Set<Lock> provideForMethod(Class<?> testClass, Method testMethod) {
+	default Set<Lock> provideForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass, Method testMethod) {
 		return emptySet();
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
@@ -82,8 +82,8 @@ public interface ResourceLocksProvider {
 	 * class is inherited from a superclass.
 	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
-	 * instances of {@code clazz}, ordered from outermost to innermost,
-	 * excluding {@code class}; never {@code null}
+	 * instances for the test class, ordered from outermost to innermost,
+	 * excluding {@code testClass}; never {@code null}
 	 * @param testClass a nested test class for which to add shared resources
 	 * @return a set of {@link Lock}; may be empty
 	 * @see org.junit.jupiter.api.Nested @Nested
@@ -115,8 +115,8 @@ public interface ResourceLocksProvider {
 	 * method is inherited from a superclass.
 	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
-	 * instances of {@code clazz}, ordered from outermost to innermost,
-	 * excluding {@code class}; never {@code null}
+	 * instances for the test class, ordered from outermost to innermost,
+	 * excluding {@code testClass}; never {@code null}
 	 * @param testClass the test class or {@link org.junit.jupiter.api.Nested @Nested}
 	 * test class that contains the {@code testMethod}
 	 * @param testMethod a test method for which to add shared resources

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/parallel/ResourceLocksProvider.java
@@ -76,8 +76,14 @@ public interface ResourceLocksProvider {
 	 * the same semantics as annotating a nested test class with an analogous
 	 * {@code @ResourceLock(value, mode)} declaration.
 	 *
+	 * @implNote The classes supplied as {@code enclosingInstanceTypes} may
+	 * differ from the classes returned from invocations of
+	 * {@link Class#getEnclosingClass()} &mdash; for example, when a nested test
+	 * class is inherited from a superclass.
+	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
-	 * instances; never {@code null}
+	 * instances of {@code clazz}, ordered from outermost to innermost,
+	 * excluding {@code class}; never {@code null}
 	 * @param testClass a nested test class for which to add shared resources
 	 * @return a set of {@link Lock}; may be empty
 	 * @see org.junit.jupiter.api.Nested @Nested
@@ -100,8 +106,17 @@ public interface ResourceLocksProvider {
 	 * has the same semantics as annotating a test method
 	 * with analogous {@code @ResourceLock(value, mode)}.
 	 *
+	 * @implNote The classes supplied as {@code enclosingInstanceTypes} may
+	 * differ from the classes returned from invocations of
+	 * {@link Class#getEnclosingClass()} &mdash; for example, when a nested test
+	 * class is inherited from a superclass. Similarly, the class instance
+	 * supplied as {@code testClass} may differ from the class returned by
+	 * {@code testMethod.getDeclaringClass()} &mdash; for example, when a test
+	 * method is inherited from a superclass.
+	 *
 	 * @param enclosingInstanceTypes the runtime types of the enclosing
-	 * instances; never {@code null}
+	 * instances of {@code clazz}, ordered from outermost to innermost,
+	 * excluding {@code class}; never {@code null}
 	 * @param testClass the test class or {@link org.junit.jupiter.api.Nested @Nested}
 	 * test class that contains the {@code testMethod}
 	 * @param testMethod a test method for which to add shared resources

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTestDescriptor.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.TestInstances;
@@ -79,8 +80,8 @@ public class ClassTestDescriptor extends ClassBasedTestDescriptor {
 	}
 
 	@Override
-	public Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider) {
-		return provider.provideForClass(getTestClass());
+	public Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> getResourceLocksProviderEvaluator() {
+		return provider -> provider.provideForClass(getTestClass());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
@@ -98,13 +99,13 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor im
 	}
 
 	@Override
-	public Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider) {
+	public Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> getResourceLocksProviderEvaluator() {
 		List<Class<?>> enclosingInstanceTypes = getParent() //
 				.filter(ClassBasedTestDescriptor.class::isInstance) //
 				.map(ClassBasedTestDescriptor.class::cast) //
 				.map(ClassBasedTestDescriptor::getEnclosingTestClasses) //
 				.orElseGet(Collections::emptyList);
-		return provider.provideForMethod(enclosingInstanceTypes, getTestClass(), getTestMethod());
+		return provider -> provider.provideForMethod(enclosingInstanceTypes, getTestClass(), getTestMethod());
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -101,7 +101,8 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor im
 	public Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider) {
 		List<Class<?>> enclosingInstanceTypes = getParent() //
 				.filter(ClassBasedTestDescriptor.class::isInstance) //
-				.map(parent -> ((ClassBasedTestDescriptor) parent).getEnclosingTestClasses()) //
+				.map(ClassBasedTestDescriptor.class::cast) //
+				.map(ClassBasedTestDescriptor::getEnclosingTestClasses) //
 				.orElseGet(Collections::emptyList);
 		return provider.provideForMethod(enclosingInstanceTypes, getTestClass(), getTestMethod());
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.engine.descriptor.DisplayNameUtils.determineDisp
 import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -98,7 +99,11 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor im
 
 	@Override
 	public Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider) {
-		return provider.provideForMethod(getTestClass(), getTestMethod());
+		List<Class<?>> enclosingInstanceTypes = getParent() //
+				.filter(ClassBasedTestDescriptor.class::isInstance) //
+				.map(parent -> ((ClassBasedTestDescriptor) parent).getEnclosingTestClasses()) //
+				.orElseGet(Collections::emptyList);
+		return provider.provideForMethod(enclosingInstanceTypes, getTestClass(), getTestMethod());
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
@@ -94,8 +95,9 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 	}
 
 	@Override
-	public Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider) {
-		return provider.provideForNestedClass(getEnclosingTestClasses(), getTestClass());
+	public Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> getResourceLocksProviderEvaluator() {
+		List<Class<?>> enclosingTestClasses = getEnclosingTestClasses();
+		return provider -> provider.provideForNestedClass(enclosingTestClasses, getTestClass());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.engine.descriptor;
 import static java.util.Collections.emptyList;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.descriptor.DisplayNameUtils.createDisplayNameSupplierForNestedClass;
+import static org.junit.jupiter.engine.descriptor.ResourceLockAware.enclosingInstanceTypesDependentResourceLocksProviderEvaluator;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -96,8 +97,8 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	@Override
 	public Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> getResourceLocksProviderEvaluator() {
-		List<Class<?>> enclosingTestClasses = getEnclosingTestClasses();
-		return provider -> provider.provideForNestedClass(enclosingTestClasses, getTestClass());
+		return enclosingInstanceTypesDependentResourceLocksProviderEvaluator(this::getEnclosingTestClasses, (provider,
+				enclosingInstanceTypes) -> provider.provideForNestedClass(enclosingInstanceTypes, getTestClass()));
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -95,7 +95,7 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	@Override
 	public Set<ResourceLocksProvider.Lock> evaluateResourceLocksProvider(ResourceLocksProvider provider) {
-		return provider.provideForNestedClass(getTestClass());
+		return provider.provideForNestedClass(getEnclosingTestClasses(), getTestClass());
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ResourceLockAware.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ResourceLockAware.java
@@ -14,8 +14,11 @@ import static org.junit.jupiter.api.parallel.ResourceLockTarget.CHILDREN;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.parallel.ResourceLocksProvider;
@@ -62,5 +65,22 @@ interface ResourceLockAware extends TestDescriptor {
 	ExclusiveResourceCollector getExclusiveResourceCollector();
 
 	Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> getResourceLocksProviderEvaluator();
+
+	static Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>> enclosingInstanceTypesDependentResourceLocksProviderEvaluator(
+			Supplier<List<Class<?>>> enclosingInstanceTypesSupplier,
+			BiFunction<ResourceLocksProvider, List<Class<?>>, Set<ResourceLocksProvider.Lock>> evaluator) {
+		return new Function<ResourceLocksProvider, Set<ResourceLocksProvider.Lock>>() {
+
+			private List<Class<?>> enclosingInstanceTypes;
+
+			@Override
+			public Set<ResourceLocksProvider.Lock> apply(ResourceLocksProvider provider) {
+				if (this.enclosingInstanceTypes == null) {
+					this.enclosingInstanceTypes = enclosingInstanceTypesSupplier.get();
+				}
+				return evaluator.apply(provider, this.enclosingInstanceTypes);
+			}
+		};
+	}
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/parallel/ResourceLockAnnotationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/parallel/ResourceLockAnnotationTests.java
@@ -361,7 +361,8 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 			}
 
 			@Override
-			public Set<Lock> provideForMethod(Class<?> testClass, Method testMethod) {
+			public Set<Lock> provideForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+					Method testMethod) {
 				return Set.of(new Lock("b1"));
 			}
 		}
@@ -369,7 +370,8 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 		static class MethodLevelProvider implements ResourceLocksProvider {
 
 			@Override
-			public Set<Lock> provideForMethod(Class<?> testClass, Method testMethod) {
+			public Set<Lock> provideForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+					Method testMethod) {
 				return Set.of(new Lock("b2"));
 			}
 		}
@@ -377,7 +379,7 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 		static class NestedClassLevelProvider implements ResourceLocksProvider {
 
 			@Override
-			public Set<Lock> provideForNestedClass(Class<?> testClass) {
+			public Set<Lock> provideForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
 				return Set.of(new Lock("c1"), new Lock("c2", ResourceAccessMode.READ));
 			}
 		}
@@ -417,12 +419,13 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 		static class SecondClassLevelProvider implements ResourceLocksProvider {
 
 			@Override
-			public Set<Lock> provideForMethod(Class<?> testClass, Method testMethod) {
+			public Set<Lock> provideForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+					Method testMethod) {
 				return Set.of(new Lock("b2", ResourceAccessMode.READ));
 			}
 
 			@Override
-			public Set<Lock> provideForNestedClass(Class<?> testClass) {
+			public Set<Lock> provideForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
 				return Set.of(new Lock("c2"));
 			}
 		}
@@ -430,7 +433,7 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 		static class NestedClassLevelProvider implements ResourceLocksProvider {
 
 			@Override
-			public Set<Lock> provideForNestedClass(Class<?> testClass) {
+			public Set<Lock> provideForNestedClass(List<Class<?>> enclosingInstanceTypes, Class<?> testClass) {
 				return Set.of(new Lock("c3"));
 			}
 		}
@@ -452,7 +455,8 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 		static class Provider implements ResourceLocksProvider {
 
 			@Override
-			public Set<Lock> provideForMethod(Class<?> testClass, Method testMethod) {
+			public Set<Lock> provideForMethod(List<Class<?>> enclosingInstanceTypes, Class<?> testClass,
+					Method testMethod) {
 				return Set.of(new Lock("a1"));
 			}
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/parallel/ResourceLocksProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/parallel/ResourceLocksProviderTests.java
@@ -68,7 +68,7 @@ class ResourceLocksProviderTests extends AbstractJupiterTestEngineTests {
 	}
 
 	private Stream<Event> execute(Class<?> testCase) {
-		return executeTestsForClass(testCase).allEvents().debug().stream();
+		return executeTestsForClass(testCase).allEvents().stream();
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #4163.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] ~Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~