### PR TITLE
Report problematic selector resolution results as discovery issues

### DIFF
--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueCollector.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueCollector.java
@@ -10,12 +10,18 @@
 
 package org.junit.platform.launcher.core;
 
+import static org.junit.platform.engine.SelectorResolutionResult.Status.FAILED;
+import static org.junit.platform.engine.SelectorResolutionResult.Status.UNRESOLVED;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.SelectorResolutionResult;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
 class DiscoveryIssueCollector implements LauncherDiscoveryListener {
@@ -25,6 +31,21 @@ class DiscoveryIssueCollector implements LauncherDiscoveryListener {
 	@Override
 	public void engineDiscoveryStarted(UniqueId engineId) {
 		this.issues.clear();
+	}
+
+	@Override
+	public void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
+		if (result.getStatus() == FAILED) {
+			this.issues.add(DiscoveryIssue.builder(Severity.ERROR, selector + " resolution failed") //
+					.cause(result.getThrowable()) //
+					.build());
+		}
+		else if (result.getStatus() == UNRESOLVED && selector instanceof UniqueIdSelector) {
+			UniqueId uniqueId = ((UniqueIdSelector) selector).getUniqueId();
+			if (uniqueId.hasPrefix(engineId)) {
+				this.issues.add(DiscoveryIssue.create(Severity.ERROR, selector + " could not be resolved"));
+			}
+		}
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListener.java
@@ -10,15 +10,8 @@
 
 package org.junit.platform.launcher.listeners.discovery;
 
-import static org.junit.platform.engine.SelectorResolutionResult.Status.FAILED;
-import static org.junit.platform.engine.SelectorResolutionResult.Status.UNRESOLVED;
-
-import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.ExceptionUtils;
-import org.junit.platform.engine.DiscoverySelector;
-import org.junit.platform.engine.SelectorResolutionResult;
 import org.junit.platform.engine.UniqueId;
-import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.launcher.EngineDiscoveryResult;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 
@@ -31,19 +24,6 @@ class AbortOnFailureLauncherDiscoveryListener implements LauncherDiscoveryListen
 	@Override
 	public void engineDiscoveryFinished(UniqueId engineId, EngineDiscoveryResult result) {
 		result.getThrowable().ifPresent(ExceptionUtils::throwAsUncheckedException);
-	}
-
-	@Override
-	public void selectorProcessed(UniqueId engineId, DiscoverySelector selector, SelectorResolutionResult result) {
-		if (result.getStatus() == FAILED) {
-			throw new JUnitException(selector + " resolution failed", result.getThrowable().orElse(null));
-		}
-		if (result.getStatus() == UNRESOLVED && selector instanceof UniqueIdSelector) {
-			UniqueId uniqueId = ((UniqueIdSelector) selector).getUniqueId();
-			if (uniqueId.hasPrefix(engineId)) {
-				throw new JUnitException(selector + " could not be resolved");
-			}
-		}
 	}
 
 	@Override

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -10,15 +10,14 @@
 
 package org.junit.jupiter.engine;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.util.Throwables.getRootCause;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass.RecursiveNestedClass;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass.RecursiveNestedSiblingClass;
-import org.junit.platform.commons.JUnitException;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
@@ -180,12 +178,12 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 	}
 
 	private void assertNestedCycle(Class<?> start, Class<?> from, Class<?> to) {
-		assertThatExceptionOfType(JUnitException.class)//
-				.isThrownBy(() -> executeTestsForClass(start))//
-				.withCauseExactlyInstanceOf(JUnitException.class)//
-				.satisfies(ex -> assertThat(getRootCause(ex)).hasMessageMatching(
-					String.format("Detected cycle in inner class hierarchy between .+%s and .+%s", from.getSimpleName(),
-						to.getSimpleName())));
+		var results = executeTestsForClass(start);
+		var expectedMessage = String.format(
+			"Cause: org.junit.platform.commons.JUnitException: Detected cycle in inner class hierarchy between %s and %s",
+			from.getName(), to.getName());
+		results.containerEvents().assertThatEvents() //
+				.haveExactly(1, finishedWithFailure(message(it -> it.contains(expectedMessage))));
 	}
 
 	// -------------------------------------------------------------------

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/AbortOnFailureLauncherDiscoveryListenerTests.java
@@ -11,9 +11,7 @@
 package org.junit.platform.launcher.listeners.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
@@ -26,51 +24,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.fakes.TestEngineStub;
 
-class AbortOnFailureLauncherDiscoveryListenerTests extends AbstractLauncherDiscoveryListenerTests {
-
-	@Test
-	void abortsDiscoveryOnUnresolvedUniqueIdSelectorWithEnginePrefix() {
-		var engine = createEngineThatCannotResolveAnything("some-engine");
-		var request = request() //
-				.listeners(abortOnFailure()) //
-				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
-				.build();
-		var launcher = createLauncher(engine);
-
-		var exception = assertThrows(JUnitException.class, () -> launcher.discover(request));
-		assertThat(exception).hasMessage("TestEngine with ID 'some-engine' failed to discover tests");
-		assertThat(exception.getCause()).hasMessage(
-			"UniqueIdSelector [uniqueId = [engine:some-engine]] could not be resolved");
-	}
-
-	@Test
-	void doesNotAbortDiscoveryOnUnresolvedUniqueIdSelectorWithoutEnginePrefix() {
-		var engine = createEngineThatCannotResolveAnything("some-engine");
-		var request = request() //
-				.listeners(abortOnFailure()) //
-				.selectors(selectUniqueId(UniqueId.forEngine("some-other-engine"))) //
-				.build();
-		var launcher = createLauncher(engine);
-
-		assertDoesNotThrow(() -> launcher.discover(request));
-	}
-
-	@Test
-	void abortsDiscoveryOnSelectorResolutionFailure() {
-		var rootCause = new RuntimeException();
-		var engine = createEngineThatFailsToResolveAnything("some-engine", rootCause);
-		var request = request() //
-				.listeners(abortOnFailure()) //
-				.selectors(selectClass(Object.class)) //
-				.build();
-		var launcher = createLauncher(engine);
-
-		var exception = assertThrows(JUnitException.class, () -> launcher.discover(request));
-		assertThat(exception).hasMessage("TestEngine with ID 'some-engine' failed to discover tests");
-		assertThat(exception.getCause()) //
-				.hasMessageEndingWith("resolution failed") //
-				.cause().isSameAs(rootCause);
-	}
+class AbortOnFailureLauncherDiscoveryListenerTests {
 
 	@Test
 	void abortsDiscoveryOnEngineDiscoveryFailure() {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
@@ -13,6 +13,8 @@ package org.junit.platform.launcher.listeners.discovery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
+import static org.junit.platform.fakes.FaultyTestEngines.createEngineThatCannotResolveAnything;
+import static org.junit.platform.fakes.FaultyTestEngines.createEngineThatFailsToResolveAnything;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
@@ -29,7 +31,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.fakes.TestEngineStub;
 
 @TrackLogRecords
-public class LoggingLauncherDiscoveryListenerTests extends AbstractLauncherDiscoveryListenerTests {
+public class LoggingLauncherDiscoveryListenerTests {
 
 	@Test
 	void logsWarningOnUnresolvedUniqueIdSelectorWithEnginePrefix(LogRecordListener log) {


### PR DESCRIPTION
## Overview

Instead of aborting test discovery on the first problematic selector
resolution result, they are now converted to discovery issues with
`ERROR` severity and reported during execution.

Issue: https://github.com/junit-team/junit5/issues/242

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] ~Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~ will be done in a later PR
