### PR TITLE
Introduce @BooleansSource for use with @ParameterizedTest

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0-RC1.adoc
@@ -26,7 +26,7 @@ repository on GitHub.
 [[release-notes-5.13.0-RC1-junit-platform-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* Added `@BooleansSource` annotation for `@ParameterizedTest` (#4507)
 
 
 [[release-notes-5.13.0-RC1-junit-jupiter]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -1818,6 +1818,20 @@ the values `1`, `2`, and `3` respectively.
 include::{testDir}/example/ParameterizedTestDemo.java[tags=ValueSource_example]
 ----
 
+[[writing-tests-parameterized-tests-argument-sources-BooleansSource]]
+===== @BooleansSource
+
+`@BooleansSource` is a composed annotation that provides a convenient way to specify
+boolean values (`true` and `false`) as arguments for a `@ParameterizedTest` method.
+
+For example, the following `@ParameterizedTest` method will be invoked twice,
+with the values `true` and `false` respectively.
+
+[source,java,indent=0]
+----
+include::{testDir}/example/ParameterizedTestDemo.java[tags=BooleanSource_example]
+----
+
 [[writing-tests-parameterized-tests-sources-null-and-empty]]
 ===== Null and Empty Sources
 

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -64,6 +64,7 @@ import org.junit.jupiter.params.converter.TypedArgumentConverter;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.BooleansSource;
 import org.junit.jupiter.params.provider.CsvFileSource;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EmptySource;
@@ -641,4 +642,12 @@ class ParameterizedTestDemo {
 		assertTrue(number > 0);
 	}
 	// end::argument_count_validation[]
+
+	// tag::BooleanSource_example[]
+	@ParameterizedTest
+	@BooleansSource
+	void testWithBooleanSource(boolean flag) {
+		assertTrue(flag || !flag);
+	}
+	// end::BooleanSource_example[]
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/BooleansSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/BooleansSource.java
@@ -10,6 +10,8 @@
 
 package org.junit.jupiter.params.provider;
 
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -18,8 +20,6 @@ import java.lang.annotation.Target;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 /**
  * {@code @BooleansSource} is a composed annotation that provides a convenient

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/BooleansSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/BooleansSource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+
+/**
+ * {@code @BooleansSource} is a composed annotation that provides a convenient
+ * way to specify {@code true} and {@code false} as arguments for
+ * a {@link ParameterizedTest @ParameterizedTest} method.
+ *
+ * <p>It serves as a shorthand for {@code @ValueSource(booleans = {true, false})},
+ * commonly used for testing behavior with feature flags or boolean conditions.
+ *
+ * <h2>Composition</h2>
+ *
+ * <p>This annotation is composed of {@link ValueSource} with predefined boolean values.
+ * It is designed to be a more readable and maintainable alternative to explicitly
+ * specifying boolean values in {@code @ValueSource}.
+ *
+ * @since 5.13
+ * @see ValueSource
+ * @see ArgumentsSource
+ * @see ParameterizedTest
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ValueSource(booleans = { true, false })
+@API(status = EXPERIMENTAL, since = "5.13")
+public @interface BooleansSource {
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/BooleansSourceTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/BooleansSourceTests.java
@@ -24,5 +24,5 @@ class BooleansSourceTests {
 	void shouldRunWithTrueAndFalse(boolean flag) {
 		assertTrue(flag || !flag);
 	}
-	
+
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/BooleansSourceTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/BooleansSourceTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.params.provider;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+
+/**
+ * @since 5.13
+ */
+class BooleansSourceTests {
+
+	@ParameterizedTest
+	@BooleansSource
+	void shouldRunWithTrueAndFalse(boolean flag) {
+		assertTrue(flag || !flag);
+	}
+	
+}


### PR DESCRIPTION
Issue: #4507

Hello 👋

I've created an implementation for Issue #4507.
If you have time, I'd appreciate it if you could review it.
Please leave a comment if there's anything that needs to be changed.
I'll be happy to make any necessary adjustments.

Thank you!

## Overview
- Add `@BooleansSource` annotation for `@ParameterizedTest`

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
