### PR TITLE
Order test descriptors children in place

### DIFF
--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine.support.descriptor;
 
+import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -38,6 +39,8 @@ class AbstractTestDescriptorTests {
 	private GroupDescriptor group1;
 	private GroupDescriptor group11;
 	private LeafDescriptor leaf111;
+	private LeafDescriptor leaf11;
+	private LeafDescriptor leaf12;
 
 	@BeforeEach
 	void initTree() {
@@ -49,8 +52,10 @@ class AbstractTestDescriptorTests {
 		group11 = new GroupDescriptor(UniqueId.root("group", "group1-1"));
 		group1.addChild(group11);
 
-		group1.addChild(new LeafDescriptor(UniqueId.root("leaf", "leaf1-1")));
-		group1.addChild(new LeafDescriptor(UniqueId.root("leaf", "leaf1-2")));
+		leaf11 = new LeafDescriptor(UniqueId.root("leaf", "leaf1-1"));
+		group1.addChild(leaf11);
+		leaf12 = new LeafDescriptor(UniqueId.root("leaf", "leaf1-2"));
+		group1.addChild(leaf12);
 
 		group2.addChild(new LeafDescriptor(UniqueId.root("leaf", "leaf2-1")));
 
@@ -76,6 +81,39 @@ class AbstractTestDescriptorTests {
 		assertFalse(group.getParent().isPresent());
 		assertTrue(group.getChildren().isEmpty());
 		assertTrue(formerChildren.stream().noneMatch(d -> d.getParent().isPresent()));
+	}
+
+	@Test
+	void orderChildren() {
+		group1.orderChildren(children -> {
+			children.sort(comparing(TestDescriptor::getDisplayName).reversed());
+			return children;
+		});
+		// Makes the compiler happy
+		List<TestDescriptor> children = new ArrayList<>(group1.getChildren());
+		assertThat(children).containsExactly(leaf12, leaf11, group11);
+	}
+
+	@Test
+	void orderChildrenRemovesDescriptor() {
+		var exception = assertThrows(JUnitException.class, () -> {
+			group1.orderChildren(children -> {
+				children.removeFirst();
+				return children;
+			});
+		});
+		assertThat(exception).hasMessage("orderer may not add or remove test descriptors");
+	}
+
+	@Test
+	void orderChildrenAddsDescriptor() {
+		var exception = assertThrows(JUnitException.class, () -> {
+			group1.orderChildren(children -> {
+				children.add(new LeafDescriptor(UniqueId.root("leaf", "leaf1-3")));
+				return children;
+			});
+		});
+		assertThat(exception).hasMessage("orderer may not add or remove test descriptors");
 	}
 
 	@Test


### PR DESCRIPTION
## Overview
Currently, it is not possible to order children
without first removing all children and then
adding them back in order. E.g:

```java
var children = new ArrayList<>(testDescriptor.getChildren());
Collections.shuffle(children);
children.forEach(testDescriptor::removeChild);
children.forEach(testDescriptor::addChild);
```
By adding `orderChildren(UnaryOperator<List<TestDescriptor>> orderer)` it now becomes possible to write:

```java
testDescriptor.orderChildren(children -> {
	Collections.shuffle(children);
	return children;
});
```


I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
