### PR TITLE
Remove version 5 where possible

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,7 @@ type: Bug
 labels: ["type: bug"]
 ---
 
-<!-- Please provide us the version of JUnit 5 you are using and, if possible, a failing unit test with your bug report. Don't forget to describe the rationale for this issue (e.g. expected vs. actual behavior). Please also mention where it's a regression compared to a previous version. -->
+<!-- Please provide us the version of JUnit you are using and, if possible, a failing unit test with your bug report. Don't forget to describe the rationale for this issue (e.g. expected vs. actual behavior). Please also mention where it's a regression compared to a previous version. -->
 
 ## Steps to reproduce
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ See [`ExtensionContext`](junit-jupiter-api/src/main/java/org/junit/jupiter/api/e
 
 ### Deprecation
 
-The JUnit 5 project uses the `@API` annotation from [API Guardian](https://github.com/apiguardian-team/apiguardian).
+The JUnit project uses the `@API` annotation from [API Guardian](https://github.com/apiguardian-team/apiguardian).
 Publicly available interfaces, classes, and methods have a defined lifecycle
 which is described in detail in the [User Guide](https://junit.org/junit5/docs/current/user-guide/#api-evolution).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# <img src="https://junit.org/junit5/assets/img/junit5-logo.png" align="right" width="100">JUnit 5
+# <img src="https://junit.org/junit5/assets/img/junit5-logo.png" align="right" width="100">JUnit
 
-This repository is the home of _JUnit 5_.
+This repository is the home of _JUnit_.
 
 ## Sponsors
 
@@ -24,7 +24,7 @@ This repository is the home of _JUnit 5_.
 
 ## Contributing
 
-Contributions to JUnit 5 are both welcomed and appreciated. For specific guidelines
+Contributions to JUnit are both welcomed and appreciated. For specific guidelines
 regarding contributions, please see [CONTRIBUTING.md] in the root directory of the
 project. Those willing to use milestone or SNAPSHOT releases are encouraged
 to file feature requests and bug reports using the project's
@@ -34,15 +34,15 @@ label are specifically targeted for community contributions.
 
 ## Getting Help
 
-Ask JUnit 5 related questions on [StackOverflow] or chat with the community on [Gitter].
+Ask JUnit-related questions on [StackOverflow] or chat with the community on [Gitter].
 
 ## Continuous Integration Builds
 
 [![CI Status](https://github.com/junit-team/junit5/workflows/CI/badge.svg)](https://github.com/junit-team/junit5/actions) [![Cross-Version Status](https://github.com/junit-team/junit5/workflows/Cross-Version/badge.svg)](https://github.com/junit-team/junit5/actions)
 
-Official CI build server for JUnit 5. Used to perform quick checks on submitted pull
-requests and for build matrices including the latest released OpenJDK and early access
-builds of the next OpenJDK.
+Official CI build server used to perform quick checks on submitted pull requests and for
+build matrices including the latest released OpenJDK and early access builds of the next
+OpenJDK.
 
 ## Code Coverage
 
@@ -56,7 +56,7 @@ in `build/reports/jacoco/jacocoRootReport/html/index.html`.
 
 [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.junit.org/scans)
 
-JUnit 5 utilizes [Develocity](https://gradle.com/) for [Build Scans](https://scans.gradle.com/),
+JUnit utilizes [Develocity](https://gradle.com/) for [Build Scans](https://scans.gradle.com/),
 [Build Cache](https://docs.gradle.org/current/userguide/build_cache.html), and
 [Predictive Test Selection](https://docs.gradle.com/enterprise/predictive-test-selection/).
 
@@ -70,7 +70,7 @@ task outputs from previous CI builds.
 
 ## Building from Source
 
-You need [JDK 21] to build JUnit 5. [Gradle toolchains] are used to detect and
+You need [JDK 21] to build JUnit. [Gradle toolchains] are used to detect and
 potentially download additional JDKs for compilation and test execution.
 
 All modules can be _built_ and _tested_ with the [Gradle Wrapper] using the following command.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://junit.org/junit5/assets/img/junit5-logo.png" align="right" width="100">JUnit
 
-This repository is the home of _JUnit_.
+This repository is the home of JUnit Platform, Jupiter, and Vintage.
 
 ## Sponsors
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 	id("junitbuild.temp-maven-repo")
 }
 
-description = "JUnit 5"
+description = "JUnit"
 
 val license by extra(License(
 	name = "Eclipse Public License v2.0",

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,6 +1,6 @@
-# JUnit 5 User Guide
+# JUnit User Guide
 
-This subproject contains the AsciiDoc sources for the JUnit 5 User Guide.
+This subproject contains the AsciiDoc sources for the JUnit User Guide.
 
 ## Structure
 

--- a/documentation/src/docs/asciidoc/release-notes/index.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/index.adoc
@@ -1,5 +1,5 @@
 [[release-notes]]
-= JUnit 5 Release Notes
+= JUnit Release Notes
 Stefan Bechtold; Sam Brannen; Johannes Link; Matthias Merdes; Marc Philipp; Juliette de Rancourt; Christian Stein
 //
 :basedir: {includedir}/release-notes
@@ -9,7 +9,7 @@ Stefan Bechtold; Sam Brannen; Johannes Link; Matthias Merdes; Marc Philipp; Juli
 :last-update-label!:
 //
 
-This document contains the _change log_ for all JUnit 5 releases since 5.11 GA.
+This document contains the _change log_ for all JUnit releases since 5.13 GA.
 
 Please refer to the <<../user-guide/index.adoc#user-guide,User Guide>> for comprehensive
 reference documentation for programmers writing tests, extension authors, and engine

--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/engines.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/engines.adoc
@@ -60,7 +60,7 @@ configuration parameters.
 Although there is currently no official guide on how to implement a custom `TestEngine`,
 you can consult the implementation of <<test-engines-junit>> or the implementation of
 third-party test engines listed in the
-https://github.com/junit-team/junit5/wiki/Third-party-Extensions#junit-platform-test-engines[JUnit 5 wiki].
+https://github.com/junit-team/junit5/wiki/Third-party-Extensions#junit-platform-test-engines[JUnit wiki].
 You will also find various tutorials and blogs on the Internet that demonstrate how to
 write a custom `TestEngine`.
 

--- a/documentation/src/docs/asciidoc/user-guide/advanced-topics/launcher-api.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/advanced-topics/launcher-api.adoc
@@ -4,13 +4,13 @@
 [[launcher-api]]
 === JUnit Platform Launcher API
 
-One of the prominent goals of JUnit 5 is to make the interface between JUnit and its
-programmatic clients – build tools and IDEs – more powerful and stable. The purpose is to
-decouple the internals of discovering and executing tests from all the filtering and
-configuration that's necessary from the outside.
+One of the prominent goals of the JUnit Platform is to make the interface between JUnit
+and its programmatic clients – build tools and IDEs – more powerful and stable. The
+purpose is to decouple the internals of discovering and executing tests from all the
+filtering and configuration that's necessary from the outside.
 
-JUnit 5 introduces the concept of a `Launcher` that can be used to discover, filter, and
-execute tests. Moreover, third party test libraries – like Spock, Cucumber, and FitNesse
+JUnit Platform introduces the concept of a `Launcher` that can be used to discover,
+filter, and execute tests. Moreover, third party test libraries – like Spock or Cucumber
 – can plug into the JUnit Platform's launching infrastructure by providing a custom
 <<test-engines,TestEngine>>.
 

--- a/documentation/src/docs/asciidoc/user-guide/api-evolution.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/api-evolution.adoc
@@ -1,12 +1,13 @@
 [[api-evolution]]
 == API Evolution
 
-One of the major goals of JUnit 5 is to improve maintainers' capabilities to evolve JUnit
-despite its being used in many projects. With JUnit 4 a lot of stuff that was originally
-added as an internal construct only got used by external extension writers and tool
-builders. That made changing JUnit 4 especially difficult and sometimes impossible.
+One of the major goals of the JUnit Platform architecture is to improve maintainers'
+capabilities to evolve JUnit despite its being used in many projects. With JUnit 4 a lot
+of stuff that was originally added as an internal construct only got used by external
+extension writers and tool builders. That made changing JUnit 4 especially difficult and
+sometimes impossible.
 
-That's why JUnit 5 introduces a defined lifecycle for all publicly available interfaces,
+That's why JUnit now uses a defined lifecycle for all publicly available interfaces,
 classes, and methods.
 
 [[api-evolution-version-and-status]]

--- a/documentation/src/docs/asciidoc/user-guide/appendix.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/appendix.adoc
@@ -4,7 +4,7 @@
 [[reproducible-builds]]
 === Reproducible Builds
 
-Starting with version 5.7, JUnit 5 aims for its non-javadoc JARs to be
+Starting with version 5.7, JUnit aims for its non-javadoc JARs to be
 https://reproducible-builds.org/[reproducible].
 
 Under identical build conditions, such as Java version, repeated builds should provide the

--- a/documentation/src/docs/asciidoc/user-guide/index.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/index.adoc
@@ -1,5 +1,5 @@
 [[user-guide]]
-= JUnit 5 User Guide
+= JUnit User Guide
 Stefan Bechtold; Sam Brannen; Johannes Link; Matthias Merdes; Marc Philipp; Juliette de Rancourt; Christian Stein
 :basedir: {includedir}/user-guide
 :pdf-fontsdir: GEM_FONTS_DIR;{includedir}/resources/fonts

--- a/documentation/src/docs/asciidoc/user-guide/overview.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/overview.adoc
@@ -12,12 +12,12 @@ endif::linkToPdf[]
 endif::backend-html5[]
 
 [[overview-what-is-junit-5]]
-=== What is JUnit 5?
+=== What is JUnit?
 
-Unlike previous versions of JUnit, JUnit 5 is composed of several different modules from
-three different sub-projects.
+Unlike previous versions of JUnit, JUnit 5 and later is composed of several different
+modules from three different sub-projects.
 
-**JUnit 5 = _JUnit Platform_ + _JUnit Jupiter_ + _JUnit Vintage_**
+**JUnit {version} = _JUnit Platform_ + _JUnit Jupiter_ + _JUnit Vintage_**
 
 The **JUnit Platform** serves as a foundation for <<launcher-api,launching testing
 frameworks>> on the JVM. It also defines the `{TestEngine}` API for developing a testing
@@ -31,7 +31,7 @@ exists in popular IDEs (see <<running-tests-ide-intellij-idea>>,
 <<running-tests-build-maven>>, and <<running-tests-build-ant>>).
 
 **JUnit Jupiter** is the combination of the <<writing-tests,programming model>> and
-<<extensions,extension model>> for writing tests and extensions in JUnit 5. The Jupiter
+<<extensions,extension model>> for writing JUnit tests and extensions. The Jupiter
 sub-project provides a `TestEngine` for running Jupiter based tests on the platform.
 
 **JUnit Vintage** provides a `TestEngine` for running JUnit 3 and JUnit 4 based tests on
@@ -41,13 +41,13 @@ path.
 [[overview-java-versions]]
 === Supported Java Versions
 
-JUnit 5 requires Java 8 (or higher) at runtime. However, you can still test code that
+JUnit requires Java 17 (or higher) at runtime. However, you can still test code that
 has been compiled with previous versions of the JDK.
 
 [[overview-getting-help]]
 === Getting Help
 
-Ask JUnit 5 related questions on {StackOverflow} or chat with the community on {Gitter}.
+Ask JUnit-related questions on {StackOverflow} or chat with the community on {Gitter}.
 
 [[overview-getting-started]]
 === Getting Started
@@ -60,9 +60,9 @@ to <<dependency-metadata>>. To set up dependency management for your build, refe
 <<running-tests-build>> and the <<overview-getting-started-example-projects>>.
 
 [[overview-getting-started-features]]
-==== JUnit 5 Features
+==== JUnit Features
 
-To find out what features are available in JUnit 5 and how to use them, read the
+To find out what features are available in JUnit {version} and how to use them, read the
 corresponding sections of this User Guide, organized by topic.
 
 * <<writing-tests, Writing Tests in JUnit Jupiter>>

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -13,7 +13,7 @@ however, that it is recommended to use IDEA 2017.3 or newer since more recent ve
 IDEA download the following JARs automatically based on the API version used in the
 project: `junit-platform-launcher`, `junit-jupiter-engine`, and `junit-vintage-engine`.
 
-In order to use a different JUnit 5 version (e.g., {version}), you may need to
+In order to use a different JUnit version (e.g., {version}), you may need to
 include the corresponding versions of the `junit-platform-launcher`,
 `junit-jupiter-engine`, and `junit-vintage-engine` JARs in the classpath.
 
@@ -68,8 +68,8 @@ testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 Eclipse IDE offers support for the JUnit Platform since the Eclipse Oxygen.1a (4.7.1a)
 release.
 
-For more information on using JUnit 5 in Eclipse consult the official _Eclipse support
-for JUnit 5_ section of the
+For more information on using JUnit Platform in Eclipse consult the official _Eclipse
+support for JUnit 5_ section of the
 https://www.eclipse.org/eclipse/news/4.7.1a/#junit-5-support[Eclipse Project Oxygen.1a
 (4.7.1a) - New and Noteworthy] documentation.
 
@@ -151,7 +151,7 @@ of JUnit used in your Spring Boot application.
 
 Unless you're using Spring Boot which defines its own way of managing dependencies, it is
 recommended to use the JUnit Platform <<dependency-metadata-junit-bom>> to align the
-versions of all JUnit 5 artifacts.
+versions of all JUnit artifacts.
 
 [source,groovy,indent=0]
 [subs=attributes+]
@@ -171,7 +171,7 @@ Since all JUnit artifacts declare a
 https://docs.gradle.org/current/userguide/platforms.html[platform] dependency on the BOM,
 you usually don't need to declare an explicit dependency on it yourself. Instead, it's
 sufficient to declare _one_ regular dependency that includes a version number. Gradle will
-then pull in the BOM automatically so you can omit the version for all other JUnit 5
+then pull in the BOM automatically so you can omit the version for all other JUnit
 artifacts.
 
 [source,groovy,indent=0]
@@ -328,7 +328,7 @@ As of JUnit 6.0, the minimum required version of Maven Surefire/Failsafe is 3.0.
 
 Unless you're using Spring Boot which defines its own way of managing dependencies, it is
 recommended to use the JUnit Platform <<dependency-metadata-junit-bom>> to align the
-versions of all JUnit 5 artifacts.
+versions of all JUnit artifacts.
 
 [source,xml,indent=0]
 [subs=attributes+]

--- a/documentation/src/javadoc/junit-overview.html
+++ b/documentation/src/javadoc/junit-overview.html
@@ -7,12 +7,12 @@
     <dd>The JUnit Platform serves as a foundation for launching testing frameworks on the JVM.
         It also defines the TestEngine API for developing a testing framework that runs on the
         platform. Furthermore, the platform provides a Console Launcher to launch the platform
-        from the command line and a JUnit 4 based Runner for running any TestEngine on the
-        platform in a JUnit 4 based environment.
+        from the command line and the Suite Engine for running a custom test suite using one
+        or more test engines on the platform
     </dd>
     <dt>Jupiter</dt>
-    <dd>JUnit Jupiter is the combination of the new programming model and extension model for
-        writing tests and extensions in JUnit 5. The Jupiter sub-project provides a TestEngine
+    <dd>JUnit Jupiter is the combination of the programming model and extension model for
+        writing JUnit tests and extensions. The Jupiter sub-project provides a TestEngine
         for running Jupiter based tests on the platform.
     </dd>
     <dt>Vintage</dt>
@@ -21,6 +21,6 @@
     </dd>
 </dl>
 
-<p>Already consulted the <a href="../user-guide/index.html">JUnit 5 User Guide</a>?</p>
+<p>Already consulted the <a href="../user-guide/index.html">JUnit User Guide</a>?</p>
 
 </body>

--- a/gradle/config/eclipse/junit-eclipse-formatter-settings.xml
+++ b/gradle/config/eclipse/junit-eclipse-formatter-settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="23">
-    <profile kind="CodeFormatterProfile" name="JUnit 5" version="23">
+    <profile kind="CodeFormatterProfile" name="JUnit" version="23">
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
@@ -124,7 +124,7 @@ if (project in mavenizedProjects) {
 					}
 				}
 				pom {
-					description = provider { "Module \"${project.name}\" of JUnit 5." }
+					description = provider { "Module \"${project.name}\" of JUnit" }
 				}
 			}
 		}

--- a/junit-jupiter-migrationsupport/README.md
+++ b/junit-jupiter-migrationsupport/README.md
@@ -9,11 +9,11 @@ implementations is not possible within the JUnit Jupiter extension model.
 
 The main purpose of this module is to facilitate the migration of large
 JUnit 4 codebases containing such JUnit 4 rules by minimizing the effort
-needed to run such legacy tests under JUnit 5.
+needed to run such legacy tests under JUnit Platform.
 By using one of the two provided class-level extensions on a test class
 such rules in legacy code bases can be left unchanged
 including the JUnit 4 rule import statements.
 
 However, if you intend to develop a *new* extension for
-JUnit 5 please use the new extension model of JUnit Jupiter instead
+JUnit please use the new extension model of JUnit Jupiter instead
 of the rule-based model of JUnit 4.

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupport.java
@@ -30,7 +30,7 @@ import org.junit.rules.ExternalResource;
  * can be left unchanged including the JUnit 4 rule import statements.
  *
  * <p>However, if you intend to develop a <em>new</em> extension for
- * JUnit 5 please use the new extension model of JUnit Jupiter instead
+ * JUnit please use the new extension model of JUnit Jupiter instead
  * of the rule-based model of JUnit 4.
  *
  * @since 5.0

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/VerifierSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/VerifierSupport.java
@@ -29,7 +29,7 @@ import org.junit.rules.Verifier;
  * can be left unchanged including the JUnit 4 rule import statements.
  *
  * <p>However, if you intend to develop a <em>new</em> extension for
- * JUnit 5 please use the new extension model of JUnit Jupiter instead
+ * JUnit please use the new extension model of JUnit Jupiter instead
  * of the rule-based model of JUnit 4.
  *
  * @since 5.0

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -94,7 +94,7 @@ public final class ReflectionUtils {
 	 * <p>When set to {@code false} (either explicitly or implicitly), field and
 	 * method searches will adhere to Java semantics regarding whether a given
 	 * field or method is visible or overridden, where the latter only applies
-	 * to methods. When set to {@code true}, the semantics used in JUnit 5 prior
+	 * to methods. When set to {@code true}, the semantics used in versions prior
 	 * to JUnit 5.11 (JUnit Platform 1.11) will be used, which means that fields
 	 * and methods can hide, shadow, or supersede fields and methods in supertypes
 	 * based solely on the field's name or the method's signature, disregarding

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
@@ -33,7 +33,7 @@ import org.junit.platform.launcher.tagexpression.TagExpression;
  * <p>Tag expressions are boolean expressions with the following allowed
  * operators: {@code !} (not), {@code &} (and), and {@code |} (or). Parentheses
  * can be used to adjust for operator precedence. Please refer to the
- * <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">JUnit 5 User Guide</a>
+ * <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">JUnit User Guide</a>
  * for usage examples.
  *
  * <p>Please note that a tag name is a valid tag expression. Thus, wherever a tag

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/ExcludeTags.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/ExcludeTags.java
@@ -31,7 +31,7 @@ import org.apiguardian.api.API;
  * <p>Tag expressions are boolean expressions with the following allowed
  * operators: {@code !} (not), {@code &} (and) and {@code |} (or). Parentheses
  * can be used to adjust for operator precedence. Please refer to the
- * <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">JUnit 5 User Guide</a>
+ * <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">JUnit User Guide</a>
  * for usage examples.
  *
  * <h2>Syntax Rules for Tags</h2>

--- a/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/IncludeTags.java
+++ b/junit-platform-suite-api/src/main/java/org/junit/platform/suite/api/IncludeTags.java
@@ -31,7 +31,7 @@ import org.apiguardian.api.API;
  * <p>Tag expressions are boolean expressions with the following allowed
  * operators: {@code !} (not), {@code &} (and) and {@code |} (or). Parentheses
  * can be used to adjust for operator precedence. Please refer to the
- * <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">JUnit 5 User Guide</a>
+ * <a href="https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions">JUnit User Guide</a>
  * for usage examples.
  *
  * <h2>Syntax Rules for Tags</h2>

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/MemoryLeakTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/MemoryLeakTests.java
@@ -29,7 +29,7 @@ class MemoryLeakTests {
 	// Allocate 500 MB of memory per test method.
 	//
 	// If the test instance is garbage collected, this should not cause any
-	// problems for the JUnit 5 build; however, if the instances of this test
+	// problems for the JUnit build; however, if the instances of this test
 	// class are NOT garbage collected, we should run out of memory pretty
 	// quickly since the instances of this test class would consume 5GB of
 	// heap space.

--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -114,7 +114,7 @@ val normalizeMavenRepo by tasks.registering(Sync::class) {
 val archUnit by testing.suites.registering(JvmTestSuite::class) {
 	dependencies {
 		implementation(libs.archunit) {
-			because("checking the architecture of JUnit 5")
+			because("checking the architecture")
 		}
 		implementation(libs.apiguardian) {
 			because("we validate that public classes are annotated")


### PR DESCRIPTION
## Overview

In preparation for 6.0

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
