### PR TITLE
Aligning the getLegacyReportingName definition with getDisplayName

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
@@ -59,7 +59,7 @@ public class TestTemplateInvocationTestDescriptor extends TestMethodTestDescript
 
 	@Override
 	public String getLegacyReportingName() {
-		return super.getLegacyReportingName() + "[" + index + "]";
+		return super.getLegacyReportingName() + this.invocationContext.getDisplayName(this.index);
 	}
 
 	@Override


### PR DESCRIPTION
## Overview

As per https://junit.org/junit5/docs/5.0.1/api/org/junit/platform/engine/TestDescriptor.html#getLegacyReportingName-- the default getLegacyReportingName is expected to use getDisplayName.

Aligning the definition accordingly, the current implementation instead always forces a [0], [1], ... at the end.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
