### PR TITLE
Inherit `ParameterizedClass` and `..Source` annotations to subclasses

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ContainerTemplate.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ContainerTemplate.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -48,8 +49,7 @@ import org.junit.platform.commons.annotation.Testable;
  *
  * <h2>Inheritance</h2>
  *
- * <p>The {@code @ContainerTemplate} annotation is not inherited to subclasses
- * but needs to be declared on each container template class individually.
+ * <p>This annotation is inherited to subclasses.
  *
  * @since 5.13
  * @see TestTemplate
@@ -61,6 +61,7 @@ import org.junit.platform.commons.annotation.Testable;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = EXPERIMENTAL, since = "5.13")
 @Testable
 public @interface ContainerTemplate {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClass.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClass.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -122,11 +123,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  *
  * <h2>Inheritance</h2>
  *
- * <p>The {@code @ParameterizedClass} annotation is <em>not</em> inherited
- * from superclasses but may be (re-)declared on a concrete parameterized
- * class. {@code Parameter}-annotated fields from superclasses are detected and
- * used for field injection as if they were declared on the concrete
- * parameterized class.
+ * <p>This annotation is inherited to subclasses.
  *
  * @since 5.13
  * @see Parameter
@@ -149,6 +146,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = EXPERIMENTAL, since = "5.13")
 @ContainerTemplate
 @ExtendWith(ParameterizedClassExtension.class)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -30,6 +31,10 @@ import org.apiguardian.api.API;
  * create a custom <em>composed annotation</em> that inherits the semantics
  * of {@code @ArgumentsSource}.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.0
  * @see org.junit.jupiter.params.provider.ArgumentsProvider
  * @see org.junit.jupiter.params.ParameterizedClass
