### PR TITLE
Document that Streams returned from argument sources closed automatically

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1954,6 +1954,10 @@ an array of primitives. The "arguments" within the stream can be supplied as an 
 of `Arguments`, an array of objects (e.g., `Object[]`), or a single value if the
 parameterized class or test method accepts a single argument.
 
+If the return type is `Stream` or one of the primitive streams,
+JUnit will properly close it by calling `BaseStream.close()`,
+making it safe to use a resource such as `Files.lines()`.
+
 If you only need a single parameter, you can return a `Stream` of instances of the
 parameter type as demonstrated in the following example.
 
@@ -2048,6 +2052,10 @@ methods, the value of a `@FieldSource` field cannot be an instance of `Stream`,
 are _consumed_ the first time they are processed. However, if you wish to use one of
 these types, you can wrap it in a `Supplier` — for example, `Supplier<IntStream>`.
 ====
+
+If the `Supplier` return type is `Stream` or one of the primitive streams,
+JUnit will properly close it by calling `BaseStream.close()`,
+making it safe to use a resource such as `Files.lines()`.
 
 Please note that a one-dimensional array of objects supplied as a set of "arguments" will
 be handled differently than other types of arguments. Specifically, all the elements of a

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProvider.java
@@ -76,6 +76,13 @@ public abstract class AnnotationBasedArgumentsProvider<A extends Annotation>
 			getClass().getName()));
 	}
 
+	/**
+	 * The returned {@code Stream} will be {@link Stream#close() properly closed}
+	 * by the default implementation of
+	 * {@link #provideArguments(ParameterDeclarations, ExtensionContext)},
+	 * making it safe to use a resource such as
+	 * {@link java.nio.file.Files#lines(java.nio.file.Path) Files.lines()}.
+	 */
 	protected Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context,
 			A annotation) {
 		return provideArguments(context, annotation);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldSource.java
@@ -61,6 +61,12 @@ import org.apiguardian.api.API;
  * use one of these types, you can wrap it in a {@code Supplier} &mdash; for
  * example, {@code Supplier<IntStream>}.
  *
+ * <p>If the {@code Supplier} return type is {@code Stream} or
+ * one of the primitive streams, JUnit will properly close it by calling
+ * {@link java.util.stream.BaseStream#close() BaseStream.close()},
+ * making it safe to use a resource such as
+ * {@link java.nio.file.Files#lines(java.nio.file.Path) Files.lines()}.
+ *
  * <p>Please note that a one-dimensional array of objects supplied as a set of
  * "arguments" will be handled differently than other types of arguments.
  * Specifically, all of the elements of a one-dimensional array of objects will

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodSource.java
@@ -50,6 +50,12 @@ import org.apiguardian.api.API;
  * {@code String[]}, etc.), or a single <em>value</em> if the parameterized test
  * method accepts a single argument.
  *
+ * <p>If the return type is {@code Stream} or
+ * one of the primitive streams, JUnit will properly close it by calling
+ * {@link java.util.stream.BaseStream#close() BaseStream.close()},
+ * making it safe to use a resource such as
+ * {@link java.nio.file.Files#lines(java.nio.file.Path) Files.lines()}.
+ *
  * <p>Please note that a one-dimensional array of objects supplied as a set of
  * "arguments" will be handled differently than other types of arguments.
  * Specifically, all of the elements of a one-dimensional array of objects will


### PR DESCRIPTION
Resolves https://github.com/junit-team/junit5/issues/4382

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
