### PR TITLE
Remove Jupiter's pre-pruning

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -105,17 +106,16 @@ public class ClassTemplateTestDescriptor extends ClassBasedTestDescriptor implem
 			this.dynamicDescendantFilter.copy(uniqueIdTransformer));
 	}
 
-	@Override
-	public void prunePriorToFiltering() {
-		// do nothing to allow PostDiscoveryFilters to be applied first
-	}
-
 	// --- TestDescriptor ------------------------------------------------------
 
 	@Override
 	public void prune() {
 		super.prune();
-		this.children.forEach(child -> child.accept(TestDescriptor::prune));
+		if (this.children.isEmpty()) {
+			return;
+		}
+		// Create copy to avoid ConcurrentModificationException
+		new LinkedHashSet<>(this.children).forEach(child -> child.accept(TestDescriptor::prune));
 		// Second iteration to avoid processing children that were pruned in the first iteration
 		this.children.forEach(child -> {
 			if (child instanceof ClassTemplateInvocationTestDescriptor) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -215,10 +215,6 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 		context.close();
 	}
 
-	public void prunePriorToFiltering() {
-		prune();
-	}
-
 	/**
 	 * {@return a deep copy (with copies of children) of this descriptor with the supplied unique ID}
 	 */

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -15,7 +15,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import org.apiguardian.api.API;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
-import org.junit.jupiter.engine.descriptor.JupiterTestDescriptor;
 import org.junit.jupiter.engine.descriptor.Validatable;
 import org.junit.jupiter.engine.discovery.predicates.IsTestClassWithTests;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -49,11 +48,7 @@ public class DiscoverySelectorResolver {
 						((Validatable) descriptor).validate(ctx.getIssueReporter());
 					}
 				})) //
-			.addTestDescriptorVisitor(ctx -> descriptor -> {
-				if (descriptor instanceof JupiterTestDescriptor) {
-					((JupiterTestDescriptor) descriptor).prunePriorToFiltering();
-				}
-			}).build();
+			.build();
 
 	private static JupiterConfiguration getConfiguration(InitializationContext<JupiterEngineDescriptor> context) {
 		return context.getEngineDescriptor().getConfiguration();


### PR DESCRIPTION
## Overview

Prior to this commit, the Jupiter engine would prune its
`TestDescriptor` tree prior to returning it to the `Launcher`. Since the
`Launcher` will later prune it anyway (after applying filters) that's
unnecessary. Removing it avoids iterating over the entire test tree once
more.

The side effect that `PostDiscoveryFilter` implementations may now see
`TestDescriptors` that would already have been pruned should not be
problematic as there is no contract that engines need to prune
themselves.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
