### PR TITLE
Fix handling of `CleanupMode.ON_SUCCESS`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/index.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/index.adoc
@@ -23,6 +23,8 @@ include::{basedir}/release-notes-5.13.0-M2.adoc[]
 
 include::{basedir}/release-notes-5.13.0-M1.adoc[]
 
+include::{basedir}/release-notes-5.12.2.adoc[]
+
 include::{basedir}/release-notes-5.12.1.adoc[]
 
 include::{basedir}/release-notes-5.12.0.adoc[]

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.2.adoc
@@ -1,0 +1,67 @@
+[[release-notes-5.12.2]]
+== 5.12.2
+
+*Date of Release:* ❓
+
+*Scope:* Bug fixes and enhancements since 5.12.1
+
+For a complete list of all _closed_ issues and pull requests for this release, consult the
+link:{junit5-repo}+/milestone/95?closed=1+[5.12.2] milestone page in the JUnit repository
+on GitHub.
+
+
+[[release-notes-5.12.2-junit-platform]]
+=== JUnit Platform
+
+[[release-notes-5.12.2-junit-platform-bug-fixes]]
+==== Bug Fixes
+
+* ❓
+
+[[release-notes-5.12.2-junit-platform-deprecations-and-breaking-changes]]
+==== Deprecations and Breaking Changes
+
+* ❓
+
+[[release-notes-5.12.2-junit-platform-new-features-and-improvements]]
+==== New Features and Improvements
+
+* ❓
+
+
+[[release-notes-5.12.2-junit-jupiter]]
+=== JUnit Jupiter
+
+[[release-notes-5.12.2-junit-jupiter-bug-fixes]]
+==== Bug Fixes
+
+*
+
+[[release-notes-5.12.2-junit-jupiter-deprecations-and-breaking-changes]]
+==== Deprecations and Breaking Changes
+
+* ❓
+
+[[release-notes-5.12.2-junit-jupiter-new-features-and-improvements]]
+==== New Features and Improvements
+
+* ❓
+
+
+[[release-notes-5.12.2-junit-vintage]]
+=== JUnit Vintage
+
+[[release-notes-5.12.2-junit-vintage-bug-fixes]]
+==== Bug Fixes
+
+* ❓
+
+[[release-notes-5.12.2-junit-vintage-deprecations-and-breaking-changes]]
+==== Deprecations and Breaking Changes
+
+* ❓
+
+[[release-notes-5.12.2-junit-vintage-new-features-and-improvements]]
+==== New Features and Improvements
+
+* ❓

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.12.2.adoc
@@ -35,7 +35,9 @@ on GitHub.
 [[release-notes-5.12.2-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-*
+* Fix handling of `CleanupMode.ON_SUCCESS` with `@TempDir` that caused no temporary
+  directories (using that mode) to be deleted after the first failure even if the
+  corresponding tests passed.
 
 [[release-notes-5.12.2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes


### PR DESCRIPTION
## Overview

- **Add 5.12.2 release notes from template**
- **Fix handling of `CleanupMode.ON_SUCCESS`**

Fixes #4464.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
