### PR TITLE
Report discovery issues for blank `@SentenceFragments`

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -29,12 +29,9 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.commons.util.ClassUtils;
 import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.commons.util.StringUtils;
 
 /**
  * {@code DisplayNameGenerator} defines the SPI for generating display names
@@ -350,8 +347,6 @@ public interface DisplayNameGenerator {
 
 		static final DisplayNameGenerator INSTANCE = new IndicativeSentences();
 
-		private static final Logger logger = LoggerFactory.getLogger(IndicativeSentences.class);
-
 		private static final Predicate<Class<?>> notIndicativeSentences = clazz -> clazz != IndicativeSentences.class;
 
 		public IndicativeSentences() {
@@ -502,22 +497,14 @@ public interface DisplayNameGenerator {
 		}
 
 		private static String getSentenceFragment(AnnotatedElement element) {
-			Optional<SentenceFragment> annotation = findAnnotation(element, SentenceFragment.class);
-			if (annotation.isPresent()) {
-				String sentenceFragment = annotation.get().value().trim();
-
-				// TODO [#242] Replace logging with precondition check once we have a proper mechanism for
-				// handling validation exceptions during the TestEngine discovery phase.
-				if (StringUtils.isBlank(sentenceFragment)) {
-					logger.warn(() -> String.format(
-						"Configuration error: @SentenceFragment on [%s] must be declared with a non-blank value.",
-						element));
-				}
-				else {
-					return sentenceFragment;
-				}
-			}
-			return null;
+			return findAnnotation(element, SentenceFragment.class) //
+					.map(SentenceFragment::value) //
+					.map(sentenceFragment -> {
+						Preconditions.notBlank(sentenceFragment, String.format(
+							"@SentenceFragment on [%s] must be declared with a non-blank value.", element));
+						return sentenceFragment.trim();
+					}) //
+					.orElse(null);
 		}
 
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoveryIssue.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoveryIssue.java
@@ -123,6 +123,9 @@ public interface DiscoveryIssue {
 
 		/**
 		 * Set the {@link TestSource} for the {@code DiscoveryIssue}.
+		 *
+		 * @param source the {@link TestSource} for the {@code DiscoveryIssue};
+		 * never {@code null} but potentially empty
 		 */
 		default Builder source(Optional<TestSource> source) {
 			source.ifPresent(this::source);
@@ -131,11 +134,17 @@ public interface DiscoveryIssue {
 
 		/**
 		 * Set the {@link TestSource} for the {@code DiscoveryIssue}.
+		 *
+		 * @param source the {@link TestSource} for the {@code DiscoveryIssue};
+		 * may be {@code null}
 		 */
 		Builder source(TestSource source);
 
 		/**
 		 * Set the {@link Throwable} that caused the {@code DiscoveryIssue}.
+		 *
+		 * @param cause the {@link Throwable} that caused the
+		 * {@code DiscoveryIssue}; never {@code null} but potentially empty
 		 */
 		default Builder cause(Optional<Throwable> cause) {
 			cause.ifPresent(this::cause);
@@ -144,6 +153,9 @@ public interface DiscoveryIssue {
 
 		/**
 		 * Set the {@link Throwable} that caused the {@code DiscoveryIssue}.
+		 *
+		 * @param cause the {@link Throwable} that caused the
+		 * {@code DiscoveryIssue}; may be {@code null}
 		 */
 		Builder cause(Throwable cause);
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
@@ -71,7 +71,7 @@ public abstract class AbstractJupiterTestEngineTests {
 	}
 
 	protected EngineDiscoveryResults discoverTests(DiscoverySelector... selectors) {
-		return discoverTests(defaultRequest().selectors(selectors));
+		return discoverTests(request -> request.selectors(selectors));
 	}
 
 	protected EngineDiscoveryResults discoverTests(LauncherDiscoveryRequestBuilder builder) {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DiscoveryIssueCollectorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DiscoveryIssueCollectorTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClasspathResource;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectDirectory;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectFile;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUri;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.net.URI;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.platform.engine.DiscoveryIssue;
+import org.junit.platform.engine.DiscoveryIssue.Severity;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.SelectorResolutionResult;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.FilePosition;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
+import org.junit.platform.engine.support.descriptor.DirectorySource;
+import org.junit.platform.engine.support.descriptor.FileSource;
+import org.junit.platform.engine.support.descriptor.PackageSource;
+import org.junit.platform.engine.support.descriptor.UriSource;
+
+class DiscoveryIssueCollectorTests {
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("pairs")
+	void reportsFailedResolutionResultAsDiscoveryIssue(Pair pair) {
+		var collector = new DiscoveryIssueCollector(mock());
+		var failure = SelectorResolutionResult.failed(new RuntimeException("boom"));
+		collector.selectorProcessed(UniqueId.forEngine("dummy"), pair.selector, failure);
+
+		var expectedIssue = DiscoveryIssue.builder(Severity.ERROR, pair.selector + " resolution failed") //
+				.cause(failure.getThrowable()) //
+				.source(pair.source).build();
+		assertThat(collector.toNotifier().getAllIssues()).containsExactly(expectedIssue);
+	}
+
+	public static Stream<Pair> pairs() {
+		return Stream.of( //
+			new Pair(selectClass("SomeClass"), ClassSource.from("SomeClass")), //
+			new Pair(selectMethod("SomeClass#someMethod(int,int)"),
+				org.junit.platform.engine.support.descriptor.MethodSource.from("SomeClass", "someMethod", "int,int")), //
+			new Pair(selectClasspathResource("someResource"), ClasspathResourceSource.from("someResource")), //
+			new Pair(selectClasspathResource("someResource", FilePosition.from(42)),
+				ClasspathResourceSource.from("someResource",
+					org.junit.platform.engine.support.descriptor.FilePosition.from(42))), //
+			new Pair(selectClasspathResource("someResource", FilePosition.from(42, 23)),
+				ClasspathResourceSource.from("someResource",
+					org.junit.platform.engine.support.descriptor.FilePosition.from(42, 23))), //
+			new Pair(selectPackage("some.package"), PackageSource.from("some.package")), //
+			new Pair(selectFile("someFile"), FileSource.from(new File("someFile"))), //
+			new Pair(selectFile("someFile", FilePosition.from(42)),
+				FileSource.from(new File("someFile"),
+					org.junit.platform.engine.support.descriptor.FilePosition.from(42))), //
+			new Pair(selectFile("someFile", FilePosition.from(42, 23)),
+				FileSource.from(new File("someFile"),
+					org.junit.platform.engine.support.descriptor.FilePosition.from(42, 23))), //
+			new Pair(selectDirectory("someDir"), DirectorySource.from(new File("someDir"))), //
+			new Pair(selectUri("some:uri"), UriSource.from(URI.create("some:uri"))) //
+		);
+	}
+
+	record Pair(DiscoverySelector selector, TestSource source) {
+	}
+}


### PR DESCRIPTION
## Overview

Issue: #242
<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] ~Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~ will be done in a later PR
