### PR TITLE
Introduce `EngineTestKit` support for test discovery

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M1.adoc
@@ -31,6 +31,9 @@ repository on GitHub.
   redirecting `stdout` and `stderr` output streams to files.
 * Add `TestDescriptor.Visitor.composite(List)` factory method for creating a composite
   visitor that delegates to the given visitors in order.
+* Introduce test _discovery_ support in `EngineTestKit` to ease testing for discovery
+  issues produced by a `TestEngine`. Please refer to the
+  <<../user-guide/index.adoc#testkit-engine, User Guide>> for details.
 
 
 [[release-notes-5.13.0-M1-junit-jupiter]]

--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/testkit.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/testkit.adoc
@@ -1,3 +1,5 @@
+:testDir: ../../../../../src/test/java
+
 [[testkit]]
 === JUnit Platform Test Kit
 
@@ -9,16 +11,17 @@ JUnit Platform and then verifying the expected results. As of JUnit Platform
 [[testkit-engine]]
 ==== Engine Test Kit
 
-The `{testkit-engine-package}` package provides support for executing a `{TestPlan}` for a
-given `{TestEngine}` running on the JUnit Platform and then accessing the results via a
-fluent API to verify the expected results. The key entry point into this API is the
-`{EngineTestKit}` which provides static factory methods named `engine()` and `execute()`.
-It is recommended that you select one of the `engine()` variants to benefit from the
-fluent API for building a `LauncherDiscoveryRequest`.
+The `{testkit-engine-package}` package provides support for discovering and executing a
+`{TestPlan}` for a given `{TestEngine}` running on the JUnit Platform and then accessing
+the results via convenient result objects. For execution, a fluent API may be used to
+verify the expected execution events were received. The key entry point into this API is
+the `{EngineTestKit}` which provides static factory methods named `engine()`,
+`discover()`, and `execute()`. It is recommended that you select one of the `engine()`
+variants to benefit from the fluent API for building a `LauncherDiscoveryRequest`.
 
 NOTE: If you prefer to use the `LauncherDiscoveryRequestBuilder` from the `Launcher` API
-to build your `LauncherDiscoveryRequest`, you must use one of the `execute()` variants in
-`EngineTestKit`.
+to build your `LauncherDiscoveryRequest`, you must use one of the `discover()` or
+`execute()` variants in `EngineTestKit`.
 
 The following test class written using JUnit Jupiter will be used in subsequent examples.
 
@@ -34,8 +37,24 @@ own `TestEngine` implementation, you need to use its unique engine ID. Alternati
 may test your own `TestEngine` by supplying an instance of it to the
 `EngineTestKit.engine(TestEngine)` static factory method.
 
+[[testkit-engine-discovery]]
+==== Verifying Test Discovery
+
+The following test demonstrates how to verify that a `TestPlan` was discovered as expected
+by the JUnit Jupiter `TestEngine`.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/testkit/EngineTestKitDiscoveryDemo.java[tags=user_guide]
+----
+<1> Select the JUnit Jupiter `TestEngine`.
+<2> Select the <<testkit-engine-ExampleTestCase, `ExampleTestCase`>> test class.
+<3> Discover the `TestPlan`.
+<4> Assert engine root descriptor has expected display name.
+<5> Assert no discovery issues were encountered.
+
 [[testkit-engine-statistics]]
-==== Asserting Statistics
+==== Asserting Execution Statistics
 
 One of the most common features of the Test Kit is the ability to assert statistics
 against events fired during the execution of a `TestPlan`. The following tests demonstrate