@@ -38,6 +43,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @Repeatable(ArgumentsSources.class)
 @API(status = STABLE, since = "5.7")
 public @interface ArgumentsSource {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSources.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,12 +29,17 @@ import org.apiguardian.api.API;
  * optional since {@code @ArgumentsSource} is a {@linkplain java.lang.annotation.Repeatable
  * repeatable} annotation.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.0
  * @see org.junit.jupiter.params.provider.ArgumentsSource
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.7")
 public @interface ArgumentsSources {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -59,6 +60,10 @@ import org.junit.jupiter.params.ParameterizedInvocationConstants;
  * column is trimmed by default. This behavior can be changed by setting the
  * {@link #ignoreLeadingAndTrailingWhitespace} attribute to {@code true}.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.0
  * @see CsvSource
  * @see org.junit.jupiter.params.provider.ArgumentsSource
@@ -68,6 +73,7 @@ import org.junit.jupiter.params.ParameterizedInvocationConstants;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @Repeatable(CsvFileSources.class)
 @API(status = STABLE, since = "5.7")
 @ArgumentsSource(CsvFileArgumentsProvider.class)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSources.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,10 @@ import org.apiguardian.api.API;
  * optional since {@code @CsvFileSource} is a {@linkplain java.lang.annotation.Repeatable
  * repeatable} annotation.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.11
  * @see CsvFileSource
  * @see java.lang.annotation.Repeatable
@@ -35,6 +40,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.11")
 public @interface CsvFileSources {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -61,6 +62,10 @@ import org.junit.jupiter.params.ParameterizedInvocationConstants;
  * physical line within the text block. Thus, if a CSV column wraps across a
  * new line in a text block, the column must be a quoted string.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.0
  * @see CsvFileSource
  * @see org.junit.jupiter.params.provider.ArgumentsSource
@@ -71,6 +76,7 @@ import org.junit.jupiter.params.ParameterizedInvocationConstants;
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(CsvSources.class)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.7")
 @ArgumentsSource(CsvArgumentsProvider.class)
 @SuppressWarnings("exports")

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSources.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,10 @@ import org.apiguardian.api.API;
  * optional since {@code @CsvSource} is a {@linkplain java.lang.annotation.Repeatable
  * repeatable} annotation.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.11
  * @see CsvSource
  * @see java.lang.annotation.Repeatable
@@ -35,6 +40,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.11")
 public @interface CsvSources {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptySource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptySource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -44,6 +45,10 @@ import org.apiguardian.api.API;
  * <li>object arrays &mdash; for example {@code String[]}, {@code Integer[][]}, etc.</li>
  * </ul>
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.4
  * @see org.junit.jupiter.params.provider.ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
@@ -54,6 +59,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.7")
 @ArgumentsSource(EmptyArgumentsProvider.class)
 @SuppressWarnings("exports")

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -16,6 +16,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -43,6 +44,10 @@ import org.junit.platform.commons.util.Preconditions;
  * <p>The set of enum constants can be restricted via the {@link #names},
  * {@link #from}, {@link #to} and {@link #mode} attributes.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.0
  * @see org.junit.jupiter.params.provider.ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
@@ -51,6 +56,7 @@ import org.junit.platform.commons.util.Preconditions;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @Repeatable(EnumSources.class)
 @API(status = STABLE, since = "5.7")
 @ArgumentsSource(EnumArgumentsProvider.class)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSources.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,10 @@ import org.apiguardian.api.API;
  * optional since {@code @EnumSource} is a {@linkplain java.lang.annotation.Repeatable
  * repeatable} annotation.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.11
  * @see EnumSource
  * @see java.lang.annotation.Repeatable
@@ -35,6 +40,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.11")
 public @interface EnumSources {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -108,6 +109,10 @@ import org.apiguardian.api.API;
  * {@link org.junit.jupiter.params.ParameterizedClass @ParameterizedClass},
  * regardless whether field or constructor injection is used.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.11
  * @see MethodSource
  * @see Arguments
@@ -119,6 +124,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @Repeatable(FieldSources.class)
 @API(status = EXPERIMENTAL, since = "5.11")
 @ArgumentsSource(FieldArgumentsProvider.class)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSources.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,10 @@ import org.apiguardian.api.API;
  * optional since {@code @FieldSource} is a {@linkplain java.lang.annotation.Repeatable
  * repeatable} annotation.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.11
  * @see FieldSource
  * @see java.lang.annotation.Repeatable
@@ -35,6 +40,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = EXPERIMENTAL, since = "5.11")
 public @interface FieldSources {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -99,6 +100,10 @@ import org.apiguardian.api.API;
  * <p>Factory methods can declare parameters, which will be provided by registered
  * implementations of {@link org.junit.jupiter.api.extension.ParameterResolver}.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.0
  * @see FieldSource
  * @see Arguments
@@ -110,6 +115,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @Repeatable(MethodSources.class)
 @API(status = STABLE, since = "5.7")
 @ArgumentsSource(MethodArgumentsProvider.class)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSources.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,10 @@ import org.apiguardian.api.API;
  * optional since {@code @MethodSource} is a {@linkplain java.lang.annotation.Repeatable
  * repeatable} annotation.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.11
  * @see MethodSource
  * @see java.lang.annotation.Repeatable
@@ -35,6 +40,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.11")
 public @interface MethodSources {
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullAndEmptySource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullAndEmptySource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,6 +30,10 @@ import org.apiguardian.api.API;
  * with {@code @NullAndEmptySource} is equivalent to annotating the method with
  * both {@code @NullSource} and {@code @EmptySource}.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.4
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
@@ -38,6 +43,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.7")
 @NullSource
 @EmptySource

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullSource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,6 +30,10 @@ import org.apiguardian.api.API;
  * a primitive type, unless the argument is converted to a corresponding wrapper
  * type with an {@link org.junit.jupiter.params.converter.ArgumentConverter}.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.4
  * @see org.junit.jupiter.params.provider.ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
@@ -39,6 +44,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.7")
 @ArgumentsSource(NullArgumentsProvider.class)
 @SuppressWarnings("exports")

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueSource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,6 +35,10 @@ import org.apiguardian.api.API;
  * <p>The supplied literal values will be provided as arguments to the
  * annotated {@code @ParameterizedClass} or {@code @ParameterizedTest}.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.0
  * @see org.junit.jupiter.params.provider.ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
@@ -42,6 +47,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @Repeatable(ValueSources.class)
 @API(status = STABLE, since = "5.7")
 @ArgumentsSource(ValueArgumentsProvider.class)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueSources.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +29,10 @@ import org.apiguardian.api.API;
  * optional since {@code @ValueSource} is a {@linkplain java.lang.annotation.Repeatable
  * repeatable} annotation.
  *
+ * <h2>Inheritance</h2>
+ *
+ * <p>This annotation is inherited to subclasses.
+ *
  * @since 5.11
  * @see ValueSource
  * @see java.lang.annotation.Repeatable
@@ -35,6 +40,7 @@ import org.apiguardian.api.API;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 @API(status = STABLE, since = "5.11")
 public @interface ValueSources {
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -76,7 +76,8 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 
 	@Override
 	public ExecutionMode getExecutionMode() {
-		return taskContext.getExecutionAdvisor().getForcedExecutionMode(testDescriptor).orElse(node.getExecutionMode());
+		return taskContext.getExecutionAdvisor().getForcedExecutionMode(testDescriptor) //
+				.orElseGet(node::getExecutionMode);
 	}
 
 	@Override

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/ContainerTemplateInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/ContainerTemplateInvocationTests.java
@@ -103,10 +103,10 @@ public class ContainerTemplateInvocationTests extends AbstractJupiterTestEngineT
 
 	@ParameterizedTest
 	@ValueSource(strings = { //
-			"class:org.junit.jupiter.engine.ContainerTemplateInvocationTests$TwoInvocationsTestCase", //
-			"uid:[engine:junit-jupiter]/[container-template:org.junit.jupiter.engine.ContainerTemplateInvocationTests$TwoInvocationsTestCase]" //
+			"class:%s", //
+			"uid:[engine:junit-jupiter]/[container-template:%s]" //
 	})
-	void executesContainerTemplateClassTwice(String selectorIdentifier) {
+	void executesContainerTemplateClassTwice(String selectorIdentifierTemplate) {
 		var engineId = UniqueId.forEngine(JupiterEngineDescriptor.ENGINE_ID);
 		var containerTemplateId = engineId.append(ContainerTemplateTestDescriptor.STATIC_CLASS_SEGMENT_TYPE,
 			TwoInvocationsTestCase.class.getName());
@@ -119,7 +119,8 @@ public class ContainerTemplateInvocationTests extends AbstractJupiterTestEngineT
 		var invocation2NestedClassId = invocationId2.append(NestedClassTestDescriptor.SEGMENT_TYPE, "NestedTestCase");
 		var invocation2NestedMethodBId = invocation2NestedClassId.append(TestMethodTestDescriptor.SEGMENT_TYPE, "b()");
 
-		var results = executeTests(DiscoverySelectors.parse(selectorIdentifier).orElseThrow());
+		var results = executeTests(DiscoverySelectors.parse(
+			selectorIdentifierTemplate.formatted(TwoInvocationsTestCase.class.getName())).orElseThrow());
 
 		results.allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
@@ -155,6 +156,13 @@ public class ContainerTemplateInvocationTests extends AbstractJupiterTestEngineT
 
 			event(container(uniqueId(containerTemplateId)), finishedSuccessfully()), //
 			event(engine(), finishedSuccessfully()));
+	}
+
+	@Test
+	void containerTemplateAnnotationIsInherited() {
+		var results = executeTestsForClass(InheritedTwoInvocationsTestCase.class);
+
+		results.allEvents().assertStatistics(stats -> stats.started(12).succeeded(12));
 	}
 
 	@Test
@@ -1518,6 +1526,13 @@ public class ContainerTemplateInvocationTests extends AbstractJupiterTestEngineT
 
 		private String format(String methodName, ExtensionContext context) {
 			return "%s%s: %s".formatted(prefix, methodName, context.getRequiredTestClass().getSimpleName());
+		}
+	}
+
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	static class InheritedTwoInvocationsTestCase extends TwoInvocationsTestCase {
+		@Test
+		void c() {
 		}
 	}
 


### PR DESCRIPTION
## Overview

All annotations related to `@ParameterizedClass` are now inherited to subclasses.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
