### PR TITLE
Optimize `ClassOrderingVisitor`

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractOrderingVisitor.java
@@ -22,7 +22,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
@@ -90,25 +89,18 @@ abstract class AbstractOrderingVisitor implements TestDescriptor.Visitor {
 			Stream<TestDescriptor> orderedTestDescriptors = matchingDescriptorWrappers.stream()//
 					.map(AbstractAnnotatedDescriptorWrapper::getTestDescriptor);
 
-			// If we are ordering children of type ClassBasedTestDescriptor, that means we
-			// are ordering top-level classes or @Nested test classes. Thus, the
-			// nonMatchingTestDescriptors list is either empty (for top-level classes) or
-			// contains only local test methods (for @Nested classes) which must be executed
-			// before tests in @Nested test classes. So we add the test methods before adding
-			// the @Nested test classes.
-			if (matchingChildrenType == ClassBasedTestDescriptor.class) {
+			if (shouldNonMatchingDescriptorsComeBeforeOrderedOnes()) {
 				return Stream.concat(nonMatchingTestDescriptors, orderedTestDescriptors)//
 						.collect(toList());
 			}
-			// Otherwise, we add the ordered descriptors before the non-matching descriptors,
-			// which is the case when we are ordering test methods. In other words, local
-			// test methods always get added before @Nested test classes.
 			else {
 				return Stream.concat(orderedTestDescriptors, nonMatchingTestDescriptors)//
 						.collect(toList());
 			}
 		});
 	}
+
+	protected abstract boolean shouldNonMatchingDescriptorsComeBeforeOrderedOnes();
 
 	/**
 	 * @param <WRAPPER> the wrapper type for the children to order

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractOrderingVisitor.java
@@ -32,19 +32,18 @@ import org.junit.platform.engine.TestDescriptor;
  * Abstract base class for {@linkplain TestDescriptor.Visitor visitors} that
  * order children nodes.
  *
- * @param <PARENT> the parent container type to search in for matching children
- * @param <CHILD> the type of children (containers or tests) to order
- * @param <WRAPPER> the wrapper type for the children to order
  * @since 5.8
  */
