### PR TITLE
Close all arguments, despite trimming, wrapping, and early failures

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M1.adoc
@@ -35,7 +35,11 @@ repository on GitHub.
 [[release-notes-5.13.0-M1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* If `@ParameterizedTest(autoCloseArguments = true)`, all arguments returned by the used
+  `ArgumentsProvider` implementations are now closed even if the test method declares
+  fewer parameters.
+* `AutoCloseable` arguments returned by an `ArgumentsProvider` are now closed even if they
+  are wrapped with `Named`.
 
 [[release-notes-5.13.0-M1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M1.adoc
@@ -40,6 +40,8 @@ repository on GitHub.
   fewer parameters.
 * `AutoCloseable` arguments returned by an `ArgumentsProvider` are now closed even if they
   are wrapped with `Named`.
+* `AutoCloseable` arguments returned by an `ArgumentsProvider` are now closed even if a
+  failure happens prior to invoking the parameterized method.
 
 [[release-notes-5.13.0-M1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes
@@ -54,6 +56,10 @@ repository on GitHub.
   times. This may be used, for example, to inject different parameters to be used by all
   tests in the container template class or to set up each invocation of the container
   template differently.
+* New `TestTemplateInvocationContext.prepareInvocation(ExtensionContext)` callback method
+  allows preparing the `ExtensionContext` before the test template method is invoked. This
+  may be used, for example, to store entries in its `Store` to benefit from its cleanup
+  support or for retrieval by other extensions.
 
 
 [[release-notes-5.13.0-M1-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ContainerTemplateInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ContainerTemplateInvocationContext.java
@@ -67,4 +67,16 @@ public interface ContainerTemplateInvocationContext {
 		return emptyList();
 	}
 
+	/**
+	 * Prepare the imminent invocation of the container template.
+	 *
+	 * <p>This may be used, for example, to store entries in the
+	 * {@link ExtensionContext.Store Store} to benefit from its cleanup support
+	 * or for retrieval by other extensions.
+	 *
+	 * @param context The invocation-level extension context.
+	 */
+	default void prepareInvocation(ExtensionContext context) {
+	}
+
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestTemplateInvocationContext.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.api.extension;
 
 import static java.util.Collections.emptyList;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.List;
@@ -64,6 +65,20 @@ public interface TestTemplateInvocationContext {
 	 */
 	default List<Extension> getAdditionalExtensions() {
 		return emptyList();
+	}
+
+	/**
+	 * Prepare the imminent invocation of the test template.
+	 *
+	 * <p>This may be used, for example, to store entries in the
+	 * {@link ExtensionContext.Store Store} to benefit from its cleanup support
+	 * or for retrieval by other extensions.
+	 *
+	 * @param context The invocation-level extension context.
+	 * @since 5.13
+	 */
+	@API(status = EXPERIMENTAL, since = "5.13")
+	default void prepareInvocation(ExtensionContext context) {
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ContainerTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ContainerTemplateInvocationTestDescriptor.java
@@ -119,6 +119,7 @@ public class ContainerTemplateInvocationTestDescriptor extends JupiterTestDescri
 		}
 		ExtensionContext extensionContext = new ContainerTemplateInvocationExtensionContext(
 			context.getExtensionContext(), context.getExecutionListener(), this, context.getConfiguration(), registry);
+		this.invocationContext.prepareInvocation(extensionContext);
 		return context.extend() //
 				.withExtensionContext(extensionContext) //
 				.withExtensionRegistry(registry) //
@@ -134,8 +135,9 @@ public class ContainerTemplateInvocationTestDescriptor extends JupiterTestDescri
 	}
 
 	@Override
-	public void cleanUp(JupiterEngineExecutionContext context) {
+	public void cleanUp(JupiterEngineExecutionContext context) throws Exception {
 		// forget invocationContext so it can be garbage collected
 		this.invocationContext = null;
+		super.cleanUp(context);
 	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ContainerTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ContainerTemplateTestDescriptor.java
@@ -178,10 +178,11 @@ public class ContainerTemplateTestDescriptor extends ClassBasedTestDescriptor im
 	}
 
 	@Override
-	public void cleanUp(JupiterEngineExecutionContext context) {
+	public void cleanUp(JupiterEngineExecutionContext context) throws Exception {
 		this.childrenPrototypes.clear();
 		this.childrenPrototypesByIndex.clear();
 		this.dynamicDescendantFilter.allowAll();
+		super.cleanUp(context);
 	}
 
 	@Override

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestMethodTestDescriptor.java
@@ -117,6 +117,7 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 		ThrowableCollector throwableCollector = createThrowableCollector();
 		MethodExtensionContext extensionContext = new MethodExtensionContext(context.getExtensionContext(),
 			context.getExecutionListener(), this, context.getConfiguration(), registry, throwableCollector);
+		throwableCollector.execute(() -> prepareExtensionContext(extensionContext));
 		// @formatter:off
 		JupiterEngineExecutionContext newContext = context.extend()
 				.withExtensionRegistry(registry)
@@ -129,6 +130,10 @@ public class TestMethodTestDescriptor extends MethodBasedTestDescriptor {
 			extensionContext.setTestInstances(testInstances);
 		});
 		return newContext;
+	}
+
+	protected void prepareExtensionContext(ExtensionContext extensionContext) {
+		// nothing to do by default
 	}
 
 	protected MutableExtensionRegistry populateNewExtensionRegistry(JupiterEngineExecutionContext context) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateInvocationTestDescriptor.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
@@ -76,15 +77,20 @@ public class TestTemplateInvocationTestDescriptor extends TestMethodTestDescript
 	@Override
 	protected MutableExtensionRegistry populateNewExtensionRegistry(JupiterEngineExecutionContext context) {
 		MutableExtensionRegistry registry = super.populateNewExtensionRegistry(context);
-		invocationContext.getAdditionalExtensions().forEach(
+		this.invocationContext.getAdditionalExtensions().forEach(
 			extension -> registry.registerExtension(extension, invocationContext));
 		return registry;
 	}
 
 	@Override
+	protected void prepareExtensionContext(ExtensionContext extensionContext) {
+		this.invocationContext.prepareInvocation(extensionContext);
+	}
+
+	@Override
 	public void after(JupiterEngineExecutionContext context) {
 		// forget invocationContext so it can be garbage collected
-		invocationContext = null;
+		this.invocationContext = null;
 	}
 
 }

--- a/junit-jupiter-params/src/jmh/java/org/junit/jupiter/params/ParameterizedTestNameFormatterBenchmarks.java
+++ b/junit-jupiter-params/src/jmh/java/org/junit/jupiter/params/ParameterizedTestNameFormatterBenchmarks.java
@@ -51,7 +51,7 @@ public class ParameterizedTestNameFormatterBenchmarks {
 			512);
 		for (int i = 0; i < argumentsList.size(); i++) {
 			Arguments arguments = argumentsList.get(i);
-			blackhole.consume(formatter.format(i, arguments, arguments.get()));
+			blackhole.consume(formatter.format(i, EvaluatedArgumentSet.allOf(arguments)));
 		}
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.IntUnaryOperator;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.platform.commons.util.Preconditions;
+
+/**
+ * Encapsulates the evaluation of an {@link Arguments} instance (so it happens
+ * only once) and access to the resulting argument values.
+ *
+ * <p>The provided accessor methods are focused on the different use cases and
+ * make it less error-prone to access the argument values.
+ *
+ * @since 5.13
+ */
+class EvaluatedArgumentSet {
+
+	static EvaluatedArgumentSet allOf(Arguments arguments) {
+		Object[] all = arguments.get();
+		return create(all, all, arguments);
+	}
+
+	static EvaluatedArgumentSet of(Arguments arguments, IntUnaryOperator consumedLengthComputer) {
+		Object[] all = arguments.get();
+		Object[] consumed = dropSurplus(all, consumedLengthComputer.applyAsInt(all.length));
+		return create(all, consumed, arguments);
+	}
+
+	private static EvaluatedArgumentSet create(Object[] all, Object[] consumed, Arguments arguments) {
+		return new EvaluatedArgumentSet(all, consumed, determineName(arguments));
+	}
+
+	private final Object[] all;
+	private final Object[] consumed;
+	private final Optional<String> name;
+
+	private EvaluatedArgumentSet(Object[] all, Object[] consumed, Optional<String> name) {
+		this.all = all;
+		this.consumed = consumed;
+		this.name = name;
+	}
+
+	int getTotalLength() {
+		return this.all.length;
+	}
+
+	Object[] getAllPayloads() {
+		return extractFromNamed(this.all, Named::getPayload);
+	}
+
+	int getConsumedLength() {
+		return this.consumed.length;
+	}
+
+	Object[] getConsumedNames() {
+		return extractFromNamed(this.consumed, Named::getName);
+	}
+
+	Object[] getConsumedPayloads() {
+		return extractFromNamed(this.consumed, Named::getPayload);
+	}
+
+	Optional<String> getName() {
+		return this.name;
+	}
+
+	private static Object[] dropSurplus(Object[] arguments, int newLength) {
+		Preconditions.condition(newLength <= arguments.length,
+			() -> String.format("New length %d must be less than or equal to the total length %d", newLength,
+				arguments.length));
+		return arguments.length > newLength ? Arrays.copyOf(arguments, newLength) : arguments;
+	}
+
+	private static Optional<String> determineName(Arguments arguments) {
+		if (arguments instanceof Arguments.ArgumentSet) {
+			return Optional.of(((Arguments.ArgumentSet) arguments).getName());
+		}
+		return Optional.empty();
+	}
+
+	private static Object[] extractFromNamed(Object[] arguments, Function<Named<?>, Object> mapper) {
+		return Arrays.stream(arguments) //
+				.map(argument -> argument instanceof Named ? mapper.apply((Named<?>) argument) : argument) //
+				.toArray();
+	}
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestParameterResolver.java
@@ -95,7 +95,7 @@ class ParameterizedTestParameterResolver implements ParameterResolver, AfterTest
 		Store store = context.getStore(NAMESPACE);
 		AtomicInteger argumentIndex = new AtomicInteger();
 
-		Arrays.stream(this.arguments.getConsumedPayloads()) //
+		Arrays.stream(this.arguments.getAllPayloads()) //
 				.filter(AutoCloseable.class::isInstance) //
 				.map(AutoCloseable.class::cast) //
 				.map(CloseableArgument::new) //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -1314,6 +1314,15 @@ class ParameterizedTestIntegrationTests {
 	}
 
 	@Test
+	void closeAutoCloseableArgumentsAfterTestDespiteEarlyFailure() {
+		var results = execute(FailureInBeforeEachTestCase.class, "test", AutoCloseableArgument.class);
+		results.allEvents().assertThatEvents() //
+				.haveExactly(1, event(test(), finishedWithFailure(message("beforeEach"))));
+
+		assertEquals(2, AutoCloseableArgument.closeCounter);
+	}
+
+	@Test
 	void executesTwoIterationsBasedOnIterationAndUniqueIdSelector() {
 		var methodId = uniqueIdForTestTemplateMethod(TestCase.class, "testWithThreeIterations(int)");
 		var results = execute(selectUniqueId(appendTestTemplateInvocationSegment(methodId, 3)),
@@ -2545,6 +2554,21 @@ class ParameterizedTestIntegrationTests {
 
 		static Book factory(String title) {
 			return new Book(title);
+		}
+	}
+
+	static class FailureInBeforeEachTestCase {
+
+		@BeforeEach
+		void beforeEach() {
+			fail("beforeEach");
+		}
+
+		@ParameterizedTest
+		@ArgumentsSource(AutoCloseableArgumentProvider.class)
+		void test(AutoCloseableArgument autoCloseable) {
+			assertNotNull(autoCloseable);
+			assertEquals(0, AutoCloseableArgument.closeCounter);
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -1129,7 +1129,7 @@ class ParameterizedTestIntegrationTests {
 			var results = execute(ArgumentCountValidationMode.STRICT, UnusedArgumentsTestCase.class,
 				"testWithTwoUnusedStringArgumentsProvider", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(EventConditions.finishedWithFailure(message(String.format(
+					.haveExactly(1, event(finishedWithFailure(message(String.format(
 						"Configuration error: the @ParameterizedTest has 1 argument(s) but there were 2 argument(s) provided.%nNote: the provided arguments are [foo, unused1]")))));
 		}
 
@@ -1138,7 +1138,7 @@ class ParameterizedTestIntegrationTests {
 			var results = execute(ArgumentCountValidationMode.STRICT, UnusedArgumentsTestCase.class,
 				"testWithMethodSourceProvidingUnusedArguments", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(EventConditions.finishedWithFailure(message(String.format(
+					.haveExactly(1, event(finishedWithFailure(message(String.format(
 						"Configuration error: the @ParameterizedTest has 1 argument(s) but there were 2 argument(s) provided.%nNote: the provided arguments are [foo, unused1]")))));
 		}
 
@@ -1147,7 +1147,7 @@ class ParameterizedTestIntegrationTests {
 			var results = execute(ArgumentCountValidationMode.NONE, UnusedArgumentsTestCase.class,
 				"testWithStrictArgumentCountValidation", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(EventConditions.finishedWithFailure(message(String.format(
+					.haveExactly(1, event(finishedWithFailure(message(String.format(
 						"Configuration error: the @ParameterizedTest has 1 argument(s) but there were 2 argument(s) provided.%nNote: the provided arguments are [foo, unused1]")))));
 		}
 
@@ -1156,7 +1156,7 @@ class ParameterizedTestIntegrationTests {
 			var results = execute(ArgumentCountValidationMode.STRICT, UnusedArgumentsTestCase.class,
 				"testWithCsvSourceContainingDifferentNumbersOfArguments", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(EventConditions.finishedWithFailure(message(String.format(
+					.haveExactly(1, event(finishedWithFailure(message(String.format(
 						"Configuration error: the @ParameterizedTest has 1 argument(s) but there were 2 argument(s) provided.%nNote: the provided arguments are [foo, unused1]"))))) //
 					.haveExactly(1,
 						event(test(), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestNameFormatterTests.java
@@ -336,7 +336,7 @@ class ParameterizedTestNameFormatterTests {
 	}
 
 	private static String format(ParameterizedTestNameFormatter formatter, int invocationIndex, Arguments arguments) {
-		return formatter.format(invocationIndex, arguments, arguments.get());
+		return formatter.format(invocationIndex, EvaluatedArgumentSet.allOf(arguments));
 	}
 
 	private static class ToStringReturnsNull {


### PR DESCRIPTION
## Overview

- **Evaluate `Arguments.get()` at most once**
- **Close all arguments, not just consumed ones**
- **Close all arguments, despite early failures**

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