--- a/documentation/src/test/java/example/testkit/EngineTestKitDiscoveryDemo.java
+++ b/documentation/src/test/java/example/testkit/EngineTestKitDiscoveryDemo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.testkit;
+
+// tag::user_guide[]
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import example.ExampleTestCase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineDiscoveryResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+class EngineTestKitDiscoveryDemo {
+
+	@Test
+	void verifyJupiterDiscovery() {
+		EngineDiscoveryResults results = EngineTestKit.engine("junit-jupiter") // <1>
+				.selectors(selectClass(ExampleTestCase.class)) // <2>
+				.discover(); // <3>
+
+		assertEquals("JUnit Jupiter", results.getEngineDescriptor().getDisplayName()); // <4>
+		assertEquals(emptyList(), results.getDiscoveryIssues()); // <5>
+	}
+
+}
+// end::user_guide[]

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
@@ -16,6 +16,7 @@ import static java.util.stream.Collectors.partitioningBy;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -35,9 +36,10 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
  */
 class DiscoveryIssueNotifier {
 
-	static final DiscoveryIssueNotifier NO_ISSUES = new DiscoveryIssueNotifier(emptyList(), emptyList());
+	static final DiscoveryIssueNotifier NO_ISSUES = new DiscoveryIssueNotifier(emptyList(), emptyList(), emptyList());
 	private static final Logger logger = LoggerFactory.getLogger(DiscoveryIssueNotifier.class);
 
+	private final List<DiscoveryIssue> allIssues;
 	private final List<DiscoveryIssue> criticalIssues;
 	private final List<DiscoveryIssue> nonCriticalIssues;
 
@@ -47,12 +49,18 @@ class DiscoveryIssueNotifier {
 				.collect(partitioningBy(issue -> issue.severity().compareTo(criticalSeverity) >= 0));
 		List<DiscoveryIssue> criticalIssues = issuesByCriticality.get(true);
 		List<DiscoveryIssue> nonCriticalIssues = issuesByCriticality.get(false);
-		return new DiscoveryIssueNotifier(criticalIssues, nonCriticalIssues);
+		return new DiscoveryIssueNotifier(new ArrayList<>(issues), criticalIssues, nonCriticalIssues);
 	}
 
-	private DiscoveryIssueNotifier(List<DiscoveryIssue> criticalIssues, List<DiscoveryIssue> nonCriticalIssues) {
+	private DiscoveryIssueNotifier(List<DiscoveryIssue> allIssues, List<DiscoveryIssue> criticalIssues,
+			List<DiscoveryIssue> nonCriticalIssues) {
+		this.allIssues = allIssues;
 		this.criticalIssues = criticalIssues;
 		this.nonCriticalIssues = nonCriticalIssues;
+	}
+
+	List<DiscoveryIssue> getAllIssues() {
+		return allIssues;
 	}
 
 	boolean hasCriticalIssues() {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryResult.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryResult.java
@@ -16,6 +16,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -23,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.reporting.OutputDirectoryProvider;
@@ -49,6 +51,11 @@ public class LauncherDiscoveryResult {
 
 	public TestDescriptor getEngineTestDescriptor(TestEngine testEngine) {
 		return getEngineResult(testEngine).getRootDescriptor();
+	}
+
+	@API(status = INTERNAL, since = "1.13")
+	public List<DiscoveryIssue> getDiscoveryIssues(TestEngine testEngine) {
+		return getEngineResult(testEngine).getDiscoveryIssueNotifier().getAllIssues();
 	}
 
 	EngineResultInfo getEngineResult(TestEngine testEngine) {

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineDiscoveryResults.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineDiscoveryResults.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.testkit.engine;
+
+import static java.util.Collections.unmodifiableList;
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+import java.util.List;
+
+import org.apiguardian.api.API;
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.DiscoveryIssue;
+import org.junit.platform.engine.TestDescriptor;
+
+/**
+ * {@code EngineDiscoveryResults} represents the results of test discovery
+ * by a {@link org.junit.platform.engine.TestEngine TestEngine} on the JUnit
+ * Platform and provides access to the {@link TestDescriptor} of the engine
+ * and any {@link DiscoveryIssue DiscoveryIssues} that were encountered.
+ *
+ * @since 1.13
+ */
+@API(status = EXPERIMENTAL, since = "1.13")
+public class EngineDiscoveryResults {
+
+	private final TestDescriptor engineDescriptor;
+	private final List<DiscoveryIssue> discoveryIssues;
+
+	EngineDiscoveryResults(TestDescriptor engineDescriptor, List<DiscoveryIssue> discoveryIssues) {
+		this.engineDescriptor = Preconditions.notNull(engineDescriptor, "Engine descriptor must not be null");
+		this.discoveryIssues = unmodifiableList(
+			Preconditions.notNull(discoveryIssues, "Discovery issues list must not be null"));
+		Preconditions.containsNoNullElements(discoveryIssues, "Discovery issues list must not contain null elements");
+	}
+
+	/**
+	 * {@return the root {@link TestDescriptor} of the engine}
+	 */
+	public TestDescriptor getEngineDescriptor() {
+		return engineDescriptor;
+	}
+
+	/**
+	 * {@return the issues that were encountered during discovery}
+	 */
+	public List<DiscoveryIssue> getDiscoveryIssues() {
+		return discoveryIssues;
+	}
+
+}

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -16,9 +16,11 @@ import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
+import static org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.Phase.DISCOVERY;
 import static org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.Phase.EXECUTION;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.stream.Stream;
@@ -29,6 +31,7 @@ import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.CollectionUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.DiscoveryFilter;
+import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.EngineExecutionListener;
@@ -46,15 +49,24 @@ import org.junit.platform.launcher.core.LauncherDiscoveryResult;
 import org.junit.platform.launcher.core.ServiceLoaderTestEngineRegistry;
 
 /**
- * {@code EngineTestKit} provides support for executing a test plan for a given
- * {@link TestEngine} and then accessing the results via
- * {@linkplain EngineExecutionResults a fluent API} to verify the expected results.
+ * {@code EngineTestKit} provides support for discovering and executing tests
+ * for a given {@link TestEngine} and provides convenient access to the results.
+ *
+ * <p>For <em>discovery</em>, {@link EngineDiscoveryResults} provides access to
+ * the {@link TestDescriptor} of the engine and any {@link DiscoveryIssue
+ * DiscoveryIssues} that were encountered.
+ *
+ * <p>For <em>execution</em>, {@link EngineExecutionResults} provides a fluent
+ * API to verify the expected results.
  *
  * @since 1.4
  * @see #engine(String)
  * @see #engine(TestEngine)
+ * @see #discover(String, LauncherDiscoveryRequest)
+ * @see #discover(TestEngine, LauncherDiscoveryRequest)
  * @see #execute(String, LauncherDiscoveryRequest)
  * @see #execute(TestEngine, LauncherDiscoveryRequest)
+ * @see EngineDiscoveryResults
  * @see EngineExecutionResults
  */
 @API(status = MAINTAINED, since = "1.7")
@@ -119,6 +131,65 @@ public final class EngineTestKit {
 	public static Builder engine(TestEngine testEngine) {
 		Preconditions.notNull(testEngine, "TestEngine must not be null");
 		return new Builder(testEngine);
+	}
+
+	/**
+	 * Discover tests for the given {@link LauncherDiscoveryRequest} using the
+	 * {@link TestEngine} with the supplied ID.
+	 *
+	 * <p>The {@code TestEngine} will be loaded via Java's {@link ServiceLoader}
+	 * mechanism, analogous to the manner in which test engines are loaded in
+	 * the JUnit Platform Launcher API.
+	 *
+	 * <p>{@link org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder}
+	 * provides a convenient way to build an appropriate discovery request to
+	 * supply to this method. As an alternative, consider using
+	 * {@link #engine(TestEngine)} for a more fluent API.
+	 *
+	 * @param engineId the ID of the {@code TestEngine} to use; must not be
+	 * {@code null} or <em>blank</em>
+	 * @param discoveryRequest the {@code LauncherDiscoveryRequest} to use
+	 * @return the results of the discovery
+	 * @throws PreconditionViolationException for invalid arguments or if the
+	 * {@code TestEngine} with the supplied ID cannot be loaded
+	 * @since 1.13
+	 * @see #discover(TestEngine, LauncherDiscoveryRequest)
+	 * @see #engine(String)
+	 * @see #engine(TestEngine)
+	 */
+	@API(status = EXPERIMENTAL, since = "1.13")
+	public static EngineDiscoveryResults discover(String engineId, LauncherDiscoveryRequest discoveryRequest) {
+		Preconditions.notBlank(engineId, "TestEngine ID must not be null or blank");
+		return discover(loadTestEngine(engineId.trim()), discoveryRequest);
+	}
+
+	/**
+	 * Discover tests for the given {@link LauncherDiscoveryRequest} using the
+	 * supplied {@link TestEngine}.
+	 *
+	 * <p>{@link org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder}
+	 * provides a convenient way to build an appropriate discovery request to
+	 * supply to this method. As an alternative, consider using
+	 * {@link #engine(TestEngine)} for a more fluent API.
+	 *
+	 * @param testEngine the {@code TestEngine} to use; must not be {@code null}
+	 * @param discoveryRequest the {@code EngineDiscoveryResults} to use; must
+	 * not be {@code null}
+	 * @return the recorded {@code EngineExecutionResults}
+	 * @throws PreconditionViolationException for invalid arguments
+	 * @since 1.13
+	 * @see #discover(String, LauncherDiscoveryRequest)
+	 * @see #engine(String)
+	 * @see #engine(TestEngine)
+	 */
+	@API(status = EXPERIMENTAL, since = "1.13")
+	public static EngineDiscoveryResults discover(TestEngine testEngine, LauncherDiscoveryRequest discoveryRequest) {
+		Preconditions.notNull(testEngine, "TestEngine must not be null");
+		Preconditions.notNull(discoveryRequest, "EngineDiscoveryRequest must not be null");
+		LauncherDiscoveryResult discoveryResult = discover(testEngine, discoveryRequest, DISCOVERY);
+		TestDescriptor engineDescriptor = discoveryResult.getEngineTestDescriptor(testEngine);
+		List<DiscoveryIssue> discoveryIssues = discoveryResult.getDiscoveryIssues(testEngine);
+		return new EngineDiscoveryResults(engineDescriptor, discoveryIssues);
 	}
 
 	/**
@@ -260,11 +331,14 @@ public final class EngineTestKit {
 
 	private static void executeUsingLauncherOrchestration(TestEngine testEngine,
 			LauncherDiscoveryRequest discoveryRequest, EngineExecutionListener listener) {
-		LauncherDiscoveryResult discoveryResult = new EngineDiscoveryOrchestrator(singleton(testEngine),
-			emptySet()).discover(discoveryRequest, EXECUTION);
-		TestDescriptor engineTestDescriptor = discoveryResult.getEngineTestDescriptor(testEngine);
-		Preconditions.notNull(engineTestDescriptor, "TestEngine did not yield a TestDescriptor");
+		LauncherDiscoveryResult discoveryResult = discover(testEngine, discoveryRequest, EXECUTION);
 		new EngineExecutionOrchestrator().execute(discoveryResult, listener);
+	}
+
+	private static LauncherDiscoveryResult discover(TestEngine testEngine, LauncherDiscoveryRequest discoveryRequest,
+			EngineDiscoveryOrchestrator.Phase phase) {
+		return new EngineDiscoveryOrchestrator(singleton(testEngine), emptySet()) //
+				.discover(discoveryRequest, phase);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -444,6 +518,25 @@ public final class EngineTestKit {
 		public Builder outputDirectoryProvider(OutputDirectoryProvider outputDirectoryProvider) {
 			this.requestBuilder.outputDirectoryProvider(outputDirectoryProvider);
 			return this;
+		}
+
+		/**
+		 * Discover tests for the configured {@link TestEngine},
+		 * {@linkplain DiscoverySelector discovery selectors},
+		 * {@linkplain DiscoveryFilter discovery filters}, and
+		 * <em>configuration parameters</em>.
+		 *
+		 * @return the recorded {@code EngineDiscoveryResults}
+		 * @since 1.13
+		 * @see #selectors(DiscoverySelector...)
+		 * @see #filters(Filter...)
+		 * @see #configurationParameter(String, String)
+		 * @see #configurationParameters(Map)
+		 */
+		@API(status = EXPERIMENTAL, since = "1.13")
+		public EngineDiscoveryResults discover() {
+			LauncherDiscoveryRequest request = this.requestBuilder.build();
+			return EngineTestKit.discover(this.testEngine, request);
 		}
 
 		/**

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/DisplayNameGenerationTests.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.testkit.engine.Event;
 
 /**
  * Check generated display names.
@@ -247,10 +248,12 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 	void indicativeSentencesOnClassTemplate() {
 		check(ClassTemplateTestCase.class, //
 			"CONTAINER: Class template", //
+			"CONTAINER: [1] Class template", //
 			"TEST: Class template, some test", //
 			"CONTAINER: Class template, Regular Nested Test Case", //
 			"TEST: Class template, Regular Nested Test Case, some nested test", //
 			"CONTAINER: Class template, Nested Class Template", //
+			"CONTAINER: [1] Class template, Nested Class Template", //
 			"TEST: Class template, Nested Class Template, some nested test" //
 		);
 
@@ -271,7 +274,9 @@ class DisplayNameGenerationTests extends AbstractJupiterTestEngineTests {
 
 	private void check(Class<?> testClass, String... expectedDisplayNames) {
 		var request = request().selectors(selectClass(testClass)).build();
-		var descriptors = discoverTests(request).getDescendants();
+		var descriptors = executeTests(request).allEvents().started().stream() //
+				.map(Event::getTestDescriptor) //
+				.skip(1); // Skip engine descriptor
 		assertThat(descriptors).map(this::describe).containsExactlyInAnyOrder(expectedDisplayNames);
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/parallel/ResourceLockAnnotationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/parallel/ResourceLockAnnotationTests.java
@@ -189,8 +189,8 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void addSharedResourcesViaAnnotationValueAndProvidersForClassTemplate() {
-		var engineDescriptor = discoverTests(
-			selectClass(SharedResourcesViaAnnotationValueAndProvidersClassTemplateTestCase.class));
+		var selector = selectClass(SharedResourcesViaAnnotationValueAndProvidersClassTemplateTestCase.class);
+		var engineDescriptor = discoverTests(selector).getEngineDescriptor();
 		engineDescriptor.accept(TestDescriptor::prune);
 
 		var classTemplateTestDescriptor = (JupiterTestDescriptor) getOnlyElement(engineDescriptor.getChildren());
@@ -214,8 +214,9 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void addSharedResourcesViaAnnotationValueAndProvidersForClassTemplateInvocation() {
-		var engineDescriptor = discoverTests(
-			selectIteration(selectClass(SharedResourcesViaAnnotationValueAndProvidersClassTemplateTestCase.class), 0));
+		var selector = selectIteration(
+			selectClass(SharedResourcesViaAnnotationValueAndProvidersClassTemplateTestCase.class), 0);
+		var engineDescriptor = discoverTests(selector).getEngineDescriptor();
 		engineDescriptor.accept(TestDescriptor::prune);
 
 		var classTemplateTestDescriptor = (JupiterTestDescriptor) getOnlyElement(engineDescriptor.getChildren());
@@ -239,8 +240,8 @@ class ResourceLockAnnotationTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void addSharedResourcesViaAnnotationValueAndProvidersForMethodInClassTemplate() {
-		var engineDescriptor = discoverTests(
-			selectMethod(SharedResourcesViaAnnotationValueAndProvidersClassTemplateTestCase.class, "test"));
+		var selector = selectMethod(SharedResourcesViaAnnotationValueAndProvidersClassTemplateTestCase.class, "test");
+		var engineDescriptor = discoverTests(selector).getEngineDescriptor();
 		engineDescriptor.accept(TestDescriptor::prune);
 
 		var classTemplateTestDescriptor = (JupiterTestDescriptor) getOnlyElement(engineDescriptor.getChildren());

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/ClassTemplateInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/ClassTemplateInvocationTests.java
@@ -979,7 +979,8 @@ public class ClassTemplateInvocationTests extends AbstractJupiterTestEngineTests
 
 	@Test
 	void propagatesTagsFromEnclosingClassesToNestedClassTemplates() {
-		var engineDescriptor = discoverTestsForClass(NestedClassTemplateWithTagOnEnclosingClassTestCase.class);
+		var engineDescriptor = discoverTestsForClass(
+			NestedClassTemplateWithTagOnEnclosingClassTestCase.class).getEngineDescriptor();
 		var classDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		var nestedClassTemplateDescriptor = getOnlyElement(classDescriptor.getChildren());
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/DefaultExecutionModeTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/DefaultExecutionModeTests.java
@@ -109,7 +109,7 @@ class DefaultExecutionModeTests extends AbstractJupiterTestEngineTests {
 		if (executionMode != null) {
 			request.configurationParameter(Constants.DEFAULT_PARALLEL_EXECUTION_MODE, executionMode.name());
 		}
-		return (JupiterEngineDescriptor) discoverTests(request.build());
+		return (JupiterEngineDescriptor) discoverTests(request.build()).getEngineDescriptor();
 	}
 
 	private static void assertExecutionMode(TestDescriptor testDescriptor, ExecutionMode expectedExecutionMode) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/DynamicNodeGenerationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/DynamicNodeGenerationTests.java
@@ -67,7 +67,7 @@ class DynamicNodeGenerationTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void testFactoryMethodsAreCorrectlyDiscoveredForClassSelector() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(MyDynamicTestCase.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertThat(engineDescriptor.getDescendants()).as("# resolved test descriptors").hasSize(13);
 	}
 
@@ -75,7 +75,7 @@ class DynamicNodeGenerationTests extends AbstractJupiterTestEngineTests {
 	void testFactoryMethodIsCorrectlyDiscoveredForMethodSelector() {
 		LauncherDiscoveryRequest request = request().selectors(
 			selectMethod(MyDynamicTestCase.class, "dynamicStream")).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertThat(engineDescriptor.getDescendants()).as("# resolved test descriptors").hasSize(2);
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -43,7 +43,7 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void nestedTestsAreCorrectlyDiscovered() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(TestCaseWithNesting.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(5, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -64,7 +64,7 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void doublyNestedTestsAreCorrectlyDiscovered() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(TestCaseWithDoubleNesting.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(8, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/StandardTestClassTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/StandardTestClassTests.java
@@ -37,7 +37,7 @@ class StandardTestClassTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void standardTestClassIsCorrectlyDiscovered() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(MyStandardTestCase.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(1 /*class*/ + 6 /*methods*/, engineDescriptor.getDescendants().size(),
 			"# resolved test descriptors");
 	}
@@ -45,7 +45,7 @@ class StandardTestClassTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void moreThanOneTestClassIsCorrectlyDiscovered() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(SecondOfTwoTestCases.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(1 /*class*/ + 3 /*methods*/, engineDescriptor.getDescendants().size(),
 			"# resolved test descriptors");
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
@@ -47,14 +47,14 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void discoverTestClass() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(LocalTestCase.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(7, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
 	void doNotDiscoverAbstractTestClass() {
 		LauncherDiscoveryRequest request = request().selectors(selectClass(AbstractTestCase.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(0, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -62,7 +62,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	void discoverMethodByUniqueId() {
 		LauncherDiscoveryRequest request = request().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test1()"))).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -70,7 +70,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	void discoverMethodByUniqueIdForOverloadedMethod() {
 		LauncherDiscoveryRequest request = request().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test4()"))).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -78,7 +78,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	void discoverMethodByUniqueIdForOverloadedMethodVariantThatAcceptsArguments() {
 		LauncherDiscoveryRequest request = request().selectors(selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(
 			LocalTestCase.class, "test4(" + TestInfo.class.getName() + ")"))).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -87,7 +87,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		Method testMethod = LocalTestCase.class.getDeclaredMethod("test3");
 
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(LocalTestCase.class, testMethod)).build();
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -96,7 +96,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest request = request().selectors(selectMethod(LocalTestCase.class, "test1"),
 			selectMethod(LocalTestCase.class, "test2")).build();
 
-		TestDescriptor engineDescriptor = discoverTests(request);
+		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 
 		assertThat(engineDescriptor.getChildren()).hasSize(1);
 		TestDescriptor classDescriptor = getOnlyElement(engineDescriptor.getChildren());
@@ -109,7 +109,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test2()")),
 			selectClass(LocalTestCase.class)).build();
 
-		TestDescriptor engineDescriptor = discoverTests(spec);
+		TestDescriptor engineDescriptor = discoverTests(spec).getEngineDescriptor();
 		assertEquals(7, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -118,7 +118,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest spec = request().selectors(
 			selectUniqueId(uniqueIdForTestTemplateMethod(TestTemplateClass.class, "testTemplate()"))).build();
 
-		TestDescriptor engineDescriptor = discoverTests(spec);
+		TestDescriptor engineDescriptor = discoverTests(spec).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -127,7 +127,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest spec = request().selectors(
 			selectMethod(TestTemplateClass.class, "testTemplate")).build();
 
-		TestDescriptor engineDescriptor = discoverTests(spec);
+		TestDescriptor engineDescriptor = discoverTests(spec).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -139,7 +139,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 			AbstractSuperClass.NestedInAbstractClass.class.getDeclaredMethod("test"));
 		LauncherDiscoveryRequest spec = request().selectors(selector).build();
 
-		TestDescriptor engineDescriptor = discoverTests(spec);
+		TestDescriptor engineDescriptor = discoverTests(spec).getEngineDescriptor();
 
 		ClassTestDescriptor topLevelClassDescriptor = (ClassTestDescriptor) getOnlyElement(
 			engineDescriptor.getChildren());

--- a/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineDiscoveryResultsIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineDiscoveryResultsIntegrationTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.testkit.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.platform.engine.DiscoveryIssue;
+import org.junit.platform.engine.DiscoveryIssue.Severity;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.fakes.TestEngineStub;
+
+@ParameterizedClass
+@EnumSource
+record EngineDiscoveryResultsIntegrationTests(TestKitApi testKit) {
+
+	@Test
+	void returnsEngineDescriptor() {
+		var results = testKit.discover("junit-jupiter", selectClass(TestCase.class));
+
+		assertThat(results.getEngineDescriptor().getDisplayName()).isEqualTo("JUnit Jupiter");
+		assertThat(getOnlyElement(results.getEngineDescriptor().getChildren()).getSource()) //
+				.contains(ClassSource.from(TestCase.class));
+	}
+
+	@Test
+	void collectsDiscoveryIssues() {
+		var issue = DiscoveryIssue.create(Severity.WARNING, "warning");
+		var testEngine = new TestEngineStub() {
+			@Override
+			public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+				var listener = discoveryRequest.getDiscoveryListener();
+				listener.issueEncountered(uniqueId, issue);
+				return super.discover(discoveryRequest, uniqueId);
+			}
+		};
+
+		var results = testKit.discover(testEngine);
+
+		assertThat(results.getDiscoveryIssues()).containsExactly(issue);
+	}
+
+	@SuppressWarnings("JUnitMalformedDeclaration")
+	static class TestCase {
+		@Test
+		void test() {
+		}
+	}
+
+	enum TestKitApi {
+
+		STATIC_METHOD {
+			@Override
+			EngineDiscoveryResults discover(String engineId, DiscoverySelector selector) {
+				return EngineTestKit.discover(engineId, request().selectors(selector).build());
+			}
+
+			@Override
+			EngineDiscoveryResults discover(TestEngine testEngine) {
+				return EngineTestKit.discover(testEngine, request().build());
+			}
+		},
+
+		FLUENT_API {
+			@Override
+			EngineDiscoveryResults discover(String engineId, DiscoverySelector selector) {
+				return EngineTestKit.engine(engineId).selectors(selector).discover();
+			}
+
+			@Override
+			EngineDiscoveryResults discover(TestEngine testEngine) {
+				return EngineTestKit.engine(testEngine).discover();
+			}
+		};
+
+		@SuppressWarnings("SameParameterValue")
+		abstract EngineDiscoveryResults discover(String engineId, DiscoverySelector selector);
+
+		abstract EngineDiscoveryResults discover(TestEngine testEngine);
+	}
+}


### PR DESCRIPTION
## Overview

The goal is to ease testing for discovery issues encountered by an
engine (see #242).

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
