### PR TITLE
Use snapshot-tests to ease adapting assertions after changes to starter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ coverage.db*
 /.tool-versions
 
 checksums*
+
+# snapshot-tests
+*.snapshot_actual
+*.snapshot_raw

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ logback = "1.5.16"
 mockito = "5.15.2"
 opentest4j = "1.3.0"
 openTestReporting = "0.2.0-M2"
+snapshotTests = "1.11.0"
 surefire = "3.5.2"
 xmlunit = "2.10.0"
 
@@ -64,6 +65,8 @@ openTestReporting-tooling-core = { module = "org.opentest4j.reporting:open-test-
 openTestReporting-tooling-spi = { module = "org.opentest4j.reporting:open-test-reporting-tooling-spi", version.ref = "openTestReporting" }
 picocli = { module = "info.picocli:picocli", version = "4.7.6" }
 slf4j-julBinding = { module = "org.slf4j:slf4j-jdk14", version = "2.0.16" }
+snapshotTests-junit5 = { module = "de.skuzzle.test:snapshot-tests-junit5", version.ref = "snapshotTests" }
+snapshotTests-xml = { module = "de.skuzzle.test:snapshot-tests-xml", version.ref = "snapshotTests" }
 spock1 = { module = "org.spockframework:spock-core", version = "1.3-groovy-2.5" }
 univocity-parsers = { module = "com.sonofab1rd:univocity-parsers", version = "2.10.1" }
 xmlunit-assertj = { module = "org.xmlunit:xmlunit-assertj3", version.ref = "xmlunit" }

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -74,6 +74,8 @@ dependencies {
 	testImplementation(libs.bundles.xmlunit)
 	testImplementation(testFixtures(projects.junitJupiterApi))
 	testImplementation(testFixtures(projects.junitPlatformReporting))
+	testImplementation(libs.snapshotTests.junit5)
+	testImplementation(libs.snapshotTests.xml)
 
 	thirdPartyJars(libs.junit4)
 	thirdPartyJars(libs.assertj)

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
@@ -18,6 +18,10 @@ import static platform.tooling.support.tests.XmlAssertions.verifyContainsExpecte
 import java.nio.file.Path;
 import java.util.List;
 
+import de.skuzzle.test.snapshots.Snapshot;
+import de.skuzzle.test.snapshots.SnapshotTestOptions;
+import de.skuzzle.test.snapshots.junit5.EnableSnapshotTests;
+
 import org.apache.tools.ant.Main;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -29,11 +33,15 @@ import platform.tooling.support.ProcessStarters;
 /**
  * @since 1.3
  */
+@EnableSnapshotTests
+@SnapshotTestOptions(alwaysPersistActualResult = true)
 class AntStarterTests {
 
 	@Test
 	@Timeout(60)
-	void ant_starter(@TempDir Path workspace, @FilePrefix("ant") OutputFiles outputFiles) throws Exception {
+	void ant_starter(@TempDir Path workspace, @FilePrefix("ant") OutputFiles outputFiles, Snapshot snapshot)
+			throws Exception {
+
 		var result = ProcessStarters.java() //
 				.workingDir(copyToWorkspace(Projects.JUPITER_STARTER, workspace)) //
 				.addArguments("-cp", System.getProperty("antJars"), Main.class.getName()) //
@@ -57,6 +65,6 @@ class AntStarterTests {
 			result.stdOutLines());
 
 		var testResultsDir = workspace.resolve("build/test-report");
-		verifyContainsExpectedStartedOpenTestReport(testResultsDir);
+		verifyContainsExpectedStartedOpenTestReport(testResultsDir, snapshot);
 	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GradleStarterTests.java
@@ -18,6 +18,10 @@ import static platform.tooling.support.tests.XmlAssertions.verifyContainsExpecte
 
 import java.nio.file.Path;
 
+import de.skuzzle.test.snapshots.Snapshot;
+import de.skuzzle.test.snapshots.SnapshotTestOptions;
+import de.skuzzle.test.snapshots.junit5.EnableSnapshotTests;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.platform.tests.process.OutputFiles;
@@ -30,10 +34,14 @@ import platform.tooling.support.ProcessStarters;
 /**
  * @since 1.3
  */
+@EnableSnapshotTests
+@SnapshotTestOptions(alwaysPersistActualResult = true)
 class GradleStarterTests {
 
 	@Test
-	void gradle_wrapper(@TempDir Path workspace, @FilePrefix("gradle") OutputFiles outputFiles) throws Exception {
+	void gradle_wrapper(@TempDir Path workspace, @FilePrefix("gradle") OutputFiles outputFiles, Snapshot snapshot)
+			throws Exception {
+
 		var result = ProcessStarters.gradlew() //
 				.workingDir(copyToWorkspace(Projects.JUPITER_STARTER, workspace)) //
 				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
@@ -47,6 +55,6 @@ class GradleStarterTests {
 		assertThat(result.stdOut()).contains("Using Java version: 1.8");
 
 		var testResultsDir = workspace.resolve("build/test-results/test");
-		verifyContainsExpectedStartedOpenTestReport(testResultsDir);
+		verifyContainsExpectedStartedOpenTestReport(testResultsDir, snapshot);
 	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
@@ -18,6 +18,10 @@ import static platform.tooling.support.tests.XmlAssertions.verifyContainsExpecte
 
 import java.nio.file.Path;
 
+import de.skuzzle.test.snapshots.Snapshot;
+import de.skuzzle.test.snapshots.SnapshotTestOptions;
+import de.skuzzle.test.snapshots.junit5.EnableSnapshotTests;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.platform.tests.process.OutputFiles;
@@ -30,6 +34,8 @@ import platform.tooling.support.ProcessStarters;
 /**
  * @since 1.3
  */
+@EnableSnapshotTests
+@SnapshotTestOptions(alwaysPersistActualResult = true)
 class MavenStarterTests {
 
 	@ManagedResource
@@ -39,8 +45,9 @@ class MavenStarterTests {
 	MavenRepoProxy mavenRepoProxy;
 
 	@Test
-	void verifyJupiterStarterProject(@TempDir Path workspace, @FilePrefix("maven") OutputFiles outputFiles)
-			throws Exception {
+	void verifyJupiterStarterProject(@TempDir Path workspace, @FilePrefix("maven") OutputFiles outputFiles,
+			Snapshot snapshot) throws Exception {
+
 		var result = ProcessStarters.maven(Helper.getJavaHome("8").orElseThrow(TestAbortedException::new)) //
 				.workingDir(copyToWorkspace(Projects.JUPITER_STARTER, workspace)) //
 				.addArguments(localMavenRepo.toCliArgument(), "-Dmaven.repo=" + MavenRepo.dir()) //
@@ -56,6 +63,6 @@ class MavenStarterTests {
 		assertThat(result.stdOut()).contains("Using Java version: 1.8");
 
 		var testResultsDir = workspace.resolve("target/surefire-reports");
-		verifyContainsExpectedStartedOpenTestReport(testResultsDir);
+		verifyContainsExpectedStartedOpenTestReport(testResultsDir, snapshot);
 	}
 }

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/AntStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/AntStarterTests_snapshots/open-test-report.xml.snapshot
@@ -1,0 +1,141 @@
+dynamic-directory: false
+snapshot-name: open-test-report.xml
+snapshot-number: 0
+test-class: platform.tooling.support.tests.AntStarterTests
+test-method: ant_starter
+
+<?xml version="1.0" encoding="UTF-8"?>
+<e:events xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0"
+			xmlns:git="https://schemas.opentest4j.org/reporting/git/0.2.0"
+			xmlns:java="https://schemas.opentest4j.org/reporting/java/0.2.0"
+			xmlns:junit="https://schemas.junit.org/open-test-reporting"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schemas.junit.org/open-test-reporting https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd">
+  
+  <infrastructure>
+    <hostName>obfuscated</hostName>
+    <userName>obfuscated</userName>
+    <operatingSystem>Linux</operatingSystem>
+    <cpuCores>16</cpuCores>
+    <java:javaVersion>21.0.5</java:javaVersion>
+    <java:fileEncoding>UTF-8</java:fileEncoding>
+    <java:heapSize max="16642998272"/>
+  </infrastructure>
+  
+  <e:started id="1" name="JUnit Jupiter" time="2025-02-11T13:40:07.062496112Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]</junit:uniqueId>
+      <junit:legacyReportingName>JUnit Jupiter</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+  </e:started>
+  
+  <e:started id="2" name="CalculatorTests" parentId="1" time="2025-02-11T13:40:07.073780457Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorTests</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorTests"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="3" name="1 + 1 = 2" parentId="2" time="2025-02-11T13:40:07.085669511Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[method:addsTwoNumbers()]</junit:uniqueId>
+      <junit:legacyReportingName>addsTwoNumbers()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="addsTwoNumbers" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="3" time="2025-02-11T13:40:07.097640921Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="4" name="add(int, int, int)" parentId="2" time="2025-02-11T13:40:07.100627944Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="5" name="0 + 1 = 1" parentId="4" time="2025-02-11T13:40:07.126338320Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[1]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="5" time="2025-02-11T13:40:07.136620739Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="6" name="1 + 2 = 3" parentId="4" time="2025-02-11T13:40:07.138368039Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[2]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="6" time="2025-02-11T13:40:07.139838798Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="7" name="49 + 51 = 100" parentId="4" time="2025-02-11T13:40:07.141924325Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#3]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[3]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="7" time="2025-02-11T13:40:07.145834226Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="8" name="1 + 100 = 101" parentId="4" time="2025-02-11T13:40:07.148382474Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#4]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[4]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="8" time="2025-02-11T13:40:07.150067857Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="4" time="2025-02-11T13:40:07.150595540Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="2" time="2025-02-11T13:40:07.151726269Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="1" time="2025-02-11T13:40:07.168385454Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+</e:events>

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/GradleStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/GradleStarterTests_snapshots/open-test-report.xml.snapshot
@@ -1,0 +1,141 @@
+dynamic-directory: false
+snapshot-name: open-test-report.xml
+snapshot-number: 0
+test-class: platform.tooling.support.tests.GradleStarterTests
+test-method: gradle_wrapper
+
+<?xml version="1.0" encoding="UTF-8"?>
+<e:events xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0"
+			xmlns:git="https://schemas.opentest4j.org/reporting/git/0.2.0"
+			xmlns:java="https://schemas.opentest4j.org/reporting/java/0.2.0"
+			xmlns:junit="https://schemas.junit.org/open-test-reporting"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schemas.junit.org/open-test-reporting https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd">
+  
+  <infrastructure>
+    <hostName>obfuscated</hostName>
+    <userName>obfuscated</userName>
+    <operatingSystem>Linux</operatingSystem>
+    <cpuCores>16</cpuCores>
+    <java:javaVersion>1.8.0_422</java:javaVersion>
+    <java:fileEncoding>UTF-8</java:fileEncoding>
+    <java:heapSize max="514850816"/>
+  </infrastructure>
+  
+  <e:started id="1" name="JUnit Jupiter" time="2025-02-11T13:40:40.710Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]</junit:uniqueId>
+      <junit:legacyReportingName>JUnit Jupiter</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+  </e:started>
+  
+  <e:started id="2" name="CalculatorTests" parentId="1" time="2025-02-11T13:40:40.729Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorTests</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorTests"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="3" name="1 + 1 = 2" parentId="2" time="2025-02-11T13:40:40.745Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[method:addsTwoNumbers()]</junit:uniqueId>
+      <junit:legacyReportingName>addsTwoNumbers()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="addsTwoNumbers" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="3" time="2025-02-11T13:40:40.755Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="4" name="add(int, int, int)" parentId="2" time="2025-02-11T13:40:40.758Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="5" name="0 + 1 = 1" parentId="4" time="2025-02-11T13:40:40.784Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[1]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="5" time="2025-02-11T13:40:40.794Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="6" name="1 + 2 = 3" parentId="4" time="2025-02-11T13:40:40.797Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[2]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="6" time="2025-02-11T13:40:40.798Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="7" name="49 + 51 = 100" parentId="4" time="2025-02-11T13:40:40.799Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#3]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[3]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="7" time="2025-02-11T13:40:40.800Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="8" name="1 + 100 = 101" parentId="4" time="2025-02-11T13:40:40.801Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#4]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[4]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="8" time="2025-02-11T13:40:40.802Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="4" time="2025-02-11T13:40:40.803Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="2" time="2025-02-11T13:40:40.804Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="1" time="2025-02-11T13:40:40.804Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+</e:events>

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/MavenStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/MavenStarterTests_snapshots/open-test-report.xml.snapshot
@@ -1,0 +1,141 @@
+dynamic-directory: false
+snapshot-name: open-test-report.xml
+snapshot-number: 0
+test-class: platform.tooling.support.tests.MavenStarterTests
+test-method: verifyJupiterStarterProject
+
+<?xml version="1.0" encoding="UTF-8"?>
+<e:events xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0"
+			xmlns:git="https://schemas.opentest4j.org/reporting/git/0.2.0"
+			xmlns:java="https://schemas.opentest4j.org/reporting/java/0.2.0"
+			xmlns:junit="https://schemas.junit.org/open-test-reporting"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schemas.junit.org/open-test-reporting https://junit.org/junit5/schemas/open-test-reporting/junit-1.9.xsd">
+  
+  <infrastructure>
+    <hostName>obfuscated</hostName>
+    <userName>obfuscated</userName>
+    <operatingSystem>Linux</operatingSystem>
+    <cpuCores>16</cpuCores>
+    <java:javaVersion>1.8.0_422</java:javaVersion>
+    <java:fileEncoding>UTF-8</java:fileEncoding>
+    <java:heapSize max="14793834496"/>
+  </infrastructure>
+  
+  <e:started id="1" name="JUnit Jupiter" time="2025-02-11T13:40:25.540Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]</junit:uniqueId>
+      <junit:legacyReportingName>JUnit Jupiter</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+  </e:started>
+  
+  <e:started id="2" name="CalculatorTests" parentId="1" time="2025-02-11T13:40:25.557Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorTests</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorTests"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="3" name="1 + 1 = 2" parentId="2" time="2025-02-11T13:40:25.574Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[method:addsTwoNumbers()]</junit:uniqueId>
+      <junit:legacyReportingName>addsTwoNumbers()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="addsTwoNumbers" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="3" time="2025-02-11T13:40:25.585Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="4" name="add(int, int, int)" parentId="2" time="2025-02-11T13:40:25.588Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="5" name="0 + 1 = 1" parentId="4" time="2025-02-11T13:40:25.611Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[1]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="5" time="2025-02-11T13:40:25.622Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="6" name="1 + 2 = 3" parentId="4" time="2025-02-11T13:40:25.624Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[2]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="6" time="2025-02-11T13:40:25.626Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="7" name="49 + 51 = 100" parentId="4" time="2025-02-11T13:40:25.627Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#3]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[3]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="7" time="2025-02-11T13:40:25.628Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="8" name="1 + 100 = 101" parentId="4" time="2025-02-11T13:40:25.629Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#4]</junit:uniqueId>
+      <junit:legacyReportingName>add(int, int, int)[4]</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorTests" methodName="add" methodParameterTypes="int, int, int"/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="8" time="2025-02-11T13:40:25.631Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="4" time="2025-02-11T13:40:25.631Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="2" time="2025-02-11T13:40:25.634Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="1" time="2025-02-11T13:40:25.635Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+</e:events>


### PR DESCRIPTION
Prior to this commit, changing the tests in the jupiter-starter sample
project required to manually adapt the expected XML string in
`XmlAssertions` which was tedious and time-consuming. Instead, the XML
report is now checked against a snapshot that is committed to version
control. When a diff is encountered, the affected test will fail. The
actual and expected snapshots can then be diffed and, if ok, the actual
snapshot can be used to overwrite the expected one.

To avoid committing host names and usernames to source control, they are
obfuscated prior to writing the snapshot files.
