### PR TITLE
Report discovery issue for competing test method annotations

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -40,7 +40,7 @@ public class DiscoverySelectorResolver {
 	private static final EngineDiscoveryRequestResolver<JupiterEngineDescriptor> resolver = EngineDiscoveryRequestResolver.<JupiterEngineDescriptor> builder() //
 			.addClassContainerSelectorResolver(new IsTestClassWithTests()) //
 			.addSelectorResolver(ctx -> new ClassSelectorResolver(ctx.getClassNameFilter(), getConfiguration(ctx))) //
-			.addSelectorResolver(ctx -> new MethodSelectorResolver(getConfiguration(ctx))) //
+			.addSelectorResolver(ctx -> new MethodSelectorResolver(getConfiguration(ctx), ctx.getIssueReporter())) //
 			.addTestDescriptorVisitor(ctx -> TestDescriptor.Visitor.composite( //
 				new ClassOrderingVisitor(getConfiguration(ctx)), //
 				new MethodOrderingVisitor(getConfiguration(ctx)), //

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolution.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolution.java
@@ -30,7 +30,6 @@ import java.util.function.Supplier;
 
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
-import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.EngineDiscoveryListener;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -260,11 +259,6 @@ class EngineDiscoveryRequestResolution {
 				parent.addChild(child.get());
 			}
 			return child;
-		}
-
-		@Override
-		public void reportIssue(DiscoveryIssue issue) {
-			issueReporter.reportIssue(issue);
 		}
 
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/SelectorResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/SelectorResolver.java
@@ -357,7 +357,7 @@ public interface SelectorResolver {
 	 * @see SelectorResolver
 	 */
 	@API(status = STABLE, since = "1.10")
-	interface Context extends DiscoveryIssueReporter {
+	interface Context {
 
 		/**
 		 * Resolve the supplied {@link TestDescriptor}, if possible.

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolverTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolverTests.java
@@ -31,11 +31,12 @@ public class EngineDiscoveryRequestResolverTests {
 	@Test
 	void allowsSelectorResolversToReportDiscoveryIssues() {
 		var resolver = EngineDiscoveryRequestResolver.builder() //
-				.addSelectorResolver(new SelectorResolver() {
+				.addSelectorResolver(ctx -> new SelectorResolver() {
 					@Override
 					public Resolution resolve(ClassSelector selector, Context context) {
-						context.reportIssue(DiscoveryIssue.builder(NOTICE, "test") //
-								.source(ClassSource.from(selector.getClassName())));
+						ctx.getIssueReporter() //
+								.reportIssue(DiscoveryIssue.builder(NOTICE, "test") //
+										.source(ClassSource.from(selector.getClassName())));
 						return unresolved();
 					}
 				}) //


### PR DESCRIPTION
## Overview

Issue: #242

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] ~Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~ will be done separately
