### PR TITLE
Move string-based argument conversion tests to `platform-test`

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -78,7 +78,7 @@ public class DefaultArgumentConverter implements ArgumentConverter {
 			Class<?> declaringClass = context.getDeclaringExecutable().getDeclaringClass();
 			ClassLoader classLoader = ClassLoaderUtils.getClassLoader(declaringClass);
 			try {
-				return ConversionSupport.convert((String) source, targetType, classLoader);
+				return convert((String) source, targetType, classLoader);
 			}
 			catch (ConversionException ex) {
 				throw new ArgumentConversionException(ex.getMessage(), ex);
@@ -88,6 +88,10 @@ public class DefaultArgumentConverter implements ArgumentConverter {
 		throw new ArgumentConversionException(
 			String.format("No built-in converter for source type %s and target type %s",
 				source.getClass().getTypeName(), targetType.getTypeName()));
+	}
+
+	Object convert(String source, Class<?> targetType, ClassLoader classLoader) {
+		return ConversionSupport.convert(source, targetType, classLoader);
 	}
 
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java
@@ -12,44 +12,24 @@ package org.junit.jupiter.params.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.platform.commons.util.ClassLoaderUtils.getClassLoader;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
-import java.lang.Thread.State;
 import java.lang.reflect.Method;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.net.URI;
-import java.net.URL;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.MonthDay;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.Period;
-import java.time.Year;
-import java.time.YearMonth;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.Currency;
-import java.util.Locale;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.commons.support.conversion.ConversionException;
 import org.junit.platform.commons.test.TestClassLoader;
 
 /**
@@ -58,6 +38,8 @@ import org.junit.platform.commons.test.TestClassLoader;
  * @since 5.0
  */
 class DefaultArgumentConverterTests {
+
+	private final DefaultArgumentConverter underTest = spy(DefaultArgumentConverter.INSTANCE);
 
 	@Test
 	void isAwareOfNull() {
@@ -92,44 +74,6 @@ class DefaultArgumentConverterTests {
 		assertConverts(1.0f, double.class, 1.0f);
 	}
 
-	@Test
-	void convertsStringsToPrimitiveTypes() {
-		assertConverts("true", boolean.class, true);
-		assertConverts("false", boolean.class, false);
-		assertConverts("o", char.class, 'o');
-		assertConverts("1", byte.class, (byte) 1);
-		assertConverts("1_0", byte.class, (byte) 10);
-		assertConverts("1", short.class, (short) 1);
-		assertConverts("1_2", short.class, (short) 12);
-		assertConverts("42", int.class, 42);
-		assertConverts("700_050_000", int.class, 700_050_000);
-		assertConverts("42", long.class, 42L);
-		assertConverts("4_2", long.class, 42L);
-		assertConverts("42.23", float.class, 42.23f);
-		assertConverts("42.2_3", float.class, 42.23f);
-		assertConverts("42.23", double.class, 42.23);
-		assertConverts("42.2_3", double.class, 42.23);
-	}
-
-	@Test
-	void convertsStringsToPrimitiveWrapperTypes() {
-		assertConverts("true", Boolean.class, true);
-		assertConverts("false", Boolean.class, false);
-		assertConverts("o", Character.class, 'o');
-		assertConverts("1", Byte.class, (byte) 1);
-		assertConverts("1_0", Byte.class, (byte) 10);
-		assertConverts("1", Short.class, (short) 1);
-		assertConverts("1_2", Short.class, (short) 12);
-		assertConverts("42", Integer.class, 42);
-		assertConverts("700_050_000", Integer.class, 700_050_000);
-		assertConverts("42", Long.class, 42L);
-		assertConverts("4_2", Long.class, 42L);
-		assertConverts("42.23", Float.class, 42.23f);
-		assertConverts("42.2_3", Float.class, 42.23f);
-		assertConverts("42.23", Double.class, 42.23);
-		assertConverts("42.2_3", Double.class, 42.23);
-	}
-
 	@ParameterizedTest(name = "[{index}] {0}")
 	@ValueSource(classes = { char.class, boolean.class, short.class, byte.class, int.class, long.class, float.class,
 			double.class, void.class })
@@ -137,142 +81,44 @@ class DefaultArgumentConverterTests {
 		assertThatExceptionOfType(ArgumentConversionException.class) //
 				.isThrownBy(() -> convert(null, type)) //
 				.withMessage("Cannot convert null to primitive value of type " + type.getCanonicalName());
-	}
 
-	@ParameterizedTest(name = "[{index}] {0}")
-	@ValueSource(classes = { Boolean.class, Character.class, Short.class, Byte.class, Integer.class, Long.class,
-			Float.class, Double.class })
-	void throwsExceptionWhenConvertingTheWordNullToPrimitiveWrapperType(Class<?> type) {
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert("null", type)) //
-				.withMessage("Failed to convert String \"null\" to type " + type.getCanonicalName());
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert("NULL", type)) //
-				.withMessage("Failed to convert String \"NULL\" to type " + type.getCanonicalName());
+		verify(underTest, never()).convert(any(), any(), any(ClassLoader.class));
 	}
 
 	@Test
-	void throwsExceptionOnInvalidStringForPrimitiveTypes() {
+	void throwsExceptionForNonStringsConversion() {
 		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert("ab", char.class)) //
-				.withMessage("Failed to convert String \"ab\" to type char") //
-				.havingCause() //
-				.havingCause() //
-				.withMessage("String must have length of 1: ab");
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert("tru", boolean.class)) //
-				.withMessage("Failed to convert String \"tru\" to type boolean") //
-				.havingCause() //
-				.havingCause() //
-				.withMessage("String must be 'true' or 'false' (ignoring case): tru");
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert("null", boolean.class)) //
-				.withMessage("Failed to convert String \"null\" to type boolean") //
-				.havingCause() //
-				.havingCause() //
-				.withMessage("String must be 'true' or 'false' (ignoring case): null");
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert("NULL", boolean.class)) //
-				.withMessage("Failed to convert String \"NULL\" to type boolean") //
-				.havingCause() //
-				.havingCause() //
-				.withMessage("String must be 'true' or 'false' (ignoring case): NULL");
-	}
-
-	@Test
-	void throwsExceptionWhenImplicitConverstionIsUnsupported() {
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert("foo", Enigma.class)) //
-				.withMessage("No built-in converter for source type java.lang.String and target type %s",
+				.isThrownBy(() -> convert(new Enigma(), String.class)) //
+				.withMessage("No built-in converter for source type %s and target type java.lang.String",
 					Enigma.class.getName());
 
+		verify(underTest, never()).convert(any(), any(), any(ClassLoader.class));
+	}
+
+	@Test
+	void delegatesStringsConversion() {
+		doReturn(null).when(underTest).convert(any(), any(), any(ClassLoader.class));
+
+		convert("value", int.class);
+
+		verify(underTest).convert("value", int.class, getClassLoader(DefaultArgumentConverterTests.class));
+	}
+
+	@Test
+	void throwsExceptionForDelegatedConversionFailure() {
+		ConversionException exception = new ConversionException("fail");
+		doThrow(exception).when(underTest).convert(any(), any(), any(ClassLoader.class));
+
 		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert(new Enigma(), int[].class)) //
