### PR TITLE
Make phase that fails due to critical discovery issues configurable

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -26,6 +26,8 @@ runs:
       run: |
         ./gradlew \
         -Porg.gradle.java.installations.auto-download=false \
+        -Pjunit.develocity.predictiveTestSelection.enabled=true \
+        -Pjunit.develocity.predictiveTestSelection.selectRemainingTests=${{ github.event_name != 'pull_request' }} \
         "-Dscan.value.GitHub job=${{ github.job }}" \
         javaToolchains \
         ${{ inputs.arguments }}

--- a/gradle/plugins/build-parameters/build.gradle.kts
+++ b/gradle/plugins/build-parameters/build.gradle.kts
@@ -39,7 +39,7 @@ buildParameters {
 			group("predictiveTestSelection") {
 				bool("enabled") {
 					description = "Whether or not to use Predictive Test Selection for selecting tests to execute"
-					defaultValue = false
+					defaultValue = true
 				}
 				bool("selectRemainingTests") {
 					// see https://docs.gradle.com/develocity/predictive-test-selection/#gradle-selection-mode

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -225,9 +225,10 @@ public class LauncherConstants {
 	 *
 	 * <p>If an engine reports an issue with a severity equal to or higher than
 	 * the configured critical severity, its tests will not be executed.
-	 * Instead, the engine will be reported as failed during execution with a
+	 * Depending on {@link #DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME}, a
 	 * {@link org.junit.platform.launcher.core.DiscoveryIssueException} listing
-	 * all critical issues.
+	 * all critical issues will be thrown during discovery or be reported as
+	 * engine-level failure during execution.
 	 *
 	 * <h4>Supported Values</h4>
 	 *
@@ -243,6 +244,22 @@ public class LauncherConstants {
 	 */
 	@API(status = EXPERIMENTAL, since = "1.13")
 	public static final String CRITICAL_DISCOVERY_ISSUE_SEVERITY_PROPERTY_NAME = "junit.platform.discovery.issue.severity.critical";
+
+	/**
+	 * Property name used to configure the phase that critical discovery issues
+	 * should cause a failure
+	 *
+	 * <h4>Supported Values</h4>
+	 *
+	 * <p>Supported values are "discovery" or "execution".
+	 *
+	 * <p>If not specified, the default is "execution".
+	 *
+	 * @since 1.13
+	 * @see #CRITICAL_DISCOVERY_ISSUE_SEVERITY_PROPERTY_NAME
+	 */
+	@API(status = EXPERIMENTAL, since = "1.13")
+	public static final String DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME = "junit.platform.discovery.issue.failure.phase";
 
 	private LauncherConstants() {
 		/* no-op */

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -253,7 +253,12 @@ public class LauncherConstants {
 	 *
 	 * <p>Supported values are "discovery" or "execution".
 	 *
-	 * <p>If not specified, the default is "execution".
+	 * <p>If not specified, the {@code Launcher} will report discovery issues
+	 * during the discovery phase if
+	 * {@link Launcher#discover(LauncherDiscoveryRequest)} is called, and during
+	 * the execution phase if
+	 * {@link Launcher#execute(LauncherDiscoveryRequest, TestExecutionListener...)}
+	 * is called.
 	 *
 	 * @since 1.13
 	 * @see #CRITICAL_DISCOVERY_ISSUE_SEVERITY_PROPERTY_NAME

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DefaultLauncher.java
@@ -12,8 +12,8 @@ package org.junit.platform.launcher.core;
 
 import static java.util.Collections.unmodifiableCollection;
 import static org.junit.platform.engine.support.store.NamespacedHierarchicalStore.CloseAction.closeAutoCloseables;
-import static org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.Phase.DISCOVERY;
-import static org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.Phase.EXECUTION;
+import static org.junit.platform.launcher.core.LauncherPhase.DISCOVERY;
+import static org.junit.platform.launcher.core.LauncherPhase.EXECUTION;
 
 import java.util.Collection;
 
@@ -100,8 +100,7 @@ class DefaultLauncher implements Launcher {
 		execute((InternalTestPlan) testPlan, listeners);
 	}
 
-	private LauncherDiscoveryResult discover(LauncherDiscoveryRequest discoveryRequest,
-			EngineDiscoveryOrchestrator.Phase phase) {
+	private LauncherDiscoveryResult discover(LauncherDiscoveryRequest discoveryRequest, LauncherPhase phase) {
 		return discoveryOrchestrator.discover(discoveryRequest, phase);
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
@@ -14,16 +14,19 @@ import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.partitioningBy;
 import static org.junit.platform.commons.util.ExceptionUtils.readStackTrace;
+import static org.junit.platform.launcher.LauncherConstants.DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.TestEngine;
@@ -139,5 +142,10 @@ class DiscoveryIssueNotifier {
 
 	private static void appendIdeCompatibleLink(StringBuilder message, String className, String methodName) {
 		message.append("\n            at ").append(className).append(".").append(methodName).append("(SourceFile:0)");
+	}
+
+	static boolean handleDiscoveryIssuesInDiscoveryPhase(ConfigurationParameters configurationParameters) {
+		Optional<String> phase = configurationParameters.get(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME);
+		return "discovery".equalsIgnoreCase(phase.orElse(null));
 	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
@@ -14,19 +14,16 @@ import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.partitioningBy;
 import static org.junit.platform.commons.util.ExceptionUtils.readStackTrace;
-import static org.junit.platform.launcher.LauncherConstants.DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.TestEngine;
@@ -142,10 +139,5 @@ class DiscoveryIssueNotifier {
 
 	private static void appendIdeCompatibleLink(StringBuilder message, String className, String methodName) {
 		message.append("\n            at ").append(className).append(".").append(methodName).append("(SourceFile:0)");
-	}
-
-	static boolean handleDiscoveryIssuesInDiscoveryPhase(ConfigurationParameters configurationParameters) {
-		Optional<String> phase = configurationParameters.get(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME);
-		return "discovery".equalsIgnoreCase(phase.orElse(null));
 	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -13,13 +13,12 @@ package org.junit.platform.launcher.core;
 import static java.util.stream.Collectors.joining;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.engine.Filter.composeFilters;
-import static org.junit.platform.launcher.core.DiscoveryIssueNotifier.handleDiscoveryIssuesInDiscoveryPhase;
+import static org.junit.platform.launcher.core.LauncherPhase.getDiscoveryIssueFailurePhase;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -29,6 +28,7 @@ import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
@@ -69,15 +69,19 @@ public class EngineDiscoveryOrchestrator {
 	}
 
 	/**
-	 * Discovers tests for the supplied request in the supplied phase using the
-	 * configured test engines.
+	 * Discovers tests for the supplied request using the configured test
+	 * engines.
 	 *
 	 * <p>Applies {@linkplain org.junit.platform.launcher.EngineFilter engine
 	 * filters} and {@linkplain PostDiscoveryFilter post-discovery filters} and
 	 * {@linkplain TestDescriptor#prune() prunes} the resulting test tree.
 	 */
-	public LauncherDiscoveryResult discover(LauncherDiscoveryRequest request, Phase phase) {
-		return discover(request, phase, UniqueId::forEngine);
+	public LauncherDiscoveryResult discover(LauncherDiscoveryRequest request) {
+		return discover(request, Optional.empty(), UniqueId::forEngine);
+	}
+
+	LauncherDiscoveryResult discover(LauncherDiscoveryRequest request, LauncherPhase phase) {
+		return discover(request, Optional.of(phase), UniqueId::forEngine);
 	}
 
 	/**
@@ -94,12 +98,12 @@ public class EngineDiscoveryOrchestrator {
 	 * {@link EngineExecutionOrchestrator} will not emit start or emit events
 	 * for engines without tests.
 	 */
-	public LauncherDiscoveryResult discover(LauncherDiscoveryRequest request, Phase phase, UniqueId parentId) {
-		LauncherDiscoveryResult result = discover(request, phase, parentId::appendEngine);
+	public LauncherDiscoveryResult discover(LauncherDiscoveryRequest request, UniqueId parentId) {
+		LauncherDiscoveryResult result = discover(request, Optional.empty(), parentId::appendEngine);
 		return result.withRetainedEngines(TestDescriptor::containsTests);
 	}
 
-	private LauncherDiscoveryResult discover(LauncherDiscoveryRequest request, Phase phase,
+	private LauncherDiscoveryResult discover(LauncherDiscoveryRequest request, Optional<LauncherPhase> phase,
 			Function<String, UniqueId> uniqueIdCreator) {
 		DiscoveryIssueCollector issueCollector = new DiscoveryIssueCollector(request.getConfigurationParameters());
 		LauncherDiscoveryListener listener = getLauncherDiscoveryListener(request, issueCollector);
@@ -120,13 +124,20 @@ public class EngineDiscoveryOrchestrator {
 		finally {
 			listener.launcherDiscoveryFinished(request);
 		}
-		if (handleDiscoveryIssuesInDiscoveryPhase(request.getConfigurationParameters())) {
-			handleDiscoveryIssues(discoveryResult);
+		if (shouldReportDiscoveryIssues(request, phase)) {
+			reportDiscoveryIssues(discoveryResult);
 		}
 		return discoveryResult;
 	}
 
-	private static void handleDiscoveryIssues(LauncherDiscoveryResult discoveryResult) {
+	private static boolean shouldReportDiscoveryIssues(LauncherDiscoveryRequest request,
+			Optional<LauncherPhase> phase) {
+		ConfigurationParameters configurationParameters = request.getConfigurationParameters();
+		return getDiscoveryIssueFailurePhase(configurationParameters).orElse(
+			phase.orElse(null)) == LauncherPhase.DISCOVERY;
+	}
+
+	private static void reportDiscoveryIssues(LauncherDiscoveryResult discoveryResult) {
 		DiscoveryIssueException exception = null;
 		for (TestEngine testEngine : discoveryResult.getTestEngines()) {
 			EngineResultInfo engineResult = discoveryResult.getEngineResult(testEngine);
@@ -142,8 +153,9 @@ public class EngineDiscoveryOrchestrator {
 		}
 	}
 
-	private Map<TestEngine, EngineResultInfo> discoverSafely(LauncherDiscoveryRequest request, Phase phase,
-			DiscoveryIssueCollector issueCollector, Function<String, UniqueId> uniqueIdCreator) {
+	private Map<TestEngine, EngineResultInfo> discoverSafely(LauncherDiscoveryRequest request,
+			Optional<LauncherPhase> phase, DiscoveryIssueCollector issueCollector,
+			Function<String, UniqueId> uniqueIdCreator) {
 		Map<TestEngine, EngineResultInfo> testEngineDescriptors = new LinkedHashMap<>();
 		EngineFilterer engineFilterer = new EngineFilterer(request.getEngineFilters());
 
@@ -151,14 +163,13 @@ public class EngineDiscoveryOrchestrator {
 			boolean engineIsExcluded = engineFilterer.isExcluded(testEngine);
 
 			if (engineIsExcluded) {
-				logger.debug(() -> String.format(
-					"Test discovery for engine '%s' was skipped due to an EngineFilter in %s phase.",
-					testEngine.getId(), phase));
+				logger.debug(() -> String.format("Test discovery for engine '%s' was skipped due to an EngineFilter%s.",
+					testEngine.getId(), phase.map(it -> String.format(" in %s phase", it)).orElse("")));
 				continue;
 			}
 
-			logger.debug(() -> String.format("Discovering tests during Launcher %s phase in engine '%s'.", phase,
-				testEngine.getId()));
+			logger.debug(() -> String.format("Discovering tests%s in engine '%s'.",
+				phase.map(it -> String.format(" during Launcher %s phase", it)).orElse(""), testEngine.getId()));
 
 			EngineResultInfo engineResult = discoverEngineRoot(testEngine, request, issueCollector, uniqueIdCreator);
 			testEngineDescriptors.put(testEngine, engineResult);
@@ -261,15 +272,6 @@ public class EngineDiscoveryOrchestrator {
 	private void acceptInAllTestEngines(Map<TestEngine, EngineResultInfo> testEngineResults,
 			TestDescriptor.Visitor visitor) {
 		testEngineResults.values().forEach(result -> result.getRootDescriptor().accept(visitor));
-	}
-
-	public enum Phase {
-		DISCOVERY, EXECUTION;
-
-		@Override
-		public String toString() {
-			return name().toLowerCase(Locale.ENGLISH);
-		}
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -13,6 +13,7 @@ package org.junit.platform.launcher.core;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.launcher.LauncherConstants.DRY_RUN_PROPERTY_NAME;
 import static org.junit.platform.launcher.LauncherConstants.STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME;
+import static org.junit.platform.launcher.core.DiscoveryIssueNotifier.handleDiscoveryIssuesInDiscoveryPhase;
 import static org.junit.platform.launcher.core.ListenerRegistry.forEngineExecutionListeners;
 
 import java.util.Optional;
@@ -185,7 +186,10 @@ public class EngineExecutionOrchestrator {
 	private void failOrExecuteEngine(LauncherDiscoveryResult discoveryResult, EngineExecutionListener listener,
 			TestEngine testEngine, NamespacedHierarchicalStore<Namespace> requestLevelStore) {
 		EngineResultInfo engineDiscoveryResult = discoveryResult.getEngineResult(testEngine);
-		DiscoveryIssueNotifier discoveryIssueNotifier = engineDiscoveryResult.getDiscoveryIssueNotifier();
+		DiscoveryIssueNotifier discoveryIssueNotifier = handleDiscoveryIssuesInDiscoveryPhase(
+			discoveryResult.getConfigurationParameters()) //
+					? DiscoveryIssueNotifier.NO_ISSUES //
+					: engineDiscoveryResult.getDiscoveryIssueNotifier();
 		TestDescriptor engineDescriptor = engineDiscoveryResult.getRootDescriptor();
 		Throwable failure = engineDiscoveryResult.getCause() //
 				.orElseGet(() -> discoveryIssueNotifier.createExceptionForCriticalIssues(testEngine));

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherPhase.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherPhase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.launcher.core;
+
+import static org.junit.platform.launcher.LauncherConstants.DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.junit.platform.engine.ConfigurationParameters;
+
+/**
+ * The phase the {@link org.junit.platform.launcher.Launcher} is in.
+ *
+ * @since 1.13
+ */
+enum LauncherPhase {
+
+	DISCOVERY, EXECUTION;
+
+	private static final Logger logger = LoggerFactory.getLogger(LauncherPhase.class);
+
+	static Optional<LauncherPhase> getDiscoveryIssueFailurePhase(ConfigurationParameters configurationParameters) {
+		return configurationParameters.get(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME, value -> {
+			try {
+				return LauncherPhase.valueOf(value.toUpperCase(Locale.ROOT));
+			}
+			catch (Exception e) {
+				logger.warn(
+					() -> String.format("Ignoring invalid LauncherPhase '%s' set via the '%s' configuration parameter.",
+						value, DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME));
+				return null;
+			}
+		});
+	}
+
+	@Override
+	public String toString() {
+		return name().toLowerCase(Locale.ENGLISH);
+	}
+}

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteLauncher.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteLauncher.java
@@ -23,7 +23,6 @@ import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.EngineDiscoveryOrchestrator;
-import org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.Phase;
 import org.junit.platform.launcher.core.EngineExecutionOrchestrator;
 import org.junit.platform.launcher.core.LauncherDiscoveryResult;
 import org.junit.platform.launcher.core.ServiceLoaderTestEngineRegistry;
@@ -56,7 +55,7 @@ class SuiteLauncher {
 	}
 
 	LauncherDiscoveryResult discover(LauncherDiscoveryRequest discoveryRequest, UniqueId parentId) {
-		return discoveryOrchestrator.discover(discoveryRequest, Phase.DISCOVERY, parentId);
+		return discoveryOrchestrator.discover(discoveryRequest, parentId);
 	}
 
 	TestExecutionSummary execute(LauncherDiscoveryResult discoveryResult,

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -17,8 +17,6 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.engine.support.store.NamespacedHierarchicalStore.CloseAction.closeAutoCloseables;
-import static org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.Phase.DISCOVERY;
-import static org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.Phase.EXECUTION;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -190,7 +188,7 @@ public final class EngineTestKit {
 	public static EngineDiscoveryResults discover(TestEngine testEngine, LauncherDiscoveryRequest discoveryRequest) {
 		Preconditions.notNull(testEngine, "TestEngine must not be null");
 		Preconditions.notNull(discoveryRequest, "EngineDiscoveryRequest must not be null");
-		LauncherDiscoveryResult discoveryResult = discover(testEngine, discoveryRequest, DISCOVERY);
+		LauncherDiscoveryResult discoveryResult = discoverUsingOrchestrator(testEngine, discoveryRequest);
 		TestDescriptor engineDescriptor = discoveryResult.getEngineTestDescriptor(testEngine);
 		List<DiscoveryIssue> discoveryIssues = discoveryResult.getDiscoveryIssues(testEngine);
 		return new EngineDiscoveryResults(engineDescriptor, discoveryIssues);
@@ -337,7 +335,7 @@ public final class EngineTestKit {
 
 	private static void executeUsingLauncherOrchestration(TestEngine testEngine,
 			LauncherDiscoveryRequest discoveryRequest, EngineExecutionListener listener) {
-		LauncherDiscoveryResult discoveryResult = discover(testEngine, discoveryRequest, EXECUTION);
+		LauncherDiscoveryResult discoveryResult = discoverUsingOrchestrator(testEngine, discoveryRequest);
 		TestDescriptor engineTestDescriptor = discoveryResult.getEngineTestDescriptor(testEngine);
 		Preconditions.notNull(engineTestDescriptor, "TestEngine did not yield a TestDescriptor");
 		withRequestLevelStore(store -> new EngineExecutionOrchestrator().execute(discoveryResult, listener, store));
@@ -354,10 +352,10 @@ public final class EngineTestKit {
 		return new NamespacedHierarchicalStore<>(parentStore, closeAutoCloseables());
 	}
 
-	private static LauncherDiscoveryResult discover(TestEngine testEngine, LauncherDiscoveryRequest discoveryRequest,
-			EngineDiscoveryOrchestrator.Phase phase) {
+	private static LauncherDiscoveryResult discoverUsingOrchestrator(TestEngine testEngine,
+			LauncherDiscoveryRequest discoveryRequest) {
 		return new EngineDiscoveryOrchestrator(singleton(testEngine), emptySet()) //
-				.discover(discoveryRequest, phase);
+				.discover(discoveryRequest);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
@@ -82,7 +82,7 @@ public abstract class AbstractJupiterTestEngineTests {
 		return EngineTestKit.discover(this.engine, request);
 	}
 
-	private static LauncherDiscoveryRequestBuilder defaultRequest() {
+	protected static LauncherDiscoveryRequestBuilder defaultRequest() {
 		return request() //
 				.outputDirectoryProvider(dummyOutputDirectoryProvider()) //
 				.configurationParameter(STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME, String.valueOf(false)) //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleConfigurationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleConfigurationTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.LauncherConstants.DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
 import java.util.ArrayList;
@@ -129,6 +130,7 @@ class TestInstanceLifecycleConfigurationTests extends AbstractJupiterTestEngineT
 			request()
 				.selectors(selectClass(testClass))
 				.configurationParameters(configParams)
+				.configurationParameter(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME, "execution")
 				.build()
 		);
 		// @formatter:on

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -819,7 +819,7 @@ class DiscoverySelectorResolverTests extends AbstractJupiterTestEngineTests {
 	}
 
 	private LauncherDiscoveryRequestBuilder request() {
-		return LauncherDiscoveryRequestBuilder.request() //
+		return defaultRequest() //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.listeners(discoveryListener);
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
@@ -25,7 +25,6 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectNeste
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectNestedMethod;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
-import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -62,21 +61,21 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void discoverTestClass() {
-		LauncherDiscoveryRequest request = request().selectors(selectClass(LocalTestCase.class)).build();
+		LauncherDiscoveryRequest request = defaultRequest().selectors(selectClass(LocalTestCase.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(7, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
 	void doNotDiscoverAbstractTestClass() {
-		LauncherDiscoveryRequest request = request().selectors(selectClass(AbstractTestCase.class)).build();
+		LauncherDiscoveryRequest request = defaultRequest().selectors(selectClass(AbstractTestCase.class)).build();
 		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(0, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
 	void discoverMethodByUniqueId() {
-		LauncherDiscoveryRequest request = request().selectors(
+		LauncherDiscoveryRequest request = defaultRequest().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test1()"))).build();
 		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
@@ -84,7 +83,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void discoverMethodByUniqueIdForOverloadedMethod() {
-		LauncherDiscoveryRequest request = request().selectors(
+		LauncherDiscoveryRequest request = defaultRequest().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test4()"))).build();
 		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
@@ -92,8 +91,9 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void discoverMethodByUniqueIdForOverloadedMethodVariantThatAcceptsArguments() {
-		LauncherDiscoveryRequest request = request().selectors(selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(
-			LocalTestCase.class, "test4(" + TestInfo.class.getName() + ")"))).build();
+		LauncherDiscoveryRequest request = defaultRequest().selectors(
+			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class,
+				"test4(" + TestInfo.class.getName() + ")"))).build();
 		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
@@ -102,14 +102,15 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	void discoverMethodByMethodReference() throws NoSuchMethodException {
 		Method testMethod = LocalTestCase.class.getDeclaredMethod("test3");
 
-		LauncherDiscoveryRequest request = request().selectors(selectMethod(LocalTestCase.class, testMethod)).build();
+		LauncherDiscoveryRequest request = defaultRequest().selectors(
+			selectMethod(LocalTestCase.class, testMethod)).build();
 		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
 	void discoverMultipleMethodsOfSameClass() {
-		LauncherDiscoveryRequest request = request().selectors(selectMethod(LocalTestCase.class, "test1"),
+		LauncherDiscoveryRequest request = defaultRequest().selectors(selectMethod(LocalTestCase.class, "test1"),
 			selectMethod(LocalTestCase.class, "test2")).build();
 
 		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
@@ -121,7 +122,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void discoverCompositeSpec() {
-		LauncherDiscoveryRequest spec = request().selectors(
+		LauncherDiscoveryRequest spec = defaultRequest().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test2()")),
 			selectClass(LocalTestCase.class)).build();
 
@@ -131,7 +132,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void discoverTestTemplateMethodByUniqueId() {
-		LauncherDiscoveryRequest spec = request().selectors(
+		LauncherDiscoveryRequest spec = defaultRequest().selectors(
 			selectUniqueId(uniqueIdForTestTemplateMethod(TestTemplateClass.class, "testTemplate()"))).build();
 
 		TestDescriptor engineDescriptor = discoverTests(spec).getEngineDescriptor();
@@ -140,7 +141,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void discoverTestTemplateMethodByMethodSelector() {
-		LauncherDiscoveryRequest spec = request().selectors(
+		LauncherDiscoveryRequest spec = defaultRequest().selectors(
 			selectMethod(TestTemplateClass.class, "testTemplate")).build();
 
 		TestDescriptor engineDescriptor = discoverTests(spec).getEngineDescriptor();
@@ -153,7 +154,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 			List.of(TestCaseWithExtendedNested.class, TestCaseWithExtendedNested.ConcreteInner1.class),
 			AbstractSuperClass.NestedInAbstractClass.class,
 			AbstractSuperClass.NestedInAbstractClass.class.getDeclaredMethod("test"));
-		LauncherDiscoveryRequest spec = request().selectors(selector).build();
+		LauncherDiscoveryRequest spec = defaultRequest().selectors(selector).build();
 
 		TestDescriptor engineDescriptor = discoverTests(spec).getEngineDescriptor();
 
@@ -198,12 +199,12 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	static List<Named<LauncherDiscoveryRequest>> requestsForTestClassWithInvalidTestMethod() {
 		return List.of( //
 			named("directly selected",
-				request().selectors(selectClass(InvalidTestCases.InvalidTestMethodTestCase.class)).build()), //
-			named("indirectly selected", request() //
+				defaultRequest().selectors(selectClass(InvalidTestCases.InvalidTestMethodTestCase.class)).build()), //
+			named("indirectly selected", defaultRequest() //
 					.selectors(selectPackage(InvalidTestCases.InvalidTestMethodTestCase.class.getPackageName())) //
 					.filters(includeClassNamePatterns(
 						Pattern.quote(InvalidTestCases.InvalidTestMethodTestCase.class.getName()))).build()), //
-			named("subclasses", request() //
+			named("subclasses", defaultRequest() //
 					.selectors(selectClass(InvalidTestCases.InvalidTestMethodSubclass1TestCase.class),
 						selectClass(InvalidTestCases.InvalidTestMethodSubclass2TestCase.class)) //
 					.build()) //
@@ -229,14 +230,14 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	static List<Arguments> requestsForTestClassWithInvalidStandaloneTestClass() {
 		return List.of( //
 			argumentSet("directly selected",
-				request().selectors(selectClass(InvalidTestCases.InvalidTestClassTestCase.class)).build(),
+				defaultRequest().selectors(selectClass(InvalidTestCases.InvalidTestClassTestCase.class)).build(),
 				InvalidTestCases.InvalidTestClassTestCase.class), //
-			argumentSet("indirectly selected", request() //
+			argumentSet("indirectly selected", defaultRequest() //
 					.selectors(selectPackage(InvalidTestCases.InvalidTestClassTestCase.class.getPackageName())) //
 					.filters(includeClassNamePatterns(
 						Pattern.quote(InvalidTestCases.InvalidTestClassTestCase.class.getName()))).build(), //
 				InvalidTestCases.InvalidTestClassTestCase.class), //
-			argumentSet("subclass", request() //
+			argumentSet("subclass", defaultRequest() //
 					.selectors(selectClass(InvalidTestCases.InvalidTestClassSubclassTestCase.class)) //
 					.build(), //
 				InvalidTestCases.InvalidTestClassSubclassTestCase.class) //
@@ -262,8 +263,8 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	static List<Named<LauncherDiscoveryRequest>> requestsForTestClassWithInvalidNestedTestClass() {
 		return List.of( //
 			named("directly selected",
-				request().selectors(selectClass(InvalidTestCases.InvalidTestClassTestCase.Inner.class)).build()), //
-			named("subclass", request() //
+				defaultRequest().selectors(selectClass(InvalidTestCases.InvalidTestClassTestCase.Inner.class)).build()), //
+			named("subclass", defaultRequest() //
 					.selectors(selectNestedClass(List.of(InvalidTestCases.InvalidTestClassSubclassTestCase.class),
 						InvalidTestCases.InvalidTestClassTestCase.Inner.class)) //
 					.build()) //

--- a/platform-tests/src/test/java/org/junit/platform/jfr/FlightRecordingDiscoveryListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/jfr/FlightRecordingDiscoveryListenerIntegrationTests.java
@@ -57,6 +57,7 @@ public class FlightRecordingDiscoveryListenerIntegrationTests {
 		EngineTestKit.discover(testEngine, request() //
 				.selectors(selectClass(FlightRecordingDiscoveryListenerIntegrationTests.class)) //
 				.listeners(new FlightRecordingDiscoveryListener()) //
+				.enableImplicitConfigurationParameters(false) //
 				.build());
 
 		jfrEvents.awaitEvents();

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -25,6 +25,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPacka
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.fakes.FaultyTestEngines.createEngineThatCannotResolveAnything;
 import static org.junit.platform.fakes.FaultyTestEngines.createEngineThatFailsToResolveAnything;
+import static org.junit.platform.launcher.LauncherConstants.DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME;
 import static org.junit.platform.launcher.LauncherConstants.DRY_RUN_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
@@ -1018,6 +1019,7 @@ class DefaultLauncherTests {
 
 		var builder = request() //
 				.enableImplicitConfigurationParameters(false) //
+				.configurationParameter(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME, "execution") //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging");
 		var request = configurer.apply(builder).build();
 		var launcher = createLauncher(engine);

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
@@ -39,6 +39,7 @@ public class LoggingLauncherDiscoveryListenerTests {
 		var request = request() //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.enableImplicitConfigurationParameters(false) //
 				.build();
 		var launcher = createLauncher(engine);
 
@@ -56,6 +57,7 @@ public class LoggingLauncherDiscoveryListenerTests {
 		var request = request() //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine("some-other-engine"))) //
+				.enableImplicitConfigurationParameters(false) //
 				.build();
 		var launcher = createLauncher(engine);
 
@@ -74,6 +76,7 @@ public class LoggingLauncherDiscoveryListenerTests {
 		var request = request() //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectClass(Object.class)) //
+				.enableImplicitConfigurationParameters(false) //
 				.build();
 		var launcher = createLauncher(engine);
 
@@ -97,6 +100,7 @@ public class LoggingLauncherDiscoveryListenerTests {
 		var request = request() //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.enableImplicitConfigurationParameters(false) //
 				.build();
 		var launcher = createLauncher(engine);
 
@@ -113,6 +117,7 @@ public class LoggingLauncherDiscoveryListenerTests {
 		var request = request() //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
+				.enableImplicitConfigurationParameters(false) //
 				.build();
 		var launcher = createLauncher(engine);
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListenerTests.java
@@ -15,6 +15,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.fakes.FaultyTestEngines.createEngineThatCannotResolveAnything;
 import static org.junit.platform.fakes.FaultyTestEngines.createEngineThatFailsToResolveAnything;
+import static org.junit.platform.launcher.LauncherConstants.DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposesOnly.createLauncher;
@@ -37,6 +38,7 @@ public class LoggingLauncherDiscoveryListenerTests {
 	void logsWarningOnUnresolvedUniqueIdSelectorWithEnginePrefix(LogRecordListener log) {
 		var engine = createEngineThatCannotResolveAnything("some-engine");
 		var request = request() //
+				.configurationParameter(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME, "execution") //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectUniqueId(UniqueId.forEngine(engine.getId()))) //
 				.enableImplicitConfigurationParameters(false) //
@@ -74,6 +76,7 @@ public class LoggingLauncherDiscoveryListenerTests {
 		var rootCause = new RuntimeException();
 		var engine = createEngineThatFailsToResolveAnything("some-engine", rootCause);
 		var request = request() //
+				.configurationParameter(DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME, "execution") //
 				.configurationParameter(DEFAULT_DISCOVERY_LISTENER_CONFIGURATION_PROPERTY_NAME, "logging") //
 				.selectors(selectClass(Object.class)) //
 				.enableImplicitConfigurationParameters(false) //

--- a/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineDiscoveryResultsIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineDiscoveryResultsIntegrationTests.java
@@ -27,6 +27,7 @@ import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.fakes.TestEngineStub;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 
 @ParameterizedClass
 @EnumSource
@@ -70,12 +71,16 @@ record EngineDiscoveryResultsIntegrationTests(TestKitApi testKit) {
 		STATIC_METHOD {
 			@Override
 			EngineDiscoveryResults discover(String engineId, DiscoverySelector selector) {
-				return EngineTestKit.discover(engineId, request().selectors(selector).build());
+				return EngineTestKit.discover(engineId, newRequest().selectors(selector).build());
 			}
 
 			@Override
 			EngineDiscoveryResults discover(TestEngine testEngine) {
-				return EngineTestKit.discover(testEngine, request().build());
+				return EngineTestKit.discover(testEngine, newRequest().build());
+			}
+
+			private static LauncherDiscoveryRequestBuilder newRequest() {
+				return request().enableImplicitConfigurationParameters(false);
 			}
 		},
 

--- a/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/testkit/engine/EngineTestKitTests.java
@@ -68,6 +68,7 @@ class EngineTestKitTests {
 		when(testEngine.getId()).thenReturn("test-engine");
 
 		LauncherDiscoveryRequest request = mock(LauncherDiscoveryRequest.class);
+		when(request.getConfigurationParameters()).thenReturn(mock());
 		when(request.getDiscoveryListener()).thenReturn(LauncherDiscoveryListener.NOOP);
 
 		try (MockedConstruction<EngineExecutionOrchestrator> mockedConstruction = mockConstruction(


### PR DESCRIPTION
## Overview

Users of the Launcher API that perform a discovery without executing the
resulting test plan are prone to accidentally hiding discovery issues
from their users unless they implement their own
`LauncherDiscoveryListener`. Therefore, the new
`junit.platform.discovery.issue.failure.phase` configuration parameter
allows configuring the `discovery` phase as the one that should fail in
case critical discovery issues are encountered. By default, they will
still be reported in the `execution` phase.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
