### PR TITLE
Report discovery errors for ineffectual lifecycle methods

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ClassTemplateInvocationLifecycleMethod.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ClassTemplateInvocationLifecycleMethod.java
@@ -32,8 +32,14 @@ import org.apiguardian.api.API;
 public @interface ClassTemplateInvocationLifecycleMethod {
 
 	/**
-	 * The actual annotation class for reporting of discovery issues.
+	 * The corresponding {@link org.junit.jupiter.api.ClassTemplate}-derived
+	 * annotation class.
 	 */
-	Class<? extends Annotation> value();
+	Class<? extends Annotation> classTemplateAnnotation();
+
+	/**
+	 * The actual lifecycle method annotation class.
+	 */
+	Class<? extends Annotation> lifecycleMethodAnnotation();
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -133,10 +133,19 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 	// --- Validatable ---------------------------------------------------------
 
 	@Override
-	public void validate(DiscoveryIssueReporter reporter) {
+	public final void validate(DiscoveryIssueReporter reporter) {
+		validateCoreLifecycleMethods(reporter);
+		validateClassTemplateInvocationLifecycleMethods(reporter);
+	}
+
+	protected void validateCoreLifecycleMethods(DiscoveryIssueReporter reporter) {
 		List<DiscoveryIssue> discoveryIssues = this.lifecycleMethods.discoveryIssues;
 		discoveryIssues.forEach(reporter::reportIssue);
 		discoveryIssues.clear();
+	}
+
+	protected void validateClassTemplateInvocationLifecycleMethods(DiscoveryIssueReporter reporter) {
+		LifecycleMethodUtils.validateNoClassTemplateInvocationLifecycleMethodsAreDeclared(getTestClass(), reporter);
 	}
 
 	// --- Node ----------------------------------------------------------------

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
@@ -14,7 +14,7 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
-import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.validateClassTemplateInvocationLifecycleMethods;
+import static org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.validateClassTemplateInvocationLifecycleMethodsAreDeclaredCorrectly;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -80,10 +80,14 @@ public class ClassTemplateTestDescriptor extends ClassBasedTestDescriptor implem
 	// --- Validatable ---------------------------------------------------------
 
 	@Override
-	public void validate(DiscoveryIssueReporter reporter) {
-		this.delegate.validate(reporter);
+	protected void validateCoreLifecycleMethods(DiscoveryIssueReporter reporter) {
+		this.delegate.validateCoreLifecycleMethods(reporter);
+	}
+
+	@Override
+	protected void validateClassTemplateInvocationLifecycleMethods(DiscoveryIssueReporter reporter) {
 		boolean requireStatic = this.classInfo.lifecycle == PER_METHOD;
-		validateClassTemplateInvocationLifecycleMethods(getTestClass(), requireStatic, reporter);
+		validateClassTemplateInvocationLifecycleMethodsAreDeclaredCorrectly(getTestClass(), requireStatic, reporter);
 	}
 
 	// --- Filterable ----------------------------------------------------------

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/AfterParameterizedClassInvocation.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/AfterParameterizedClassInvocation.java
@@ -158,7 +158,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(status = EXPERIMENTAL, since = "5.13")
-@ClassTemplateInvocationLifecycleMethod(AfterParameterizedClassInvocation.class)
+@ClassTemplateInvocationLifecycleMethod(classTemplateAnnotation = ParameterizedClass.class, lifecycleMethodAnnotation = AfterParameterizedClassInvocation.class)
 public @interface AfterParameterizedClassInvocation {
 
 	/**

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/BeforeParameterizedClassInvocation.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/BeforeParameterizedClassInvocation.java
@@ -159,7 +159,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @API(status = EXPERIMENTAL, since = "5.13")
-@ClassTemplateInvocationLifecycleMethod(BeforeParameterizedClassInvocation.class)
+@ClassTemplateInvocationLifecycleMethod(classTemplateAnnotation = ParameterizedClass.class, lifecycleMethodAnnotation = BeforeParameterizedClassInvocation.class)
 public @interface BeforeParameterizedClassInvocation {
 
 	/**


### PR DESCRIPTION
## Overview

Declaring `Before`/`AfterParameterizedClassInvocation` in regular test
classes not annotated with `ParameterizedClass` now causes a discovery
issue with severity `ERROR` to be reported.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
