### PR TITLE
Add support for Kotlin suspending functions as test/lifecycle methods

### DIFF
--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
 	testImplementation(projects.junitPlatformTestkit)
 	testImplementation(projects.junitVintageEngine)
 	testImplementation(kotlin("stdlib"))
+	testRuntimeOnly(libs.kotlinx.coroutines)
+	testRuntimeOnly(kotlin("reflect"))
 
 	toolsImplementation(projects.junitPlatformCommons)
 	toolsImplementation(libs.classgraph)

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
@@ -96,7 +96,7 @@ repository on GitHub.
 [[release-notes-6.0.0-M1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements
 
-* ❓
+* Add support for using Kotlin's `suspend` modifier on test and lifecycle methods.
 
 
 [[release-notes-6.0.0-M1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -294,6 +294,13 @@ keyword for testing code using coroutines.
 include::{kotlinTestDir}/example/KotlinCoroutinesDemo.kt[tags=user_guide]
 ----
 
+NOTE: Using suspending functions as test or lifecycle methods requires
+https://central.sonatype.com/artifact/org.jetbrains.kotlin/kotlin-stdlib[`kotlin-stdlib`],
+https://central.sonatype.com/artifact/org.jetbrains.kotlin/kotlin-reflect[`kotlin-reflect`],
+and
+https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core[`kotlinx-coroutines-core`]
+to be present on the classpath or module path.
+
 [[writing-tests-display-names]]
 === Display Names
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -271,7 +271,7 @@ lifecycle methods. For further information on runtime semantics, see
 <<extensions-execution-order-wrapping-behavior>>.
 
 [source,java,indent=0]
-.A standard test class
+.A standard Java test class
 ----
 include::{testDir}/example/StandardTests.java[tags=user_guide]
 ----
@@ -283,6 +283,15 @@ following example.
 .A test class written as a Java record
 ----
 include::{testRelease21Dir}/example/MyFirstJUnitJupiterRecordTests.java[tags=user_guide]
+----
+
+Test and lifecycle methods may be written in Kotlin and may optionally use the `suspend`
+keyword for testing code using coroutines.
+
+[source,kotlin]
+.A test class written in Kotlin
+----
+include::{kotlinTestDir}/example/KotlinCoroutinesDemo.kt[tags=user_guide]
 ----
 
 [[writing-tests-display-names]]

--- a/documentation/src/test/kotlin/example/KotlinCoroutinesDemo.kt
+++ b/documentation/src/test/kotlin/example/KotlinCoroutinesDemo.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package example
+
+// tag::user_guide[]
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+// end::user_guide[]
+// tag::user_guide[]
+@Suppress("JUnitMalformedDeclaration")
+class KotlinCoroutinesDemo {
+    @BeforeEach
+    fun regularSetUp() {
+    }
+
+    @BeforeEach
+    suspend fun coroutineSetUp() {
+    }
+
+    @Test
+    fun regularTest() {
+    }
+
+    @Test
+    suspend fun coroutineTest() {
+    }
+}
+// end::user_guide[]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -17,6 +17,8 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.support.ModifierSupport.isStatic;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionParameterTypes;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -195,7 +197,10 @@ public interface DisplayNameGenerator {
 	 */
 	static String parameterTypesAsString(Method method) {
 		Preconditions.notNull(method, "Method must not be null");
-		return '(' + ClassUtils.nullSafeToString(Class::getSimpleName, method.getParameterTypes()) + ')';
+		var parameterTypes = isKotlinSuspendingFunction(method) //
+				? getKotlinSuspendingFunctionParameterTypes(method) //
+				: method.getParameterTypes();
+		return '(' + ClassUtils.nullSafeToString(Class::getSimpleName, parameterTypes) + ')';
 	}
 
 	/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtils.java
@@ -10,11 +10,10 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import static org.junit.jupiter.engine.support.MethodReflectionUtils.getReturnType;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatedMethods;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.util.CollectionUtils.toUnmodifiableList;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionReturnType;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 import static org.junit.platform.engine.support.discovery.DiscoveryIssueReporter.Condition.alwaysSatisfied;
 
 import java.lang.annotation.Annotation;
@@ -183,12 +182,6 @@ final class LifecycleMethodUtils {
 				annotationNameProvider.apply(method), method.toGenericString());
 			return createIssue(Severity.ERROR, message, method);
 		});
-	}
-
-	private static Class<?> getReturnType(Method method) {
-		return isKotlinSuspendingFunction(method) //
-				? getKotlinSuspendingFunctionReturnType(method) //
-				: method.getReturnType();
 	}
 
 	private static String classTemplateInvocationLifecycleMethodAnnotationName(Method method) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.discovery.predicates;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.junit.jupiter.engine.support.MethodReflectionUtils.getReturnType;
 import static org.junit.platform.commons.util.CollectionUtils.isConvertibleToStream;
 
 import java.lang.annotation.Annotation;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -53,7 +53,7 @@ public class IsTestFactoryMethod extends IsTestableMethod {
 	}
 
 	private static boolean isCompatible(Method method, DiscoveryIssueReporter issueReporter) {
-		Class<?> returnType = method.getReturnType();
+		Class<?> returnType = getReturnType(method);
 		if (DynamicNode.class.isAssignableFrom(returnType) || DynamicNode[].class.isAssignableFrom(returnType)) {
 			return true;
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.discovery.predicates;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.junit.jupiter.engine.support.MethodReflectionUtils.getGenericReturnType;
 import static org.junit.jupiter.engine.support.MethodReflectionUtils.getReturnType;
 import static org.junit.platform.commons.util.CollectionUtils.isConvertibleToStream;
 
@@ -67,7 +68,7 @@ public class IsTestFactoryMethod extends IsTestableMethod {
 	}
 
 	private static boolean isCompatibleContainerType(Method method, DiscoveryIssueReporter issueReporter) {
-		Type genericReturnType = method.getGenericReturnType();
+		Type genericReturnType = getGenericReturnType(method);
 
 		if (genericReturnType instanceof ParameterizedType) {
 			Type[] typeArguments = ((ParameterizedType) genericReturnType).getActualTypeArguments();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -10,9 +10,8 @@
 
 package org.junit.jupiter.engine.discovery.predicates;
 
+import static org.junit.jupiter.engine.support.MethodReflectionUtils.getReturnType;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionReturnType;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -74,12 +73,6 @@ abstract class IsTestableMethod implements Predicate<Method> {
 			DiscoveryIssueReporter issueReporter) {
 		return issueReporter.createReportingCondition(method -> getReturnType(method) == void.class,
 			method -> createIssue(annotationType, method, "must not return a value"));
-	}
-
-	protected static Class<?> getReturnType(Method method) {
-		return isKotlinSuspendingFunction(method) //
-				? getKotlinSuspendingFunctionReturnType(method) //
-				: method.getReturnType();
 	}
 
 	protected static DiscoveryIssue createIssue(Class<? extends Annotation> annotationType, Method method,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -11,6 +11,8 @@
 package org.junit.jupiter.engine.discovery.predicates;
 
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionReturnType;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -18,7 +20,6 @@ import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import org.junit.platform.commons.support.ModifierSupport;
-import org.junit.platform.commons.util.ReflectionUtils;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.support.descriptor.MethodSource;
@@ -71,8 +72,14 @@ abstract class IsTestableMethod implements Predicate<Method> {
 
 	protected static Condition<Method> hasVoidReturnType(Class<? extends Annotation> annotationType,
 			DiscoveryIssueReporter issueReporter) {
-		return issueReporter.createReportingCondition(ReflectionUtils::returnsPrimitiveVoid,
+		return issueReporter.createReportingCondition(method -> getReturnType(method) == void.class,
 			method -> createIssue(annotationType, method, "must not return a value"));
+	}
+
+	protected static Class<?> getReturnType(Method method) {
+		return isKotlinSuspendingFunction(method) //
+				? getKotlinSuspendingFunctionReturnType(method) //
+				: method.getReturnType();
 	}
 
 	protected static DiscoveryIssue createIssue(Class<? extends Annotation> annotationType, Method method,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultExecutableInvoker.java
@@ -12,8 +12,6 @@ package org.junit.jupiter.engine.execution;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.execution.ParameterResolutionUtils.resolveParameters;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.invokeKotlinSuspendingFunction;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -23,7 +21,7 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
-import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.jupiter.engine.support.MethodReflectionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
@@ -51,10 +49,7 @@ public class DefaultExecutableInvoker implements ExecutableInvoker {
 	public Object invoke(Method method, Object target) {
 		Object[] arguments = resolveParameters(method, Optional.ofNullable(target), extensionContext,
 			extensionRegistry);
-		if (isKotlinSuspendingFunction(method)) {
-			return invokeKotlinSuspendingFunction(method, target, arguments);
-		}
-		return ReflectionSupport.invokeMethod(method, target, arguments);
+		return MethodReflectionUtils.invoke(method, target, arguments);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultExecutableInvoker.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.engine.execution;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.engine.execution.ParameterResolutionUtils.resolveParameters;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.invokeKotlinSuspendingFunction;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -21,6 +23,7 @@ import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.engine.extension.ExtensionRegistry;
+import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
@@ -48,7 +51,10 @@ public class DefaultExecutableInvoker implements ExecutableInvoker {
 	public Object invoke(Method method, Object target) {
 		Object[] arguments = resolveParameters(method, Optional.ofNullable(target), extensionContext,
 			extensionRegistry);
-		return ReflectionUtils.invokeMethod(method, target, arguments);
+		if (isKotlinSuspendingFunction(method)) {
+			return invokeKotlinSuspendingFunction(method, target, arguments);
+		}
+		return ReflectionSupport.invokeMethod(method, target, arguments);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/MethodInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/MethodInvocation.java
@@ -11,8 +11,6 @@
 package org.junit.jupiter.engine.execution;
 
 import static java.util.Collections.unmodifiableList;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.invokeKotlinSuspendingFunction;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -21,7 +19,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.extension.InvocationInterceptor.Invocation;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
-import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.jupiter.engine.support.MethodReflectionUtils;
 
 class MethodInvocation<T> implements Invocation<T>, ReflectiveInvocationContext<Method> {
 
@@ -60,10 +58,7 @@ class MethodInvocation<T> implements Invocation<T>, ReflectiveInvocationContext<
 	@SuppressWarnings("unchecked")
 	public T proceed() {
 		var actualTarget = this.target.orElse(null);
-		if (isKotlinSuspendingFunction(method)) {
-			return (T) invokeKotlinSuspendingFunction(this.method, actualTarget, this.arguments);
-		}
-		return (T) ReflectionSupport.invokeMethod(this.method, actualTarget, this.arguments);
+		return (T) MethodReflectionUtils.invoke(this.method, actualTarget, this.arguments);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/MethodInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/MethodInvocation.java
@@ -11,6 +11,8 @@
 package org.junit.jupiter.engine.execution;
 
 import static java.util.Collections.unmodifiableList;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.invokeKotlinSuspendingFunction;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -57,7 +59,11 @@ class MethodInvocation<T> implements Invocation<T>, ReflectiveInvocationContext<
 	@Override
 	@SuppressWarnings("unchecked")
 	public T proceed() {
-		return (T) ReflectionSupport.invokeMethod(this.method, this.target.orElse(null), this.arguments);
+		var actualTarget = this.target.orElse(null);
+		if (isKotlinSuspendingFunction(method)) {
+			return (T) invokeKotlinSuspendingFunction(this.method, actualTarget, this.arguments);
+		}
+		return (T) ReflectionSupport.invokeMethod(this.method, actualTarget, this.arguments);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -13,6 +13,8 @@ package org.junit.jupiter.engine.execution;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.getSuspendingFunctionParameters;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 import static org.junit.platform.commons.util.ReflectionUtils.isAssignableTo;
 
 import java.lang.reflect.Constructor;
@@ -61,7 +63,11 @@ public class ParameterResolutionUtils {
 	public static Object[] resolveParameters(Method method, Optional<Object> target, ExtensionContext extensionContext,
 			ExtensionRegistry extensionRegistry) {
 
-		return resolveParameters(method, target, Optional.empty(), extensionContext, extensionRegistry);
+		var parameters = isKotlinSuspendingFunction(method) //
+				? getSuspendingFunctionParameters(method) //
+				: method.getParameters();
+		return resolveParameters(method, target, Optional.empty(), __ -> extensionContext, extensionRegistry,
+			parameters);
 	}
 
 	/**
@@ -90,9 +96,16 @@ public class ParameterResolutionUtils {
 			Optional<Object> outerInstance, ExtensionContextSupplier extensionContext,
 			ExtensionRegistry extensionRegistry) {
 
+		return resolveParameters(executable, target, outerInstance, extensionContext, extensionRegistry,
+			executable.getParameters());
+	}
+
+	private static Object[] resolveParameters(Executable executable, Optional<Object> target,
+			Optional<Object> outerInstance, ExtensionContextSupplier extensionContext,
+			ExtensionRegistry extensionRegistry, Parameter[] parameters) {
+
 		Preconditions.notNull(target, "target must not be null");
 
-		Parameter[] parameters = executable.getParameters();
 		Object[] values = new Object[parameters.length];
 		int start = 0;
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -63,11 +63,10 @@ public class ParameterResolutionUtils {
 	public static Object[] resolveParameters(Method method, Optional<Object> target, ExtensionContext extensionContext,
 			ExtensionRegistry extensionRegistry) {
 
-		var parameters = isKotlinSuspendingFunction(method) //
-				? getSuspendingFunctionParameters(method) //
-				: method.getParameters();
 		return resolveParameters(method, target, Optional.empty(), __ -> extensionContext, extensionRegistry,
-			parameters);
+			isKotlinSuspendingFunction(method) //
+					? getSuspendingFunctionParameters(method) //
+					: method.getParameters());
 	}
 
 	/**

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -13,7 +13,7 @@ package org.junit.jupiter.engine.execution;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.apiguardian.api.API.Status.INTERNAL;
-import static org.junit.platform.commons.util.KotlinReflectionUtils.getSuspendingFunctionParameters;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionParameters;
 import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 import static org.junit.platform.commons.util.ReflectionUtils.isAssignableTo;
 
@@ -65,7 +65,7 @@ public class ParameterResolutionUtils {
 
 		return resolveParameters(method, target, Optional.empty(), __ -> extensionContext, extensionRegistry,
 			isKotlinSuspendingFunction(method) //
-					? getSuspendingFunctionParameters(method) //
+					? getKotlinSuspendingFunctionParameters(method) //
 					: method.getParameters());
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/MethodReflectionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/MethodReflectionUtils.java
@@ -13,12 +13,14 @@ package org.junit.jupiter.engine.support;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionGenericReturnType;
 import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionReturnType;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.invokeKotlinSuspendingFunction;
 import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
 import org.apiguardian.api.API;
+import org.junit.platform.commons.support.ReflectionSupport;
 
 @API(status = INTERNAL, since = "6.0")
 public class MethodReflectionUtils {
@@ -35,4 +37,10 @@ public class MethodReflectionUtils {
 				: method.getGenericReturnType();
 	}
 
+	public static Object invoke(Method method, Object target, Object[] arguments) {
+		if (isKotlinSuspendingFunction(method)) {
+			return invokeKotlinSuspendingFunction(method, target, arguments);
+		}
+		return ReflectionSupport.invokeMethod(method, target, arguments);
+	}
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/MethodReflectionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/MethodReflectionUtils.java
@@ -11,10 +11,12 @@
 package org.junit.jupiter.engine.support;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionGenericReturnType;
 import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionReturnType;
 import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 import org.apiguardian.api.API;
 
@@ -25,6 +27,12 @@ public class MethodReflectionUtils {
 		return isKotlinSuspendingFunction(method) //
 				? getKotlinSuspendingFunctionReturnType(method) //
 				: method.getReturnType();
+	}
+
+	public static Type getGenericReturnType(Method method) {
+		return isKotlinSuspendingFunction(method) //
+				? getKotlinSuspendingFunctionGenericReturnType(method) //
+				: method.getGenericReturnType();
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/MethodReflectionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/MethodReflectionUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine.support;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.getKotlinSuspendingFunctionReturnType;
+import static org.junit.platform.commons.util.KotlinReflectionUtils.isKotlinSuspendingFunction;
+
+import java.lang.reflect.Method;
+
+import org.apiguardian.api.API;
+
+@API(status = INTERNAL, since = "6.0")
+public class MethodReflectionUtils {
+
+	public static Class<?> getReturnType(Method method) {
+		return isKotlinSuspendingFunction(method) //
+				? getKotlinSuspendingFunctionReturnType(method) //
+				: method.getReturnType();
+	}
+
+}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassContext.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassContext.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.params;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.reverse;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotatedMethods;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.extension.ClassTemplateInvocationContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
-import org.junit.platform.commons.support.ModifierSupport;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 class ParameterizedClassContext implements ParameterizedDeclarationContext<ClassTemplateInvocationContext> {
@@ -155,9 +153,6 @@ class ParameterizedClassContext implements ParameterizedDeclarationContext<Class
 		List<Method> methods = findAnnotatedMethods(testClass, annotationType, traversalMode);
 
 		return methods.stream() //
-				.filter(ModifierSupport::isNotPrivate) //
-				.filter(testInstanceLifecycle == PER_METHOD ? ModifierSupport::isStatic : __ -> true) //
-				.filter(ReflectionUtils::returnsPrimitiveVoid) //
 				.map(method -> {
 					A annotation = getAnnotation(method, annotationType);
 					if (injectArgumentsPredicate.test(annotation)) {

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -17,4 +17,7 @@ dependencies {
 
 tasks.compileJava {
 	options.compilerArgs.add("-Xlint:-module") // due to qualified exports
+	options.compilerArgumentProviders.add(CommandLineArgumentProvider {
+		listOf("--patch-module", "${javaModuleName}=${sourceSets.main.get().output.asPath}")
+	})
 }

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -17,8 +17,10 @@ dependencies {
 
 tasks.compileJava {
 	options.compilerArgs.add("-Xlint:-module") // due to qualified exports
+	val moduleName = javaModuleName
+	val mainOutput = files(sourceSets.main.get().output)
 	options.compilerArgumentProviders.add(CommandLineArgumentProvider {
-		listOf("--patch-module", "${javaModuleName}=${sourceSets.main.get().output.asPath}")
+		listOf("--patch-module", "${moduleName}=${mainOutput.asPath}")
 	})
 }
 

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("junitbuild.java-library-conventions")
+	id("junitbuild.kotlin-library-conventions")
 	`java-test-fixtures`
 }
 
@@ -9,6 +9,10 @@ dependencies {
 	api(platform(projects.junitBom))
 
 	compileOnlyApi(libs.apiguardian)
+
+	compileOnly(kotlin("stdlib"))
+	compileOnly(kotlin("reflect"))
+	compileOnly(libs.kotlinx.coroutines)
 }
 
 tasks.compileJava {

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -1,3 +1,5 @@
+import junitbuild.extensions.javaModuleName
+
 plugins {
 	id("junitbuild.kotlin-library-conventions")
 	`java-test-fixtures`

--- a/junit-platform-commons/junit-platform-commons.gradle.kts
+++ b/junit-platform-commons/junit-platform-commons.gradle.kts
@@ -21,3 +21,16 @@ tasks.compileJava {
 		listOf("--patch-module", "${javaModuleName}=${sourceSets.main.get().output.asPath}")
 	})
 }
+
+tasks.jar {
+	bundle {
+		val importAPIGuardian: String by extra
+		bnd("""
+			Import-Package: \
+				$importAPIGuardian,\
+				kotlin.*;resolution:="optional",\
+				kotlinx.*;resolution:="optional",\
+				*
+		""")
+	}
+}

--- a/junit-platform-commons/src/main/java/module-info.java
+++ b/junit-platform-commons/src/main/java/module-info.java
@@ -18,6 +18,10 @@ module org.junit.platform.commons {
 	requires java.management; // needed by RuntimeUtils to determine input arguments
 	requires static transitive org.apiguardian.api;
 
+	requires static kotlin.stdlib;
+	requires static kotlin.reflect;
+	requires static kotlinx.coroutines.core;
+
 	exports org.junit.platform.commons;
 	exports org.junit.platform.commons.annotation;
 	exports org.junit.platform.commons.function;

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
@@ -10,28 +10,11 @@
 
 package org.junit.platform.commons.util;
 
-import static kotlin.jvm.JvmClassMappingKt.getJavaClass;
-import static kotlin.reflect.full.KCallables.callSuspendBy;
-import static kotlin.reflect.jvm.KCallablesJvm.isAccessible;
-import static kotlin.reflect.jvm.KCallablesJvm.setAccessible;
-import static kotlin.reflect.jvm.KTypesJvm.getJvmErasure;
-import static kotlinx.coroutines.BuildersKt.runBlocking;
-import static org.junit.platform.commons.util.ExceptionUtils.throwAsUncheckedException;
-import static org.junit.platform.commons.util.ReflectionUtils.getUnderlyingCause;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.platform.commons.function.Try;
-
-import kotlin.coroutines.EmptyCoroutineContext;
-import kotlin.reflect.KFunction;
-import kotlin.reflect.KParameter;
-import kotlin.reflect.jvm.ReflectJvmMapping;
 
 public class KotlinReflectionUtils {
 
@@ -68,71 +51,19 @@ public class KotlinReflectionUtils {
 	}
 
 	public static Class<?> getKotlinSuspendingFunctionReturnType(Method method) {
-		var returnType = getJvmErasure(getKotlinFunction(method).getReturnType());
-		if ("kotlin.Unit".equals(returnType.getQualifiedName())) {
-			return void.class;
-		}
-		return getJavaClass(returnType);
+		return KotlinReflectionKt.getReturnType(method);
 	}
 
 	public static Parameter[] getSuspendingFunctionParameters(Method method) {
-		var parameterCount = method.getParameterCount();
-		if (parameterCount == 1) {
-			return new Parameter[0];
-		}
-		return Arrays.copyOf(method.getParameters(), parameterCount - 1);
+		return KotlinReflectionKt.getParameters(method);
 	}
 
 	public static Class<?>[] getKotlinSuspendingFunctionParameterTypes(Method method) {
-		var parameterCount = method.getParameterCount();
-		if (parameterCount == 1) {
-			return new Class<?>[0];
-		}
-		return Arrays.stream(method.getParameterTypes()).limit(parameterCount - 1).toArray(Class<?>[]::new);
+		return KotlinReflectionKt.getParameterTypes(method);
 	}
 
 	public static Object invokeKotlinSuspendingFunction(Method method, Object target, Object[] args) {
-		try {
-			return invokeKotlinSuspendingFunction(getKotlinFunction(method), target, args);
-		}
-		catch (InterruptedException e) {
-			throw throwAsUncheckedException(e);
-		}
-	}
-
-	private static <T> T invokeKotlinSuspendingFunction(KFunction<T> function, Object target, Object[] args)
-			throws InterruptedException {
-		if (!isAccessible(function)) {
-			setAccessible(function, true);
-		}
-		return runBlocking(EmptyCoroutineContext.INSTANCE, (__, continuation) -> {
-			try {
-				return callSuspendBy(function, toArgumentMap(target, args, function), continuation);
-			}
-			catch (Exception e) {
-				throw throwAsUncheckedException(getUnderlyingCause(e));
-			}
-		});
-	}
-
-	private static Map<KParameter, Object> toArgumentMap(Object target, Object[] args, KFunction<?> function) {
-		Map<KParameter, Object> arguments = new HashMap<>(args.length + 1);
-		int index = 0;
-		for (KParameter parameter : function.getParameters()) {
-			switch (parameter.getKind()) {
-				case INSTANCE -> arguments.put(parameter, target);
-				case VALUE, EXTENSION_RECEIVER -> {
-					arguments.put(parameter, args[index]);
-					index++;
-				}
-			}
-		}
-		return arguments;
-	}
-
-	private static KFunction<?> getKotlinFunction(Method method) {
-		return Preconditions.notNull(ReflectJvmMapping.getKotlinFunction(method),
-			() -> "Failed to get Kotlin function for method: " + method);
+		return KotlinReflectionKt.invoke(method, target, args);
 	}
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
@@ -10,13 +10,22 @@
 
 package org.junit.platform.commons.util;
 
+import static org.apiguardian.api.API.Status.INTERNAL;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 
+import org.apiguardian.api.API;
 import org.junit.platform.commons.function.Try;
 
+/**
+ * Internal Kotlin-specific reflection utilities
+ *
+ * @since 6.0
+ */
+@API(status = INTERNAL, since = "6.0")
 public class KotlinReflectionUtils {
 
 	private static final Class<? extends Annotation> kotlinMetadata;

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
@@ -13,6 +13,7 @@ package org.junit.platform.commons.util;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
 
 import org.junit.platform.commons.function.Try;
 
@@ -51,19 +52,23 @@ public class KotlinReflectionUtils {
 	}
 
 	public static Class<?> getKotlinSuspendingFunctionReturnType(Method method) {
-		return KotlinReflectionKt.getReturnType(method);
+		return KotlinReflectionUtilsKt.getReturnType(method);
 	}
 
-	public static Parameter[] getSuspendingFunctionParameters(Method method) {
-		return KotlinReflectionKt.getParameters(method);
+	public static Type getKotlinSuspendingFunctionGenericReturnType(Method method) {
+		return KotlinReflectionUtilsKt.getGenericReturnType(method);
+	}
+
+	public static Parameter[] getKotlinSuspendingFunctionParameters(Method method) {
+		return KotlinReflectionUtilsKt.getParameters(method);
 	}
 
 	public static Class<?>[] getKotlinSuspendingFunctionParameterTypes(Method method) {
-		return KotlinReflectionKt.getParameterTypes(method);
+		return KotlinReflectionUtilsKt.getParameterTypes(method);
 	}
 
 	public static Object invokeKotlinSuspendingFunction(Method method, Object target, Object[] args) {
-		return KotlinReflectionKt.invoke(method, target, args);
+		return KotlinReflectionUtilsKt.invoke(method, target, args);
 	}
 
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.commons.util;
+
+import static kotlin.jvm.JvmClassMappingKt.getJavaClass;
+import static kotlin.reflect.full.KCallables.callSuspendBy;
+import static kotlin.reflect.jvm.KCallablesJvm.isAccessible;
+import static kotlin.reflect.jvm.KCallablesJvm.setAccessible;
+import static kotlin.reflect.jvm.KTypesJvm.getJvmErasure;
+import static kotlinx.coroutines.BuildersKt.runBlocking;
+import static org.junit.platform.commons.util.ExceptionUtils.throwAsUncheckedException;
+import static org.junit.platform.commons.util.ReflectionUtils.getUnderlyingCause;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.platform.commons.function.Try;
+
+import kotlin.coroutines.EmptyCoroutineContext;
+import kotlin.reflect.KFunction;
+import kotlin.reflect.KParameter;
+import kotlin.reflect.jvm.ReflectJvmMapping;
+
+public class KotlinReflectionUtils {
+
+	private static final Class<? extends Annotation> kotlinMetadata;
+	private static final Class<?> kotlinCoroutineContinuation;
+
+	static {
+		var metadata = tryToLoadKotlinMetadataClass();
+		kotlinMetadata = metadata.toOptional().orElse(null);
+		kotlinCoroutineContinuation = metadata //
+				.andThen(__ -> ReflectionUtils.tryToLoadClass("kotlin.coroutines.Continuation")) //
+				.toOptional() //
+				.orElse(null);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Try<Class<? extends Annotation>> tryToLoadKotlinMetadataClass() {
+		return ReflectionUtils.tryToLoadClass("kotlin.Metadata") //
+				.andThenTry(it -> (Class<? extends Annotation>) it);
+	}
+
+	public static boolean isKotlinSuspendingFunction(Method method) {
+		if (kotlinCoroutineContinuation != null && isKotlinType(method.getDeclaringClass())) {
+			int parameterCount = method.getParameterCount();
+			return parameterCount > 0 //
+					&& method.getParameterTypes()[parameterCount - 1] == kotlinCoroutineContinuation;
+		}
+		return false;
+	}
+
+	private static boolean isKotlinType(Class<?> clazz) {
+		return kotlinMetadata != null //
+				&& clazz.getDeclaredAnnotation(kotlinMetadata) != null;
+	}
+
+	public static Class<?> getKotlinSuspendingFunctionReturnType(Method method) {
+		var returnType = getJvmErasure(getKotlinFunction(method).getReturnType());
+		if ("kotlin.Unit".equals(returnType.getQualifiedName())) {
+			return void.class;
+		}
+		return getJavaClass(returnType);
+	}
+
+	public static Parameter[] getSuspendingFunctionParameters(Method method) {
+		var parameterCount = method.getParameterCount();
+		if (parameterCount == 1) {
+			return new Parameter[0];
+		}
+		return Arrays.copyOf(method.getParameters(), parameterCount - 1);
+	}
+
+	public static Class<?>[] getKotlinSuspendingFunctionParameterTypes(Method method) {
+		var parameterCount = method.getParameterCount();
+		if (parameterCount == 1) {
+			return new Class<?>[0];
+		}
+		return Arrays.stream(method.getParameterTypes()).limit(parameterCount - 1).toArray(Class<?>[]::new);
+	}
+
+	public static Object invokeKotlinSuspendingFunction(Method method, Object target, Object[] args) {
+		try {
+			return invokeKotlinSuspendingFunction(getKotlinFunction(method), target, args);
+		}
+		catch (InterruptedException e) {
+			throw throwAsUncheckedException(e);
+		}
+	}
+
+	private static <T> T invokeKotlinSuspendingFunction(KFunction<T> function, Object target, Object[] args)
+			throws InterruptedException {
+		if (!isAccessible(function)) {
+			setAccessible(function, true);
+		}
+		return runBlocking(EmptyCoroutineContext.INSTANCE, (__, continuation) -> {
+			try {
+				return callSuspendBy(function, toArgumentMap(target, args, function), continuation);
+			}
+			catch (Exception e) {
+				throw throwAsUncheckedException(getUnderlyingCause(e));
+			}
+		});
+	}
+
+	private static Map<KParameter, Object> toArgumentMap(Object target, Object[] args, KFunction<?> function) {
+		Map<KParameter, Object> arguments = new HashMap<>(args.length + 1);
+		int index = 0;
+		for (KParameter parameter : function.getParameters()) {
+			switch (parameter.getKind()) {
+				case INSTANCE -> arguments.put(parameter, target);
+				case VALUE, EXTENSION_RECEIVER -> {
+					arguments.put(parameter, args[index]);
+					index++;
+				}
+			}
+		}
+		return arguments;
+	}
+
+	private static KFunction<?> getKotlinFunction(Method method) {
+		return Preconditions.notNull(ReflectJvmMapping.getKotlinFunction(method),
+			() -> "Failed to get Kotlin function for method: " + method);
+	}
+
+}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -1984,7 +1984,7 @@ public final class ReflectionUtils {
 	 * {@linkplain InvocationTargetException#getTargetException() target
 	 * exception}; otherwise, this method returns the supplied {@code Throwable}.
 	 */
-	static Throwable getUnderlyingCause(Throwable t) {
+	private static Throwable getUnderlyingCause(Throwable t) {
 		if (t instanceof InvocationTargetException) {
 			return getUnderlyingCause(((InvocationTargetException) t).getTargetException());
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -1984,7 +1984,7 @@ public final class ReflectionUtils {
 	 * {@linkplain InvocationTargetException#getTargetException() target
 	 * exception}; otherwise, this method returns the supplied {@code Throwable}.
 	 */
-	private static Throwable getUnderlyingCause(Throwable t) {
+	static Throwable getUnderlyingCause(Throwable t) {
 		if (t instanceof InvocationTargetException) {
 			return getUnderlyingCause(((InvocationTargetException) t).getTargetException());
 		}

--- a/junit-platform-commons/src/main/kotlin/org/junit/platform/commons/util/KotlinReflection.kt
+++ b/junit-platform-commons/src/main/kotlin/org/junit/platform/commons/util/KotlinReflection.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.platform.commons.util
+
+import kotlinx.coroutines.runBlocking
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.valueParameters
+import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.jvm.kotlinFunction
+
+internal fun getReturnType(method: Method): Class<out Any> =
+    with(method.kotlinFunction!!.returnType.jvmErasure) {
+        if (this == Unit::class) {
+            Void.TYPE
+        } else {
+            java
+        }
+    }
+
+internal fun getParameterTypes(method: Method) =
+    method.kotlinFunction!!
+        .parameters
+        .map { it.type.jvmErasure.java }
+        .toTypedArray()
+
+internal fun getParameters(method: Method) =
+    method.kotlinFunction!!.valueParameters.size.let {
+        if (it > 0) {
+            method.parameters.copyOf(it)
+        } else {
+            emptyArray()
+        }
+    }
+
+internal fun invoke(
+    method: Method,
+    target: Any?,
+    vararg args: Any?
+) = runBlocking {
+    try {
+        method.kotlinFunction!!.callSuspend(target, *args)
+    } catch (e: InvocationTargetException) {
+        throw e.targetException
+    }
+}

--- a/junit-platform-commons/src/main/kotlin/org/junit/platform/commons/util/KotlinReflectionUtils.kt
+++ b/junit-platform-commons/src/main/kotlin/org/junit/platform/commons/util/KotlinReflectionUtils.kt
@@ -14,6 +14,7 @@ import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.valueParameters
+import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.jvm.kotlinFunction
 
@@ -25,6 +26,8 @@ internal fun getReturnType(method: Method): Class<out Any> =
             java
         }
     }
+
+internal fun getGenericReturnType(method: Method) = method.kotlinFunction!!.returnType.javaType
 
 internal fun getParameterTypes(method: Method) =
     method.kotlinFunction!!

--- a/junit-platform-commons/src/main/kotlin/org/junit/platform/commons/util/KotlinReflectionUtils.kt
+++ b/junit-platform-commons/src/main/kotlin/org/junit/platform/commons/util/KotlinReflectionUtils.kt
@@ -7,6 +7,8 @@
  *
  * https://www.eclipse.org/legal/epl-v20.html
  */
+@file:JvmName("KotlinReflectionUtilsKt")
+
 package org.junit.platform.commons.util
 
 import kotlinx.coroutines.runBlocking

--- a/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
+++ b/junit-platform-console-standalone/junit-platform-console-standalone.gradle.kts
@@ -59,6 +59,7 @@ tasks {
 				Import-Package: \
 					$importAPIGuardian,\
 					kotlin.*;resolution:="optional",\
+					kotlinx.*;resolution:="optional",\
 					*
 				# Disable the APIGuardian plugin since everything was already
 				# processed, again because this is an aggregate jar

--- a/jupiter-tests/jupiter-tests.gradle.kts
+++ b/jupiter-tests/jupiter-tests.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
 	testImplementation(testFixtures(projects.junitJupiterEngine))
 	testImplementation(testFixtures(projects.junitPlatformLauncher))
 	testImplementation(testFixtures(projects.junitPlatformReporting))
+
+	testRuntimeOnly(kotlin("reflect"))
 }
 
 tasks {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine;
 
+import static kotlin.jvm.JvmClassMappingKt.getJavaClass;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
@@ -29,6 +30,8 @@ import org.junit.platform.testkit.engine.EngineDiscoveryResults;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
+import kotlin.reflect.KClass;
+
 /**
  * Abstract base class for tests involving the {@link JupiterTestEngine}.
  *
@@ -37,6 +40,10 @@ import org.junit.platform.testkit.engine.EngineTestKit;
 public abstract class AbstractJupiterTestEngineTests {
 
 	private final JupiterTestEngine engine = new JupiterTestEngine();
+
+	protected EngineExecutionResults executeTestsForClass(KClass<?> testClass) {
+		return executeTestsForClass(getJavaClass(testClass));
+	}
 
 	protected EngineExecutionResults executeTestsForClass(Class<?> testClass) {
 		return executeTests(selectClass(testClass));

--- a/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinSuspendFunctionsTests.kt
+++ b/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinSuspendFunctionsTests.kt
@@ -10,52 +10,181 @@
 package org.junit.jupiter.api
 
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests
+import org.junit.jupiter.params.AfterParameterizedClassInvocation
 import org.junit.jupiter.params.BeforeParameterizedClassInvocation
 import org.junit.jupiter.params.Parameter
 import org.junit.jupiter.params.ParameterizedClass
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.junit.platform.engine.reporting.ReportEntry
+import org.junit.platform.testkit.engine.EngineExecutionResults
+import java.util.stream.Stream
 
-@Disabled("needs to be converted into a proper test with assertions")
-@ParameterizedClass
-@ValueSource(ints = [1, 2])
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class KotlinSuspendFunctionsTests {
-    @BeforeParameterizedClassInvocation(injectArguments = false)
-    suspend fun beforeInvocation() {
-        suspendingPrintln("beforeInvocation")
-    }
-
-    @Parameter
-    var parameter: Int = 0
-
-    @Suppress("JUnitMalformedDeclaration")
-    @BeforeEach
-    suspend fun beforeEach() {
-        suspendingPrintln("beforeEach")
+class KotlinSuspendFunctionsTests : AbstractJupiterTestEngineTests() {
+    @Test
+    fun suspendingTestMethodsAreSupported() {
+        val results = executeTestsForClass(TestMethodTestCase::class)
+        assertAllTestsPassed(results, 1)
+        assertThat(getPublishedEvents(results)).containsExactly("test")
     }
 
     @Test
-    fun regularTest() {
-        runBlocking {
-            suspendingFail("regular")
+    fun suspendingTestTemplateMethodsAreSupported() {
+        val results = executeTestsForClass(TestTemplateTestCase::class)
+        assertAllTestsPassed(results, 2)
+        assertThat(getPublishedEvents(results)).containsExactly("foo", "bar")
+    }
+
+    @Test
+    fun suspendingTestFactoryMethodsAreSupported() {
+        val results = executeTestsForClass(TestFactoryTestCase::class)
+        assertAllTestsPassed(results, 2)
+        assertThat(getPublishedEvents(results)).containsExactly("test", "foo", "bar")
+    }
+
+    @Test
+    fun suspendingLifecycleMethodsAreSupported() {
+        val results = executeTestsForClass(LifecycleMethodsTestCase::class)
+        assertAllTestsPassed(results, 1)
+        assertThat(getPublishedEvents(results)).containsExactly("beforeAll", "beforeEach", "test", "afterEach", "afterAll")
+    }
+
+    @Test
+    fun suspendingParameterizedLifecycleMethodsAreSupported() {
+        val results = executeTestsForClass(ParameterizedLifecycleMethodsTestCase::class)
+        assertAllTestsPassed(results, 2)
+        assertThat(
+            getPublishedEvents(results)
+        ).containsExactly("beforeInvocation[1]", "test[1]", "afterInvocation[1]", "beforeInvocation[2]", "test[2]", "afterInvocation[2]")
+    }
+
+    private fun assertAllTestsPassed(
+        results: EngineExecutionResults,
+        numTests: Long
+    ) {
+        results.testEvents().assertStatistics {
+            it.started(numTests).succeeded(numTests)
+        }
+    }
+
+    private fun getPublishedEvents(results: EngineExecutionResults) =
+        results
+            .allEvents()
+            .reportingEntryPublished() //
+            .map { it.getRequiredPayload(ReportEntry::class.java) } //
+            .map(ReportEntry::getKeyValuePairs)
+            .map { it["value"] }
+
+    @Suppress("JUnitMalformedDeclaration")
+    class TestMethodTestCase {
+        @Test
+        suspend fun test(reporter: TestReporter) {
+            suspendingPublish(reporter, "test")
         }
     }
 
     @Suppress("JUnitMalformedDeclaration")
-    @ParameterizedTest
-    @ValueSource(strings = ["foo", "bar"])
-    suspend fun suspendingTest(message: String) {
-        suspendingFail(message)
+    class TestTemplateTestCase {
+        @ParameterizedTest
+        @ValueSource(strings = ["foo", "bar"])
+        suspend fun test(
+            message: String,
+            reporter: TestReporter
+        ) {
+            suspendingPublish(reporter, message)
+        }
     }
 
-    @Test
-    fun manualCoroutineTest(): Unit =
-        runBlocking {
-            suspendingFail("manual")
+    class TestFactoryTestCase {
+        @TestFactory
+        suspend fun test(reporter: TestReporter): Stream<DynamicTest> {
+            suspendingPublish(reporter, "test")
+            return Stream.of("foo", "bar").map {
+                dynamicTest(it) {
+                    runBlocking {
+                        suspendingPublish(reporter, it)
+                    }
+                }
+            }
+        }
+    }
+
+    @Suppress("JUnitMalformedDeclaration")
+    @TestInstance(PER_CLASS)
+    class LifecycleMethodsTestCase {
+        @BeforeAll
+        suspend fun beforeAll(reporter: TestReporter) {
+            suspendingPublish(reporter, "beforeAll")
         }
 
-    private suspend fun suspendingFail(message: String): Nothing = fail(message)
+        @BeforeEach
+        suspend fun beforeEach(reporter: TestReporter) {
+            suspendingPublish(reporter, "beforeEach")
+        }
 
-    private suspend fun suspendingPrintln(message: String) = println(message)
+        @Test
+        suspend fun test(reporter: TestReporter) {
+            suspendingPublish(reporter, "test")
+        }
+
+        @AfterEach
+        suspend fun afterEach(reporter: TestReporter) {
+            suspendingPublish(reporter, "afterEach")
+        }
+
+        @AfterAll
+        suspend fun afterAll(reporter: TestReporter) {
+            suspendingPublish(reporter, "afterAll")
+        }
+    }
+
+    @Suppress("JUnitMalformedDeclaration", "RedundantSuspendModifier")
+    @ParameterizedClass
+    @ValueSource(ints = [1, 2])
+    @TestInstance(PER_CLASS)
+    class ParameterizedLifecycleMethodsTestCase {
+        @BeforeParameterizedClassInvocation
+        suspend fun beforeInvocation() {}
+
+        @BeforeParameterizedClassInvocation
+        suspend fun beforeInvocation(
+            parameter: Int,
+            reporter: TestReporter
+        ) {
+            suspendingPublish(reporter, "beforeInvocation[$parameter]")
+        }
+
+        @AfterParameterizedClassInvocation
+        suspend fun afterInvocation() {}
+
+        @AfterParameterizedClassInvocation
+        suspend fun afterInvocation(
+            parameter: Int,
+            reporter: TestReporter
+        ) {
+            suspendingPublish(reporter, "afterInvocation[$parameter]")
+        }
+
+        @Parameter
+        var parameter: Int = 0
+
+        @Test
+        suspend fun test(reporter: TestReporter) {
+            suspendingPublish(reporter, "test[$parameter]")
+        }
+    }
+
+    @Suppress("RedundantSuspendModifier")
+    companion object {
+        suspend fun suspendingPublish(
+            reporter: TestReporter,
+            message: String
+        ) {
+            reporter.publishEntry(message)
+        }
+    }
 }

--- a/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinSuspendFunctionsTests.kt
+++ b/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinSuspendFunctionsTests.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.params.BeforeParameterizedClassInvocation
+import org.junit.jupiter.params.Parameter
+import org.junit.jupiter.params.ParameterizedClass
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@Disabled("needs to be converted into a proper test with assertions")
+@ParameterizedClass
+@ValueSource(ints = [1, 2])
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KotlinSuspendFunctionsTests {
+    @BeforeParameterizedClassInvocation(injectArguments = false)
+    suspend fun beforeInvocation() {
+        suspendingPrintln("beforeInvocation")
+    }
+
+    @Parameter
+    var parameter: Int = 0
+
+    @Suppress("JUnitMalformedDeclaration")
+    @BeforeEach
+    suspend fun beforeEach() {
+        suspendingPrintln("beforeEach")
+    }
+
+    @Test
+    fun regularTest() {
+        runBlocking {
+            suspendingFail("regular")
+        }
+    }
+
+    @Suppress("JUnitMalformedDeclaration")
+    @ParameterizedTest
+    @ValueSource(strings = ["foo", "bar"])
+    suspend fun suspendingTest(message: String) {
+        suspendingFail(message)
+    }
+
+    @Test
+    fun manualCoroutineTest(): Unit =
+        runBlocking {
+            suspendingFail("manual")
+        }
+
+    private suspend fun suspendingFail(message: String): Nothing = fail(message)
+
+    private suspend fun suspendingPrintln(message: String) = println(message)
+}

--- a/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
+++ b/platform-tooling-support-tests/projects/jar-describe-module/junit-platform-commons.expected.txt
@@ -8,6 +8,9 @@ exports org.junit.platform.commons.support.scanning
 requires java.base mandated
 requires java.logging
 requires java.management
+requires kotlin.reflect static
+requires kotlin.stdlib static
+requires kotlinx.coroutines.core static
 requires org.apiguardian.api static transitive
 uses org.junit.platform.commons.support.scanning.ClasspathScanner
 qualified exports org.junit.platform.commons.logging to org.junit.jupiter.api org.junit.jupiter.engine org.junit.jupiter.migrationsupport org.junit.jupiter.params org.junit.platform.console org.junit.platform.engine org.junit.platform.launcher org.junit.platform.reporting org.junit.platform.suite.api org.junit.platform.suite.engine org.junit.platform.testkit org.junit.vintage.engine

--- a/platform-tooling-support-tests/projects/kotlin-coroutines/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/kotlin-coroutines/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+	kotlin("jvm") version "2.1.20"
+}
+
+val junitVersion: String by project
+
+repositories {
+	maven { url = uri(file(System.getProperty("maven.repo"))) }
+	mavenCentral()
+}
+
+dependencies {
+	testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	if (!project.hasProperty("withoutKotlinReflect")) {
+		testImplementation(kotlin("reflect"))
+	}
+
+	if (!project.hasProperty("withoutKotlinxCoroutines")) {
+		testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+	}
+}
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
+}
+
+tasks.test {
+	useJUnitPlatform()
+	testLogging {
+		exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+	}
+	systemProperty("junit.platform.stacktrace.pruning.enabled", "false")
+}

--- a/platform-tooling-support-tests/projects/kotlin-coroutines/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/kotlin-coroutines/settings.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}
+
+rootProject.name = "kotlin-coroutines"

--- a/platform-tooling-support-tests/projects/kotlin-coroutines/src/test/kotlin/com/example/project/SuspendFunctionTests.kt
+++ b/platform-tooling-support-tests/projects/kotlin-coroutines/src/test/kotlin/com/example/project/SuspendFunctionTests.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package com.example.project
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+
+class SuspendFunctionTests {
+    @Test
+    suspend fun test() {
+        fail("expected")
+    }
+}

--- a/platform-tooling-support-tests/src/archUnit/java/platform/tooling/support/tests/ArchUnitTests.java
+++ b/platform-tooling-support-tests/src/archUnit/java/platform/tooling/support/tests/ArchUnitTests.java
@@ -17,6 +17,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.TOP_LEVEL_CL
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
 import static com.tngtech.archunit.core.domain.JavaModifier.PUBLIC;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
@@ -61,6 +62,8 @@ class ArchUnitTests {
 			.and(TOP_LEVEL_CLASSES) //
 			.and(not(ANONYMOUS_CLASSES)) //
 			.and(not(describe("are Kotlin SAM type implementations", simpleName("")))) //
+			.and(not(describe("are Kotlin-generated classes that contain only top-level functions",
+				simpleNameEndingWith("Kt")))) //
 			.and(not(describe("are shadowed", resideInAnyPackage("..shadow..")))) //
 			.should().beAnnotatedWith(API.class);
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/KotlinCoroutinesTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/KotlinCoroutinesTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package platform.tooling.support.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static platform.tooling.support.tests.Projects.copyToWorkspace;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.tests.process.OutputFiles;
+import org.junit.platform.tests.process.ProcessResult;
+import org.opentest4j.TestAbortedException;
+
+import platform.tooling.support.Helper;
+import platform.tooling.support.MavenRepo;
+import platform.tooling.support.ProcessStarters;
+
+/**
+ * @since 6.0
+ */
+class KotlinCoroutinesTests {
+
+	@Test
+	void failsExpectedlyWhenAllOptionalDependenciesArePresent(@TempDir Path workspace,
+			@FilePrefix("gradle") OutputFiles outputFiles) throws Exception {
+		var result = runBuild(workspace, outputFiles);
+
+		assertEquals(1, result.exitCode(), "result=" + result);
+		assertThat(result.stdOut()).contains("AssertionFailedError: expected");
+		assertThat(result.stdErr()).contains("BUILD FAILED");
+	}
+
+	@Test
+	void failsWithHelpfulErrorMessageWhenKotlinxCoroutinesIsMissing(@TempDir Path workspace,
+			@FilePrefix("gradle") OutputFiles outputFiles) throws Exception {
+		var result = runBuild(workspace, outputFiles, "-PwithoutKotlinxCoroutines");
+
+		assertEquals(1, result.exitCode(), "result=" + result);
+		assertThat(result.stdOut()).contains("PreconditionViolationException: Kotlin suspending function "
+				+ "[public final java.lang.Object com.example.project.SuspendFunctionTests.test(kotlin.coroutines.Continuation<? super kotlin.Unit>)] "
+				+ "requires org.jetbrains.kotlinx:kotlinx-coroutines-core to be on the classpath or module path. "
+				+ "Please add a corresponding dependency.");
+		assertThat(result.stdErr()).contains("BUILD FAILED");
+	}
+
+	@Test
+	void failsWithHelpfulErrorMessageWhenKotlinReflectIsMissing(@TempDir Path workspace,
+			@FilePrefix("gradle") OutputFiles outputFiles) throws Exception {
+		var result = runBuild(workspace, outputFiles, "-PwithoutKotlinReflect");
+
+		assertEquals(1, result.exitCode(), "result=" + result);
+		assertThat(result.stdOut()).contains("PreconditionViolationException: Kotlin suspending function "
+				+ "[public final java.lang.Object com.example.project.SuspendFunctionTests.test(kotlin.coroutines.Continuation<? super kotlin.Unit>)] "
+				+ "requires org.jetbrains.kotlin:kotlin-reflect to be on the classpath or module path. "
+				+ "Please add a corresponding dependency.");
+		assertThat(result.stdErr()).contains("BUILD FAILED");
+	}
+
+	private static ProcessResult runBuild(Path workspace, OutputFiles outputFiles, String... extraArgs)
+			throws InterruptedException, IOException {
+
+		return ProcessStarters.gradlew() //
+				.workingDir(copyToWorkspace(Projects.KOTLIN_COROUTINES, workspace)) //
+				.addArguments("-Dmaven.repo=" + MavenRepo.dir()) //
+				.addArguments("build", "--no-daemon", "--stacktrace", "--no-build-cache", "--warning-mode=fail") //
+				.addArguments(extraArgs).putEnvironment("JDK17",
+					Helper.getJavaHome(17).orElseThrow(TestAbortedException::new).toString()) //
+				.redirectOutput(outputFiles) //
+				.startAndWait();
+	}
+}

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/Projects.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/Projects.java
@@ -22,6 +22,7 @@ public class Projects {
 	public static final String GRADLE_MISSING_ENGINE = "gradle-missing-engine";
 	public static final String JAR_DESCRIBE_MODULE = "jar-describe-module";
 	public static final String JUPITER_STARTER = "jupiter-starter";
+	public static final String KOTLIN_COROUTINES = "kotlin-coroutines";
 	public static final String MAVEN_SUREFIRE_COMPATIBILITY = "maven-surefire-compatibility";
 	public static final String MULTI_RELEASE_JAR = "multi-release-jar";
 	public static final String REFLECTION_TESTS = "reflection-tests";


### PR DESCRIPTION
## Overview

Contrary to #4515, the solution in this PR does not introduce a new artifact that users would have to add to their builds, but works if three Kotlin dependencies are on the classpath or module path: `kotlin-stdlib`, `kotlin-reflect`, and `kotlinx-coroutines-core`. They are likely to be already present, if Kotlin coroutines are used in production code. The new `KotlinReflectionUtils` checks for their availability when it needs them but only if a method has been found that looks like a suspending function.

Resolves #1914.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
