### PR TITLE
improve junit vintage docs about parallel execution

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -45,8 +45,8 @@ concurrent test execution. It can be enabled and configured using the following
 <<running-tests-config-params, configuration parameters>>:
 
 `junit.vintage.execution.parallel.enabled=true|false`::
-  Enable/disable parallel execution (defaults to `false`). Requires opt-in for `classes`
-  or `methods` to be executed in parallel using the configuration parameters below.
+  Enable/disable parallel execution (defaults to `false`).
+Requires opt-in for `classes` or `methods` to be executed in parallel using the configuration parameters below.
 
 `junit.vintage.execution.parallel.classes=true|false`::
   Enable/disable parallel execution of test classes (defaults to `false`).
@@ -55,21 +55,76 @@ concurrent test execution. It can be enabled and configured using the following
   Enable/disable parallel execution of test methods (defaults to `false`).
 
 `junit.vintage.execution.parallel.pool-size=<number>`::
-  Specifies the size of the thread pool to be used for parallel execution. By default, the
-  number of available processors is used.
+  Specifies the size of the thread pool to be used for parallel execution.
+By default, the  number of available processors is used.
 
-Example configuration in `junit-platform.properties`:
+
+Let's assume we have two test classes `FooTest` and `BarTest` with each class containing three unit tests.
+Now, let's enable the parallel execution of test classes:
+
+[source,properties]
+----
+junit.vintage.execution.parallel.enabled=true
+junit.vintage.execution.parallel.classes=true
+----
+
+With this setup, the `VintageTestEngine` will use two different threads,
+one for each test class:
+
+[source,plaintext]
+----
+ForkJoinPool-1-worker-1 - BarTest::test1
+ForkJoinPool-1-worker-2 - FooTest::test1
+ForkJoinPool-1-worker-1 - BarTest::test2
+ForkJoinPool-1-worker-2 - FooTest::test2
+ForkJoinPool-1-worker-1 - BarTest::test3
+ForkJoinPool-1-worker-2 - FooTest::test3
+----
+
+On the other hand, we can enable the parallel test execution at a `method` level,
+rather than the `class` level:
+
+[source,properties]
+----
+junit.vintage.execution.parallel.enabled=true
+junit.vintage.execution.parallel.methods=true
+----
+
+Therefore, the test methods from within a class will be executed in parallel,
+while different test classes will be executed sequentially:
+
+[source,plaintext]
+----
+ForkJoinPool-1-worker-1 - BarTest::test1
+ForkJoinPool-1-worker-2 - BarTest::test2
+ForkJoinPool-1-worker-3 - BarTest::test3
+
+ForkJoinPool-1-worker-3 - FooTest::test1
+ForkJoinPool-1-worker-2 - FooTest::test2
+ForkJoinPool-1-worker-1 - FooTest::test3
+----
+
+Finally, we can also enable the parallelization at both `class` and `method` level:
 
 [source,properties]
 ----
 junit.vintage.execution.parallel.enabled=true
 junit.vintage.execution.parallel.classes=true
 junit.vintage.execution.parallel.methods=true
-junit.vintage.execution.parallel.pool-size=4
 ----
 
-With these properties set, the `VintageTestEngine` will execute tests in parallel,
-potentially significantly reducing the overall test suite execution time.
+With these properties set, the `VintageTestEngine` will execute all the tests classes
+and methods in parallel, potentially significantly reducing the overall test suite execution time:
+
+[source,plaintext]
+----
+ForkJoinPool-1-worker-6 - FooTest::test2
+ForkJoinPool-1-worker-7 - BarTest::test3
+ForkJoinPool-1-worker-3 - FooTest::test1
+ForkJoinPool-1-worker-8 - FooTest::test3
+ForkJoinPool-1-worker-5 - BarTest::test2
+ForkJoinPool-1-worker-4 - BarTest::test1
+----
 
 [[migrating-from-junit4-tips]]
 === Migration Tips


### PR DESCRIPTION
Issue: #4321

## Overview

Improving user guide section about parallel test execution at class/methods level with JUnit Vintage.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] (n/a) There are no TODOs left in the code
- [ ] (n/a) Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] (n/a) [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] (n/a) Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] (n/a) Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] (n/a) Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
