### PR TITLE
Fix handling of Windows junctions during temp dir cleanup

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-RC1.adoc
@@ -36,7 +36,7 @@ repository on GitHub.
 [[release-notes-5.12.0-RC1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Delete broken "junctions" on Windows during `@TempDir` cleanup
 
 [[release-notes-5.12.0-RC1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-RC1.adoc
@@ -36,7 +36,8 @@ repository on GitHub.
 [[release-notes-5.12.0-RC1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* Delete broken "junctions" on Windows during `@TempDir` cleanup
+* Fix handling of "junctions" on Windows during `@TempDir` cleanup: junctions will no
+  longer be followed when deleting directories and broken junctions will be deleted.
 
 [[release-notes-5.12.0-RC1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -407,12 +407,9 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				}
 
 				@Override
-				public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+				public FileVisitResult visitFileFailed(Path file, IOException exc) {
 					LOGGER.trace(exc, () -> "visitFileFailed: " + file);
-					if (exc instanceof NoSuchFileException) {
-						if (Files.exists(file)) {
-							fileOperations.delete(file);
-						}
+					if (exc instanceof NoSuchFileException && !Files.exists(file)) {
 						return CONTINUE;
 					}
 					// IOException includes `AccessDeniedException` thrown by non-readable or non-executable flags

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -399,6 +399,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 				@Override
 				public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+					LOGGER.trace(() -> "preVisitDirectory: " + dir);
 					if (!dir.equals(CloseablePath.this.dir)) {
 						tryToResetPermissions(dir);
 					}
@@ -407,6 +408,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 				@Override
 				public FileVisitResult visitFileFailed(Path file, IOException exc) {
+					LOGGER.trace(exc, () -> "visitFileFailed: " + file);
 					if (exc instanceof NoSuchFileException) {
 						return CONTINUE;
 					}
@@ -417,11 +419,13 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 				@Override
 				public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
+					LOGGER.trace(() -> "visitFile: " + file);
 					return deleteAndContinue(file);
 				}
 
 				@Override
 				public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+					LOGGER.trace(exc, () -> "postVisitDirectory: " + dir);
 					return deleteAndContinue(dir);
 				}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -32,6 +32,7 @@ import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -407,7 +408,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				@Override
 				public FileVisitResult visitFileFailed(Path file, IOException exc) {
 					LOGGER.trace(exc, () -> "visitFileFailed: " + file);
-					if (exc instanceof NoSuchFileException && !Files.exists(file)) {
+					if (exc instanceof NoSuchFileException && !Files.exists(file, LinkOption.NOFOLLOW_LINKS)) {
 						return CONTINUE;
 					}
 					// IOException includes `AccessDeniedException` thrown by non-readable or non-executable flags

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -84,8 +84,6 @@ import org.junit.platform.commons.util.ToStringBuilder;
  */
 class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterResolver {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(TempDirectory.class);
-
 	// package-private for testing purposes
 	static final Namespace NAMESPACE = Namespace.create(TempDirectory.class);
 	static final String FILE_OPERATIONS_KEY = "file.operations";
@@ -291,7 +289,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 	static class CloseablePath implements CloseableResource {
 
-		private static final Logger logger = LoggerFactory.getLogger(CloseablePath.class);
+		private static final Logger LOGGER = LoggerFactory.getLogger(CloseablePath.class);
 
 		private final Path dir;
 		private final TempDirFactory factory;
@@ -329,7 +327,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 			try {
 				if (this.cleanupMode == NEVER
 						|| (this.cleanupMode == ON_SUCCESS && selfOrChildFailed(this.extensionContext))) {
-					logger.info(() -> String.format("Skipping cleanup of temp dir %s for %s due to CleanupMode.%s.",
+					LOGGER.info(() -> String.format("Skipping cleanup of temp dir %s for %s due to CleanupMode.%s.",
 						this.dir, descriptionFor(this.annotatedElement), this.cleanupMode.name()));
 					return;
 				}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -407,9 +407,12 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				}
 
 				@Override
-				public FileVisitResult visitFileFailed(Path file, IOException exc) {
+				public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
 					LOGGER.trace(exc, () -> "visitFileFailed: " + file);
 					if (exc instanceof NoSuchFileException) {
+						if (Files.exists(file)) {
+							fileOperations.delete(file);
+						}
 						return CONTINUE;
 					}
 					// IOException includes `AccessDeniedException` thrown by non-readable or non-executable flags

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -405,6 +405,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
 					LOGGER.trace(() -> "preVisitDirectory: " + dir);
 					if (isLink(dir)) {
+						delete(dir);
 						return SKIP_SUBTREE;
 					}
 					if (!dir.equals(rootDir)) {
@@ -433,16 +434,18 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				@Override
 				public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
 					LOGGER.trace(() -> "visitFile: " + file);
-					return deleteAndContinue(file);
+					delete(file);
+					return CONTINUE;
 				}
 
 				@Override
 				public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
 					LOGGER.trace(exc, () -> "postVisitDirectory: " + dir);
-					return deleteAndContinue(dir);
+					delete(dir);
+					return CONTINUE;
 				}
 
-				private FileVisitResult deleteAndContinue(Path path) {
+				private void delete(Path path) {
 					try {
 						fileOperations.delete(path);
 					}
@@ -456,7 +459,6 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 						// IOException includes `AccessDeniedException` thrown by non-readable or non-executable flags
 						resetPermissionsAndTryToDeleteAgain(path, exception);
 					}
-					return CONTINUE;
 				}
 
 				private void resetPermissionsAndTryToDeleteAgain(Path path, IOException exception) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
@@ -476,7 +476,7 @@ class TempDirectoryCleanupTests extends AbstractJupiterTestEngineTests {
 
 			JunctionTestCase.target = outsideDir;
 			try {
-				executeTestsForClass(JunctionTestCase.class).testEvents() //
+				executeTestsForClass(JunctionTestCase.class).testEvents().debug() //
 						.assertStatistics(stats -> stats.started(1).succeeded(1));
 			}
 			finally {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
@@ -472,13 +472,19 @@ class TempDirectoryCleanupTests extends AbstractJupiterTestEngineTests {
 		@Test
 		void doesNotFollowJunctions(@TempDir Path tempDir) throws IOException {
 			var outsideDir = Files.createDirectory(tempDir.resolve("outside"));
-			Files.writeString(outsideDir.resolve("test.txt"), "test");
-			JunctionTestCase.target = outsideDir;
+			var testFile = Files.writeString(outsideDir.resolve("test.txt"), "test");
 
-			executeTestsForClass(JunctionTestCase.class).testEvents() //
-					.assertStatistics(stats -> stats.started(1).succeeded(1));
+			JunctionTestCase.target = outsideDir;
+			try {
+				executeTestsForClass(JunctionTestCase.class).testEvents() //
+						.assertStatistics(stats -> stats.started(1).succeeded(1));
+			}
+			finally {
+				JunctionTestCase.target = null;
+			}
 
 			assertThat(outsideDir).exists();
+			assertThat(testFile).exists();
 		}
 
 		@SuppressWarnings("JUnitMalformedDeclaration")

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
@@ -476,7 +476,7 @@ class TempDirectoryCleanupTests extends AbstractJupiterTestEngineTests {
 
 			JunctionTestCase.target = outsideDir;
 			try {
-				executeTestsForClass(JunctionTestCase.class).testEvents().debug() //
+				executeTestsForClass(JunctionTestCase.class).testEvents() //
 						.assertStatistics(stats -> stats.started(1).succeeded(1));
 			}
 			finally {

--- a/jupiter-tests/src/test/resources/junit-platform.properties
+++ b/jupiter-tests/src/test/resources/junit-platform.properties
@@ -1,1 +1,4 @@
 junit.jupiter.extensions.autodetection.enabled=true
+
+junit.platform.output.capture.stdout=true
+junit.platform.output.capture.stderr=true

--- a/jupiter-tests/src/test/resources/log4j2-test.xml
+++ b/jupiter-tests/src/test/resources/log4j2-test.xml
@@ -11,7 +11,7 @@
 		<Logger name="org.junit.jupiter.engine" level="off" />
 		<Logger name="org.junit.platform.launcher.listeners.discovery.LoggingLauncherDiscoveryListener" level="off" />
 		<Logger name="org.junit.jupiter.engine.extension.MutableExtensionRegistry" level="off" />
-		<Logger name="org.junit.jupiter.engine.extension.TempDirectory" level="trace" />
+		<Logger name="org.junit.jupiter.engine.extension.TempDirectory$CloseablePath" level="trace" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>

--- a/jupiter-tests/src/test/resources/log4j2-test.xml
+++ b/jupiter-tests/src/test/resources/log4j2-test.xml
@@ -11,6 +11,7 @@
 		<Logger name="org.junit.jupiter.engine" level="off" />
 		<Logger name="org.junit.platform.launcher.listeners.discovery.LoggingLauncherDiscoveryListener" level="off" />
 		<Logger name="org.junit.jupiter.engine.extension.MutableExtensionRegistry" level="off" />
+		<Logger name="org.junit.jupiter.engine.extension.TempDirectory" level="trace" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>

--- a/jupiter-tests/src/test/resources/log4j2-test.xml
+++ b/jupiter-tests/src/test/resources/log4j2-test.xml
@@ -11,7 +11,7 @@
 		<Logger name="org.junit.jupiter.engine" level="off" />
 		<Logger name="org.junit.platform.launcher.listeners.discovery.LoggingLauncherDiscoveryListener" level="off" />
 		<Logger name="org.junit.jupiter.engine.extension.MutableExtensionRegistry" level="off" />
-		<Logger name="org.junit.jupiter.engine.extension.TempDirectory$CloseablePath" level="trace" />
+		<Logger name="org.junit.jupiter.engine.extension.TempDirectory$CloseablePath" level="off" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>

--- a/jupiter-tests/src/test/resources/log4j2-test.xml
+++ b/jupiter-tests/src/test/resources/log4j2-test.xml
@@ -11,7 +11,7 @@
 		<Logger name="org.junit.jupiter.engine" level="off" />
 		<Logger name="org.junit.platform.launcher.listeners.discovery.LoggingLauncherDiscoveryListener" level="off" />
 		<Logger name="org.junit.jupiter.engine.extension.MutableExtensionRegistry" level="off" />
-		<Logger name="org.junit.jupiter.engine.extension.TempDirectory$CloseablePath" level="off" />
+		<Logger name="org.junit.jupiter.engine.extension.TempDirectory$CloseablePath" level="trace" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>


### PR DESCRIPTION
## Overview

Issue: #4299

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