-abstract class AbstractOrderingVisitor<PARENT extends TestDescriptor, CHILD extends TestDescriptor, WRAPPER extends AbstractAnnotatedDescriptorWrapper<?>>
-		implements TestDescriptor.Visitor {
+abstract class AbstractOrderingVisitor implements TestDescriptor.Visitor {
 
 	private static final Logger logger = LoggerFactory.getLogger(AbstractOrderingVisitor.class);
 
+	/**
+	 * @param <PARENT> the parent container type to search in for matching children
+	 */
 	@SuppressWarnings("unchecked")
-	protected void doWithMatchingDescriptor(Class<PARENT> parentTestDescriptorType, TestDescriptor testDescriptor,
-			Consumer<PARENT> action, Function<PARENT, String> errorMessageBuilder) {
+	protected <PARENT extends TestDescriptor> void doWithMatchingDescriptor(Class<PARENT> parentTestDescriptorType,
+			TestDescriptor testDescriptor, Consumer<PARENT> action, Function<PARENT, String> errorMessageBuilder) {
 
 		if (parentTestDescriptorType.isInstance(testDescriptor)) {
 			PARENT parentTestDescriptor = (PARENT) testDescriptor;
@@ -58,8 +57,17 @@ abstract class AbstractOrderingVisitor<PARENT extends TestDescriptor, CHILD exte
 		}
 	}
 
-	protected void orderChildrenTestDescriptors(TestDescriptor parentTestDescriptor, Class<CHILD> matchingChildrenType,
-			Function<CHILD, WRAPPER> descriptorWrapperFactory, DescriptorWrapperOrderer descriptorWrapperOrderer) {
+	/**
+	 * @param <CHILD> the type of children (containers or tests) to order
+	 */
+	protected <CHILD extends TestDescriptor, WRAPPER extends AbstractAnnotatedDescriptorWrapper<?>> void orderChildrenTestDescriptors(
+			TestDescriptor parentTestDescriptor, Class<CHILD> matchingChildrenType,
+			Function<CHILD, WRAPPER> descriptorWrapperFactory,
+			DescriptorWrapperOrderer<WRAPPER> descriptorWrapperOrderer) {
+
+		if (!descriptorWrapperOrderer.canOrderWrappers()) {
+			return;
+		}
 
 		List<WRAPPER> matchingDescriptorWrappers = parentTestDescriptor.getChildren()//
 				.stream()//
@@ -73,67 +81,50 @@ abstract class AbstractOrderingVisitor<PARENT extends TestDescriptor, CHILD exte
 			return;
 		}
 
-		if (descriptorWrapperOrderer.canOrderWrappers()) {
-			parentTestDescriptor.orderChildren(children -> {
-				Stream<TestDescriptor> nonMatchingTestDescriptors = children.stream()//
-						.filter(childTestDescriptor -> !matchingChildrenType.isInstance(childTestDescriptor));
+		parentTestDescriptor.orderChildren(children -> {
+			Stream<TestDescriptor> nonMatchingTestDescriptors = children.stream()//
+					.filter(childTestDescriptor -> !matchingChildrenType.isInstance(childTestDescriptor));
 
-				descriptorWrapperOrderer.orderWrappers(matchingDescriptorWrappers);
+			descriptorWrapperOrderer.orderWrappers(matchingDescriptorWrappers);
 
-				Stream<TestDescriptor> orderedTestDescriptors = matchingDescriptorWrappers.stream()//
-						.map(AbstractAnnotatedDescriptorWrapper::getTestDescriptor);
+			Stream<TestDescriptor> orderedTestDescriptors = matchingDescriptorWrappers.stream()//
+					.map(AbstractAnnotatedDescriptorWrapper::getTestDescriptor);
 
-				// If we are ordering children of type ClassBasedTestDescriptor, that means we
-				// are ordering top-level classes or @Nested test classes. Thus, the
-				// nonMatchingTestDescriptors list is either empty (for top-level classes) or
-				// contains only local test methods (for @Nested classes) which must be executed
-				// before tests in @Nested test classes. So we add the test methods before adding
-				// the @Nested test classes.
-				if (matchingChildrenType == ClassBasedTestDescriptor.class) {
-					return Stream.concat(nonMatchingTestDescriptors, orderedTestDescriptors)//
-							.collect(toList());
-				}
-				// Otherwise, we add the ordered descriptors before the non-matching descriptors,
-				// which is the case when we are ordering test methods. In other words, local
-				// test methods always get added before @Nested test classes.
-				else {
-					return Stream.concat(orderedTestDescriptors, nonMatchingTestDescriptors)//
-							.collect(toList());
-				}
-			});
-		}
-
-		// Recurse through the children in order to support ordering for @Nested test classes.
-		matchingDescriptorWrappers.forEach(descriptorWrapper -> {
-			TestDescriptor newParentTestDescriptor = descriptorWrapper.getTestDescriptor();
-			DescriptorWrapperOrderer newDescriptorWrapperOrderer = getDescriptorWrapperOrderer(descriptorWrapperOrderer,
-				descriptorWrapper);
-
-			orderChildrenTestDescriptors(newParentTestDescriptor, matchingChildrenType, descriptorWrapperFactory,
-				newDescriptorWrapperOrderer);
+			// If we are ordering children of type ClassBasedTestDescriptor, that means we
+			// are ordering top-level classes or @Nested test classes. Thus, the
+			// nonMatchingTestDescriptors list is either empty (for top-level classes) or
+			// contains only local test methods (for @Nested classes) which must be executed
+			// before tests in @Nested test classes. So we add the test methods before adding
+			// the @Nested test classes.
+			if (matchingChildrenType == ClassBasedTestDescriptor.class) {
+				return Stream.concat(nonMatchingTestDescriptors, orderedTestDescriptors)//
+						.collect(toList());
+			}
+			// Otherwise, we add the ordered descriptors before the non-matching descriptors,
+			// which is the case when we are ordering test methods. In other words, local
+			// test methods always get added before @Nested test classes.
+			else {
+				return Stream.concat(orderedTestDescriptors, nonMatchingTestDescriptors)//
+						.collect(toList());
+			}
 		});
 	}
 
 	/**
-	 * Get the {@link DescriptorWrapperOrderer} for the supplied {@link AbstractAnnotatedDescriptorWrapper}.
-	 *
-	 * <p>The default implementation returns the supplied {@code DescriptorWrapperOrderer}.
-	 *
-	 * @return a new {@code DescriptorWrapperOrderer} or the one supplied as an argument
+	 * @param <WRAPPER> the wrapper type for the children to order
 	 */
-	protected DescriptorWrapperOrderer getDescriptorWrapperOrderer(
-			DescriptorWrapperOrderer inheritedDescriptorWrapperOrderer,
-			AbstractAnnotatedDescriptorWrapper<?> descriptorWrapper) {
+	protected static class DescriptorWrapperOrderer<WRAPPER> {
 
-		return inheritedDescriptorWrapperOrderer;
-	}
+		private static final DescriptorWrapperOrderer<?> NOOP = new DescriptorWrapperOrderer<>(null, __ -> "",
+			___ -> "");
 
-	protected class DescriptorWrapperOrderer {
+		@SuppressWarnings("unchecked")
+		protected static <WRAPPER> DescriptorWrapperOrderer<WRAPPER> noop() {
+			return (DescriptorWrapperOrderer<WRAPPER>) NOOP;
+		}
 
 		private final Consumer<List<WRAPPER>> orderingAction;
-
 		private final MessageGenerator descriptorsAddedMessageGenerator;
-
 		private final MessageGenerator descriptorsRemovedMessageGenerator;
 
 		DescriptorWrapperOrderer(Consumer<List<WRAPPER>> orderingAction,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.engine.discovery;
 
-import java.lang.reflect.AnnotatedElement;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -21,67 +20,86 @@ import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.platform.commons.util.LruCache;
 import org.junit.platform.engine.TestDescriptor;
 
 /**
  * @since 5.8
  */
-class ClassOrderingVisitor
-		extends AbstractOrderingVisitor<JupiterEngineDescriptor, ClassBasedTestDescriptor, DefaultClassDescriptor> {
+class ClassOrderingVisitor extends AbstractOrderingVisitor {
 
+	private final LruCache<ClassBasedTestDescriptor, DescriptorWrapperOrderer<DefaultClassDescriptor>> ordererCache = new LruCache<>(
+		10);
 	private final JupiterConfiguration configuration;
+	private final DescriptorWrapperOrderer<DefaultClassDescriptor> globalOrderer;
 
 	ClassOrderingVisitor(JupiterConfiguration configuration) {
 		this.configuration = configuration;
+		this.globalOrderer = createGlobalOrderer(configuration);
 	}
 
 	@Override
 	public void visit(TestDescriptor testDescriptor) {
-		ClassOrderer globalClassOrderer = this.configuration.getDefaultTestClassOrderer().orElse(null);
-		doWithMatchingDescriptor(JupiterEngineDescriptor.class, testDescriptor,
-			descriptor -> orderContainedClasses(descriptor, globalClassOrderer),
-			descriptor -> "Failed to order classes");
+		doWithMatchingDescriptor(JupiterEngineDescriptor.class, testDescriptor, this::orderTopLevelClasses,
+			descriptor -> "Failed to order top-level classes");
+		doWithMatchingDescriptor(ClassBasedTestDescriptor.class, testDescriptor, this::orderNestedClasses,
+			descriptor -> "Failed to order nested classes for " + descriptor.getTestClass());
 	}
 
-	private void orderContainedClasses(JupiterEngineDescriptor jupiterEngineDescriptor, ClassOrderer classOrderer) {
+	private void orderTopLevelClasses(JupiterEngineDescriptor engineDescriptor) {
 		orderChildrenTestDescriptors(//
-			jupiterEngineDescriptor, //
+			engineDescriptor, //
 			ClassBasedTestDescriptor.class, //
 			DefaultClassDescriptor::new, //
-			createDescriptorWrapperOrderer(classOrderer));
+			globalOrderer);
 	}
 
-	@Override
-	protected DescriptorWrapperOrderer getDescriptorWrapperOrderer(
-			DescriptorWrapperOrderer inheritedDescriptorWrapperOrderer,
-			AbstractAnnotatedDescriptorWrapper<?> descriptorWrapper) {
+	private void orderNestedClasses(ClassBasedTestDescriptor descriptor) {
+		orderChildrenTestDescriptors(//
+			descriptor, //
+			ClassBasedTestDescriptor.class, //
+			DefaultClassDescriptor::new, //
+			lookupOrCreateClassLevelOrderer(descriptor));
+	}
 
-		AnnotatedElement annotatedElement = descriptorWrapper.getAnnotatedElement();
-		return AnnotationSupport.findAnnotation(annotatedElement, TestClassOrder.class)//
+	private DescriptorWrapperOrderer<DefaultClassDescriptor> createGlobalOrderer(JupiterConfiguration configuration) {
+		ClassOrderer classOrderer = configuration.getDefaultTestClassOrderer().orElse(null);
+		return classOrderer == null ? DescriptorWrapperOrderer.noop() : createDescriptorWrapperOrderer(classOrderer);
+	}
+
+	private DescriptorWrapperOrderer<DefaultClassDescriptor> lookupOrCreateClassLevelOrderer(
+			ClassBasedTestDescriptor classBasedTestDescriptor) {
+		return ordererCache.computeIfAbsent(classBasedTestDescriptor, this::createClassLevelOrderer);
+	}
+
+	private DescriptorWrapperOrderer<DefaultClassDescriptor> createClassLevelOrderer(
+			ClassBasedTestDescriptor classBasedTestDescriptor) {
+		return AnnotationSupport.findAnnotation(classBasedTestDescriptor.getTestClass(), TestClassOrder.class)//
 				.map(TestClassOrder::value)//
-				.<ClassOrderer> map(ReflectionSupport::newInstance)//
+				.map(ReflectionSupport::newInstance)//
 				.map(this::createDescriptorWrapperOrderer)//
-				.orElse(inheritedDescriptorWrapperOrderer);
+				.orElseGet(() -> {
+					Object parent = classBasedTestDescriptor.getParent().orElse(null);
+					if (parent instanceof ClassBasedTestDescriptor) {
+						return lookupOrCreateClassLevelOrderer((ClassBasedTestDescriptor) parent);
+					}
+					return globalOrderer;
+				});
 	}
 
-	private DescriptorWrapperOrderer createDescriptorWrapperOrderer(ClassOrderer classOrderer) {
-		Consumer<List<DefaultClassDescriptor>> orderingAction = classOrderer == null ? null : //
-				classDescriptors -> classOrderer.orderClasses(
-					new DefaultClassOrdererContext(classDescriptors, this.configuration));
+	private DescriptorWrapperOrderer<DefaultClassDescriptor> createDescriptorWrapperOrderer(ClassOrderer classOrderer) {
+		Consumer<List<DefaultClassDescriptor>> orderingAction = classDescriptors -> classOrderer.orderClasses(
+			new DefaultClassOrdererContext(classDescriptors, this.configuration));
 
 		MessageGenerator descriptorsAddedMessageGenerator = number -> String.format(
-			"ClassOrderer [%s] added %s ClassDescriptor(s) which will be ignored.", nullSafeToString(classOrderer),
+			"ClassOrderer [%s] added %s ClassDescriptor(s) which will be ignored.", classOrderer.getClass().getName(),
 			number);
 		MessageGenerator descriptorsRemovedMessageGenerator = number -> String.format(
 			"ClassOrderer [%s] removed %s ClassDescriptor(s) which will be retained with arbitrary ordering.",
-			nullSafeToString(classOrderer), number);
+			classOrderer.getClass().getName(), number);
 
-		return new DescriptorWrapperOrderer(orderingAction, descriptorsAddedMessageGenerator,
+		return new DescriptorWrapperOrderer<>(orderingAction, descriptorsAddedMessageGenerator,
 			descriptorsRemovedMessageGenerator);
-	}
-
-	private static String nullSafeToString(ClassOrderer classOrderer) {
-		return (classOrderer != null ? classOrderer.getClass().getName() : "<unknown>");
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -46,6 +46,15 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 			descriptor -> "Failed to order nested classes for " + descriptor.getTestClass());
 	}
 
+	@Override
+	protected boolean shouldNonMatchingDescriptorsComeBeforeOrderedOnes() {
+		// Non-matching descriptors can only occur when ordering nested classes in which
+		// case they contain only local test methods (for @Nested classes) which must be
+		// executed before tests in @Nested test classes. So we add the test methods before
+		// adding the @Nested test classes.
+		return true;
+	}
+
 	private void orderTopLevelClasses(JupiterEngineDescriptor engineDescriptor) {
 		orderChildrenTestDescriptors(//
 			engineDescriptor, //

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
@@ -28,8 +28,7 @@ import org.junit.platform.engine.TestDescriptor;
 /**
  * @since 5.5
  */
-class MethodOrderingVisitor
-		extends AbstractOrderingVisitor<ClassBasedTestDescriptor, MethodBasedTestDescriptor, DefaultMethodDescriptor> {
+class MethodOrderingVisitor extends AbstractOrderingVisitor {
 
 	private final JupiterConfiguration configuration;
 
@@ -65,8 +64,8 @@ class MethodOrderingVisitor
 						"MethodOrderer [%s] removed %s MethodDescriptor(s) for test class [%s] which will be retained with arbitrary ordering.",
 						methodOrderer.getClass().getName(), number, testClass.getName());
 
-					DescriptorWrapperOrderer descriptorWrapperOrderer = new DescriptorWrapperOrderer(orderingAction,
-						descriptorsAddedMessageGenerator, descriptorsRemovedMessageGenerator);
+					DescriptorWrapperOrderer<DefaultMethodDescriptor> descriptorWrapperOrderer = new DescriptorWrapperOrderer<>(
+						orderingAction, descriptorsAddedMessageGenerator, descriptorsRemovedMessageGenerator);
 
 					orderChildrenTestDescriptors(classBasedTestDescriptor, //
 						MethodBasedTestDescriptor.class, //

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
@@ -43,6 +43,13 @@ class MethodOrderingVisitor extends AbstractOrderingVisitor {
 			descriptor -> "Failed to order methods for " + descriptor.getTestClass());
 	}
 
+	@Override
+	protected boolean shouldNonMatchingDescriptorsComeBeforeOrderedOnes() {
+		// Non-matching descriptors can only contain @Nested test classes which should be
+		// added after local test methods.
+		return false;
+	}
+
 	/**
 	 * @since 5.4
 	 */

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -618,7 +618,11 @@ class OrderedMethodTests {
 	static class OuterTestCase {
 
 		@Nested
-		class NestedOrderAnnotationTestCase extends OrderAnnotationTestCase {
+		class InnerTestCase {
+
+			@Nested
+			class NestedOrderAnnotationTestCase extends OrderAnnotationTestCase {
+			}
 		}
 	}
 


### PR DESCRIPTION
## Overview

- **Avoid recursing over test tree multiple times for class ordering**
- **Avoid knowledge of subclasses in base class**

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
