### PR TITLE
Make validation of including `EngineFilters` more strict

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M3.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-M3.adoc
@@ -65,6 +65,10 @@ to start reporting discovery issues.
   - Invalid `@BeforeSuite`/`@AfterSuite` method declarations (for example, when not
     `static`)
   - Cyclic dependencies between `@Suite` classes
+* Make validation of including `EngineFilters` more strict to avoid misconfiguration, for
+  example, due to typos. Prior to this release, an exception was only thrown when _none_
+  of a filter's included IDs matched any engine. Now, an exception is thrown if at least
+  one included ID across all filters did not match any engine.
 
 
 [[release-notes-5.13.0-M3-junit-jupiter]]

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineFilterer.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineFilterer.java
@@ -12,11 +12,14 @@ package org.junit.platform.launcher.core;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toSet;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -69,12 +72,14 @@ class EngineFilterer {
 	}
 
 	private SortedSet<String> getUnmatchedEngineIdsOfIncludeFilters() {
+		Set<String> checkedTestEngineIds = checkedTestEngines.keySet().stream() //
+				.map(TestEngine::getId) //
+				.collect(toSet());
 		return engineFilters.stream() //
 				.filter(EngineFilter::isIncludeFilter) //
-				.filter(engineFilter -> checkedTestEngines.keySet().stream() //
-						.map(engineFilter::apply) //
-						.noneMatch(FilterResult::included)) //
-				.flatMap(engineFilter -> engineFilter.getEngineIds().stream()) //
+				.map(EngineFilter::getEngineIds) //
+				.flatMap(Collection::stream) //
+				.filter(id -> !checkedTestEngineIds.contains(id)) //
 				.collect(toCollection(TreeSet::new));
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherEngineFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherEngineFilterTests.java
@@ -168,6 +168,26 @@ class DefaultLauncherEngineFilterTests {
 	}
 
 	@Test
+	void launcherThrowsExceptionWhenNoEngineMatchesIdInIncludeEngineFilter(@TrackLogRecords LogRecordListener log) {
+		var engine = new DemoHierarchicalTestEngine("first");
+		TestDescriptor test1 = engine.addTest("test1", noOp);
+		LauncherDiscoveryRequest request = request() //
+				.selectors(selectUniqueId(test1.getUniqueId())) //
+				.filters(includeEngines("first", "second")) //
+				.build();
+
+		var launcher = createLauncher(engine);
+		var exception = assertThrows(JUnitException.class, () -> launcher.discover(request));
+
+		assertThat(exception.getMessage()) //
+				.startsWith("No TestEngine ID matched the following include EngineFilters: [second].") //
+				.contains("Please fix/remove the filter or add the engine.") //
+				.contains("Registered TestEngines:\n- first (") //
+				.endsWith("Registered EngineFilters:\n- EngineFilter that includes engines with IDs [first, second]");
+		assertThat(log.stream(WARNING)).isEmpty();
+	}
+
+	@Test
 	void launcherWillLogWarningWhenAllEnginesWereExcluded(@TrackLogRecords LogRecordListener log) {
 		var engine = new DemoHierarchicalTestEngine("first");
 		TestDescriptor test = engine.addTest("test1", noOp);

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -192,12 +192,6 @@ val test by testing.suites.getting(JvmTestSuite::class) {
 				jvmArgumentProviders += JarPath(project, antJarsClasspath.get(), "antJars")
 				jvmArgumentProviders += MavenDistribution(project, unzipMavenDistribution, mavenDistributionDir)
 
-				if (buildParameters.javaToolchain.version.getOrElse(21) < 24) {
-					(options as JUnitPlatformOptions).apply {
-						includeEngines("archunit")
-					}
-				}
-
 				inputs.apply {
 					dir("projects").withPathSensitivity(RELATIVE)
 					file("${rootDir}/gradle.properties").withPathSensitivity(RELATIVE)


### PR DESCRIPTION
## Overview

Prior to this commit, an exception was only thrown when _none_ of a
filter's included IDs matched any engine. Now, an exception is thrown if
at least one included ID across all filters did not match any engine.

Related issue: #2824

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
