### PR TITLE
Fix constructor invocation of `Nested` classes on Java versions < 21

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M2.adoc
@@ -35,7 +35,8 @@ repository on GitHub.
 [[release-notes-5.13.0-M2-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Fix regression when executing `@Nested` classes compiled without `-parameters` in
+  versions of Java prior to 21.
 
 [[release-notes-5.13.0-M2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -99,7 +99,6 @@ public class ParameterResolutionUtils {
 		// Ensure that the outer instance is resolved as the first parameter if
 		// the executable is a constructor for an inner class.
 		if (outerInstance.isPresent()) {
-			Preconditions.condition(parameters[0].isImplicit(), "First parameter must be implicit");
 			values[0] = outerInstance.get();
 			start = 1;
 		}
@@ -114,9 +113,6 @@ public class ParameterResolutionUtils {
 
 	private static Object resolveParameter(ParameterContext parameterContext, Executable executable,
 			ExtensionContextSupplier extensionContext, ExtensionRegistry extensionRegistry) {
-
-		Preconditions.condition(!parameterContext.getParameter().isImplicit(),
-			() -> String.format("Parameter at index %d must not be implicit", parameterContext.getIndex()));
 
 		try {
 			// @formatter:off

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
 import static org.junit.platform.commons.support.ReflectionSupport.makeAccessible;
+import static org.junit.platform.commons.util.ReflectionUtils.isInnerClass;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
@@ -100,9 +101,8 @@ class ResolverFacade {
 	}
 
 	static ResolverFacade create(Constructor<?> constructor, ParameterizedClass annotation) {
-		java.lang.reflect.Parameter[] parameters = constructor.getParameters();
-		// Inner classes get the outer instance as first parameter
-		int implicitParameters = parameters.length > 0 && parameters[0].isImplicit() ? 1 : 0;
+		// Inner classes get the outer instance as first (implicit) parameter
+		int implicitParameters = isInnerClass(constructor.getDeclaringClass()) ? 1 : 0;
 		return create(constructor, annotation, implicitParameters);
 	}
 

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -223,6 +223,7 @@ val test by testing.suites.getting(JvmTestSuite::class) {
 					}
 				}
 				jvmArgumentProviders += JavaHomeDir(project, 8, develocity.testDistribution.enabled)
+				jvmArgumentProviders += JavaHomeDir(project, 17, develocity.testDistribution.enabled)
 
 				val gradleJavaVersion = JavaVersion.current().majorVersion.toInt()
 				jvmArgumentProviders += JavaHomeDir(project, gradleJavaVersion, develocity.testDistribution.enabled)

--- a/platform-tooling-support-tests/projects/jupiter-starter/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/jupiter-starter/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(8)
+		languageVersion = JavaLanguageVersion.of(System.getProperty("java.toolchain.version"))
 	}
 }
 
@@ -26,6 +26,7 @@ tasks.test {
 
 	testLogging {
 		events("passed", "skipped", "failed", "standardOut")
+		exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 	}
 
 	reports {

--- a/platform-tooling-support-tests/projects/jupiter-starter/gradle.properties
+++ b/platform-tooling-support-tests/projects/jupiter-starter/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.java.installations.fromEnv=JDK8
+org.gradle.java.installations.fromEnv=JDK8,JDK17

--- a/platform-tooling-support-tests/projects/jupiter-starter/src/test/java/com/example/project/CalculatorParameterizedClassTests.java
+++ b/platform-tooling-support-tests/projects/jupiter-starter/src/test/java/com/example/project/CalculatorParameterizedClassTests.java
@@ -12,6 +12,7 @@ package com.example.project;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -25,16 +26,28 @@ class CalculatorParameterizedClassTests {
 	@Parameter
 	int i;
 
-	@Test
-	void regularTest() {
-		Calculator calculator = new Calculator();
-		assertEquals(2 * i, calculator.add(i, i), () -> i + " + " + i + " should equal 2 * " + i);
-	}
-
 	@ParameterizedTest
 	@ValueSource(ints = { 1, 2 })
 	void parameterizedTest(int j) {
 		Calculator calculator = new Calculator();
 		assertEquals(i + j, calculator.add(i, j));
+	}
+
+	@Nested
+	@ParameterizedClass
+	@ValueSource(ints = { 1, 2 })
+	class Inner {
+
+		final int j;
+
+		Inner(int j) {
+			this.j = j;
+		}
+
+		@Test
+		void regularTest() {
+			Calculator calculator = new Calculator();
+			assertEquals(i + j, calculator.add(i, j));
+		}
 	}
 }

--- a/platform-tooling-support-tests/projects/jupiter-starter/src/test/resources/junit-platform.properties
+++ b/platform-tooling-support-tests/projects/jupiter-starter/src/test/resources/junit-platform.properties
@@ -1,2 +1,4 @@
 junit.jupiter.testclass.order.default = \
   org.junit.jupiter.api.ClassOrderer$ClassName
+
+junit.platform.stacktrace.pruning.enabled = false

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/AntStarterTests.java
@@ -52,7 +52,7 @@ class AntStarterTests {
 		assertLinesMatch(List.of(">> HEAD >>", //
 			"test.junit.launcher:", //
 			">>>>", //
-			"\\[junitlauncher\\] Tests run: 6, Failures: 0, Aborted: 0, Skipped: 0, Time elapsed: .+ sec", //
+			"\\[junitlauncher\\] Tests run: 8, Failures: 0, Aborted: 0, Skipped: 0, Time elapsed: .+ sec", //
 			"\\[junitlauncher\\] Running com.example.project.CalculatorTests", //
 			"\\[junitlauncher\\] Tests run: 5, Failures: 0, Aborted: 0, Skipped: 0, Time elapsed: .+ sec", //
 			">>>>", //
@@ -60,7 +60,7 @@ class AntStarterTests {
 			">>>>", //
 			"     \\[java\\] Test run finished after [\\d]+ ms", //
 			">>>>", //
-			"     \\[java\\] \\[        11 tests successful      \\]", //
+			"     \\[java\\] \\[        13 tests successful      \\]", //
 			"     \\[java\\] \\[         0 tests failed          \\]", //
 			">> TAIL >>"), //
 			result.stdOutLines());

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/MavenStarterTests.java
@@ -57,7 +57,7 @@ class MavenStarterTests {
 
 		var result = runMaven(outputFiles, "verify");
 
-		assertThat(result.stdOutLines()).contains("[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0");
+		assertThat(result.stdOutLines()).contains("[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0");
 		assertThat(result.stdOut()).contains("Using Java version: 1.8");
 
 		var testResultsDir = workspace.resolve("target/surefire-reports");
@@ -67,11 +67,11 @@ class MavenStarterTests {
 	@Test
 	void runOnlyOneMethodInClassTemplate(@FilePrefix("maven") OutputFiles outputFiles) throws Exception {
 
-		var result = runMaven(outputFiles, "test", "-Dtest=CalculatorParameterizedClassTests#regularTest");
+		var result = runMaven(outputFiles, "test", "-Dtest=CalculatorParameterizedClassTests$Inner#regularTest");
 
 		assertThat(result.stdOutLines()) //
 				.doesNotContain("CalculatorTests") //
-				.contains("[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0");
+				.contains("[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0");
 
 		result = runMaven(outputFiles, "test", "-Dtest=CalculatorParameterizedClassTests#parameterizedTest");
 

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/AntStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/AntStarterTests_snapshots/open-test-report.xml.snapshot
@@ -21,7 +21,7 @@ test-method: ant_starter
     <java:heapSize max="16642998272"/>
   </infrastructure>
   
-  <e:started id="1" name="JUnit Jupiter" time="2025-03-19T08:25:12.176536071Z">
+  <e:started id="1" name="JUnit Jupiter" time="2025-03-23T13:14:52.951241041Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]</junit:uniqueId>
       <junit:legacyReportingName>JUnit Jupiter</junit:legacyReportingName>
@@ -29,7 +29,7 @@ test-method: ant_starter
     </metadata>
   </e:started>
   
-  <e:started id="2" name="CalculatorParameterizedClassTests" parentId="1" time="2025-03-19T08:25:12.187202576Z">
+  <e:started id="2" name="CalculatorParameterizedClassTests" parentId="1" time="2025-03-23T13:14:52.960839993Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests</junit:legacyReportingName>
@@ -40,7 +40,7 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:started id="3" name="[1] i=1" parentId="2" time="2025-03-19T08:25:12.219462563Z">
+  <e:started id="3" name="[1] i=1" parentId="2" time="2025-03-23T13:14:52.996188880Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests[1]</junit:legacyReportingName>
@@ -51,22 +51,7 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:started id="4" name="regularTest()" parentId="3" time="2025-03-19T08:25:12.226698218Z">
-    <metadata>
-      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
-      <junit:type>TEST</junit:type>
-    </metadata>
-    <sources>
-      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests" methodName="regularTest" methodParameterTypes=""/>
-    </sources>
-  </e:started>
-  
-  <e:finished id="4" time="2025-03-19T08:25:12.237922352Z">
-    <result status="SUCCESSFUL"/>
-  </e:finished>
-  
-  <e:started id="5" name="parameterizedTest(int)" parentId="3" time="2025-03-19T08:25:12.239995429Z">
+  <e:started id="4" name="parameterizedTest(int)" parentId="3" time="2025-03-23T13:14:52.998289212Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
@@ -77,7 +62,7 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:started id="6" name="[1] 1" parentId="5" time="2025-03-19T08:25:12.244055143Z">
+  <e:started id="5" name="[1] 1" parentId="4" time="2025-03-23T13:14:53.008677106Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
@@ -88,11 +73,11 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="6" time="2025-03-19T08:25:12.247194485Z">
+  <e:finished id="5" time="2025-03-23T13:14:53.021459727Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="7" name="[2] 2" parentId="5" time="2025-03-19T08:25:12.248453322Z">
+  <e:started id="6" name="[2] 2" parentId="4" time="2025-03-23T13:14:53.023592120Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
@@ -103,19 +88,94 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="7" time="2025-03-19T08:25:12.249598606Z">
+  <e:finished id="6" time="2025-03-23T13:14:53.024929218Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="5" time="2025-03-19T08:25:12.250062548Z">
+  <e:finished id="4" time="2025-03-23T13:14:53.025433141Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="3" time="2025-03-19T08:25:12.250544274Z">
+  <e:started id="7" name="Inner" parentId="3" time="2025-03-23T13:14:53.026002648Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="8" name="[1] 1" parentId="7" time="2025-03-23T13:14:53.027989515Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="9" name="regularTest()" parentId="8" time="2025-03-23T13:14:53.029786032Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="9" time="2025-03-23T13:14:53.031533627Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="8" name="[2] i=2" parentId="2" time="2025-03-19T08:25:12.251159110Z">
+  <e:finished id="8" time="2025-03-23T13:14:53.032074670Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="10" name="[2] 2" parentId="7" time="2025-03-23T13:14:53.032699802Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="11" name="regularTest()" parentId="10" time="2025-03-23T13:14:53.033608120Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="11" time="2025-03-23T13:14:53.034539892Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="10" time="2025-03-23T13:14:53.034869134Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="7" time="2025-03-23T13:14:53.035718962Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="3" time="2025-03-23T13:14:53.036032224Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="12" name="[2] i=2" parentId="2" time="2025-03-23T13:14:53.036908591Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests[2]</junit:legacyReportingName>
@@ -126,22 +186,7 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:started id="9" name="regularTest()" parentId="8" time="2025-03-19T08:25:12.251909601Z">
-    <metadata>
-      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
-      <junit:type>TEST</junit:type>
-    </metadata>
-    <sources>
-      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests" methodName="regularTest" methodParameterTypes=""/>
-    </sources>
-  </e:started>
-  
-  <e:finished id="9" time="2025-03-19T08:25:12.252685009Z">
-    <result status="SUCCESSFUL"/>
-  </e:finished>
-  
-  <e:started id="10" name="parameterizedTest(int)" parentId="8" time="2025-03-19T08:25:12.253042802Z">
+  <e:started id="13" name="parameterizedTest(int)" parentId="12" time="2025-03-23T13:14:53.037827579Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
@@ -152,7 +197,7 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:started id="11" name="[1] 1" parentId="10" time="2025-03-19T08:25:12.254855760Z">
+  <e:started id="14" name="[1] 1" parentId="13" time="2025-03-23T13:14:53.039333837Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
@@ -163,11 +208,11 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="11" time="2025-03-19T08:25:12.255914752Z">
+  <e:finished id="14" time="2025-03-23T13:14:53.040335962Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="12" name="[2] 2" parentId="10" time="2025-03-19T08:25:12.256624005Z">
+  <e:started id="15" name="[2] 2" parentId="13" time="2025-03-23T13:14:53.041061063Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
@@ -178,23 +223,98 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="12" time="2025-03-19T08:25:12.257549555Z">
+  <e:finished id="15" time="2025-03-23T13:14:53.041975923Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="10" time="2025-03-19T08:25:12.257869196Z">
+  <e:finished id="13" time="2025-03-23T13:14:53.042340052Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="8" time="2025-03-19T08:25:12.258154884Z">
+  <e:started id="16" name="Inner" parentId="12" time="2025-03-23T13:14:53.042817885Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="17" name="[1] 1" parentId="16" time="2025-03-23T13:14:53.044477163Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="18" name="regularTest()" parentId="17" time="2025-03-23T13:14:53.045461144Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="18" time="2025-03-23T13:14:53.046287717Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="2" time="2025-03-19T08:25:12.259033776Z">
+  <e:finished id="17" time="2025-03-23T13:14:53.046556225Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="13" name="CalculatorTests" parentId="1" time="2025-03-19T08:25:12.259405265Z">
+  <e:started id="19" name="[2] 2" parentId="16" time="2025-03-23T13:14:53.047014521Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="20" name="regularTest()" parentId="19" time="2025-03-23T13:14:53.047746896Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="20" time="2025-03-23T13:14:53.048485633Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="19" time="2025-03-23T13:14:53.048703245Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="16" time="2025-03-23T13:14:53.049033289Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="12" time="2025-03-23T13:14:53.049289143Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="2" time="2025-03-23T13:14:53.049552260Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="21" name="CalculatorTests" parentId="1" time="2025-03-23T13:14:53.049874820Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorTests</junit:legacyReportingName>
@@ -205,7 +325,7 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:started id="14" name="1 + 1 = 2" parentId="13" time="2025-03-19T08:25:12.261265602Z">
+  <e:started id="22" name="1 + 1 = 2" parentId="21" time="2025-03-23T13:14:53.052051266Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[method:addsTwoNumbers()]</junit:uniqueId>
       <junit:legacyReportingName>addsTwoNumbers()</junit:legacyReportingName>
@@ -216,11 +336,11 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="14" time="2025-03-19T08:25:12.262250144Z">
+  <e:finished id="22" time="2025-03-23T13:14:53.053400437Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="15" name="add(int, int, int)" parentId="13" time="2025-03-19T08:25:12.262697745Z">
+  <e:started id="23" name="add(int, int, int)" parentId="21" time="2025-03-23T13:14:53.053815011Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)</junit:legacyReportingName>
@@ -231,7 +351,7 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:started id="16" name="0 + 1 = 1" parentId="15" time="2025-03-19T08:25:12.271957345Z">
+  <e:started id="24" name="0 + 1 = 1" parentId="23" time="2025-03-23T13:14:53.062809720Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[1]</junit:legacyReportingName>
@@ -242,11 +362,11 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="16" time="2025-03-19T08:25:12.278945856Z">
+  <e:finished id="24" time="2025-03-23T13:14:53.069498418Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="17" name="1 + 2 = 3" parentId="15" time="2025-03-19T08:25:12.279904328Z">
+  <e:started id="25" name="1 + 2 = 3" parentId="23" time="2025-03-23T13:14:53.070373092Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[2]</junit:legacyReportingName>
@@ -257,11 +377,11 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="17" time="2025-03-19T08:25:12.280837683Z">
+  <e:finished id="25" time="2025-03-23T13:14:53.071217268Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="18" name="49 + 51 = 100" parentId="15" time="2025-03-19T08:25:12.281428183Z">
+  <e:started id="26" name="49 + 51 = 100" parentId="23" time="2025-03-23T13:14:53.071906341Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#3]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[3]</junit:legacyReportingName>
@@ -272,11 +392,11 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="18" time="2025-03-19T08:25:12.282431319Z">
+  <e:finished id="26" time="2025-03-23T13:14:53.072581168Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="19" name="1 + 100 = 101" parentId="15" time="2025-03-19T08:25:12.283057897Z">
+  <e:started id="27" name="1 + 100 = 101" parentId="23" time="2025-03-23T13:14:53.072999348Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#4]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[4]</junit:legacyReportingName>
@@ -287,19 +407,19 @@ test-method: ant_starter
     </sources>
   </e:started>
   
-  <e:finished id="19" time="2025-03-19T08:25:12.283833025Z">
+  <e:finished id="27" time="2025-03-23T13:14:53.073695966Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="15" time="2025-03-19T08:25:12.284076412Z">
+  <e:finished id="23" time="2025-03-23T13:14:53.073872339Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="13" time="2025-03-19T08:25:12.284279965Z">
+  <e:finished id="21" time="2025-03-23T13:14:53.074042781Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="1" time="2025-03-19T08:25:12.298292893Z">
+  <e:finished id="1" time="2025-03-23T13:14:53.087258793Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/GradleStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/GradleStarterTests_snapshots/open-test-report.xml.snapshot
@@ -16,12 +16,12 @@ test-method: buildJupiterStarterProject
     <userName>obfuscated</userName>
     <operatingSystem>Linux</operatingSystem>
     <cpuCores>16</cpuCores>
-    <java:javaVersion>1.8.0_442</java:javaVersion>
+    <java:javaVersion>17.0.14</java:javaVersion>
     <java:fileEncoding>UTF-8</java:fileEncoding>
-    <java:heapSize max="514850816"/>
+    <java:heapSize max="536870912"/>
   </infrastructure>
   
-  <e:started id="1" name="JUnit Jupiter" time="2025-03-19T08:23:41.473Z">
+  <e:started id="1" name="JUnit Jupiter" time="2025-03-23T13:09:41.890797679Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]</junit:uniqueId>
       <junit:legacyReportingName>JUnit Jupiter</junit:legacyReportingName>
@@ -29,7 +29,7 @@ test-method: buildJupiterStarterProject
     </metadata>
   </e:started>
   
-  <e:started id="2" name="CalculatorParameterizedClassTests" parentId="1" time="2025-03-19T08:23:41.489Z">
+  <e:started id="2" name="CalculatorParameterizedClassTests" parentId="1" time="2025-03-23T13:09:41.902196698Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests</junit:legacyReportingName>
@@ -40,7 +40,7 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="3" name="[1] i=1" parentId="2" time="2025-03-19T08:23:41.519Z">
+  <e:started id="3" name="[1] i=1" parentId="2" time="2025-03-23T13:09:41.931884743Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests[1]</junit:legacyReportingName>
@@ -51,22 +51,7 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="4" name="regularTest()" parentId="3" time="2025-03-19T08:23:41.527Z">
-    <metadata>
-      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
-      <junit:type>TEST</junit:type>
-    </metadata>
-    <sources>
-      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests" methodName="regularTest" methodParameterTypes=""/>
-    </sources>
-  </e:started>
-  
-  <e:finished id="4" time="2025-03-19T08:23:41.539Z">
-    <result status="SUCCESSFUL"/>
-  </e:finished>
-  
-  <e:started id="5" name="parameterizedTest(int)" parentId="3" time="2025-03-19T08:23:41.541Z">
+  <e:started id="4" name="parameterizedTest(int)" parentId="3" time="2025-03-23T13:09:41.934481780Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
@@ -77,7 +62,7 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="6" name="[1] 1" parentId="5" time="2025-03-19T08:23:41.547Z">
+  <e:started id="5" name="[1] 1" parentId="4" time="2025-03-23T13:09:41.945209083Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
@@ -88,11 +73,11 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="6" time="2025-03-19T08:23:41.551Z">
+  <e:finished id="5" time="2025-03-23T13:09:41.956136851Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="7" name="[2] 2" parentId="5" time="2025-03-19T08:23:41.554Z">
+  <e:started id="6" name="[2] 2" parentId="4" time="2025-03-23T13:09:41.958401457Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
@@ -103,19 +88,94 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="7" time="2025-03-19T08:23:41.555Z">
+  <e:finished id="6" time="2025-03-23T13:09:41.960706287Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="5" time="2025-03-19T08:23:41.556Z">
+  <e:finished id="4" time="2025-03-23T13:09:41.961760790Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="3" time="2025-03-19T08:23:41.557Z">
+  <e:started id="7" name="Inner" parentId="3" time="2025-03-23T13:09:41.962824770Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="8" name="[1] 1" parentId="7" time="2025-03-23T13:09:41.966042658Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="9" name="regularTest()" parentId="8" time="2025-03-23T13:09:41.967595502Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="9" time="2025-03-23T13:09:41.969414795Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="8" name="[2] i=2" parentId="2" time="2025-03-19T08:23:41.557Z">
+  <e:finished id="8" time="2025-03-23T13:09:41.970045825Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="10" name="[2] 2" parentId="7" time="2025-03-23T13:09:41.970717090Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="11" name="regularTest()" parentId="10" time="2025-03-23T13:09:41.972023454Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="11" time="2025-03-23T13:09:41.973604180Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="10" time="2025-03-23T13:09:41.974020399Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="7" time="2025-03-23T13:09:41.975557263Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="3" time="2025-03-23T13:09:41.976039134Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="12" name="[2] i=2" parentId="2" time="2025-03-23T13:09:41.977230472Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests[2]</junit:legacyReportingName>
@@ -126,22 +186,7 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="9" name="regularTest()" parentId="8" time="2025-03-19T08:23:41.558Z">
-    <metadata>
-      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
-      <junit:type>TEST</junit:type>
-    </metadata>
-    <sources>
-      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests" methodName="regularTest" methodParameterTypes=""/>
-    </sources>
-  </e:started>
-  
-  <e:finished id="9" time="2025-03-19T08:23:41.560Z">
-    <result status="SUCCESSFUL"/>
-  </e:finished>
-  
-  <e:started id="10" name="parameterizedTest(int)" parentId="8" time="2025-03-19T08:23:41.560Z">
+  <e:started id="13" name="parameterizedTest(int)" parentId="12" time="2025-03-23T13:09:41.978390792Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
@@ -152,7 +197,7 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="11" name="[1] 1" parentId="10" time="2025-03-19T08:23:41.562Z">
+  <e:started id="14" name="[1] 1" parentId="13" time="2025-03-23T13:09:41.980269927Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
@@ -163,11 +208,11 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="11" time="2025-03-19T08:23:41.563Z">
+  <e:finished id="14" time="2025-03-23T13:09:41.981947024Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="12" name="[2] 2" parentId="10" time="2025-03-19T08:23:41.564Z">
+  <e:started id="15" name="[2] 2" parentId="13" time="2025-03-23T13:09:41.983240152Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
@@ -178,23 +223,98 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="12" time="2025-03-19T08:23:41.565Z">
+  <e:finished id="15" time="2025-03-23T13:09:41.984221508Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="10" time="2025-03-19T08:23:41.566Z">
+  <e:finished id="13" time="2025-03-23T13:09:41.984628138Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="8" time="2025-03-19T08:23:41.566Z">
+  <e:started id="16" name="Inner" parentId="12" time="2025-03-23T13:09:41.985103698Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="17" name="[1] 1" parentId="16" time="2025-03-23T13:09:41.986693621Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="18" name="regularTest()" parentId="17" time="2025-03-23T13:09:41.988031503Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="18" time="2025-03-23T13:09:41.989093379Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="2" time="2025-03-19T08:23:41.567Z">
+  <e:finished id="17" time="2025-03-23T13:09:41.989392178Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="13" name="CalculatorTests" parentId="1" time="2025-03-19T08:23:41.567Z">
+  <e:started id="19" name="[2] 2" parentId="16" time="2025-03-23T13:09:41.989884669Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="20" name="regularTest()" parentId="19" time="2025-03-23T13:09:41.990722727Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="20" time="2025-03-23T13:09:41.991603774Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="19" time="2025-03-23T13:09:41.992183429Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="16" time="2025-03-23T13:09:41.992649731Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="12" time="2025-03-23T13:09:41.992954521Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="2" time="2025-03-23T13:09:41.993344490Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="21" name="CalculatorTests" parentId="1" time="2025-03-23T13:09:41.993726985Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorTests</junit:legacyReportingName>
@@ -205,7 +325,7 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="14" name="1 + 1 = 2" parentId="13" time="2025-03-19T08:23:41.570Z">
+  <e:started id="22" name="1 + 1 = 2" parentId="21" time="2025-03-23T13:09:41.996516132Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[method:addsTwoNumbers()]</junit:uniqueId>
       <junit:legacyReportingName>addsTwoNumbers()</junit:legacyReportingName>
@@ -216,11 +336,11 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="14" time="2025-03-19T08:23:41.571Z">
+  <e:finished id="22" time="2025-03-23T13:09:41.997752745Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="15" name="add(int, int, int)" parentId="13" time="2025-03-19T08:23:41.571Z">
+  <e:started id="23" name="add(int, int, int)" parentId="21" time="2025-03-23T13:09:41.998212855Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)</junit:legacyReportingName>
@@ -231,7 +351,7 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="16" name="0 + 1 = 1" parentId="15" time="2025-03-19T08:23:41.585Z">
+  <e:started id="24" name="0 + 1 = 1" parentId="23" time="2025-03-23T13:09:42.008039935Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[1]</junit:legacyReportingName>
@@ -242,11 +362,11 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="16" time="2025-03-19T08:23:41.592Z">
+  <e:finished id="24" time="2025-03-23T13:09:42.014819085Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="17" name="1 + 2 = 3" parentId="15" time="2025-03-19T08:23:41.592Z">
+  <e:started id="25" name="1 + 2 = 3" parentId="23" time="2025-03-23T13:09:42.015676499Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[2]</junit:legacyReportingName>
@@ -257,11 +377,11 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="17" time="2025-03-19T08:23:41.594Z">
+  <e:finished id="25" time="2025-03-23T13:09:42.016658205Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="18" name="49 + 51 = 100" parentId="15" time="2025-03-19T08:23:41.594Z">
+  <e:started id="26" name="49 + 51 = 100" parentId="23" time="2025-03-23T13:09:42.017224073Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#3]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[3]</junit:legacyReportingName>
@@ -272,11 +392,11 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="18" time="2025-03-19T08:23:41.596Z">
+  <e:finished id="26" time="2025-03-23T13:09:42.018034639Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="19" name="1 + 100 = 101" parentId="15" time="2025-03-19T08:23:41.596Z">
+  <e:started id="27" name="1 + 100 = 101" parentId="23" time="2025-03-23T13:09:42.018526409Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#4]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[4]</junit:legacyReportingName>
@@ -287,19 +407,19 @@ test-method: buildJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="19" time="2025-03-19T08:23:41.597Z">
+  <e:finished id="27" time="2025-03-23T13:09:42.019307600Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="15" time="2025-03-19T08:23:41.598Z">
+  <e:finished id="23" time="2025-03-23T13:09:42.019509488Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="13" time="2025-03-19T08:23:41.598Z">
+  <e:finished id="21" time="2025-03-23T13:09:42.019717778Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="1" time="2025-03-19T08:23:41.598Z">
+  <e:finished id="1" time="2025-03-23T13:09:42.020137663Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   

--- a/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/MavenStarterTests_snapshots/open-test-report.xml.snapshot
+++ b/platform-tooling-support-tests/src/test/resources/platform/tooling/support/tests/MavenStarterTests_snapshots/open-test-report.xml.snapshot
@@ -21,7 +21,7 @@ test-method: verifyJupiterStarterProject
     <java:heapSize max="14793834496"/>
   </infrastructure>
   
-  <e:started id="1" name="JUnit Jupiter" time="2025-03-19T08:25:30.239Z">
+  <e:started id="1" name="JUnit Jupiter" time="2025-03-23T13:17:16.842Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]</junit:uniqueId>
       <junit:legacyReportingName>JUnit Jupiter</junit:legacyReportingName>
@@ -29,7 +29,7 @@ test-method: verifyJupiterStarterProject
     </metadata>
   </e:started>
   
-  <e:started id="2" name="CalculatorParameterizedClassTests" parentId="1" time="2025-03-19T08:25:30.258Z">
+  <e:started id="2" name="CalculatorParameterizedClassTests" parentId="1" time="2025-03-23T13:17:16.865Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests</junit:legacyReportingName>
@@ -40,7 +40,7 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="3" name="[1] i=1" parentId="2" time="2025-03-19T08:25:30.291Z">
+  <e:started id="3" name="[1] i=1" parentId="2" time="2025-03-23T13:17:16.910Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests[1]</junit:legacyReportingName>
@@ -51,22 +51,7 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="4" name="regularTest()" parentId="3" time="2025-03-19T08:25:30.298Z">
-    <metadata>
-      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
-      <junit:type>TEST</junit:type>
-    </metadata>
-    <sources>
-      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests" methodName="regularTest" methodParameterTypes=""/>
-    </sources>
-  </e:started>
-  
-  <e:finished id="4" time="2025-03-19T08:25:30.310Z">
-    <result status="SUCCESSFUL"/>
-  </e:finished>
-  
-  <e:started id="5" name="parameterizedTest(int)" parentId="3" time="2025-03-19T08:25:30.312Z">
+  <e:started id="4" name="parameterizedTest(int)" parentId="3" time="2025-03-23T13:17:16.913Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
@@ -77,7 +62,7 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="6" name="[1] 1" parentId="5" time="2025-03-19T08:25:30.316Z">
+  <e:started id="5" name="[1] 1" parentId="4" time="2025-03-23T13:17:16.927Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
@@ -88,11 +73,11 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="6" time="2025-03-19T08:25:30.320Z">
+  <e:finished id="5" time="2025-03-23T13:17:16.943Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="7" name="[2] 2" parentId="5" time="2025-03-19T08:25:30.322Z">
+  <e:started id="6" name="[2] 2" parentId="4" time="2025-03-23T13:17:16.948Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
@@ -103,19 +88,94 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="7" time="2025-03-19T08:25:30.323Z">
+  <e:finished id="6" time="2025-03-23T13:17:16.950Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="5" time="2025-03-19T08:25:30.325Z">
+  <e:finished id="4" time="2025-03-23T13:17:16.951Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="3" time="2025-03-19T08:25:30.328Z">
+  <e:started id="7" name="Inner" parentId="3" time="2025-03-23T13:17:16.952Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="8" name="[1] 1" parentId="7" time="2025-03-23T13:17:16.956Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="9" name="regularTest()" parentId="8" time="2025-03-23T13:17:16.959Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="9" time="2025-03-23T13:17:16.961Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="8" name="[2] i=2" parentId="2" time="2025-03-19T08:25:30.329Z">
+  <e:finished id="8" time="2025-03-23T13:17:16.963Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="10" name="[2] 2" parentId="7" time="2025-03-23T13:17:16.965Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="11" name="regularTest()" parentId="10" time="2025-03-23T13:17:16.966Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#1]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="11" time="2025-03-23T13:17:16.968Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="10" time="2025-03-23T13:17:16.970Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="7" time="2025-03-23T13:17:16.972Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="3" time="2025-03-23T13:17:16.973Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="12" name="[2] i=2" parentId="2" time="2025-03-23T13:17:16.975Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests[2]</junit:legacyReportingName>
@@ -126,22 +186,7 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="9" name="regularTest()" parentId="8" time="2025-03-19T08:25:30.330Z">
-    <metadata>
-      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
-      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
-      <junit:type>TEST</junit:type>
-    </metadata>
-    <sources>
-      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests" methodName="regularTest" methodParameterTypes=""/>
-    </sources>
-  </e:started>
-  
-  <e:finished id="9" time="2025-03-19T08:25:30.332Z">
-    <result status="SUCCESSFUL"/>
-  </e:finished>
-  
-  <e:started id="10" name="parameterizedTest(int)" parentId="8" time="2025-03-19T08:25:30.332Z">
+  <e:started id="13" name="parameterizedTest(int)" parentId="12" time="2025-03-23T13:17:16.976Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)</junit:legacyReportingName>
@@ -152,7 +197,7 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="11" name="[1] 1" parentId="10" time="2025-03-19T08:25:30.334Z">
+  <e:started id="14" name="[1] 1" parentId="13" time="2025-03-23T13:17:16.978Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[1]</junit:legacyReportingName>
@@ -163,11 +208,11 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="11" time="2025-03-19T08:25:30.336Z">
+  <e:finished id="14" time="2025-03-23T13:17:16.980Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="12" name="[2] 2" parentId="10" time="2025-03-19T08:25:30.337Z">
+  <e:started id="15" name="[2] 2" parentId="13" time="2025-03-23T13:17:16.981Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[test-template:parameterizedTest(int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>parameterizedTest(int)[2]</junit:legacyReportingName>
@@ -178,23 +223,98 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="12" time="2025-03-19T08:25:30.339Z">
+  <e:finished id="15" time="2025-03-23T13:17:16.982Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="10" time="2025-03-19T08:25:30.340Z">
+  <e:finished id="13" time="2025-03-23T13:17:16.982Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="8" time="2025-03-19T08:25:30.341Z">
+  <e:started id="16" name="Inner" parentId="12" time="2025-03-23T13:17:16.983Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="17" name="[1] 1" parentId="16" time="2025-03-23T13:17:16.985Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[1]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="18" name="regularTest()" parentId="17" time="2025-03-23T13:17:16.987Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#1]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="18" time="2025-03-23T13:17:16.988Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="2" time="2025-03-19T08:25:30.343Z">
+  <e:finished id="17" time="2025-03-23T13:17:16.989Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="13" name="CalculatorTests" parentId="1" time="2025-03-19T08:25:30.344Z">
+  <e:started id="19" name="[2] 2" parentId="16" time="2025-03-23T13:17:16.989Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]</junit:uniqueId>
+      <junit:legacyReportingName>com.example.project.CalculatorParameterizedClassTests$Inner[2]</junit:legacyReportingName>
+      <junit:type>CONTAINER</junit:type>
+    </metadata>
+    <sources>
+      <java:classSource className="com.example.project.CalculatorParameterizedClassTests$Inner"/>
+    </sources>
+  </e:started>
+  
+  <e:started id="20" name="regularTest()" parentId="19" time="2025-03-23T13:17:16.990Z">
+    <metadata>
+      <junit:uniqueId>[engine:junit-jupiter]/[class-template:com.example.project.CalculatorParameterizedClassTests]/[class-template-invocation:#2]/[nested-class-template:Inner]/[class-template-invocation:#2]/[method:regularTest()]</junit:uniqueId>
+      <junit:legacyReportingName>regularTest()</junit:legacyReportingName>
+      <junit:type>TEST</junit:type>
+    </metadata>
+    <sources>
+      <java:methodSource className="com.example.project.CalculatorParameterizedClassTests$Inner" methodName="regularTest" methodParameterTypes=""/>
+    </sources>
+  </e:started>
+  
+  <e:finished id="20" time="2025-03-23T13:17:16.991Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="19" time="2025-03-23T13:17:16.992Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="16" time="2025-03-23T13:17:16.993Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="12" time="2025-03-23T13:17:16.993Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:finished id="2" time="2025-03-23T13:17:16.994Z">
+    <result status="SUCCESSFUL"/>
+  </e:finished>
+  
+  <e:started id="21" name="CalculatorTests" parentId="1" time="2025-03-23T13:17:16.994Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]</junit:uniqueId>
       <junit:legacyReportingName>com.example.project.CalculatorTests</junit:legacyReportingName>
@@ -205,7 +325,7 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="14" name="1 + 1 = 2" parentId="13" time="2025-03-19T08:25:30.346Z">
+  <e:started id="22" name="1 + 1 = 2" parentId="21" time="2025-03-23T13:17:16.996Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[method:addsTwoNumbers()]</junit:uniqueId>
       <junit:legacyReportingName>addsTwoNumbers()</junit:legacyReportingName>
@@ -216,11 +336,11 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="14" time="2025-03-19T08:25:30.347Z">
+  <e:finished id="22" time="2025-03-23T13:17:16.997Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="15" name="add(int, int, int)" parentId="13" time="2025-03-19T08:25:30.347Z">
+  <e:started id="23" name="add(int, int, int)" parentId="21" time="2025-03-23T13:17:16.998Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)</junit:legacyReportingName>
@@ -231,7 +351,7 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:started id="16" name="0 + 1 = 1" parentId="15" time="2025-03-19T08:25:30.359Z">
+  <e:started id="24" name="0 + 1 = 1" parentId="23" time="2025-03-23T13:17:17.012Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#1]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[1]</junit:legacyReportingName>
@@ -242,11 +362,11 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="16" time="2025-03-19T08:25:30.367Z">
+  <e:finished id="24" time="2025-03-23T13:17:17.019Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="17" name="1 + 2 = 3" parentId="15" time="2025-03-19T08:25:30.368Z">
+  <e:started id="25" name="1 + 2 = 3" parentId="23" time="2025-03-23T13:17:17.020Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#2]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[2]</junit:legacyReportingName>
@@ -257,11 +377,11 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="17" time="2025-03-19T08:25:30.369Z">
+  <e:finished id="25" time="2025-03-23T13:17:17.021Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="18" name="49 + 51 = 100" parentId="15" time="2025-03-19T08:25:30.370Z">
+  <e:started id="26" name="49 + 51 = 100" parentId="23" time="2025-03-23T13:17:17.022Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#3]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[3]</junit:legacyReportingName>
@@ -272,11 +392,11 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="18" time="2025-03-19T08:25:30.371Z">
+  <e:finished id="26" time="2025-03-23T13:17:17.023Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:started id="19" name="1 + 100 = 101" parentId="15" time="2025-03-19T08:25:30.372Z">
+  <e:started id="27" name="1 + 100 = 101" parentId="23" time="2025-03-23T13:17:17.023Z">
     <metadata>
       <junit:uniqueId>[engine:junit-jupiter]/[class:com.example.project.CalculatorTests]/[test-template:add(int, int, int)]/[test-template-invocation:#4]</junit:uniqueId>
       <junit:legacyReportingName>add(int, int, int)[4]</junit:legacyReportingName>
@@ -287,19 +407,19 @@ test-method: verifyJupiterStarterProject
     </sources>
   </e:started>
   
-  <e:finished id="19" time="2025-03-19T08:25:30.373Z">
+  <e:finished id="27" time="2025-03-23T13:17:17.024Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="15" time="2025-03-19T08:25:30.373Z">
+  <e:finished id="23" time="2025-03-23T13:17:17.024Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="13" time="2025-03-19T08:25:30.374Z">
+  <e:finished id="21" time="2025-03-23T13:17:17.025Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   
-  <e:finished id="1" time="2025-03-19T08:25:30.374Z">
+  <e:finished id="1" time="2025-03-23T13:17:17.025Z">
     <result status="SUCCESSFUL"/>
   </e:finished>
   


### PR DESCRIPTION
## Overview

Fixes #4417.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
