### PR TITLE
Set stable module name for the standalone JAR file

### DIFF
--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
@@ -27,6 +27,7 @@ val vintageVersion: String by project
 tasks {
 	jar {
 		manifest {
+			attributes("Automatic-Module-Name" to "org.junit.platform.console.standalone")
 			attributes("Main-Class" to "org.junit.platform.console.ConsoleLauncher")
 		}
 	}


### PR DESCRIPTION
Set stable module name for the standalone JAR file to `org.junit.platform.console.standalone`.

Closes #4079

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