-				.withMessage("No built-in converter for source type %s and target type int[]", Enigma.class.getName());
+				.isThrownBy(() -> convert("value", int.class)) //
+				.withCause(exception) //
+				.withMessage(exception.getMessage());
 
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert(new long[] {}, int[].class)) //
-				.withMessage("No built-in converter for source type long[] and target type int[]");
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert(new String[] {}, boolean.class)) //
-				.withMessage("No built-in converter for source type java.lang.String[] and target type boolean");
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert(Class.class, int[].class)) //
-				.withMessage("No built-in converter for source type java.lang.Class and target type int[]");
-	}
-
-	/**
-	 * @since 5.4
-	 */
-	@Test
-	@SuppressWarnings("OctalInteger") // We test parsing octal integers here as well as hex.
-	void convertsEncodedStringsToIntegralTypes() {
-		assertConverts("0x1f", byte.class, (byte) 0x1F);
-		assertConverts("-0x1F", byte.class, (byte) -0x1F);
-		assertConverts("010", byte.class, (byte) 010);
-
-		assertConverts("0x1f00", short.class, (short) 0x1F00);
-		assertConverts("-0x1F00", short.class, (short) -0x1F00);
-		assertConverts("01000", short.class, (short) 01000);
-
-		assertConverts("0x1f000000", int.class, 0x1F000000);
-		assertConverts("-0x1F000000", int.class, -0x1F000000);
-		assertConverts("010000000", int.class, 010000000);
-
-		assertConverts("0x1f000000000", long.class, 0x1F000000000L);
-		assertConverts("-0x1F000000000", long.class, -0x1F000000000L);
-		assertConverts("0100000000000", long.class, 0100000000000L);
+		verify(underTest).convert("value", int.class, getClassLoader(DefaultArgumentConverterTests.class));
 	}
 
 	@Test
