### PR TITLE
Warn when deleting symlinks targeting locations outside temp dir

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-RC2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.0-RC2.adoc
@@ -45,7 +45,9 @@ repository on GitHub.
 [[release-notes-5.12.0-RC2-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* The `@TempDir` now warns when deleting symlinks that target locations outside the
+  temporary directory to signal that the target file or directory is _not_ deleted, only
+  the link to it.
 
 
 [[release-notes-5.12.0-RC2-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDir.java
@@ -84,8 +84,11 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
  * &mdash; when the test method or class has finished execution &mdash; JUnit will
  * attempt to clean up the temporary directory by recursively deleting all files
  * and directories in the temporary directory and, finally, the temporary directory
- * itself. In case deletion of a file or directory fails, an {@link IOException}
- * will be thrown that will cause the test or test class to fail.
+ * itself. Symbolic and other types of links, such as junctions on Windows, are
+ * not followed. A warning is logged when deleting a link that targets a
+ * location outside the temporary directory. In case deletion of a file or
+ * directory fails, an {@link IOException} will be thrown that will cause the
+ * test or test class to fail.
  *
  * <p>The {@link #cleanup} attribute allows you to configure the {@link CleanupMode}.
  * If the cleanup mode is set to {@link CleanupMode#NEVER NEVER}, the temporary

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -443,10 +443,17 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 					return CONTINUE;
 				}
 
-				private boolean isLinkWithTargetOutsideTempDir(Path path) throws IOException {
+				private boolean isLinkWithTargetOutsideTempDir(Path path) {
 					// While `Files.walkFileTree` does not follow symbolic links, it may follow other links
 					// such as "junctions" on Windows
-					return !path.toRealPath().startsWith(rootRealPath);
+					try {
+						return !path.toRealPath().startsWith(rootRealPath);
+					}
+					catch (IOException e) {
+						LOGGER.trace(e,
+							() -> "Failed to determine real path for " + path + "; assuming it is not a link");
+						return false;
+					}
 				}
 
 				private void warnAboutLinkWithTargetOutsideTempDir(String linkType, Path file) throws IOException {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
@@ -448,7 +448,7 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 				assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage) //
 						.contains(("Deleting symbolic link from location inside of temp dir (%s) "
 								+ "to location outside of temp dir (%s) but not the target file/directory").formatted(
-									symbolicLink, directoryOutsideTempDir));
+									symbolicLink, directoryOutsideTempDir.toRealPath()));
 			}
 			finally {
 				Files.deleteIfExists(directoryOutsideTempDir);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
@@ -445,7 +445,8 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 				verify(factory).close();
 				assertThat(rootDir).doesNotExist();
 				assertThat(directoryOutsideTempDir).isDirectory();
-				assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage) //
+				assertThat(listener.stream(Level.WARNING)) //
+						.map(LogRecord::getMessage) //
 						.contains(("Deleting symbolic link from location inside of temp dir (%s) "
 								+ "to location outside of temp dir (%s) but not the target file/directory").formatted(
 									symbolicLink, directoryOutsideTempDir.toRealPath()));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/CloseablePathTests.java
@@ -43,6 +43,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -395,6 +396,64 @@ class CloseablePathTests extends AbstractJupiterTestEngineTests {
 					.noneMatch(m -> m.startsWith("Skipping cleanup of temp dir"));
 		}
 
+		@DisplayName("deletes symbolic links targeting directory inside temp dir")
+		@ParameterizedTest
+		@ElementTypeSource
+		@DisabledOnOs(WINDOWS)
+		void deletesSymbolicLinksTargetingDirInsideTempDir(Class<?> elementType,
+				@TrackLogRecords LogRecordListener listener) throws IOException {
+
+			reset(factory);
+
+			closeablePath = TempDirectory.createTempDir(factory, ON_SUCCESS, elementType, elementContext,
+				extensionContext);
+			var rootDir = closeablePath.get();
+			assertThat(rootDir).isDirectory();
+
+			var subDir = createDirectory(rootDir.resolve("subDir"));
+			Files.createFile(subDir.resolve("file"));
+			Files.createSymbolicLink(rootDir.resolve("symbolicLink"), subDir);
+
+			closeablePath.close();
+
+			verify(factory).close();
+			assertThat(rootDir).doesNotExist();
+			assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage).isEmpty();
+
+		}
+
+		@DisplayName("deletes symbolic links targeting directory outside temp dir")
+		@ParameterizedTest
+		@ElementTypeSource
+		@DisabledOnOs(WINDOWS)
+		void deletesSymbolicLinksTargetingDirOutsideTempDir(Class<?> elementType,
+				@TrackLogRecords LogRecordListener listener) throws IOException {
+
+			reset(factory);
+
+			closeablePath = TempDirectory.createTempDir(factory, ON_SUCCESS, elementType, elementContext,
+				extensionContext);
+			var rootDir = closeablePath.get();
+			assertThat(rootDir).isDirectory();
+
+			var directoryOutsideTempDir = createTempDirectory("junit-");
+			try {
+				var symbolicLink = createSymbolicLink(rootDir.resolve("symbolicLink"), directoryOutsideTempDir);
+
+				closeablePath.close();
+
+				verify(factory).close();
+				assertThat(rootDir).doesNotExist();
+				assertThat(directoryOutsideTempDir).isDirectory();
+				assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage) //
+						.contains(("Deleting symbolic link from location inside of temp dir (%s) "
+								+ "to location outside of temp dir (%s) but not the target file/directory").formatted(
+									symbolicLink, directoryOutsideTempDir));
+			}
+			finally {
+				Files.deleteIfExists(directoryOutsideTempDir);
+			}
+		}
 	}
 
 	static class TestCase {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
@@ -490,7 +490,8 @@ class TempDirectoryCleanupTests extends AbstractJupiterTestEngineTests {
 
 			assertThat(outsideDir).exists();
 			assertThat(testFile).exists();
-			assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage) //
+			assertThat(listener.stream(Level.WARNING)) //
+					.map(LogRecord::getMessage) //
 					.anyMatch(m -> m.matches(
 						"Deleting link from location inside of temp dir \\(.+\\) to location outside of temp dir \\(.+\\) but not the target file/directory"));
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryCleanupTests.java
@@ -24,6 +24,8 @@ import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.r
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -32,9 +34,11 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.fixtures.TrackLogRecords;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.platform.commons.logging.LogRecordListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 
 /**
@@ -470,7 +474,8 @@ class TempDirectoryCleanupTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Test
-		void doesNotFollowJunctions(@TempDir Path tempDir) throws IOException {
+		void doesNotFollowJunctions(@TempDir Path tempDir, @TrackLogRecords LogRecordListener listener)
+				throws IOException {
 			var outsideDir = Files.createDirectory(tempDir.resolve("outside"));
 			var testFile = Files.writeString(outsideDir.resolve("test.txt"), "test");
 
@@ -485,6 +490,9 @@ class TempDirectoryCleanupTests extends AbstractJupiterTestEngineTests {
 
 			assertThat(outsideDir).exists();
 			assertThat(testFile).exists();
+			assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage) //
+					.anyMatch(m -> m.matches(
+						"Deleting link from location inside of temp dir \\(.+\\) to location outside of temp dir \\(.+\\) but not the target file/directory"));
 		}
 
 		@SuppressWarnings("JUnitMalformedDeclaration")


### PR DESCRIPTION
## Overview

Resolves #4303.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
