### PR TITLE
Adjust CI builds to JDK 24 release

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -25,9 +25,6 @@ jobs:
         - version: 24
           type: ga
           distribution: oracle
-        - version: 24
-          type: ea
-          release: leyden
         - version: 25
           type: ea
     name: "OpenJDK ${{ matrix.jdk.version }} (${{ matrix.jdk.release || matrix.jdk.type }})"

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -22,10 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         jdk:
-        - version: 23
-          type: ga
         - version: 24
-          type: ea
+          type: ga
+          distribution: oracle
         - version: 24
           type: ea
           release: leyden


### PR DESCRIPTION
## Overview

- **Switch to GA release of JDK 24**
- **Remove Leyden EA build**

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