-	void convertsStringsToEnumConstants() {
-		assertConverts("DAYS", TimeUnit.class, TimeUnit.DAYS);
-	}
-
-	// --- java.io and java.nio ------------------------------------------------
-
-	@Test
-	void convertsStringToCharset() {
-		assertConverts("ISO-8859-1", Charset.class, StandardCharsets.ISO_8859_1);
-		assertConverts("UTF-8", Charset.class, StandardCharsets.UTF_8);
-	}
-
-	@Test
-	void convertsStringToFile() {
-		assertConverts("file", File.class, new File("file"));
-		assertConverts("/file", File.class, new File("/file"));
-		assertConverts("/some/file", File.class, new File("/some/file"));
-	}
-
-	@Test
-	void convertsStringToPath() {
-		assertConverts("path", Path.class, Paths.get("path"));
-		assertConverts("/path", Path.class, Paths.get("/path"));
-		assertConverts("/some/path", Path.class, Paths.get("/some/path"));
-	}
-
-	// --- java.lang -----------------------------------------------------------
-
-	@Test
-	void convertsStringToClass() {
-		assertConverts("java.lang.Integer", Class.class, Integer.class);
-		assertConverts("java.lang.Void", Class.class, Void.class);
-		assertConverts("java.lang.Thread$State", Class.class, State.class);
-		assertConverts("byte", Class.class, byte.class);
-		assertConverts("void", Class.class, void.class);
-		assertConverts("char[]", Class.class, char[].class);
-		assertConverts("java.lang.Long[][]", Class.class, Long[][].class);
-		assertConverts("[[[I", Class.class, int[][][].class);
-		assertConverts("[[Ljava.lang.String;", Class.class, String[][].class);
-	}
-
-	@Test
-	void convertsStringToClassWithCustomTypeFromDifferentClassLoader() throws Exception {
+	void delegatesStringToClassWithCustomTypeFromDifferentClassLoaderConversion() throws Exception {
 		String customTypeName = Enigma.class.getName();
 		try (var testClassLoader = TestClassLoader.forClasses(Enigma.class)) {
 			var customType = testClassLoader.loadClass(customTypeName);
@@ -281,79 +127,15 @@ class DefaultArgumentConverterTests {
 			var declaringExecutable = ReflectionSupport.findMethod(customType, "foo").get();
 			assertThat(declaringExecutable.getDeclaringClass().getClassLoader()).isSameAs(testClassLoader);
 
+			doReturn(customType).when(underTest).convert(any(), any(), any(ClassLoader.class));
+
 			var clazz = (Class<?>) convert(customTypeName, Class.class, parameterContext(declaringExecutable));
 			assertThat(clazz).isNotEqualTo(Enigma.class);
 			assertThat(clazz).isEqualTo(customType);
 			assertThat(clazz.getClassLoader()).isSameAs(testClassLoader);
+
+			verify(underTest).convert(customTypeName, Class.class, testClassLoader);
 		}
-	}
-
-	// --- java.math -----------------------------------------------------------
-
-	@Test
-	void convertsStringToBigDecimal() {
-		assertConverts("123.456e789", BigDecimal.class, new BigDecimal("123.456e789"));
-	}
-
-	@Test
-	void convertsStringToBigInteger() {
-		assertConverts("1234567890123456789", BigInteger.class, new BigInteger("1234567890123456789"));
-	}
-
-	// --- java.net ------------------------------------------------------------
-
-	@Test
-	void convertsStringToURI() {
-		assertConverts("https://docs.oracle.com/en/java/javase/12/", URI.class,
-			URI.create("https://docs.oracle.com/en/java/javase/12/"));
-	}
-
-	@Test
-	void convertsStringToURL() throws Exception {
-		assertConverts("https://junit.org/junit5", URL.class, URI.create("https://junit.org/junit5").toURL());
-	}
-
-	// --- java.time -----------------------------------------------------------
-
-	@Test
-	void convertsStringsToJavaTimeInstances() {
-		assertConverts("PT1234.5678S", Duration.class, Duration.ofSeconds(1234, 567800000));
-		assertConverts("1970-01-01T00:00:00Z", Instant.class, Instant.ofEpochMilli(0));
-		assertConverts("2017-03-14", LocalDate.class, LocalDate.of(2017, 3, 14));
-		assertConverts("2017-03-14T12:34:56.789", LocalDateTime.class,
-			LocalDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000));
-		assertConverts("12:34:56.789", LocalTime.class, LocalTime.of(12, 34, 56, 789_000_000));
-		assertConverts("--03-14", MonthDay.class, MonthDay.of(3, 14));
-		assertConverts("2017-03-14T12:34:56.789Z", OffsetDateTime.class,
-			OffsetDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC));
-		assertConverts("12:34:56.789Z", OffsetTime.class, OffsetTime.of(12, 34, 56, 789_000_000, ZoneOffset.UTC));
-		assertConverts("P2M6D", Period.class, Period.of(0, 2, 6));
-		assertConverts("2017", Year.class, Year.of(2017));
-		assertConverts("2017-03", YearMonth.class, YearMonth.of(2017, 3));
-		assertConverts("2017-03-14T12:34:56.789Z", ZonedDateTime.class,
-			ZonedDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC));
-		assertConverts("Europe/Berlin", ZoneId.class, ZoneId.of("Europe/Berlin"));
-		assertConverts("+02:30", ZoneOffset.class, ZoneOffset.ofHoursMinutes(2, 30));
-	}
-
-	// --- java.util -----------------------------------------------------------
-
-	@Test
-	void convertsStringToCurrency() {
-		assertConverts("JPY", Currency.class, Currency.getInstance("JPY"));
-	}
-
-	@Test
-	@SuppressWarnings("deprecation")
-	void convertsStringToLocale() {
-		assertConverts("en", Locale.class, Locale.ENGLISH);
-		assertConverts("en_us", Locale.class, new Locale(Locale.US.toString()));
-	}
-
-	@Test
-	void convertsStringToUUID() {
-		var uuid = "d043e930-7b3b-48e3-bdbe-5a3ccfb833db";
-		assertConverts(uuid, UUID.class, UUID.fromString(uuid));
 	}
 
 	// -------------------------------------------------------------------------
