### PR TITLE
Detect GraalVM on CI via env var set by GitHub action

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache.parallel=true
-org.gradle.java.installations.fromEnv=JDK8,JDK18,JDK19,JDK20,JDK21,JDK22,JDK23,JDK24
+org.gradle.java.installations.fromEnv=GRAALVM_HOME,JDK8,JDK18,JDK19,JDK20,JDK21,JDK22,JDK23,JDK24
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # Test Distribution

--- a/platform-tooling-support-tests/projects/graalvm-starter/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/graalvm-starter/build.gradle.kts
@@ -34,11 +34,29 @@ tasks.test {
 	}
 }
 
+// These will be part of the next version of native-build-tools
+// see https://github.com/graalvm/native-build-tools/pull/693
+val initializeAtBuildTime = listOf(
+	"org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor\$ClassInfo",
+	"org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor\$LifecycleMethods",
+	"org.junit.jupiter.engine.descriptor.ClassTemplateInvocationTestDescriptor",
+	"org.junit.jupiter.engine.descriptor.ClassTemplateTestDescriptor",
+	"org.junit.jupiter.engine.descriptor.DynamicDescendantFilter\$Mode",
+	"org.junit.jupiter.engine.descriptor.ExclusiveResourceCollector\$1",
+	"org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor\$MethodInfo",
+	"org.junit.jupiter.engine.discovery.ClassSelectorResolver\$DummyClassTemplateInvocationContext",
+	"org.junit.platform.launcher.core.DiscoveryIssueNotifier",
+	"org.junit.platform.launcher.core.HierarchicalOutputDirectoryProvider",
+	"org.junit.platform.launcher.core.LauncherDiscoveryResult\$EngineResultInfo",
+	"org.junit.platform.suite.engine.SuiteTestDescriptor\$LifecycleMethods",
+)
+
 graalvmNative {
 	binaries {
 		named("test") {
 			buildArgs.add("--strict-image-heap")
 			buildArgs.add("-H:+ReportExceptionStackTraces")
+			buildArgs.add("--initialize-at-build-time=${initializeAtBuildTime.joinToString(",")}")
 		}
 	}
 }

--- a/platform-tooling-support-tests/projects/graalvm-starter/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/graalvm-starter/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
 	plugins {
+		// TODO Remove custom config in build.gradle.kts when upgrading
 		id("org.graalvm.buildtools.native") version "0.10.6"
 	}
 	repositories {


### PR DESCRIPTION
## Overview

Fix GraalVM setup on CI
<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
