### PR TITLE
Report discovery issues for class and method ordering

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -44,6 +44,7 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 	private final Condition<ClassBasedTestDescriptor> noOrderAnnotation;
 
 	ClassOrderingVisitor(JupiterConfiguration configuration, DiscoveryIssueReporter issueReporter) {
+		super(issueReporter);
 		this.configuration = configuration;
 		this.globalOrderer = createGlobalOrderer(configuration);
 		this.noOrderAnnotation = issueReporter.createReportingCondition(

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -10,10 +10,14 @@
 
 package org.junit.jupiter.engine.discovery;
 
+import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
+
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
@@ -21,21 +25,36 @@ import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.commons.util.LruCache;
+import org.junit.platform.engine.DiscoveryIssue;
+import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
+import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter.Condition;
 
 /**
  * @since 5.8
  */
 class ClassOrderingVisitor extends AbstractOrderingVisitor {
 
-	private final LruCache<ClassBasedTestDescriptor, DescriptorWrapperOrderer<DefaultClassDescriptor>> ordererCache = new LruCache<>(
+	private final LruCache<ClassBasedTestDescriptor, DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor>> ordererCache = new LruCache<>(
 		10);
 	private final JupiterConfiguration configuration;
-	private final DescriptorWrapperOrderer<DefaultClassDescriptor> globalOrderer;
+	private final DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> globalOrderer;
+	private final Condition<ClassBasedTestDescriptor> noOrderAnnotation;
 
-	ClassOrderingVisitor(JupiterConfiguration configuration) {
+	ClassOrderingVisitor(JupiterConfiguration configuration, DiscoveryIssueReporter issueReporter) {
 		this.configuration = configuration;
 		this.globalOrderer = createGlobalOrderer(configuration);
+		this.noOrderAnnotation = issueReporter.createReportingCondition(
+			testDescriptor -> !isAnnotated(testDescriptor.getTestClass(), Order.class), testDescriptor -> {
+				String message = String.format(
+					"Ineffective @Order annotation on class '%s'. It will not be applied because ClassOrderer.OrderAnnotation is not in use.",
+					testDescriptor.getTestClass().getName());
+				return DiscoveryIssue.builder(Severity.INFO, message) //
+						.source(ClassSource.from(testDescriptor.getTestClass())) //
+						.build();
+			});
 	}
 
 	@Override
@@ -59,31 +78,37 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 		orderChildrenTestDescriptors(//
 			engineDescriptor, //
 			ClassBasedTestDescriptor.class, //
+			toValidationAction(globalOrderer), //
 			DefaultClassDescriptor::new, //
 			globalOrderer);
 	}
 
 	private void orderNestedClasses(ClassBasedTestDescriptor descriptor) {
+		DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> wrapperOrderer = createAndCacheClassLevelOrderer(
+			descriptor);
 		orderChildrenTestDescriptors(//
 			descriptor, //
 			ClassBasedTestDescriptor.class, //
+			toValidationAction(wrapperOrderer), //
 			DefaultClassDescriptor::new, //
-			createAndCacheClassLevelOrderer(descriptor));
+			wrapperOrderer);
 	}
 
-	private DescriptorWrapperOrderer<DefaultClassDescriptor> createGlobalOrderer(JupiterConfiguration configuration) {
+	private DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> createGlobalOrderer(
+			JupiterConfiguration configuration) {
 		ClassOrderer classOrderer = configuration.getDefaultTestClassOrderer().orElse(null);
 		return classOrderer == null ? DescriptorWrapperOrderer.noop() : createDescriptorWrapperOrderer(classOrderer);
 	}
 
-	private DescriptorWrapperOrderer<DefaultClassDescriptor> createAndCacheClassLevelOrderer(
+	private DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> createAndCacheClassLevelOrderer(
 			ClassBasedTestDescriptor classBasedTestDescriptor) {
-		DescriptorWrapperOrderer<DefaultClassDescriptor> orderer = createClassLevelOrderer(classBasedTestDescriptor);
+		DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> orderer = createClassLevelOrderer(
+			classBasedTestDescriptor);
 		ordererCache.put(classBasedTestDescriptor, orderer);
 		return orderer;
 	}
 
-	private DescriptorWrapperOrderer<DefaultClassDescriptor> createClassLevelOrderer(
+	private DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> createClassLevelOrderer(
 			ClassBasedTestDescriptor classBasedTestDescriptor) {
 		return AnnotationSupport.findAnnotation(classBasedTestDescriptor.getTestClass(), TestClassOrder.class)//
 				.map(TestClassOrder::value)//
@@ -93,7 +118,7 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 					Object parent = classBasedTestDescriptor.getParent().orElse(null);
 					if (parent instanceof ClassBasedTestDescriptor) {
 						ClassBasedTestDescriptor parentClassTestDescriptor = (ClassBasedTestDescriptor) parent;
-						DescriptorWrapperOrderer<DefaultClassDescriptor> cacheEntry = ordererCache.get(
+						DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> cacheEntry = ordererCache.get(
 							parentClassTestDescriptor);
 						return cacheEntry != null ? cacheEntry : createClassLevelOrderer(parentClassTestDescriptor);
 					}
@@ -101,7 +126,8 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 				});
 	}
 
-	private DescriptorWrapperOrderer<DefaultClassDescriptor> createDescriptorWrapperOrderer(ClassOrderer classOrderer) {
+	private DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> createDescriptorWrapperOrderer(
+			ClassOrderer classOrderer) {
 		Consumer<List<DefaultClassDescriptor>> orderingAction = classDescriptors -> classOrderer.orderClasses(
 			new DefaultClassOrdererContext(classDescriptors, this.configuration));
 
@@ -112,8 +138,17 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 			"ClassOrderer [%s] removed %s ClassDescriptor(s) which will be retained with arbitrary ordering.",
 			classOrderer.getClass().getName(), number);
 
-		return new DescriptorWrapperOrderer<>(orderingAction, descriptorsAddedMessageGenerator,
+		return new DescriptorWrapperOrderer<>(classOrderer, orderingAction, descriptorsAddedMessageGenerator,
 			descriptorsRemovedMessageGenerator);
+	}
+
+	private Optional<Consumer<ClassBasedTestDescriptor>> toValidationAction(
+			DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> wrapperOrderer) {
+
+		if (wrapperOrderer.getOrderer() instanceof ClassOrderer.OrderAnnotation) {
+			return Optional.empty();
+		}
+		return Optional.of(noOrderAnnotation::check);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -44,8 +44,8 @@ public class DiscoverySelectorResolver {
 				ctx.getIssueReporter())) //
 			.addSelectorResolver(ctx -> new MethodSelectorResolver(getConfiguration(ctx), ctx.getIssueReporter())) //
 			.addTestDescriptorVisitor(ctx -> TestDescriptor.Visitor.composite( //
-				new ClassOrderingVisitor(getConfiguration(ctx)), //
-				new MethodOrderingVisitor(getConfiguration(ctx)), //
+				new ClassOrderingVisitor(getConfiguration(ctx), ctx.getIssueReporter()), //
+				new MethodOrderingVisitor(getConfiguration(ctx), ctx.getIssueReporter()), //
 				descriptor -> {
 					if (descriptor instanceof Validatable) {
 						((Validatable) descriptor).validate(ctx.getIssueReporter());

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
@@ -41,6 +41,7 @@ class MethodOrderingVisitor extends AbstractOrderingVisitor {
 	private final Condition<MethodBasedTestDescriptor> noOrderAnnotation;
 
 	MethodOrderingVisitor(JupiterConfiguration configuration, DiscoveryIssueReporter issueReporter) {
+		super(issueReporter);
 		this.configuration = configuration;
 		this.noOrderAnnotation = issueReporter.createReportingCondition(
 			testDescriptor -> !isAnnotated(testDescriptor.getTestMethod(), Order.class), testDescriptor -> {


### PR DESCRIPTION
## Overview

- **Report discovery issues for ineffective `@Order` annotations**
- **Report discovery issues misbehaving orderers**

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] ~Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)~ will be done in a later PR