@@ -364,6 +146,8 @@ class DefaultArgumentConverterTests {
 		assertThat(result) //
 				.describedAs(input + " --(" + targetClass.getName() + ")--> " + expectedOutput) //
 				.isEqualTo(expectedOutput);
+
+		verify(underTest, never()).convert(any(), any(), any(ClassLoader.class));
 	}
 
 	private Object convert(Object input, Class<?> targetClass) {
@@ -371,7 +155,7 @@ class DefaultArgumentConverterTests {
 	}
 
 	private Object convert(Object input, Class<?> targetClass, ParameterContext parameterContext) {
-		return DefaultArgumentConverter.INSTANCE.convert(input, targetClass, parameterContext);
+		return underTest.convert(input, targetClass, parameterContext);
 	}
 
 	private static ParameterContext parameterContext() {

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.support.conversion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Currency;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.commons.test.TestClassLoader;
+import org.junit.platform.commons.util.ClassLoaderUtils;
+
+/**
+ * Unit tests for {@link ConversionSupport}.
+ *
+ * @since 5.12
+ */
+class ConversionSupportTests {
+
+	@Test
+	void isAwareOfNull() {
+		assertConverts(null, Object.class, null);
+		assertConverts(null, String.class, null);
+		assertConverts(null, Boolean.class, null);
+	}
+
+	@Test
+	void convertsStringsToPrimitiveTypes() {
+		assertConverts("true", boolean.class, true);
+		assertConverts("false", boolean.class, false);
+		assertConverts("o", char.class, 'o');
+		assertConverts("1", byte.class, (byte) 1);
+		assertConverts("1_0", byte.class, (byte) 10);
+		assertConverts("1", short.class, (short) 1);
+		assertConverts("1_2", short.class, (short) 12);
+		assertConverts("42", int.class, 42);
+		assertConverts("700_050_000", int.class, 700_050_000);
+		assertConverts("42", long.class, 42L);
+		assertConverts("4_2", long.class, 42L);
+		assertConverts("42.23", float.class, 42.23f);
+		assertConverts("42.2_3", float.class, 42.23f);
+		assertConverts("42.23", double.class, 42.23);
+		assertConverts("42.2_3", double.class, 42.23);
+	}
+
+	@Test
+	void convertsStringsToPrimitiveWrapperTypes() {
+		assertConverts("true", Boolean.class, true);
+		assertConverts("false", Boolean.class, false);
+		assertConverts("o", Character.class, 'o');
+		assertConverts("1", Byte.class, (byte) 1);
+		assertConverts("1_0", Byte.class, (byte) 10);
+		assertConverts("1", Short.class, (short) 1);
+		assertConverts("1_2", Short.class, (short) 12);
+		assertConverts("42", Integer.class, 42);
+		assertConverts("700_050_000", Integer.class, 700_050_000);
+		assertConverts("42", Long.class, 42L);
+		assertConverts("4_2", Long.class, 42L);
+		assertConverts("42.23", Float.class, 42.23f);
+		assertConverts("42.2_3", Float.class, 42.23f);
+		assertConverts("42.23", Double.class, 42.23);
+		assertConverts("42.2_3", Double.class, 42.23);
+	}
+
+	@ParameterizedTest(name = "[{index}] {0}")
+	@ValueSource(classes = { char.class, boolean.class, short.class, byte.class, int.class, long.class, float.class,
+			double.class, void.class })
+	void throwsExceptionForNullToPrimitiveTypeConversion(Class<?> type) {
+		assertThatExceptionOfType(ConversionException.class) //
+				.isThrownBy(() -> convert(null, type)) //
+				.withMessage("Cannot convert null to primitive value of type " + type.getCanonicalName());
+	}
+
+	@ParameterizedTest(name = "[{index}] {0}")
+	@ValueSource(classes = { Boolean.class, Character.class, Short.class, Byte.class, Integer.class, Long.class,
+			Float.class, Double.class })
+	void throwsExceptionWhenConvertingTheWordNullToPrimitiveWrapperType(Class<?> type) {
+		assertThatExceptionOfType(ConversionException.class) //
+				.isThrownBy(() -> convert("null", type)) //
+				.withMessage("Failed to convert String \"null\" to type " + type.getCanonicalName());
+		assertThatExceptionOfType(ConversionException.class) //
+				.isThrownBy(() -> convert("NULL", type)) //
+				.withMessage("Failed to convert String \"NULL\" to type " + type.getCanonicalName());
+	}
+
+	@Test
+	void throwsExceptionOnInvalidStringForPrimitiveTypes() {
+		assertThatExceptionOfType(ConversionException.class) //
+				.isThrownBy(() -> convert("ab", char.class)) //
+				.withMessage("Failed to convert String \"ab\" to type char") //
+				.havingCause() //
+				.withMessage("String must have length of 1: ab");
+
+		assertThatExceptionOfType(ConversionException.class) //
+				.isThrownBy(() -> convert("tru", boolean.class)) //
+				.withMessage("Failed to convert String \"tru\" to type boolean") //
+				.havingCause() //
+				.withMessage("String must be 'true' or 'false' (ignoring case): tru");
+
+		assertThatExceptionOfType(ConversionException.class) //
+				.isThrownBy(() -> convert("null", boolean.class)) //
+				.withMessage("Failed to convert String \"null\" to type boolean") //
+				.havingCause() //
+				.withMessage("String must be 'true' or 'false' (ignoring case): null");
+
+		assertThatExceptionOfType(ConversionException.class) //
+				.isThrownBy(() -> convert("NULL", boolean.class)) //
+				.withMessage("Failed to convert String \"NULL\" to type boolean") //
+				.havingCause() //
+				.withMessage("String must be 'true' or 'false' (ignoring case): NULL");
+	}
+
+	@Test
+	void throwsExceptionWhenImplicitConversionIsUnsupported() {
+		assertThatExceptionOfType(ConversionException.class) //
+				.isThrownBy(() -> convert("foo", Enigma.class)) //
+				.withMessage("No built-in converter for source type java.lang.String and target type %s",
+					Enigma.class.getName());
+	}
+
+	/**
+	 * @since 5.4
+	 */
+	@Test
+	@SuppressWarnings("OctalInteger") // We test parsing octal integers here as well as hex.
+	void convertsEncodedStringsToIntegralTypes() {
+		assertConverts("0x1f", byte.class, (byte) 0x1F);
+		assertConverts("-0x1F", byte.class, (byte) -0x1F);
+		assertConverts("010", byte.class, (byte) 010);
+
+		assertConverts("0x1f00", short.class, (short) 0x1F00);
+		assertConverts("-0x1F00", short.class, (short) -0x1F00);
+		assertConverts("01000", short.class, (short) 01000);
+
+		assertConverts("0x1f000000", int.class, 0x1F000000);
+		assertConverts("-0x1F000000", int.class, -0x1F000000);
+		assertConverts("010000000", int.class, 010000000);
+
+		assertConverts("0x1f000000000", long.class, 0x1F000000000L);
+		assertConverts("-0x1F000000000", long.class, -0x1F000000000L);
+		assertConverts("0100000000000", long.class, 0100000000000L);
+	}
+
+	@Test
+	void convertsStringsToEnumConstants() {
+		assertConverts("DAYS", TimeUnit.class, TimeUnit.DAYS);
+	}
+
+	// --- java.io and java.nio ------------------------------------------------
+
+	@Test
+	void convertsStringToCharset() {
+		assertConverts("ISO-8859-1", Charset.class, StandardCharsets.ISO_8859_1);
+		assertConverts("UTF-8", Charset.class, StandardCharsets.UTF_8);
+	}
+
+	@Test
+	void convertsStringToFile() {
+		assertConverts("file", File.class, new File("file"));
+		assertConverts("/file", File.class, new File("/file"));
+		assertConverts("/some/file", File.class, new File("/some/file"));
+	}
+
+	@Test
+	void convertsStringToPath() {
+		assertConverts("path", Path.class, Paths.get("path"));
+		assertConverts("/path", Path.class, Paths.get("/path"));
+		assertConverts("/some/path", Path.class, Paths.get("/some/path"));
+	}
+
+	// --- java.lang -----------------------------------------------------------
+
+	@Test
+	void convertsStringToClass() {
+		assertConverts("java.lang.Integer", Class.class, Integer.class);
+		assertConverts("java.lang.Void", Class.class, Void.class);
+		assertConverts("java.lang.Thread$State", Class.class, Thread.State.class);
+		assertConverts("byte", Class.class, byte.class);
+		assertConverts("void", Class.class, void.class);
+		assertConverts("char[]", Class.class, char[].class);
+		assertConverts("java.lang.Long[][]", Class.class, Long[][].class);
+		assertConverts("[[[I", Class.class, int[][][].class);
+		assertConverts("[[Ljava.lang.String;", Class.class, String[][].class);
+	}
+
+	@Test
+	void convertsStringToClassWithCustomTypeFromDifferentClassLoader() throws Exception {
+		String customTypeName = Enigma.class.getName();
+		try (var testClassLoader = TestClassLoader.forClasses(Enigma.class)) {
+			var customType = testClassLoader.loadClass(customTypeName);
+			assertThat(customType.getClassLoader()).isSameAs(testClassLoader);
+
+			var declaringExecutable = ReflectionSupport.findMethod(customType, "foo").get();
+			assertThat(declaringExecutable.getDeclaringClass().getClassLoader()).isSameAs(testClassLoader);
+
+			var clazz = (Class<?>) convert(customTypeName, Class.class, classLoader(declaringExecutable));
+			assertThat(clazz).isNotEqualTo(Enigma.class);
+			assertThat(clazz).isEqualTo(customType);
+			assertThat(clazz.getClassLoader()).isSameAs(testClassLoader);
+		}
+	}
+
+	// --- java.math -----------------------------------------------------------
+
+	@Test
+	void convertsStringToBigDecimal() {
+		assertConverts("123.456e789", BigDecimal.class, new BigDecimal("123.456e789"));
+	}
+
+	@Test
+	void convertsStringToBigInteger() {
+		assertConverts("1234567890123456789", BigInteger.class, new BigInteger("1234567890123456789"));
+	}
+
+	// --- java.net ------------------------------------------------------------
+
+	@Test
+	void convertsStringToURI() {
+		assertConverts("https://docs.oracle.com/en/java/javase/12/", URI.class,
+			URI.create("https://docs.oracle.com/en/java/javase/12/"));
+	}
+
+	@Test
+	void convertsStringToURL() throws Exception {
+		assertConverts("https://junit.org/junit5", URL.class, URI.create("https://junit.org/junit5").toURL());
+	}
+
+	// --- java.time -----------------------------------------------------------
+
+	@Test
+	void convertsStringsToJavaTimeInstances() {
+		assertConverts("PT1234.5678S", Duration.class, Duration.ofSeconds(1234, 567800000));
+		assertConverts("1970-01-01T00:00:00Z", Instant.class, Instant.ofEpochMilli(0));
+		assertConverts("2017-03-14", LocalDate.class, LocalDate.of(2017, 3, 14));
+		assertConverts("2017-03-14T12:34:56.789", LocalDateTime.class,
+			LocalDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000));
+		assertConverts("12:34:56.789", LocalTime.class, LocalTime.of(12, 34, 56, 789_000_000));
+		assertConverts("--03-14", MonthDay.class, MonthDay.of(3, 14));
+		assertConverts("2017-03-14T12:34:56.789Z", OffsetDateTime.class,
+			OffsetDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC));
+		assertConverts("12:34:56.789Z", OffsetTime.class, OffsetTime.of(12, 34, 56, 789_000_000, ZoneOffset.UTC));
+		assertConverts("P2M6D", Period.class, Period.of(0, 2, 6));
+		assertConverts("2017", Year.class, Year.of(2017));
+		assertConverts("2017-03", YearMonth.class, YearMonth.of(2017, 3));
+		assertConverts("2017-03-14T12:34:56.789Z", ZonedDateTime.class,
+			ZonedDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000, ZoneOffset.UTC));
+		assertConverts("Europe/Berlin", ZoneId.class, ZoneId.of("Europe/Berlin"));
+		assertConverts("+02:30", ZoneOffset.class, ZoneOffset.ofHoursMinutes(2, 30));
+	}
+
+	// --- java.util -----------------------------------------------------------
+
+	@Test
+	void convertsStringToCurrency() {
+		assertConverts("JPY", Currency.class, Currency.getInstance("JPY"));
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void convertsStringToLocale() {
+		assertConverts("en", Locale.class, Locale.ENGLISH);
+		assertConverts("en_us", Locale.class, new Locale(Locale.US.toString()));
+	}
+
+	@Test
+	void convertsStringToUUID() {
+		var uuid = "d043e930-7b3b-48e3-bdbe-5a3ccfb833db";
+		assertConverts(uuid, UUID.class, UUID.fromString(uuid));
+	}
+
+	// -------------------------------------------------------------------------
+
+	private void assertConverts(String input, Class<?> targetClass, Object expectedOutput) {
+		var result = convert(input, targetClass);
+
+		assertThat(result) //
+				.describedAs(input + " --(" + targetClass.getName() + ")--> " + expectedOutput) //
+				.isEqualTo(expectedOutput);
+	}
+
+	private Object convert(String input, Class<?> targetClass) {
+		return convert(input, targetClass, classLoader());
+	}
+
+	private Object convert(String input, Class<?> targetClass, ClassLoader classLoader) {
+		return ConversionSupport.convert(input, targetClass, classLoader);
+	}
+
+	private static ClassLoader classLoader() {
+		Method declaringExecutable = ReflectionSupport.findMethod(ConversionSupportTests.class, "foo").get();
+		return classLoader(declaringExecutable);
+	}
+
+	private static ClassLoader classLoader(Method declaringExecutable) {
+		return ClassLoaderUtils.getClassLoader(declaringExecutable.getDeclaringClass());
+	}
+
+	@SuppressWarnings("unused")
+	private static void foo() {
+	}
+
+	private static class Enigma {
+
+		@SuppressWarnings("unused")
+		void foo() {
+		}
+	}
+
+}


