### PR TITLE
Relax Kotlin contracts for `Executable` passed to `assertTimeout`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
@@ -99,6 +99,9 @@ repository on GitHub.
   `@EnabledOnJre` and `@DisabledOnJre`.
 * `@EnabledForJreRange` and `@DisabledForJreRange` now use `JAVA_17` as their default
   `min` value.
+* The contracts for the `Executable` parameter of Kotlin-specific `assertTimeout`
+  functions was changed from `callsInPlace(executable, EXACTLY_ONCE)` to
+  `callsInPlace(executable, AT_MOST_ONCE)` which might result in compile errors.
 
 [[release-notes-6.0.0-M1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements

--- a/junit-jupiter-api/junit-jupiter-api.gradle.kts
+++ b/junit-jupiter-api/junit-jupiter-api.gradle.kts
@@ -22,10 +22,6 @@ dependencies {
 }
 
 tasks {
-	compileKotlin {
-		// https://github.com/junit-team/junit5/issues/4371
-		compilerOptions.allWarningsAsErrors = false
-	}
 	jar {
 		bundle {
 			val version = project.version

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertDoesNotThrow.java
@@ -10,10 +10,12 @@
 
 package org.junit.jupiter.api;
 
+import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 
 import java.util.function.Supplier;
 
+import org.apiguardian.api.API;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.junit.platform.commons.util.StringUtils;
@@ -76,7 +78,8 @@ class AssertDoesNotThrow {
 		}
 	}
 
-	private static AssertionFailedError createAssertionFailedError(Object messageOrSupplier, Throwable t) {
+	@API(status = INTERNAL, since = "6.0")
+	public static AssertionFailedError createAssertionFailedError(Object messageOrSupplier, Throwable t) {
 		return assertionFailure() //
 				.message(messageOrSupplier) //
 				.reason("Unexpected exception thrown: " + t.getClass().getName() + buildSuffix(t.getMessage())) //

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
@@ -379,7 +379,7 @@ inline fun <R> assertDoesNotThrow(
     executable: () -> R
 ): R {
     contract {
-        callsInPlace(executable, AT_MOST_ONCE)
+        callsInPlace(executable, EXACTLY_ONCE)
     }
 
     return assertDoesNotThrow({ message }, executable)

--- a/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
+++ b/junit-jupiter-api/src/main/kotlin/org/junit/jupiter/api/Assertions.kt
@@ -351,7 +351,7 @@ inline fun <reified T : Throwable> assertThrows(
 @API(status = STABLE, since = "5.11")
 inline fun <R> assertDoesNotThrow(executable: () -> R): R {
     contract {
-        callsInPlace(executable, EXACTLY_ONCE)
+        callsInPlace(executable, AT_MOST_ONCE)
     }
 
     return Assertions.assertDoesNotThrow(evaluateAndWrap(executable))
@@ -374,7 +374,7 @@ inline fun <R> assertDoesNotThrow(
     executable: () -> R
 ): R {
     contract {
-        callsInPlace(executable, EXACTLY_ONCE)
+        callsInPlace(executable, AT_MOST_ONCE)
     }
 
     return assertDoesNotThrow({ message }, executable)
@@ -397,7 +397,7 @@ inline fun <R> assertDoesNotThrow(
     executable: () -> R
 ): R {
     contract {
-        callsInPlace(executable, EXACTLY_ONCE)
+        callsInPlace(executable, AT_MOST_ONCE)
         callsInPlace(message, AT_MOST_ONCE)
     }
 
@@ -411,7 +411,7 @@ inline fun <R> assertDoesNotThrow(
 @PublishedApi
 internal inline fun <R> evaluateAndWrap(executable: () -> R): ThrowingSupplier<R> {
     contract {
-        callsInPlace(executable, EXACTLY_ONCE)
+        callsInPlace(executable, AT_MOST_ONCE)
     }
 
     return try {
@@ -439,7 +439,7 @@ fun <R> assertTimeout(
     executable: () -> R
 ): R {
     contract {
-        callsInPlace(executable, EXACTLY_ONCE)
+        callsInPlace(executable, AT_MOST_ONCE)
     }
 
     return Assertions.assertTimeout(timeout, executable)
@@ -463,7 +463,7 @@ fun <R> assertTimeout(
     executable: () -> R
 ): R {
     contract {
-        callsInPlace(executable, EXACTLY_ONCE)
+        callsInPlace(executable, AT_MOST_ONCE)
     }
 
     return Assertions.assertTimeout(timeout, executable, message)
@@ -487,7 +487,7 @@ fun <R> assertTimeout(
     executable: () -> R
 ): R {
     contract {
-        callsInPlace(executable, EXACTLY_ONCE)
+        callsInPlace(executable, AT_MOST_ONCE)
         callsInPlace(message, AT_MOST_ONCE)
     }
 

--- a/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
+++ b/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
@@ -156,8 +156,8 @@ internal class KotlinAssertTimeoutAssertionsTests {
     }
 
     @Test
-    fun `assertTimeout with value initialization in lambda`() {
-        val value: Int
+    fun `assertTimeout with value assignment in lambda`() {
+        var value = 0
 
         assertTimeout(ofMillis(500)) { value = 10 }
 
@@ -165,8 +165,8 @@ internal class KotlinAssertTimeoutAssertionsTests {
     }
 
     @Test
-    fun `assertTimeout with message and value initialization in lambda`() {
-        val value: Int
+    fun `assertTimeout with message and value assignment in lambda`() {
+        var value = 0
 
         assertTimeout(ofMillis(500), "message") { value = 10 }
 
@@ -174,8 +174,8 @@ internal class KotlinAssertTimeoutAssertionsTests {
     }
 
     @Test
-    fun `assertTimeout with message supplier and value initialization in lambda`() {
-        val value: Int
+    fun `assertTimeout with message supplier and value assignment in lambda`() {
+        var value = 0
 
         @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
         val valueInMessageSupplier: Int

--- a/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
+++ b/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/KotlinAssertTimeoutAssertionsTests.kt
@@ -157,11 +157,12 @@ internal class KotlinAssertTimeoutAssertionsTests {
 
     @Test
     fun `assertTimeout with value assignment in lambda`() {
-        var value = 0
+        val value: Int
 
-        assertTimeout(ofMillis(500)) { value = 10 }
-
-        assertEquals(10, value)
+        assertTimeout(ofMillis(500)) {
+            value = 10 // Val can be assigned in the message supplier lambda.
+            assertEquals(10, value)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Overview

Since `Executable` is allowed/expected to throw exceptions, the
semantics of being called `EXACTLY_ONCE` are blurry because it might not
be executed entirely when throwing an exception. Since the Kotlin 2.1
compiler emits a warning for these parameters, we're relaxing their
contracts to be called `AT_MOST_ONCE` instead.

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
