### PR TITLE
Improve validation of JRE execution condition annotations

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-RC1.adoc
@@ -35,7 +35,7 @@ repository on GitHub.
 [[release-notes-5.13.0-RC1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Validate _all_ versions specified in `@EnabledOnJre` and `@DisabledOnJre` annotations.
 
 [[release-notes-5.13.0-RC1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
@@ -70,9 +70,6 @@ abstract class AbstractJreRangeCondition<A extends Annotation> extends BooleanEx
 		// Finally, we need to validate the effective minimum and maximum values.
 		Preconditions.condition((min != JRE.MINIMUM_VERSION || max != Integer.MAX_VALUE),
 			() -> "You must declare a non-default value for the minimum or maximum value in @" + this.annotationName);
-		Preconditions.condition(min >= JRE.MINIMUM_VERSION,
-			() -> String.format("@%s's minimum value [%d] must greater than or equal to %d", this.annotationName, min,
-				JRE.MINIMUM_VERSION));
 		Preconditions.condition(min <= max,
 			() -> String.format("@%s's minimum value [%d] must be less than or equal to its maximum value [%d]",
 				this.annotationName, min, max));

--- a/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java.jte
+++ b/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java.jte
@@ -50,7 +50,7 @@ class DisabledOnJreIntegrationTests {
 
 	@Test
 	@Disabled("Only used in a unit test via reflection")
-	@DisabledOnJre(versions = 7)
+	@DisabledOnJre(value = JAVA_17, versions = { 21, 7 })
 	void version7() {
 	}
 

--- a/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java.jte
+++ b/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java.jte
@@ -49,7 +49,7 @@ class EnabledOnJreIntegrationTests {
 
 	@Test
 	@Disabled("Only used in a unit test via reflection")
-	@EnabledOnJre(versions = 7)
+	@EnabledOnJre(value = JAVA_17, versions = { 21, 7 })
 	void version7() {
 	}
 


### PR DESCRIPTION
## Overview

- **Validate all versions in `@EnabledOnJre` and `@DisabledOnJre`**
- **Remove unreachable validation**

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