### PR DESCRIPTION
## Overview

Prior to this commit, `platform-tests` had no dedicated tests for `ConversionSupport`. Instead, `DefaultArgumentConverterTests` from `jupiter-tests` provided the corresponding coverage.

Now, string-based tests are moved to `ConversionSupportTests`, while `DefaultArgumentConverterTests` verify that the delegation to `ConversionSupport` happens correctly.

See https://github.com/junit-team/junit5/pull/4219#discussion_r1948126955.

For an easier review, here's the diff between `DefaultArgumentConverterTests` from `main` and `ConversionSupportTests` from this PR:

<details><summary>Diff</summary>
<p>

```diff
--- jupiter-tests/src/test/java/org/junit/jupiter/params/converter/DefaultArgumentConverterTests.java	2025-02-09 16:22:11
+++ platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java	2025-02-09 17:34:21
@@ -8,15 +8,12 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit.jupiter.params.converter;
+package org.junit.platform.commons.support.conversion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.lang.Thread.State;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -46,18 +43,18 @@
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.commons.test.TestClassLoader;
+import org.junit.platform.commons.util.ClassLoaderUtils;
 
 /**
- * Unit tests for {@link DefaultArgumentConverter}.
+ * Unit tests for {@link ConversionSupport}.
  *
- * @since 5.0
+ * @since 5.12
  */
-class DefaultArgumentConverterTests {
+class ConversionSupportTests {
 
 	@Test
 	void isAwareOfNull() {
@@ -67,32 +64,6 @@
 	}
 
 	@Test
-	void isAwareOfWrapperTypesForPrimitiveTypes() {
-		assertConverts(true, boolean.class, true);
-		assertConverts(false, boolean.class, false);
-		assertConverts((byte) 1, byte.class, (byte) 1);
-		assertConverts('o', char.class, 'o');
-		assertConverts((short) 1, short.class, (short) 1);
-		assertConverts(1, int.class, 1);
-		assertConverts(1L, long.class, 1L);
-		assertConverts(1.0f, float.class, 1.0f);
-		assertConverts(1.0d, double.class, 1.0d);
-	}
-
-	@Test
-	void isAwareOfWideningConversions() {
-		assertConverts((byte) 1, short.class, (byte) 1);
-		assertConverts((short) 1, int.class, (short) 1);
-		assertConverts((char) 1, int.class, (char) 1);
-		assertConverts((byte) 1, long.class, (byte) 1);
-		assertConverts(1, long.class, 1);
-		assertConverts((char) 1, float.class, (char) 1);
-		assertConverts(1, float.class, 1);
-		assertConverts(1L, double.class, 1L);
-		assertConverts(1.0f, double.class, 1.0f);
-	}
-
-	@Test
 	void convertsStringsToPrimitiveTypes() {
 		assertConverts("true", boolean.class, true);
 		assertConverts("false", boolean.class, false);
@@ -134,7 +105,7 @@
 	@ValueSource(classes = { char.class, boolean.class, short.class, byte.class, int.class, long.class, float.class,
 			double.class, void.class })
 	void throwsExceptionForNullToPrimitiveTypeConversion(Class<?> type) {
-		assertThatExceptionOfType(ArgumentConversionException.class) //
+		assertThatExceptionOfType(ConversionException.class) //
 				.isThrownBy(() -> convert(null, type)) //
 				.withMessage("Cannot convert null to primitive value of type " + type.getCanonicalName());
 	}
@@ -143,67 +114,47 @@
 	@ValueSource(classes = { Boolean.class, Character.class, Short.class, Byte.class, Integer.class, Long.class,
 			Float.class, Double.class })
 	void throwsExceptionWhenConvertingTheWordNullToPrimitiveWrapperType(Class<?> type) {
-		assertThatExceptionOfType(ArgumentConversionException.class) //
+		assertThatExceptionOfType(ConversionException.class) //
 				.isThrownBy(() -> convert("null", type)) //
 				.withMessage("Failed to convert String \"null\" to type " + type.getCanonicalName());
-		assertThatExceptionOfType(ArgumentConversionException.class) //
+		assertThatExceptionOfType(ConversionException.class) //
 				.isThrownBy(() -> convert("NULL", type)) //
 				.withMessage("Failed to convert String \"NULL\" to type " + type.getCanonicalName());
 	}
 
 	@Test
 	void throwsExceptionOnInvalidStringForPrimitiveTypes() {
-		assertThatExceptionOfType(ArgumentConversionException.class) //
+		assertThatExceptionOfType(ConversionException.class) //
 				.isThrownBy(() -> convert("ab", char.class)) //
 				.withMessage("Failed to convert String \"ab\" to type char") //
 				.havingCause() //
-				.havingCause() //
 				.withMessage("String must have length of 1: ab");
 
-		assertThatExceptionOfType(ArgumentConversionException.class) //
+		assertThatExceptionOfType(ConversionException.class) //
 				.isThrownBy(() -> convert("tru", boolean.class)) //
 				.withMessage("Failed to convert String \"tru\" to type boolean") //
 				.havingCause() //
-				.havingCause() //
 				.withMessage("String must be 'true' or 'false' (ignoring case): tru");
 
-		assertThatExceptionOfType(ArgumentConversionException.class) //
+		assertThatExceptionOfType(ConversionException.class) //
 				.isThrownBy(() -> convert("null", boolean.class)) //
 				.withMessage("Failed to convert String \"null\" to type boolean") //
 				.havingCause() //
-				.havingCause() //
 				.withMessage("String must be 'true' or 'false' (ignoring case): null");
 
-		assertThatExceptionOfType(ArgumentConversionException.class) //
+		assertThatExceptionOfType(ConversionException.class) //
 				.isThrownBy(() -> convert("NULL", boolean.class)) //
 				.withMessage("Failed to convert String \"NULL\" to type boolean") //
 				.havingCause() //
-				.havingCause() //
 				.withMessage("String must be 'true' or 'false' (ignoring case): NULL");
 	}
 
 	@Test
 	void throwsExceptionWhenImplicitConversionIsUnsupported() {
-		assertThatExceptionOfType(ArgumentConversionException.class) //
+		assertThatExceptionOfType(ConversionException.class) //
 				.isThrownBy(() -> convert("foo", Enigma.class)) //
 				.withMessage("No built-in converter for source type java.lang.String and target type %s",
 					Enigma.class.getName());
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert(new Enigma(), int[].class)) //
-				.withMessage("No built-in converter for source type %s and target type int[]", Enigma.class.getName());
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert(new long[] {}, int[].class)) //
-				.withMessage("No built-in converter for source type long[] and target type int[]");
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert(new String[] {}, boolean.class)) //
-				.withMessage("No built-in converter for source type java.lang.String[] and target type boolean");
-
-		assertThatExceptionOfType(ArgumentConversionException.class) //
-				.isThrownBy(() -> convert(Class.class, int[].class)) //
-				.withMessage("No built-in converter for source type java.lang.Class and target type int[]");
 	}
 
 	/**
@@ -262,7 +213,7 @@
 	void convertsStringToClass() {
 		assertConverts("java.lang.Integer", Class.class, Integer.class);
 		assertConverts("java.lang.Void", Class.class, Void.class);
-		assertConverts("java.lang.Thread$State", Class.class, State.class);
+		assertConverts("java.lang.Thread$State", Class.class, Thread.State.class);
 		assertConverts("byte", Class.class, byte.class);
 		assertConverts("void", Class.class, void.class);
 		assertConverts("char[]", Class.class, char[].class);
@@ -281,7 +232,7 @@
 			var declaringExecutable = ReflectionSupport.findMethod(customType, "foo").get();
 			assertThat(declaringExecutable.getDeclaringClass().getClassLoader()).isSameAs(testClassLoader);
 
-			var clazz = (Class<?>) convert(customTypeName, Class.class, parameterContext(declaringExecutable));
+			var clazz = (Class<?>) convert(customTypeName, Class.class, classLoader(declaringExecutable));
 			assertThat(clazz).isNotEqualTo(Enigma.class);
 			assertThat(clazz).isEqualTo(customType);
 			assertThat(clazz.getClassLoader()).isSameAs(testClassLoader);
@@ -358,7 +309,7 @@
 
 	// -------------------------------------------------------------------------
 
-	private void assertConverts(Object input, Class<?> targetClass, Object expectedOutput) {
+	private void assertConverts(String input, Class<?> targetClass, Object expectedOutput) {
 		var result = convert(input, targetClass);
 
 		assertThat(result) //
@@ -366,23 +317,21 @@
 				.isEqualTo(expectedOutput);
 	}
 
-	private Object convert(Object input, Class<?> targetClass) {
-		return convert(input, targetClass, parameterContext());
+	private Object convert(String input, Class<?> targetClass) {
+		return convert(input, targetClass, classLoader());
 	}
 
-	private Object convert(Object input, Class<?> targetClass, ParameterContext parameterContext) {
-		return DefaultArgumentConverter.INSTANCE.convert(input, targetClass, parameterContext);
+	private Object convert(String input, Class<?> targetClass, ClassLoader classLoader) {
+		return ConversionSupport.convert(input, targetClass, classLoader);
 	}
 
-	private static ParameterContext parameterContext() {
-		Method declaringExecutable = ReflectionSupport.findMethod(DefaultArgumentConverterTests.class, "foo").get();
-		return parameterContext(declaringExecutable);
+	private static ClassLoader classLoader() {
+		Method declaringExecutable = ReflectionSupport.findMethod(ConversionSupportTests.class, "foo").get();
+		return classLoader(declaringExecutable);
 	}
 
-	private static ParameterContext parameterContext(Method declaringExecutable) {
-		ParameterContext parameterContext = mock();
-		when(parameterContext.getDeclaringExecutable()).thenReturn(declaringExecutable);
-		return parameterContext;
+	private static ClassLoader classLoader(Method declaringExecutable) {
+		return ClassLoaderUtils.getClassLoader(declaringExecutable.getDeclaringClass());
 	}
 
 	@SuppressWarnings("unused")
```

</p>
</details> 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
