### PR TITLE
Support `@TempDir` constructor injection for Java record classes

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.io.CleanupMode.ON_SUCCESS;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatedFields;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.support.ReflectionSupport.makeAccessible;
+import static org.junit.platform.commons.util.ReflectionUtils.isRecordObject;
 
 import java.io.File;
 import java.io.IOException;
@@ -135,7 +136,9 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 	}
 
 	private void injectInstanceFields(ExtensionContext context, Object instance) {
-		injectFields(context, instance, instance.getClass(), ModifierSupport::isNotStatic);
+		if (!isRecordObject(instance)) {
+			injectFields(context, instance, instance.getClass(), ModifierSupport::isNotStatic);
+		}
 	}
 
 	private void injectFields(ExtensionContext context, Object testInstance, Class<?> testClass,

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -366,6 +366,24 @@ public final class ReflectionUtils {
 	}
 
 	/**
+	 * {@return whether the supplied {@code object} is an instance of a record class}
+	 * @since 1.12
+	 */
+	@API(status = INTERNAL, since = "1.12")
+	public static boolean isRecordObject(Object object) {
+		return object != null && isRecordClass(object.getClass());
+	}
+
+	/**
+	 * {@return whether the supplied {@code clazz} is a record class}
+	 * @since 1.12
+	 */
+	@API(status = INTERNAL, since = "1.12")
+	public static boolean isRecordClass(Class<?> clazz) {
+		return "java.lang.Record".equals(clazz.getSuperclass().getName());
+	}
+
+	/**
 	 * Determine if the return type of the supplied method is primitive {@code void}.
 	 *
 	 * @param method the method to test; never {@code null}
@@ -1991,24 +2009,6 @@ public final class ReflectionUtils {
 		Set<Class<?>> result = new LinkedHashSet<>();
 		getAllAssignmentCompatibleClasses(clazz, result);
 		return result;
-	}
-
-	/**
-	 * {@return whether the supplied {@code object} is an instance of a record class}
-	 * @since 1.12
-	 */
-	@API(status = INTERNAL, since = "1.12")
-	public static boolean isRecordObject(Object object) {
-		return object != null && isRecordClass(object.getClass());
-	}
-
-	/**
-	 * {@return whether the supplied {@code clazz} is a record class}
-	 * @since 1.12
-	 */
-	@API(status = INTERNAL, since = "1.12")
-	public static boolean isRecordClass(Class<?> clazz) {
-		return "java.lang.Record".equals(clazz.getSuperclass().getName());
 	}
 
 	private static void getAllAssignmentCompatibleClasses(Class<?> clazz, Set<Class<?>> result) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -380,7 +380,8 @@ public final class ReflectionUtils {
 	 */
 	@API(status = INTERNAL, since = "1.12")
 	public static boolean isRecordClass(Class<?> clazz) {
-		return "java.lang.Record".equals(clazz.getSuperclass().getName());
+		Class<?> superclass = clazz.getSuperclass();
+		return superclass != null && "java.lang.Record".equals(superclass.getName());
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -1993,6 +1993,24 @@ public final class ReflectionUtils {
 		return result;
 	}
 
+	/**
+	 * {@return whether the supplied {@code object} is an instance of a record class}
+	 * @since 1.12
+	 */
+	@API(status = INTERNAL, since = "1.12")
+	public static boolean isRecordObject(Object object) {
+		return object != null && isRecordClass(object.getClass());
+	}
+
+	/**
+	 * {@return whether the supplied {@code clazz} is a record class}
+	 * @since 1.12
+	 */
+	@API(status = INTERNAL, since = "1.12")
+	public static boolean isRecordClass(Class<?> clazz) {
+		return "java.lang.Record".equals(clazz.getSuperclass().getName());
+	}
+
 	private static void getAllAssignmentCompatibleClasses(Class<?> clazz, Set<Class<?>> result) {
 		for (Class<?> current = clazz; current != null; current = current.getSuperclass()) {
 			result.add(current);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPerDeclarationTests.java
@@ -165,6 +165,12 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 	}
 
 	@Test
+	void supportsConstructorInjectionOnRecords() {
+		executeTestsForClass(TempDirRecordTestCase.class).testEvents()//
+				.assertStatistics(stats -> stats.started(1).succeeded(1));
+	}
+
+	@Test
 	@DisplayName("does not prevent constructor parameter resolution")
 	void tempDirectoryDoesNotPreventConstructorParameterResolution() {
 		executeTestsForClass(TempDirectoryDoesNotPreventConstructorParameterResolutionTestCase.class).testEvents()//
@@ -1525,6 +1531,14 @@ class TempDirectoryPerDeclarationTests extends AbstractJupiterTestEngineTests {
 			// never called
 		}
 
+	}
+
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	record TempDirRecordTestCase(@TempDir Path tempDir) {
+		@Test
+		void shouldExists() {
+			assertTrue(Files.exists(tempDir));
+		}
 	}
 
 }

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -285,6 +285,21 @@ class ReflectionUtilsTests {
 			assertThat(interfaceMethod.getDeclaringClass()).isEqualTo(Closeable.class);
 		}
 
+		@Test
+		void isRecordObject() {
+			assertTrue(ReflectionUtils.isRecordObject(new SomeRecord(1)));
+			assertFalse(ReflectionUtils.isRecordObject(new ClassWithOneCustomConstructor("")));
+		}
+
+		@Test
+		void isRecordClass() {
+			assertTrue(ReflectionUtils.isRecordClass(SomeRecord.class));
+			assertFalse(ReflectionUtils.isRecordClass(ClassWithOneCustomConstructor.class));
+		}
+
+		record SomeRecord(int n) {
+		}
+
 		static class ClassWithVoidAndNonVoidMethods {
 
 			void voidMethod() {

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -289,12 +289,14 @@ class ReflectionUtilsTests {
 		void isRecordObject() {
 			assertTrue(ReflectionUtils.isRecordObject(new SomeRecord(1)));
 			assertFalse(ReflectionUtils.isRecordObject(new ClassWithOneCustomConstructor("")));
+			assertFalse(ReflectionUtils.isRecordObject(null));
 		}
 
 		@Test
 		void isRecordClass() {
 			assertTrue(ReflectionUtils.isRecordClass(SomeRecord.class));
 			assertFalse(ReflectionUtils.isRecordClass(ClassWithOneCustomConstructor.class));
+			assertFalse(ReflectionUtils.isRecordClass(Object.class));
 		}
 
 		record SomeRecord(int n) {


### PR DESCRIPTION
The `@TempDir` annotation on a constructor parameter is copied to the
generated `final` instance field. This caused it top be picked up by
`TempDirectory` for instance field injection which then failed because
the field was `final`. This change now checks if a test class is an
instance of a record type and skips instance field injection. Since
records cannot have any instance fields besides the ones generated from
their constructor, there's no need to inject values into any of them.
