### PR TITLE
Apply Open Rewrite's Java 17 recipes

### DIFF
--- a/documentation/src/test/java/example/HttpServerDemo.java
+++ b/documentation/src/test/java/example/HttpServerDemo.java
@@ -37,7 +37,7 @@ public class HttpServerDemo {
 	void httpCall(HttpServer server) throws Exception {
 		String hostName = server.getAddress().getHostName();
 		int port = server.getAddress().getPort();
-		String rawUrl = String.format("http://%s:%d/example", hostName, port);
+		String rawUrl = "http://%s:%d/example".formatted(hostName, port);
 		URL requestUrl = URI.create(rawUrl).toURL();
 
 		String responseBody = sendRequest(requestUrl);

--- a/documentation/src/test/java/example/ParameterizedTestDemo.java
+++ b/documentation/src/test/java/example/ParameterizedTestDemo.java
@@ -465,8 +465,8 @@ class ParameterizedTestDemo {
 		@Override
 		protected Object convert(Object source, Class<?> targetType) {
 			assertEquals(String.class, targetType, "Can only convert to String");
-			if (source instanceof Enum<?>) {
-				return ((Enum<?>) source).name();
+			if (source instanceof Enum<?> constant) {
+				return constant.name();
 			}
 			return String.valueOf(source);
 		}

--- a/documentation/src/test/java/example/RepeatedTestsDemo.java
+++ b/documentation/src/test/java/example/RepeatedTestsDemo.java
@@ -38,7 +38,7 @@ class RepeatedTestsDemo {
 		int currentRepetition = repetitionInfo.getCurrentRepetition();
 		int totalRepetitions = repetitionInfo.getTotalRepetitions();
 		String methodName = testInfo.getTestMethod().get().getName();
-		logger.info(String.format("About to execute repetition %d of %d for %s", //
+		logger.info("About to execute repetition %d of %d for %s".formatted( //
 			currentRepetition, totalRepetitions, methodName));
 	}
 

--- a/documentation/src/test/java/example/UsingTheLauncherDemo.java
+++ b/documentation/src/test/java/example/UsingTheLauncherDemo.java
@@ -17,7 +17,6 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPacka
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.TestDescriptor;
@@ -111,7 +110,7 @@ class UsingTheLauncherDemo {
 
 	@org.junit.jupiter.api.Test
 	void launcherConfig() {
-		Path reportsDir = Paths.get("target", "xml-reports");
+		Path reportsDir = Path.of("target", "xml-reports");
 		PrintWriter out = new PrintWriter(System.out);
 		// @formatter:off
 		// tag::launcherConfig[]

--- a/documentation/src/test/java/example/testinterface/TestLifecycleLogger.java
+++ b/documentation/src/test/java/example/testinterface/TestLifecycleLogger.java
@@ -39,13 +39,13 @@ interface TestLifecycleLogger {
 
 	@BeforeEach
 	default void beforeEachTest(TestInfo testInfo) {
-		logger.info(() -> String.format("About to execute [%s]",
+		logger.info(() -> "About to execute [%s]".formatted(
 			testInfo.getDisplayName()));
 	}
 
 	@AfterEach
 	default void afterEachTest(TestInfo testInfo) {
-		logger.info(() -> String.format("Finished executing [%s]",
+		logger.info(() -> "Finished executing [%s]".formatted(
 			testInfo.getDisplayName()));
 	}
 

--- a/documentation/src/test/java/example/timing/TimingExtension.java
+++ b/documentation/src/test/java/example/timing/TimingExtension.java
@@ -47,7 +47,7 @@ public class TimingExtension implements BeforeTestExecutionCallback, AfterTestEx
 		long duration = System.currentTimeMillis() - startTime;
 
 		logger.info(() ->
-			String.format("Method [%s] took %s ms.", testMethod.getName(), duration));
+			"Method [%s] took %s ms.".formatted(testMethod.getName(), duration));
 	}
 
 	private Store getStore(ExtensionContext context) {

--- a/documentation/src/test/java21/example/DynamicTestsNamedDemo.java
+++ b/documentation/src/test/java21/example/DynamicTestsNamedDemo.java
@@ -64,7 +64,7 @@ public class DynamicTestsNamedDemo {
 
 		@Override
 		public String getName() {
-			return String.format("'%s' is a palindrome", text);
+			return "'%s' is a palindrome".formatted(text);
 		}
 
 		@Override

--- a/documentation/src/tools/java/org/junit/api/tools/AbstractApiReportWriter.java
+++ b/documentation/src/tools/java/org/junit/api/tools/AbstractApiReportWriter.java
@@ -39,7 +39,7 @@ abstract class AbstractApiReportWriter implements ApiReportWriter {
 		out.println(h1("@API Declarations"));
 		out.println();
 		out.println(paragraph(
-			format("Discovered %d types with %s declarations.", this.apiReport.types().size(), code("@API"))));
+			"Discovered %d types with %s declarations.".formatted(this.apiReport.types().size(), code("@API"))));
 		out.println();
 	}
 
@@ -76,7 +76,7 @@ abstract class AbstractApiReportWriter implements ApiReportWriter {
 			// omit section header when only a single status is printed
 			return;
 		}
-		out.println(h2(format("@API(%s)", status)));
+		out.println(h2("@API(%s)".formatted(status)));
 		out.println();
 		out.println(
 			paragraph(format("Discovered %d " + code("@API(%s)") + " declarations.", declarations.size(), status)));

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
@@ -351,32 +351,32 @@ class AssertArrayEquals {
 	private static void assertArrayElementsEqual(Object expected, Object actual, Deque<Integer> indexes,
 			Object messageOrSupplier) {
 
-		if (expected instanceof Object[] && actual instanceof Object[]) {
-			assertArrayEquals((Object[]) expected, (Object[]) actual, indexes, messageOrSupplier);
+		if (expected instanceof Object[] expectedArray && actual instanceof Object[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
-		else if (expected instanceof byte[] && actual instanceof byte[]) {
-			assertArrayEquals((byte[]) expected, (byte[]) actual, indexes, messageOrSupplier);
+		else if (expected instanceof byte[] expectedArray && actual instanceof byte[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
-		else if (expected instanceof short[] && actual instanceof short[]) {
-			assertArrayEquals((short[]) expected, (short[]) actual, indexes, messageOrSupplier);
+		else if (expected instanceof short[] expectedArray && actual instanceof short[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
-		else if (expected instanceof int[] && actual instanceof int[]) {
-			assertArrayEquals((int[]) expected, (int[]) actual, indexes, messageOrSupplier);
+		else if (expected instanceof int[] expectedArray && actual instanceof int[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
-		else if (expected instanceof long[] && actual instanceof long[]) {
-			assertArrayEquals((long[]) expected, (long[]) actual, indexes, messageOrSupplier);
+		else if (expected instanceof long[] expectedArray && actual instanceof long[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
-		else if (expected instanceof char[] && actual instanceof char[]) {
-			assertArrayEquals((char[]) expected, (char[]) actual, indexes, messageOrSupplier);
+		else if (expected instanceof char[] expectedArray && actual instanceof char[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
-		else if (expected instanceof float[] && actual instanceof float[]) {
-			assertArrayEquals((float[]) expected, (float[]) actual, indexes, messageOrSupplier);
+		else if (expected instanceof float[] expectedArray && actual instanceof float[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
-		else if (expected instanceof double[] && actual instanceof double[]) {
-			assertArrayEquals((double[]) expected, (double[]) actual, indexes, messageOrSupplier);
+		else if (expected instanceof double[] expectedArray && actual instanceof double[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
-		else if (expected instanceof boolean[] && actual instanceof boolean[]) {
-			assertArrayEquals((boolean[]) expected, (boolean[]) actual, indexes, messageOrSupplier);
+		else if (expected instanceof boolean[] expectedArray && actual instanceof boolean[] actualArray) {
+			assertArrayEquals(expectedArray, actualArray, indexes, messageOrSupplier);
 		}
 		else if (!Objects.equals(expected, actual)) {
 			if (expected == null && isArray(actual)) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -88,7 +88,7 @@ class AssertIterableEquals {
 		}
 
 		// If both are iterables, we need to check whether they contain the same elements.
-		if (expected instanceof Iterable && actual instanceof Iterable) {
+		if (expected instanceof Iterable<?> expectedIterable && actual instanceof Iterable<?> actualIterable) {
 
 			Pair pair = new Pair(expected, actual);
 
@@ -109,8 +109,7 @@ class AssertIterableEquals {
 			// Otherwise, we put the pair under investigation and recurse.
 			investigatedElements.put(pair, Status.UNDER_INVESTIGATION);
 
-			assertIterableEquals((Iterable<?>) expected, (Iterable<?>) actual, indexes, messageOrSupplier,
-				investigatedElements);
+			assertIterableEquals(expectedIterable, actualIterable, indexes, messageOrSupplier, investigatedElements);
 
 			// If we reach this point, we've checked that the two iterables contain the same elements so we store this information
 			// in case we come across the same pair again.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api;
 
-import static java.lang.String.format;
 import static java.lang.String.join;
 import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.platform.commons.util.Preconditions.condition;
@@ -196,7 +195,7 @@ class AssertLinesMatch {
 			String newLine = System.lineSeparator();
 			assertionFailure() //
 					.message(messageOrSupplier) //
-					.reason(format(format, args)) //
+					.reason(format.formatted(args)) //
 					.expected(join(newLine, expectedLines)) //
 					.actual(join(newLine, actualLines)) //
 					.includeValuesInMessage(false) //
@@ -214,7 +213,7 @@ class AssertLinesMatch {
 		String text = fastForwardLine.substring(2, fastForwardLine.length() - 2).trim();
 		try {
 			int limit = Integer.parseInt(text);
-			condition(limit > 0, () -> format("fast-forward(%d) limit must be greater than zero", limit));
+			condition(limit > 0, () -> "fast-forward(%d) limit must be greater than zero".formatted(limit));
 			return limit;
 		}
 		catch (NumberFormatException e) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrows.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api;
 
-import static java.lang.String.format;
 import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
 
@@ -69,7 +68,7 @@ class AssertThrows {
 		}
 		throw assertionFailure() //
 				.message(messageOrSupplier) //
-				.reason(format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType))) //
+				.reason("Expected %s to be thrown, but nothing was thrown.".formatted(getCanonicalName(expectedType))) //
 				.build();
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertThrowsExactly.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api;
 
-import static java.lang.String.format;
 import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.AssertionUtils.getCanonicalName;
 
@@ -70,7 +69,7 @@ class AssertThrowsExactly {
 
 		throw assertionFailure() //
 				.message(messageOrSupplier) //
-				.reason(format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType))) //
+				.reason("Expected %s to be thrown, but nothing was thrown.".formatted(getCanonicalName(expectedType))) //
 				.build();
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
@@ -171,10 +171,10 @@ public class AssertionFailureBuilder {
 		String expectedString = toString(expected);
 		String actualString = toString(actual);
 		if (expectedString.equals(actualString)) {
-			return String.format("expected: %s but was: %s", formatClassAndValue(expected, expectedString),
+			return "expected: %s but was: %s".formatted(formatClassAndValue(expected, expectedString),
 				formatClassAndValue(actual, actualString));
 		}
-		return String.format("expected: <%s> but was: <%s>", expectedString, actualString);
+		return "expected: <%s> but was: <%s>".formatted(expectedString, actualString);
 	}
 
 	private static String formatClassAndValue(Object value, String valueString) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
@@ -156,8 +156,8 @@ public class AssertionFailureBuilder {
 		if (messageOrSupplier == null) {
 			return null;
 		}
-		if (messageOrSupplier instanceof Supplier) {
-			Object message = ((Supplier<?>) messageOrSupplier).get();
+		if (messageOrSupplier instanceof Supplier<?> supplier) {
+			Object message = supplier.get();
 			return StringUtils.nullSafeToString(message);
 		}
 		return StringUtils.nullSafeToString(messageOrSupplier);
@@ -188,8 +188,8 @@ public class AssertionFailureBuilder {
 	}
 
 	private static String toString(Object obj) {
-		if (obj instanceof Class) {
-			return getCanonicalName((Class<?>) obj);
+		if (obj instanceof Class<?> clazz) {
+			return getCanonicalName(clazz);
 		}
 		return StringUtils.nullSafeToString(obj);
 	}
@@ -200,7 +200,7 @@ public class AssertionFailureBuilder {
 
 	private static String getClassName(Object obj) {
 		return (obj == null ? "null"
-				: obj instanceof Class ? getCanonicalName((Class<?>) obj) : obj.getClass().getName());
+				: obj instanceof Class<?> clazz ? getCanonicalName(clazz) : obj.getClass().getName());
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -505,8 +505,8 @@ public interface DisplayNameGenerator {
 			return findAnnotation(element, SentenceFragment.class) //
 					.map(SentenceFragment::value) //
 					.map(sentenceFragment -> {
-						Preconditions.notBlank(sentenceFragment, String.format(
-							"@SentenceFragment on [%s] must be declared with a non-blank value.", element));
+						Preconditions.notBlank(sentenceFragment,
+							"@SentenceFragment on [%s] must be declared with a non-blank value.".formatted(element));
 						return sentenceFragment.trim();
 					}) //
 					.orElse(null);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RandomOrdererUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/RandomOrdererUtils.java
@@ -36,7 +36,7 @@ class RandomOrdererUtils {
 			Logger logger) {
 		return configurationParameterLookup.apply(RANDOM_SEED_PROPERTY_NAME).map(configurationParameter -> {
 			try {
-				logger.config(() -> String.format("Using custom seed for configuration parameter [%s] with value [%s].",
+				logger.config(() -> "Using custom seed for configuration parameter [%s] with value [%s].".formatted(
 					RANDOM_SEED_PROPERTY_NAME, configurationParameter));
 				return Long.valueOf(configurationParameter);
 			}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreCondition.java
@@ -47,7 +47,7 @@ abstract class AbstractJreCondition<A extends Annotation> extends BooleanExecuti
 		Preconditions.condition(Arrays.stream(jres).noneMatch(isEqual(JRE.UNDEFINED)),
 			() -> "JRE.UNDEFINED is not supported in @" + this.annotationName);
 		Arrays.stream(versions).min().ifPresent(version -> Preconditions.condition(version >= JRE.MINIMUM_VERSION,
-			() -> String.format("Version [%d] in @%s must be greater than or equal to %d", version, this.annotationName,
+			() -> "Version [%d] in @%s must be greater than or equal to %d".formatted(version, this.annotationName,
 				JRE.MINIMUM_VERSION)));
 
 		return IntStream.concat(//

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
@@ -43,20 +43,20 @@ abstract class AbstractJreRangeCondition<A extends Annotation> extends BooleanEx
 		boolean maxVersionSet = maxVersion != JRE.UNDEFINED_VERSION;
 
 		// Users must choose between JRE enum constants and version numbers.
-		Preconditions.condition(!minJreSet || !minVersionSet, () -> String.format(
-			"@%s's minimum value must be configured with either a JRE enum constant or numeric version, but not both",
-			this.annotationName));
-		Preconditions.condition(!maxJreSet || !maxVersionSet, () -> String.format(
-			"@%s's maximum value must be configured with either a JRE enum constant or numeric version, but not both",
-			this.annotationName));
+		Preconditions.condition(!minJreSet || !minVersionSet,
+			() -> "@%s's minimum value must be configured with either a JRE enum constant or numeric version, but not both".formatted(
+				this.annotationName));
+		Preconditions.condition(!maxJreSet || !maxVersionSet,
+			() -> "@%s's maximum value must be configured with either a JRE enum constant or numeric version, but not both".formatted(
+				this.annotationName));
 
 		// Users must supply valid values for minVersion and maxVersion.
 		Preconditions.condition(!minVersionSet || (minVersion >= JRE.MINIMUM_VERSION),
-			() -> String.format("@%s's minVersion [%d] must be greater than or equal to %d", this.annotationName,
-				minVersion, JRE.MINIMUM_VERSION));
+			() -> "@%s's minVersion [%d] must be greater than or equal to %d".formatted(this.annotationName, minVersion,
+				JRE.MINIMUM_VERSION));
 		Preconditions.condition(!maxVersionSet || (maxVersion >= JRE.MINIMUM_VERSION),
-			() -> String.format("@%s's maxVersion [%d] must be greater than or equal to %d", this.annotationName,
-				maxVersion, JRE.MINIMUM_VERSION));
+			() -> "@%s's maxVersion [%d] must be greater than or equal to %d".formatted(this.annotationName, maxVersion,
+				JRE.MINIMUM_VERSION));
 
 		// Now that we have checked the basic preconditions, we need to ensure that we are
 		// using valid JRE enum constants.
@@ -74,7 +74,7 @@ abstract class AbstractJreRangeCondition<A extends Annotation> extends BooleanEx
 		Preconditions.condition((min != DEFAULT_MINIMUM_JRE.version() || max != DEFAULT_MAXIMUM_JRE.version()),
 			() -> "You must declare a non-default value for the minimum or maximum value in @" + this.annotationName);
 		Preconditions.condition(min <= max,
-			() -> String.format("@%s's minimum value [%d] must be less than or equal to its maximum value [%d]",
+			() -> "@%s's minimum value [%d] must be less than or equal to its maximum value [%d]".formatted(
 				this.annotationName, min, max));
 
 		return JRE.isCurrentVersionWithinRange(min, max);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractOsBasedExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractOsBasedExecutionCondition.java
@@ -50,7 +50,7 @@ abstract class AbstractOsBasedExecutionCondition<A extends Annotation> implement
 				.append(osSpecified ? " on operating system: " : " on architecture: ");
 
 		if (osSpecified && archSpecified) {
-			reason.append(String.format("%s (%s)", CURRENT_OS, CURRENT_ARCHITECTURE));
+			reason.append("%s (%s)".formatted(CURRENT_OS, CURRENT_ARCHITECTURE));
 		}
 		else if (osSpecified) {
 			reason.append(CURRENT_OS);
@@ -63,7 +63,7 @@ abstract class AbstractOsBasedExecutionCondition<A extends Annotation> implement
 	}
 
 	private ConditionEvaluationResult enabledByDefault() {
-		String reason = String.format("@%s is not present", this.annotationType.getSimpleName());
+		String reason = "@%s is not present".formatted(this.annotationType.getSimpleName());
 		return enabled(reason);
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractRepeatableAnnotationCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractRepeatableAnnotationCondition.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import static java.lang.String.format;
 import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
 
 import java.lang.annotation.Annotation;
@@ -66,7 +65,7 @@ abstract class AbstractRepeatableAnnotationCondition<A extends Annotation> imple
 	protected abstract ConditionEvaluationResult getNoDisabledConditionsEncounteredResult();
 
 	private void logResult(A annotation, AnnotatedElement annotatedElement, ConditionEvaluationResult result) {
-		logger.trace(() -> format("Evaluation of %s on [%s] resulted in: %s", annotation, annotatedElement, result));
+		logger.trace(() -> "Evaluation of %s on [%s] resulted in: %s".formatted(annotation, annotatedElement, result));
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/BooleanExecutionCondition.java
@@ -48,7 +48,7 @@ abstract class BooleanExecutionCondition<A extends Annotation> implements Execut
 	abstract boolean isEnabled(A annotation);
 
 	private ConditionEvaluationResult enabledByDefault() {
-		String reason = String.format("@%s is not present", this.annotationType.getSimpleName());
+		String reason = "@%s is not present".formatted(this.annotationType.getSimpleName());
 		return enabled(reason);
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariableCondition.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 
@@ -49,16 +48,16 @@ class DisabledIfEnvironmentVariableCondition
 
 		// Nothing to match against?
 		if (actual == null) {
-			return enabled(format("Environment variable [%s] does not exist", name));
+			return enabled("Environment variable [%s] does not exist".formatted(name));
 		}
 
 		if (actual.matches(regex)) {
-			return disabled(format("Environment variable [%s] with value [%s] matches regular expression [%s]", name,
+			return disabled("Environment variable [%s] with value [%s] matches regular expression [%s]".formatted(name,
 				actual, regex), annotation.disabledReason());
 		}
 		// else
-		return enabled(format("Environment variable [%s] with value [%s] does not match regular expression [%s]", name,
-			actual, regex));
+		return enabled("Environment variable [%s] with value [%s] does not match regular expression [%s]".formatted(
+			name, actual, regex));
 	}
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemPropertyCondition.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 
@@ -48,17 +47,17 @@ class DisabledIfSystemPropertyCondition extends AbstractRepeatableAnnotationCond
 
 		// Nothing to match against?
 		if (actual == null) {
-			return enabled(format("System property [%s] does not exist", name));
+			return enabled("System property [%s] does not exist".formatted(name));
 		}
 
 		if (actual.matches(regex)) {
 			return disabled(
-				format("System property [%s] with value [%s] matches regular expression [%s]", name, actual, regex),
+				"System property [%s] with value [%s] matches regular expression [%s]".formatted(name, actual, regex),
 				annotation.disabledReason());
 		}
 		// else
-		return enabled(
-			format("System property [%s] with value [%s] does not match regular expression [%s]", name, actual, regex));
+		return enabled("System property [%s] with value [%s] does not match regular expression [%s]".formatted(name,
+			actual, regex));
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariableCondition.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 
@@ -50,14 +49,14 @@ class EnabledIfEnvironmentVariableCondition
 
 		// Nothing to match against?
 		if (actual == null) {
-			return disabled(format("Environment variable [%s] does not exist", name), annotation.disabledReason());
+			return disabled("Environment variable [%s] does not exist".formatted(name), annotation.disabledReason());
 		}
 		if (actual.matches(regex)) {
-			return enabled(format("Environment variable [%s] with value [%s] matches regular expression [%s]", name,
+			return enabled("Environment variable [%s] with value [%s] matches regular expression [%s]".formatted(name,
 				actual, regex));
 		}
-		return disabled(format("Environment variable [%s] with value [%s] does not match regular expression [%s]", name,
-			actual, regex), annotation.disabledReason());
+		return disabled("Environment variable [%s] with value [%s] does not match regular expression [%s]".formatted(
+			name, actual, regex), annotation.disabledReason());
 	}
 
 	/**

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemPropertyCondition.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 
@@ -49,15 +48,14 @@ class EnabledIfSystemPropertyCondition extends AbstractRepeatableAnnotationCondi
 
 		// Nothing to match against?
 		if (actual == null) {
-			return disabled(format("System property [%s] does not exist", name), annotation.disabledReason());
+			return disabled("System property [%s] does not exist".formatted(name), annotation.disabledReason());
 		}
 		if (actual.matches(regex)) {
 			return enabled(
-				format("System property [%s] with value [%s] matches regular expression [%s]", name, actual, regex));
+				"System property [%s] with value [%s] matches regular expression [%s]".formatted(name, actual, regex));
 		}
-		return disabled(
-			format("System property [%s] with value [%s] does not match regular expression [%s]", name, actual, regex),
-			annotation.disabledReason());
+		return disabled("System property [%s] with value [%s] does not match regular expression [%s]".formatted(name,
+			actual, regex), annotation.disabledReason());
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.api.condition;
 
-import static java.lang.String.format;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
 import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
@@ -69,7 +68,7 @@ abstract class MethodBasedCondition<A extends Annotation> implements ExecutionCo
 		String methodName = methodParts[1];
 		ClassLoader classLoader = ClassLoaderUtils.getClassLoader(testClass);
 		Class<?> clazz = ReflectionSupport.tryToLoadClass(className, classLoader).getOrThrow(
-			cause -> new JUnitException(format("Could not load class [%s]", className), cause));
+			cause -> new JUnitException("Could not load class [%s]".formatted(className), cause));
 		return findMethod(clazz, methodName);
 	}
 
@@ -80,9 +79,9 @@ abstract class MethodBasedCondition<A extends Annotation> implements ExecutionCo
 
 	private boolean invokeConditionMethod(Method method, ExtensionContext context) {
 		Preconditions.condition(method.getReturnType() == boolean.class,
-			() -> format("Method [%s] must return a boolean", method));
+			() -> "Method [%s] must return a boolean".formatted(method));
 		Preconditions.condition(acceptsExtensionContextOrNoArguments(method),
-			() -> format("Method [%s] must accept either an ExtensionContext or no arguments", method));
+			() -> "Method [%s] must accept either an ExtensionContext or no arguments".formatted(method));
 
 		Object testInstance = context.getTestInstance().orElse(null);
 		if (method.getParameterCount() == 0) {
@@ -97,7 +96,7 @@ abstract class MethodBasedCondition<A extends Annotation> implements ExecutionCo
 	}
 
 	private ConditionEvaluationResult buildConditionEvaluationResult(boolean methodResult, A annotation) {
-		Supplier<String> defaultReason = () -> format("@%s(\"%s\") evaluated to %s",
+		Supplier<String> defaultReason = () -> "@%s(\"%s\") evaluated to %s".formatted(
 			this.annotationType.getSimpleName(), this.methodName.apply(annotation), methodResult);
 		if (isEnabled(methodResult)) {
 			return enabled(defaultReason.get());
@@ -109,7 +108,7 @@ abstract class MethodBasedCondition<A extends Annotation> implements ExecutionCo
 	protected abstract boolean isEnabled(boolean methodResult);
 
 	private ConditionEvaluationResult enabledByDefault() {
-		return enabled(format("@%s is not present", this.annotationType.getSimpleName()));
+		return enabled("@%s is not present".formatted(this.annotationType.getSimpleName()));
 	}
 
 }

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ConditionEvaluationResult.java
@@ -60,7 +60,7 @@ public class ConditionEvaluationResult {
 		if (StringUtils.isBlank(customReason)) {
 			return disabled(reason);
 		}
-		return disabled(String.format("%s ==> %s", reason, customReason));
+		return disabled("%s ==> %s".formatted(reason, customReason));
 	}
 
 	private final boolean enabled;

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionConfigurationException.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionConfigurationException.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.api.extension;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -24,6 +26,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = STABLE, since = "5.0")
 public class ExtensionConfigurationException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public ExtensionConfigurationException(String message) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContextException.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContextException.java
@@ -13,6 +13,8 @@ package org.junit.jupiter.api.extension;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.platform.commons.JUnitException;
@@ -26,6 +28,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = STABLE, since = "5.0")
 public class ExtensionContextException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	@SuppressWarnings("unused")

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterResolutionException.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterResolutionException.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.api.extension;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -25,6 +27,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = STABLE, since = "5.0")
 public class ParameterResolutionException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public ParameterResolutionException(String message) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TemplateInvocationValidationException.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TemplateInvocationValidationException.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.api.extension;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -27,6 +29,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = EXPERIMENTAL, since = "5.13")
 public class TemplateInvocationValidationException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public TemplateInvocationValidationException(String message) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstantiationException.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstantiationException.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.api.extension;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -24,6 +26,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = STABLE, since = "5.10")
 public class TestInstantiationException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public TestInstantiationException(String message) {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolver.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolver.java
@@ -69,10 +69,10 @@ public abstract class TypeBasedParameterResolver<T> implements ParameterResolver
 		}
 
 		Type genericSuperclass = clazz.getGenericSuperclass();
-		if (genericSuperclass instanceof ParameterizedType) {
-			Type rawType = ((ParameterizedType) genericSuperclass).getRawType();
+		if (genericSuperclass instanceof ParameterizedType type) {
+			Type rawType = type.getRawType();
 			if (rawType == TypeBasedParameterResolver.class) {
-				return (ParameterizedType) genericSuperclass;
+				return type;
 			}
 		}
 		return findTypeBasedParameterResolverSuperclass(superclass);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/EnumConfigurationParameterConverter.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/EnumConfigurationParameterConverter.java
@@ -53,8 +53,8 @@ public class EnumConfigurationParameterConverter<E extends Enum<E>> {
 			try {
 				constantName = value.get().trim().toUpperCase(Locale.ROOT);
 				E result = Enum.valueOf(enumType, constantName);
-				logger.config(() -> String.format("Using %s '%s' set via the '%s' configuration parameter.",
-					enumDisplayName, result, key));
+				logger.config(() -> "Using %s '%s' set via the '%s' configuration parameter.".formatted(enumDisplayName,
+					result, key));
 				return result;
 			}
 			catch (Exception ex) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/InstantiatingConfigurationParameterConverter.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/InstantiatingConfigurationParameterConverter.java
@@ -67,7 +67,7 @@ class InstantiatingConfigurationParameterConverter<T> {
 	}
 
 	private void logSuccessMessage(String className, String key) {
-		logger.config(() -> String.format("Using default %s '%s' set via the '%s' configuration parameter.", this.name,
+		logger.config(() -> "Using default %s '%s' set via the '%s' configuration parameter.".formatted(this.name,
 			className, key));
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -93,17 +93,17 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 		return (__, ___, value) -> {
 			boolean isAutoCloseEnabled = this.configuration.isClosingStoredAutoCloseablesEnabled();
 
-			if (value instanceof AutoCloseable && isAutoCloseEnabled) {
-				((AutoCloseable) value).close();
+			if (value instanceof AutoCloseable closeable && isAutoCloseEnabled) {
+				closeable.close();
 				return;
 			}
 
-			if (value instanceof Store.CloseableResource) {
+			if (value instanceof Store.CloseableResource resource) {
 				if (isAutoCloseEnabled) {
 					LOGGER.warn(
 						() -> "Type implements CloseableResource but not AutoCloseable: " + value.getClass().getName());
 				}
-				((Store.CloseableResource) value).close();
+				resource.close();
 			}
 		};
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -142,7 +142,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 
 	private void validateDisplayNameAnnotation(DiscoveryIssueReporter reporter) {
 		DisplayNameUtils.validateAnnotation(getTestClass(), //
-			() -> String.format("class '%s'", getTestClass().getName()), //
+			() -> "class '%s'".formatted(getTestClass().getName()), //
 			() -> getSource().orElse(null), //
 			reporter);
 	}
@@ -300,8 +300,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 					.map(factory -> factory.getClass().getName())//
 					.collect(joining(", "));
 
-			String errorMessage = String.format(
-				"The following TestInstanceFactory extensions were registered for test class [%s], but only one is permitted: %s",
+			String errorMessage = "The following TestInstanceFactory extensions were registered for test class [%s], but only one is permitted: %s".formatted(
 				getTestClass().getName(), factoryNames);
 
 			throw new ExtensionConfigurationException(errorMessage);
@@ -370,7 +369,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 				throw (TestInstantiationException) throwable;
 			}
 
-			String message = String.format("TestInstanceFactory [%s] failed to instantiate test class [%s]",
+			String message = "TestInstanceFactory [%s] failed to instantiate test class [%s]".formatted(
 				this.testInstanceFactory.getClass().getName(), getTestClass().getName());
 			if (StringUtils.isNotBlank(throwable.getMessage())) {
 				message += ": " + throwable.getMessage();
@@ -390,8 +389,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 				testClassName += "@" + Integer.toHexString(System.identityHashCode(getTestClass()));
 				instanceClassName += "@" + Integer.toHexString(System.identityHashCode(instanceClass));
 			}
-			String message = String.format(
-				"TestInstanceFactory [%s] failed to return an instance of [%s] and instead returned an instance of [%s].",
+			String message = "TestInstanceFactory [%s] failed to return an instance of [%s] and instead returned an instance of [%s].".formatted(
 				this.testInstanceFactory.getClass().getName(), testClassName, instanceClassName);
 
 			throw new TestInstantiationException(message);
@@ -561,7 +559,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 		ClassInfo(Class<?> testClass, JupiterConfiguration configuration) {
 			this.testClass = testClass;
 			this.tags = getTags(testClass, //
-				() -> String.format("class '%s'", testClass.getName()), //
+				() -> "class '%s'".formatted(testClass.getName()), //
 				() -> ClassSource.from(testClass), //
 				discoveryIssues::add);
 			this.lifecycle = getTestInstanceLifecycle(testClass, configuration);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -365,8 +365,8 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 		catch (Throwable throwable) {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 
-			if (throwable instanceof TestInstantiationException) {
-				throw (TestInstantiationException) throwable;
+			if (throwable instanceof TestInstantiationException exception) {
+				throw exception;
 			}
 
 			String message = "TestInstanceFactory [%s] failed to instantiate test class [%s]".formatted(

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
@@ -221,7 +221,7 @@ public class ClassTemplateTestDescriptor extends ClassBasedTestDescriptor implem
 
 		@Override
 		protected String getNoRegisteredProviderErrorMessage() {
-			return String.format("You must register at least one %s that supports @%s class [%s]",
+			return "You must register at least one %s that supports @%s class [%s]".formatted(
 				ClassTemplateInvocationContextProvider.class.getSimpleName(), ClassTemplate.class.getSimpleName(),
 				getTestClass().getName());
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
@@ -134,8 +134,8 @@ public class ClassTemplateTestDescriptor extends ClassBasedTestDescriptor implem
 		new LinkedHashSet<>(this.children).forEach(child -> child.accept(TestDescriptor::prune));
 		// Second iteration to avoid processing children that were pruned in the first iteration
 		this.children.forEach(child -> {
-			if (child instanceof ClassTemplateInvocationTestDescriptor) {
-				int index = ((ClassTemplateInvocationTestDescriptor) child).getIndex();
+			if (child instanceof ClassTemplateInvocationTestDescriptor descriptor) {
+				int index = descriptor.getIndex();
 				this.dynamicDescendantFilter.allowIndex(index - 1);
 				this.childrenPrototypesByIndex.put(index, child.getChildren());
 			}
@@ -180,8 +180,8 @@ public class ClassTemplateTestDescriptor extends ClassBasedTestDescriptor implem
 	public Set<ExclusiveResource> getExclusiveResources() {
 		Set<ExclusiveResource> result = determineExclusiveResources().collect(toCollection(HashSet::new));
 		Visitor visitor = testDescriptor -> {
-			if (testDescriptor instanceof Node) {
-				result.addAll(((Node<?>) testDescriptor).getExclusiveResources());
+			if (testDescriptor instanceof Node<?> node) {
+				result.addAll(node.getExclusiveResources());
 			}
 		};
 		this.childrenPrototypes.forEach(child -> child.accept(visitor));

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DisplayNameUtils.java
@@ -87,7 +87,7 @@ final class DisplayNameUtils {
 				.map(DisplayName::value) //
 				.filter(StringUtils::isBlank) //
 				.ifPresent(__ -> {
-					String message = String.format("@DisplayName on %s must be declared with a non-blank value.",
+					String message = "@DisplayName on %s must be declared with a non-blank value.".formatted(
 						elementDescription.get());
 					reporter.reportIssue(
 						DiscoveryIssue.builder(Severity.WARNING, message).source(sourceProvider.get()).build());

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/DynamicContainerTestDescriptor.java
@@ -69,8 +69,7 @@ class DynamicContainerTestDescriptor extends DynamicNodeTestDescriptor {
 						Preconditions.notNull(child, "individual dynamic node must not be null");
 						return toDynamicDescriptor(index.getAndIncrement(), child);
 					})
-					.filter(Optional::isPresent)
-					.map(Optional::get)
+					.flatMap(Optional::stream)
 					.forEachOrdered(dynamicTestExecutor::execute);
 			// @formatter:on
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -142,11 +142,11 @@ final class ExtensionUtils {
 			List<Class<? extends Extension>> declarativeExtensionTypes) {
 		Object value = tryToReadFieldValue(field, instance) //
 				.getOrThrow(e -> new PreconditionViolationException(
-					String.format("Failed to read @RegisterExtension field [%s]", field), e));
+					"Failed to read @RegisterExtension field [%s]".formatted(field), e));
 
-		Preconditions.condition(value instanceof Extension, () -> String.format(
-			"Failed to register extension via @RegisterExtension field [%s]: field value's type [%s] must implement an [%s] API.",
-			field, (value != null ? value.getClass().getName() : null), Extension.class.getName()));
+		Preconditions.condition(value instanceof Extension,
+			() -> "Failed to register extension via @RegisterExtension field [%s]: field value's type [%s] must implement an [%s] API.".formatted(
+				field, (value != null ? value.getClass().getName() : null), Extension.class.getName()));
 
 		declarativeExtensionTypes.forEach(extensionType -> {
 			Class<?> valueType = value.getClass();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -85,9 +85,8 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 				.filter(tag -> {
 					boolean isValid = TestTag.isValid(tag);
 					if (!isValid) {
-						String message = String.format(
-							"Invalid tag syntax in @Tag(\"%s\") declaration on %s. Tag will be ignored.", tag,
-							elementDescription.get());
+						String message = "Invalid tag syntax in @Tag(\"%s\") declaration on %s. Tag will be ignored.".formatted(
+							tag, elementDescription.get());
 						if (source.get() == null) {
 							source.set(sourceProvider.get());
 						}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -181,8 +181,8 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 
 	@Override
 	public Set<ExclusiveResource> getExclusiveResources() {
-		if (this instanceof ResourceLockAware) {
-			return ((ResourceLockAware) this).determineExclusiveResources().collect(toSet());
+		if (this instanceof ResourceLockAware aware) {
+			return aware.determineExclusiveResources().collect(toSet());
 		}
 		return emptySet();
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/LifecycleMethodUtils.java
@@ -76,8 +76,7 @@ final class LifecycleMethodUtils {
 		findAllClassTemplateInvocationLifecycleMethods(testClass) //
 				.forEach(method -> findClassTemplateInvocationLifecycleMethodAnnotation(method) //
 						.ifPresent(annotation -> {
-							String message = String.format(
-								"@%s method '%s' must not be declared in test class '%s' because it is not annotated with @%s.",
+							String message = "@%s method '%s' must not be declared in test class '%s' because it is not annotated with @%s.".formatted(
 								annotation.lifecycleMethodAnnotation().getSimpleName(), method.toGenericString(),
 								testClass.getName(), annotation.classTemplateAnnotation().getSimpleName());
 							issueReporter.reportIssue(createIssue(Severity.ERROR, message, method));
@@ -141,8 +140,7 @@ final class LifecycleMethodUtils {
 	private static Condition<Method> isStatic(DiscoveryIssueReporter issueReporter,
 			Function<Method, String> annotationNameProvider) {
 		return issueReporter.createReportingCondition(ModifierSupport::isStatic, method -> {
-			String message = String.format(
-				"@%s method '%s' must be static unless the test class is annotated with @TestInstance(Lifecycle.PER_CLASS).",
+			String message = "@%s method '%s' must be static unless the test class is annotated with @TestInstance(Lifecycle.PER_CLASS).".formatted(
 				annotationNameProvider.apply(method), method.toGenericString());
 			return createIssue(Severity.ERROR, message, method);
 		});
@@ -151,7 +149,7 @@ final class LifecycleMethodUtils {
 	private static Condition<Method> isNotStatic(DiscoveryIssueReporter issueReporter,
 			Function<Method, String> annotationNameProvider) {
 		return issueReporter.createReportingCondition(ModifierSupport::isNotStatic, method -> {
-			String message = String.format("@%s method '%s' must not be static.", annotationNameProvider.apply(method),
+			String message = "@%s method '%s' must not be static.".formatted(annotationNameProvider.apply(method),
 				method.toGenericString());
 			return createIssue(Severity.ERROR, message, method);
 		});
@@ -159,7 +157,7 @@ final class LifecycleMethodUtils {
 
 	private static Condition<Method> isNotPrivateError(DiscoveryIssueReporter issueReporter) {
 		return issueReporter.createReportingCondition(ModifierSupport::isNotPrivate, method -> {
-			String message = String.format("@%s method '%s' must not be private.",
+			String message = "@%s method '%s' must not be private.".formatted(
 				classTemplateInvocationLifecycleMethodAnnotationName(method), method.toGenericString());
 			return createIssue(Severity.ERROR, message, method);
 		});
@@ -168,8 +166,7 @@ final class LifecycleMethodUtils {
 	private static Condition<Method> isNotPrivateWarning(DiscoveryIssueReporter issueReporter,
 			Supplier<String> annotationNameProvider) {
 		return issueReporter.createReportingCondition(ModifierSupport::isNotPrivate, method -> {
-			String message = String.format(
-				"@%s method '%s' should not be private. This will be disallowed in a future release.",
+			String message = "@%s method '%s' should not be private. This will be disallowed in a future release.".formatted(
 				annotationNameProvider.get(), method.toGenericString());
 			return createIssue(Severity.WARNING, message, method);
 		});
@@ -178,8 +175,8 @@ final class LifecycleMethodUtils {
 	private static Condition<Method> returnsPrimitiveVoid(DiscoveryIssueReporter issueReporter,
 			Function<Method, String> annotationNameProvider) {
 		return issueReporter.createReportingCondition(method -> getReturnType(method) == void.class, method -> {
-			String message = String.format("@%s method '%s' must not return a value.",
-				annotationNameProvider.apply(method), method.toGenericString());
+			String message = "@%s method '%s' must not return a value.".formatted(annotationNameProvider.apply(method),
+				method.toGenericString());
 			return createIssue(Severity.ERROR, message, method);
 		});
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -88,7 +88,7 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor
 
 	@Override
 	public String getLegacyReportingName() {
-		return String.format("%s(%s)", getTestMethod().getName(),
+		return "%s(%s)".formatted(getTestMethod().getName(),
 			ClassUtils.nullSafeToString(Class::getSimpleName, getTestMethod().getParameterTypes()));
 	}
 
@@ -114,7 +114,7 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor
 	public void validate(DiscoveryIssueReporter reporter) {
 		Validatable.reportAndClear(this.methodInfo.discoveryIssues, reporter);
 		DisplayNameUtils.validateAnnotation(getTestMethod(), //
-			() -> String.format("method '%s'", getTestMethod().toGenericString()), //
+			() -> "method '%s'".formatted(getTestMethod().toGenericString()), //
 			// Use _declaring_ class here because that's where the `@DisplayName` annotation is declared
 			() -> MethodSource.from(getTestMethod()), //
 			reporter);
@@ -178,7 +178,7 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor
 				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 				ExtensionContext extensionContext = context.getExtensionContext();
 				logger.warn(throwable,
-					() -> String.format("Failed to invoke TestWatcher [%s] for method [%s] with display name [%s]",
+					() -> "Failed to invoke TestWatcher [%s] for method [%s] with display name [%s]".formatted(
 						watcher.getClass().getName(),
 						ReflectionUtils.getFullyQualifiedMethodName(extensionContext.getRequiredTestClass(),
 							extensionContext.getRequiredTestMethod()),
@@ -209,7 +209,7 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor
 			this.testClass = Preconditions.notNull(testClass, "Class must not be null");
 			this.testMethod = testMethod;
 			this.tags = getTags(testMethod, //
-				() -> String.format("method '%s'", testMethod.toGenericString()), //
+				() -> "method '%s'".formatted(testMethod.toGenericString()), //
 				// Use _declaring_ class here because that's where the `@Tag` annotation is declared
 				() -> MethodSource.from(testMethod.getDeclaringClass(), testMethod), //
 				discoveryIssues::add);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -88,8 +88,7 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 
 	@API(status = INTERNAL, since = "5.12")
 	public static List<Class<?>> getEnclosingTestClasses(TestDescriptor parent) {
-		if (parent instanceof TestClassAware) {
-			TestClassAware parentClassDescriptor = (TestClassAware) parent;
+		if (parent instanceof TestClassAware parentClassDescriptor) {
 			List<Class<?>> result = new ArrayList<>(parentClassDescriptor.getEnclosingTestClasses());
 			result.add(parentClassDescriptor.getTestClass());
 			return result;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -141,7 +141,7 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 	}
 
 	private JUnitException invalidReturnTypeException(Throwable cause) {
-		String message = String.format("Objects produced by @TestFactory method '%s' must be of type %s.",
+		String message = "Objects produced by @TestFactory method '%s' must be of type %s.".formatted(
 			getTestMethod().toGenericString(), DynamicNode.class.getName());
 		return new JUnitException(message, cause);
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -134,8 +134,8 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 
 	@SuppressWarnings("unchecked")
 	private Stream<DynamicNode> toDynamicNodeStream(Object testFactoryMethodResult) {
-		if (testFactoryMethodResult instanceof DynamicNode) {
-			return Stream.of((DynamicNode) testFactoryMethodResult);
+		if (testFactoryMethodResult instanceof DynamicNode node) {
+			return Stream.of(node);
 		}
 		return (Stream<DynamicNode>) CollectionUtils.toStream(testFactoryMethodResult);
 	}
@@ -155,8 +155,7 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 		Optional<TestSource> customTestSource = node.getTestSourceUri().map(TestFactoryTestDescriptor::fromUri);
 		TestSource source = customTestSource.orElse(defaultTestSource);
 
-		if (node instanceof DynamicTest) {
-			DynamicTest test = (DynamicTest) node;
+		if (node instanceof DynamicTest test) {
 			uniqueId = parent.getUniqueId().append(DYNAMIC_TEST_SEGMENT_TYPE, "#" + index);
 			descriptorCreator = () -> new DynamicTestTestDescriptor(uniqueId, index, test, source, configuration);
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -127,7 +127,7 @@ public class TestTemplateTestDescriptor extends MethodBasedTestDescriptor implem
 
 		@Override
 		protected String getNoRegisteredProviderErrorMessage() {
-			return String.format("You must register at least one %s that supports @%s method [%s]",
+			return "You must register at least one %s that supports @%s method [%s]".formatted(
 				TestTemplateInvocationContextProvider.class.getSimpleName(), TestTemplate.class.getSimpleName(),
 				getTestMethod());
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/UniqueIdPrefixTransformer.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/UniqueIdPrefixTransformer.java
@@ -34,7 +34,7 @@ class UniqueIdPrefixTransformer implements UnaryOperator<UniqueId> {
 	@Override
 	public UniqueId apply(UniqueId uniqueId) {
 		Preconditions.condition(uniqueId.hasPrefix(oldPrefix),
-			() -> String.format("Unique ID %s does not have the expected prefix %s", uniqueId, oldPrefix));
+			() -> "Unique ID %s does not have the expected prefix %s".formatted(uniqueId, oldPrefix));
 		List<UniqueId.Segment> oldSegments = uniqueId.getSegments();
 		List<UniqueId.Segment> suffix = oldSegments.subList(oldPrefixLength, oldSegments.size());
 		UniqueId newValue = newPrefix;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -49,8 +49,7 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 		this.globalOrderer = createGlobalOrderer(configuration);
 		this.noOrderAnnotation = issueReporter.createReportingCondition(
 			testDescriptor -> !isAnnotated(testDescriptor.getTestClass(), Order.class), testDescriptor -> {
-				String message = String.format(
-					"Ineffective @Order annotation on class '%s'. It will not be applied because ClassOrderer.OrderAnnotation is not in use.",
+				String message = "Ineffective @Order annotation on class '%s'. It will not be applied because ClassOrderer.OrderAnnotation is not in use.".formatted(
 					testDescriptor.getTestClass().getName());
 				return DiscoveryIssue.builder(Severity.INFO, message) //
 						.source(ClassSource.from(testDescriptor.getTestClass())) //
@@ -132,11 +131,9 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 		Consumer<List<DefaultClassDescriptor>> orderingAction = classDescriptors -> classOrderer.orderClasses(
 			new DefaultClassOrdererContext(classDescriptors, this.configuration));
 
-		MessageGenerator descriptorsAddedMessageGenerator = number -> String.format(
-			"ClassOrderer [%s] added %s ClassDescriptor(s) which will be ignored.", classOrderer.getClass().getName(),
-			number);
-		MessageGenerator descriptorsRemovedMessageGenerator = number -> String.format(
-			"ClassOrderer [%s] removed %s ClassDescriptor(s) which will be retained with arbitrary ordering.",
+		MessageGenerator descriptorsAddedMessageGenerator = number -> "ClassOrderer [%s] added %s ClassDescriptor(s) which will be ignored.".formatted(
+			classOrderer.getClass().getName(), number);
+		MessageGenerator descriptorsRemovedMessageGenerator = number -> "ClassOrderer [%s] removed %s ClassDescriptor(s) which will be retained with arbitrary ordering.".formatted(
 			classOrderer.getClass().getName(), number);
 
 		return new DescriptorWrapperOrderer<>(classOrderer, orderingAction, descriptorsAddedMessageGenerator,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassOrderingVisitor.java
@@ -116,8 +116,7 @@ class ClassOrderingVisitor extends AbstractOrderingVisitor {
 				.map(this::createDescriptorWrapperOrderer)//
 				.orElseGet(() -> {
 					Object parent = classBasedTestDescriptor.getParent().orElse(null);
-					if (parent instanceof ClassBasedTestDescriptor) {
-						ClassBasedTestDescriptor parentClassTestDescriptor = (ClassBasedTestDescriptor) parent;
+					if (parent instanceof ClassBasedTestDescriptor parentClassTestDescriptor) {
 						DescriptorWrapperOrderer<ClassOrderer, DefaultClassDescriptor> cacheEntry = ordererCache.get(
 							parentClassTestDescriptor);
 						return cacheEntry != null ? cacheEntry : createClassLevelOrderer(parentClassTestDescriptor);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
@@ -155,12 +155,12 @@ class ClassSelectorResolver implements SelectorResolver {
 	@Override
 	public Resolution resolve(IterationSelector selector, Context context) {
 		DiscoverySelector parentSelector = selector.getParentSelector();
-		if (parentSelector instanceof ClassSelector
-				&& this.predicates.isAnnotatedWithClassTemplate.test(((ClassSelector) parentSelector).getJavaClass())) {
+		if (parentSelector instanceof ClassSelector classSelector
+				&& this.predicates.isAnnotatedWithClassTemplate.test(classSelector.getJavaClass())) {
 			return resolveIterations(selector, context);
 		}
-		if (parentSelector instanceof NestedClassSelector && this.predicates.isAnnotatedWithClassTemplate.test(
-			((NestedClassSelector) parentSelector).getNestedClass())) {
+		if (parentSelector instanceof NestedClassSelector nestedClassSelector
+				&& this.predicates.isAnnotatedWithClassTemplate.test(nestedClassSelector.getNestedClass())) {
 			return resolveIterations(selector, context);
 		}
 		return unresolved();
@@ -283,8 +283,7 @@ class ClassSelectorResolver implements SelectorResolver {
 	private Supplier<Set<? extends DiscoverySelector>> expansionCallback(TestDescriptor testDescriptor,
 			Supplier<List<Class<?>>> testClassesSupplier) {
 		return () -> {
-			if (testDescriptor instanceof Filterable) {
-				Filterable filterable = (Filterable) testDescriptor;
+			if (testDescriptor instanceof Filterable filterable) {
 				filterable.getDynamicDescendantFilter().allowAll();
 			}
 			List<Class<?>> testClasses = testClassesSupplier.get();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
@@ -113,8 +113,7 @@ class ClassSelectorResolver implements SelectorResolver {
 			}
 		}
 		else if (isInnerClass(nestedClass) && predicates.looksLikeIntendedTestClass(nestedClass)) {
-			String message = String.format(
-				"Inner class '%s' looks like it was intended to be a test class but will not be executed. It must be static or annotated with @Nested.",
+			String message = "Inner class '%s' looks like it was intended to be a test class but will not be executed. It must be static or annotated with @Nested.".formatted(
 				nestedClass.getName());
 			issueReporter.reportIssue(DiscoveryIssue.builder(Severity.WARNING, message) //
 					.source(ClassSource.from(nestedClass)));

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
@@ -172,8 +172,7 @@ class ClassSelectorResolver implements SelectorResolver {
 				.map(index -> context.addToParent(() -> parentSelector,
 					parent -> Optional.of(newDummyClassTemplateInvocationTestDescriptor(parent, index + 1)))) //
 				.map(this::toInvocationMatch) //
-				.filter(Optional::isPresent) //
-				.map(Optional::get) //
+				.flatMap(Optional::stream) //
 				.collect(toSet());
 		return matches.isEmpty() ? unresolved() : Resolution.matches(matches);
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolver.java
@@ -47,8 +47,8 @@ public class DiscoverySelectorResolver {
 				new ClassOrderingVisitor(getConfiguration(ctx), ctx.getIssueReporter()), //
 				new MethodOrderingVisitor(getConfiguration(ctx), ctx.getIssueReporter()), //
 				descriptor -> {
-					if (descriptor instanceof Validatable) {
-						((Validatable) descriptor).validate(ctx.getIssueReporter());
+					if (descriptor instanceof Validatable validatable) {
+						validatable.validate(ctx.getIssueReporter());
 					}
 				})) //
 			.build();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodFinder.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodFinder.java
@@ -30,7 +30,7 @@ class MethodFinder {
 		Matcher matcher = METHOD_PATTERN.matcher(methodSpecPart);
 
 		Preconditions.condition(matcher.matches(),
-			() -> String.format("Method [%s] does not match pattern [%s]", methodSpecPart, METHOD_PATTERN));
+			() -> "Method [%s] does not match pattern [%s]".formatted(methodSpecPart, METHOD_PATTERN));
 
 		String methodName = matcher.group(1);
 		String parameterTypeNames = matcher.group(2);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodOrderingVisitor.java
@@ -45,8 +45,7 @@ class MethodOrderingVisitor extends AbstractOrderingVisitor {
 		this.configuration = configuration;
 		this.noOrderAnnotation = issueReporter.createReportingCondition(
 			testDescriptor -> !isAnnotated(testDescriptor.getTestMethod(), Order.class), testDescriptor -> {
-				String message = String.format(
-					"Ineffective @Order annotation on method '%s'. It will not be applied because MethodOrderer.OrderAnnotation is not in use.",
+				String message = "Ineffective @Order annotation on method '%s'. It will not be applied because MethodOrderer.OrderAnnotation is not in use.".formatted(
 					testDescriptor.getTestMethod().toGenericString());
 				return DiscoveryIssue.builder(Severity.INFO, message) //
 						.source(MethodSource.from(testDescriptor.getTestMethod())) //
@@ -112,11 +111,9 @@ class MethodOrderingVisitor extends AbstractOrderingVisitor {
 		Consumer<List<DefaultMethodDescriptor>> orderingAction = methodDescriptors -> methodOrderer.orderMethods(
 			new DefaultMethodOrdererContext(testClass, methodDescriptors, this.configuration));
 
-		MessageGenerator descriptorsAddedMessageGenerator = number -> String.format(
-			"MethodOrderer [%s] added %s MethodDescriptor(s) for test class [%s] which will be ignored.",
+		MessageGenerator descriptorsAddedMessageGenerator = number -> "MethodOrderer [%s] added %s MethodDescriptor(s) for test class [%s] which will be ignored.".formatted(
 			methodOrderer.getClass().getName(), number, testClass.getName());
-		MessageGenerator descriptorsRemovedMessageGenerator = number -> String.format(
-			"MethodOrderer [%s] removed %s MethodDescriptor(s) for test class [%s] which will be retained with arbitrary ordering.",
+		MessageGenerator descriptorsRemovedMessageGenerator = number -> "MethodOrderer [%s] removed %s MethodDescriptor(s) for test class [%s] which will be retained with arbitrary ordering.".formatted(
 			methodOrderer.getClass().getName(), number, testClass.getName());
 
 		return new DescriptorWrapperOrderer<>(methodOrderer, orderingAction, descriptorsAddedMessageGenerator,

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
@@ -95,8 +95,7 @@ class MethodSelectorResolver implements SelectorResolver {
 		// @formatter:off
 		Set<Match> matches = methodTypes.stream()
 				.map(methodType -> methodType.resolve(enclosingClasses, testClass, method, context, configuration))
-				.filter(Optional::isPresent)
-				.map(Optional::get)
+				.flatMap(Optional::stream)
 				.map(testDescriptor -> matchFactory.apply(testDescriptor, expansionCallback(testDescriptor)))
 				.collect(toSet());
 		// @formatter:on
@@ -119,8 +118,7 @@ class MethodSelectorResolver implements SelectorResolver {
 		// @formatter:off
 		return methodTypes.stream()
 				.map(methodType -> methodType.resolveUniqueIdIntoTestDescriptor(uniqueId, context, configuration))
-				.filter(Optional::isPresent)
-				.map(Optional::get)
+				.flatMap(Optional::stream)
 				.map(testDescriptor -> {
 					boolean exactMatch = uniqueId.equals(testDescriptor.getUniqueId());
 					if (testDescriptor instanceof Filterable) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
@@ -236,7 +236,7 @@ class MethodSelectorResolver implements SelectorResolver {
 		}
 
 		private UniqueId createUniqueId(Method method, TestDescriptor parent) {
-			String methodId = String.format("%s(%s)", method.getName(),
+			String methodId = "%s(%s)".formatted(method.getName(),
 				ClassUtils.nullSafeToString(method.getParameterTypes()));
 			return parent.getUniqueId().append(segmentType, methodId);
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
@@ -121,8 +121,7 @@ class MethodSelectorResolver implements SelectorResolver {
 				.flatMap(Optional::stream)
 				.map(testDescriptor -> {
 					boolean exactMatch = uniqueId.equals(testDescriptor.getUniqueId());
-					if (testDescriptor instanceof Filterable) {
-						Filterable filterable = (Filterable) testDescriptor;
+					if (testDescriptor instanceof Filterable filterable) {
 						if (exactMatch) {
 							filterable.getDynamicDescendantFilter().allowAll();
 						}
@@ -143,8 +142,7 @@ class MethodSelectorResolver implements SelectorResolver {
 			MethodSelector methodSelector = (MethodSelector) selector.getParentSelector();
 			return resolve(context, emptyList(), methodSelector.getJavaClass(), methodSelector::getJavaMethod,
 				(testDescriptor, childSelectorsSupplier) -> {
-					if (testDescriptor instanceof Filterable) {
-						Filterable filterable = (Filterable) testDescriptor;
+					if (testDescriptor instanceof Filterable filterable) {
 						filterable.getDynamicDescendantFilter().allowIndex(selector.getIterationIndices());
 					}
 					return Match.partial(testDescriptor, childSelectorsSupplier);
@@ -155,8 +153,7 @@ class MethodSelectorResolver implements SelectorResolver {
 
 	private Supplier<Set<? extends DiscoverySelector>> expansionCallback(TestDescriptor testDescriptor) {
 		return () -> {
-			if (testDescriptor instanceof Filterable) {
-				Filterable filterable = (Filterable) testDescriptor;
+			if (testDescriptor instanceof Filterable filterable) {
 				filterable.getDynamicDescendantFilter().allowAll();
 			}
 			return emptySet();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -40,8 +40,7 @@ import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
 @API(status = INTERNAL, since = "5.0")
 public class IsTestFactoryMethod extends IsTestableMethod {
 
-	private static final String EXPECTED_RETURN_TYPE_MESSAGE = String.format(
-		"must return a single %1$s or a Stream, Collection, Iterable, Iterator, Iterator provider, or array of %1$s",
+	private static final String EXPECTED_RETURN_TYPE_MESSAGE = "must return a single %1$s or a Stream, Collection, Iterable, Iterator, Iterator provider, or array of %1$s".formatted(
 		DynamicNode.class.getName());
 
 	public IsTestFactoryMethod(DiscoveryIssueReporter issueReporter) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -69,20 +69,19 @@ public class IsTestFactoryMethod extends IsTestableMethod {
 	private static boolean isCompatibleContainerType(Method method, DiscoveryIssueReporter issueReporter) {
 		Type genericReturnType = getGenericReturnType(method);
 
-		if (genericReturnType instanceof ParameterizedType) {
-			Type[] typeArguments = ((ParameterizedType) genericReturnType).getActualTypeArguments();
+		if (genericReturnType instanceof ParameterizedType type) {
+			Type[] typeArguments = type.getActualTypeArguments();
 			if (typeArguments.length == 1) {
 				Type typeArgument = typeArguments[0];
-				if (typeArgument instanceof Class) {
+				if (typeArgument instanceof Class<?> clazz) {
 					// Stream<DynamicNode> etc.
-					return DynamicNode.class.isAssignableFrom((Class<?>) typeArgument);
+					return DynamicNode.class.isAssignableFrom(clazz);
 				}
-				if (typeArgument instanceof WildcardType) {
-					WildcardType wildcardType = (WildcardType) typeArgument;
+				if (typeArgument instanceof WildcardType wildcardType) {
 					Type[] upperBounds = wildcardType.getUpperBounds();
 					Type[] lowerBounds = wildcardType.getLowerBounds();
-					if (upperBounds.length == 1 && lowerBounds.length == 0 && upperBounds[0] instanceof Class) {
-						Class<?> upperBound = (Class<?>) upperBounds[0];
+					if (upperBounds.length == 1 && lowerBounds.length == 0
+							&& upperBounds[0] instanceof Class<?> upperBound) {
 						if (Object.class.equals(upperBound)) { // Stream<?> etc.
 							issueReporter.reportIssue(createTooGenericReturnTypeIssue(method));
 							return true;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -77,7 +77,7 @@ abstract class IsTestableMethod implements Predicate<Method> {
 
 	protected static DiscoveryIssue createIssue(Class<? extends Annotation> annotationType, Method method,
 			String condition) {
-		String message = String.format("@%s method '%s' %s. It will not be executed.", annotationType.getSimpleName(),
+		String message = "@%s method '%s' %s. It will not be executed.".formatted(annotationType.getSimpleName(),
 			method.toGenericString(), condition);
 		return DiscoveryIssue.builder(Severity.WARNING, message) //
 				.source(MethodSource.from(method)) //

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicates.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicates.java
@@ -126,7 +126,7 @@ public class TestClassPredicates {
 	}
 
 	private static DiscoveryIssue createIssue(String prefix, Class<?> testClass, String detailMessage) {
-		String message = String.format("%s class '%s' %s. It will not be executed.", prefix, testClass.getName(),
+		String message = "%s class '%s' %s. It will not be executed.".formatted(prefix, testClass.getName(),
 			detailMessage);
 		return DiscoveryIssue.builder(DiscoveryIssue.Severity.WARNING, message) //
 				.source(ClassSource.from(testClass)) //

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ConditionEvaluationException.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ConditionEvaluationException.java
@@ -10,6 +10,8 @@
 
 package org.junit.jupiter.engine.execution;
 
+import java.io.Serial;
+
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.platform.commons.JUnitException;
 
@@ -22,6 +24,7 @@ import org.junit.platform.commons.JUnitException;
  */
 class ConditionEvaluationException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public ConditionEvaluationException(String message, Throwable cause) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ConditionEvaluator.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ConditionEvaluator.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.engine.execution;
 
-import static java.lang.String.format;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
@@ -71,14 +70,14 @@ public class ConditionEvaluator {
 	}
 
 	private void logResult(Class<?> conditionType, ConditionEvaluationResult result, ExtensionContext context) {
-		logger.trace(() -> format("Evaluation of condition [%s] on [%s] resulted in: %s", conditionType.getName(),
+		logger.trace(() -> "Evaluation of condition [%s] on [%s] resulted in: %s".formatted(conditionType.getName(),
 			context.getElement().orElse(null), result));
 	}
 
 	private ConditionEvaluationException evaluationException(Class<?> conditionType, Exception ex) {
 		String cause = StringUtils.isNotBlank(ex.getMessage()) ? ": " + ex.getMessage() : "";
 		return new ConditionEvaluationException(
-			format("Failed to evaluate condition [%s]%s", conditionType.getName(), cause), ex);
+			"Failed to evaluate condition [%s]%s".formatted(conditionType.getName(), cause), ex);
 	}
 
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/JupiterEngineExecutionContext.java
@@ -45,9 +45,9 @@ public class JupiterEngineExecutionContext implements EngineExecutionContext {
 
 	public void close() throws Exception {
 		ExtensionContext extensionContext = getExtensionContext();
-		if (extensionContext instanceof AutoCloseable) {
+		if (extensionContext instanceof AutoCloseable closeable) {
 			try {
-				((AutoCloseable) extensionContext).close();
+				closeable.close();
 			}
 			catch (Exception e) {
 				throw new JUnitException("Failed to close extension context", e);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -135,7 +135,7 @@ public class ParameterResolutionUtils {
 
 			if (matchingResolvers.isEmpty()) {
 				throw new ParameterResolutionException(
-					String.format("No ParameterResolver registered for parameter [%s] in %s [%s].",
+					"No ParameterResolver registered for parameter [%s] in %s [%s].".formatted(
 						parameterContext.getParameter(), asLabel(executable), executable.toGenericString()));
 			}
 
@@ -146,7 +146,7 @@ public class ParameterResolutionUtils {
 						.collect(joining(", "));
 				// @formatter:on
 				throw new ParameterResolutionException(
-					String.format("Discovered multiple competing ParameterResolvers for parameter [%s] in %s [%s]: %s",
+					"Discovered multiple competing ParameterResolvers for parameter [%s] in %s [%s]: %s".formatted(
 						parameterContext.getParameter(), asLabel(executable), executable.toGenericString(), resolvers));
 			}
 
@@ -154,10 +154,10 @@ public class ParameterResolutionUtils {
 			Object value = resolver.resolveParameter(parameterContext, extensionContext.get(resolver));
 			validateResolvedType(parameterContext.getParameter(), value, executable, resolver);
 
-			logger.trace(() -> String.format(
-				"ParameterResolver [%s] resolved a value of type [%s] for parameter [%s] in %s [%s].",
-				resolver.getClass().getName(), (value != null ? value.getClass().getName() : null),
-				parameterContext.getParameter(), asLabel(executable), executable.toGenericString()));
+			logger.trace(
+				() -> "ParameterResolver [%s] resolved a value of type [%s] for parameter [%s] in %s [%s].".formatted(
+					resolver.getClass().getName(), (value != null ? value.getClass().getName() : null),
+					parameterContext.getParameter(), asLabel(executable), executable.toGenericString()));
 
 			return value;
 		}
@@ -167,8 +167,8 @@ public class ParameterResolutionUtils {
 		catch (Throwable throwable) {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 
-			String message = String.format("Failed to resolve parameter [%s] in %s [%s]",
-				parameterContext.getParameter(), asLabel(executable), executable.toGenericString());
+			String message = "Failed to resolve parameter [%s] in %s [%s]".formatted(parameterContext.getParameter(),
+				asLabel(executable), executable.toGenericString());
 
 			if (StringUtils.isNotBlank(throwable.getMessage())) {
 				message += ": " + throwable.getMessage();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/AutoCloseExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/AutoCloseExtension.java
@@ -75,7 +75,7 @@ class AutoCloseExtension implements TestInstancePreDestroyCallback, AfterAllCall
 
 		Object fieldValue = ReflectionSupport.tryToReadFieldValue(field, testInstance).get();
 		if (fieldValue == null) {
-			logger.warn(() -> String.format("Cannot @AutoClose field %s because it is null.", getQualifiedName(field)));
+			logger.warn(() -> "Cannot @AutoClose field %s because it is null.".formatted(getQualifiedName(field)));
 		}
 		else {
 			invokeCloseMethod(field, fieldValue, methodName.trim());
@@ -92,15 +92,15 @@ class AutoCloseExtension implements TestInstancePreDestroyCallback, AfterAllCall
 		Class<?> targetType = target.getClass();
 		Method closeMethod = ReflectionSupport.findMethod(targetType, methodName).orElseThrow(
 			() -> new ExtensionConfigurationException(
-				String.format("Cannot @AutoClose field %s because %s does not define method %s().",
-					getQualifiedName(field), targetType.getName(), methodName)));
+				"Cannot @AutoClose field %s because %s does not define method %s().".formatted(getQualifiedName(field),
+					targetType.getName(), methodName)));
 
 		closeMethod = ReflectionUtils.getInterfaceMethodIfPossible(closeMethod, targetType);
 		ReflectionSupport.invokeMethod(closeMethod, target);
 	}
 
 	private static void checkCondition(boolean condition, String messageFormat, Field field) {
-		Preconditions.condition(condition, () -> String.format(messageFormat, getQualifiedName(field)));
+		Preconditions.condition(condition, () -> messageFormat.formatted(getQualifiedName(field)));
 	}
 
 	private static String getQualifiedName(Field field) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/AutoCloseExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/AutoCloseExtension.java
@@ -84,8 +84,8 @@ class AutoCloseExtension implements TestInstancePreDestroyCallback, AfterAllCall
 
 	private static void invokeCloseMethod(Field field, Object target, String methodName) throws Exception {
 		// Avoid reflection if we can directly invoke close() via AutoCloseable.
-		if (target instanceof AutoCloseable && "close".equals(methodName)) {
-			((AutoCloseable) target).close();
+		if (target instanceof AutoCloseable closeable && "close".equals(methodName)) {
+			closeable.close();
 			return;
 		}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -167,8 +167,7 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		this.lateInitExtensions = new LinkedHashMap<>();
 		registeredExtensions.forEach(entry -> {
 			Entry newEntry = entry;
-			if (entry instanceof LateInitEntry) {
-				LateInitEntry lateInitEntry = (LateInitEntry) entry;
+			if (entry instanceof LateInitEntry lateInitEntry) {
 				newEntry = lateInitEntry.getExtension() //
 						.map(Entry::of) //
 						.orElseGet(() -> getLateInitExtensions(lateInitEntry.getTestClass()).add(lateInitEntry.copy()));
@@ -271,8 +270,7 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		if (source == null) {
 			return "";
 		}
-		if (source instanceof Member) {
-			Member member = (Member) source;
+		if (source instanceof Member member) {
 			Object type = (member instanceof Method ? "method" : "field");
 			source = "%s %s.%s".formatted(type, member.getDeclaringClass().getName(), member.getName());
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -124,8 +124,8 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 					.map(Class::getName)
 					.collect(Collectors.toList());
 			// @formatter:on
-			logger.config(() -> String.format(
-				"Excluded auto-detected extensions due to configured includes/excludes: %s", excludeExtensionNames));
+			logger.config(() -> "Excluded auto-detected extensions due to configured includes/excludes: %s".formatted(
+				excludeExtensionNames));
 		}
 	}
 
@@ -218,8 +218,8 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		Preconditions.notNull(source, "source must not be null");
 		Preconditions.notNull(initializer, "initializer must not be null");
 
-		logger.trace(() -> String.format("Registering local extension (late-init) for [%s]%s",
-			source.getType().getName(), buildSourceInfo(source)));
+		logger.trace(() -> "Registering local extension (late-init) for [%s]%s".formatted(source.getType().getName(),
+			buildSourceInfo(source)));
 
 		LateInitEntry entry = getLateInitExtensions(testClass) //
 				.add(new LateInitEntry(testClass, initializer));
@@ -261,8 +261,7 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		Preconditions.notBlank(category, "category must not be null or blank");
 		Preconditions.notNull(extension, "extension must not be null");
 
-		logger.trace(
-			() -> String.format("Registering %s extension [%s]%s", category, extension, buildSourceInfo(source)));
+		logger.trace(() -> "Registering %s extension [%s]%s".formatted(category, extension, buildSourceInfo(source)));
 
 		this.registeredExtensions.add(Entry.of(extension));
 		this.registeredExtensionTypes.add(extension.getClass());
@@ -275,7 +274,7 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		if (source instanceof Member) {
 			Member member = (Member) source;
 			Object type = (member instanceof Method ? "method" : "field");
-			source = String.format("%s %s.%s", type, member.getDeclaringClass().getName(), member.getName());
+			source = "%s %s.%s".formatted(type, member.getDeclaringClass().getName(), member.getName());
 		}
 		return " from source [" + source + "]";
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -312,12 +312,12 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		}
 
 		void initialize(Object testInstance) {
-			Preconditions.condition(!extension.isPresent(), "Extension already initialized");
+			Preconditions.condition(extension.isEmpty(), "Extension already initialized");
 			extension = Optional.of(initializer.apply(testInstance));
 		}
 
 		LateInitEntry copy() {
-			Preconditions.condition(!extension.isPresent(), "Extension already initialized");
+			Preconditions.condition(extension.isEmpty(), "Extension already initialized");
 			return new LateInitEntry(testClass, initializer);
 		}
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
@@ -57,8 +57,9 @@ class RepeatedTestExtension implements TestTemplateInvocationContextProvider {
 
 	private int totalRepetitions(RepeatedTest repeatedTest, Method method) {
 		int repetitions = repeatedTest.value();
-		Preconditions.condition(repetitions > 0, () -> String.format(
-			"Configuration error: @RepeatedTest on method [%s] must be declared with a positive 'value'.", method));
+		Preconditions.condition(repetitions > 0,
+			() -> "Configuration error: @RepeatedTest on method [%s] must be declared with a positive 'value'.".formatted(
+				method));
 		return repetitions;
 	}
 
@@ -76,8 +77,9 @@ class RepeatedTestExtension implements TestTemplateInvocationContextProvider {
 
 	private RepeatedTestDisplayNameFormatter displayNameFormatter(RepeatedTest repeatedTest, Method method,
 			String displayName) {
-		String pattern = Preconditions.notBlank(repeatedTest.name().trim(), () -> String.format(
-			"Configuration error: @RepeatedTest on method [%s] must be declared with a non-empty name.", method));
+		String pattern = Preconditions.notBlank(repeatedTest.name().trim(),
+			() -> "Configuration error: @RepeatedTest on method [%s] must be declared with a non-empty name.".formatted(
+				method));
 		return new RepeatedTestDisplayNameFormatter(pattern, displayName);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -344,12 +344,10 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		 * @since 5.12
 		 */
 		private static String descriptionFor(AnnotatedElement annotatedElement) {
-			if (annotatedElement instanceof Field) {
-				Field field = (Field) annotatedElement;
+			if (annotatedElement instanceof Field field) {
 				return "field " + field.getDeclaringClass().getSimpleName() + "." + field.getName();
 			}
-			if (annotatedElement instanceof Parameter) {
-				Parameter parameter = (Parameter) annotatedElement;
+			if (annotatedElement instanceof Parameter parameter) {
 				Executable executable = parameter.getDeclaringExecutable();
 				return "parameter '" + parameter.getName() + "' in " + descriptionFor(executable);
 			}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -36,7 +36,6 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributeView;
@@ -514,7 +513,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		}
 
 		private IOException createIOExceptionWithAttachedFailures(SortedMap<Path, IOException> failures) {
-			Path emptyPath = Paths.get("");
+			Path emptyPath = Path.of("");
 			String joinedPaths = failures.keySet().stream() //
 					.map(this::tryToDeleteOnExit) //
 					.map(this::relativizeSafely) //

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -311,7 +311,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 			try {
 				if (this.cleanupMode == NEVER
 						|| (this.cleanupMode == ON_SUCCESS && selfOrChildFailed(this.extensionContext))) {
-					LOGGER.info(() -> String.format("Skipping cleanup of temp dir %s for %s due to CleanupMode.%s.",
+					LOGGER.info(() -> "Skipping cleanup of temp dir %s for %s due to CleanupMode.%s.".formatted(
 						this.dir, descriptionFor(this.annotatedElement), this.cleanupMode.name()));
 					return;
 				}
@@ -364,7 +364,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 			boolean isConstructor = executable instanceof Constructor<?>;
 			String type = isConstructor ? "constructor" : "method";
 			String name = isConstructor ? executable.getDeclaringClass().getSimpleName() : executable.getName();
-			return String.format("%s %s(%s)", type, name,
+			return "%s %s(%s)".formatted(type, name,
 				ClassUtils.nullSafeToString(Class::getSimpleName, executable.getParameterTypes()));
 		}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutConfiguration.java
@@ -105,7 +105,7 @@ class TimeoutConfiguration {
 			}
 			catch (Exception e) {
 				logger.warn(e,
-					() -> String.format("Ignored invalid timeout '%s' set via the '%s' configuration parameter.", value,
+					() -> "Ignored invalid timeout '%s' set via the '%s' configuration parameter.".formatted(value,
 						key));
 				return null;
 			}
@@ -128,17 +128,17 @@ class TimeoutConfiguration {
 			try {
 				ThreadMode threadMode = ThreadMode.valueOf(value.toUpperCase());
 				if (threadMode == ThreadMode.INFERRED) {
-					logger.warn(() -> String.format(
-						"Invalid timeout thread mode '%s', only %s and %s can be used as configuration parameter for %s.",
-						value, SAME_THREAD, SEPARATE_THREAD, DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME));
+					logger.warn(
+						() -> "Invalid timeout thread mode '%s', only %s and %s can be used as configuration parameter for %s.".formatted(
+							value, SAME_THREAD, SEPARATE_THREAD, DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME));
 					return null;
 				}
 				return threadMode;
 			}
 			catch (Exception e) {
 				logger.warn(e,
-					() -> String.format("Invalid timeout thread mode '%s' set via the '%s' configuration parameter.",
-						value, DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME));
+					() -> "Invalid timeout thread mode '%s' set via the '%s' configuration parameter.".formatted(value,
+						DEFAULT_TIMEOUT_THREAD_MODE_PROPERTY_NAME));
 				return null;
 			}
 		});

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExceptionFactory.java
@@ -23,7 +23,7 @@ class TimeoutExceptionFactory {
 	}
 
 	static TimeoutException create(String methodSignature, TimeoutDuration timeoutDuration, Throwable failure) {
-		String message = String.format("%s timed out after %s",
+		String message = "%s timed out after %s".formatted(
 			Preconditions.notNull(methodSignature, "method signature must not be null"),
 			Preconditions.notNull(timeoutDuration, "timeout duration must not be null"));
 		TimeoutException timeoutException = new TimeoutException(message);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutExtension.java
@@ -202,7 +202,7 @@ class TimeoutExtension implements BeforeAllCallback, BeforeEachCallback, Invocat
 		Method method = invocationContext.getExecutable();
 		Optional<Class<?>> testClass = extensionContext.getTestClass();
 		if (testClass.isPresent() && invocationContext.getTargetClass().equals(testClass.get())) {
-			return String.format("%s(%s)", method.getName(), ClassUtils.nullSafeToString(method.getParameterTypes()));
+			return "%s(%s)".formatted(method.getName(), ClassUtils.nullSafeToString(method.getParameterTypes()));
 		}
 		return ReflectionUtils.getFullyQualifiedMethodName(invocationContext.getTargetClass(), method);
 	}

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/adapter/AbstractTestRuleAdapter.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/adapter/AbstractTestRuleAdapter.java
@@ -43,7 +43,7 @@ public abstract class AbstractTestRuleAdapter implements GenericBeforeAndAfterAd
 
 	protected Object executeMethod(String methodName, Class<?>[] parameterTypes, Object... arguments) {
 		Method method = findMethod(this.target.getClass(), methodName, parameterTypes).orElseThrow(
-			() -> new JUnitException(String.format("Failed to find method %s(%s) in class %s", methodName,
+			() -> new JUnitException("Failed to find method %s(%s) in class %s".formatted(methodName,
 				ClassUtils.nullSafeToString(parameterTypes), this.target.getClass().getName())));
 
 		return invokeMethod(method, this.target, arguments);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ArgumentCountValidator.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ArgumentCountValidator.java
@@ -45,12 +45,12 @@ class ArgumentCountValidator {
 				int consumedCount = this.declarationContext.getResolverFacade().determineConsumedArgumentCount(
 					this.arguments);
 				int totalCount = this.arguments.getTotalLength();
-				Preconditions.condition(consumedCount == totalCount, () -> String.format(
-					"Configuration error: @%s consumes %s %s but there %s %s %s provided.%nNote: the provided arguments were %s",
-					this.declarationContext.getAnnotationName(), consumedCount,
-					pluralize(consumedCount, "parameter", "parameters"), pluralize(totalCount, "was", "were"),
-					totalCount, pluralize(totalCount, "argument", "arguments"),
-					Arrays.toString(this.arguments.getAllPayloads())));
+				Preconditions.condition(consumedCount == totalCount,
+					() -> "Configuration error: @%s consumes %s %s but there %s %s %s provided.%nNote: the provided arguments were %s".formatted(
+						this.declarationContext.getAnnotationName(), consumedCount,
+						pluralize(consumedCount, "parameter", "parameters"), pluralize(totalCount, "was", "were"),
+						totalCount, pluralize(totalCount, "argument", "arguments"),
+						Arrays.toString(this.arguments.getAllPayloads())));
 				break;
 			default:
 				throw new ExtensionConfigurationException(
@@ -80,9 +80,9 @@ class ArgumentCountValidator {
 					ArgumentCountValidationMode.values()).filter(
 						mode -> mode.name().equalsIgnoreCase(configValue)).findFirst();
 				if (enumValue.isPresent()) {
-					logger.config(() -> String.format(
-						"Using ArgumentCountValidationMode '%s' set via the '%s' configuration parameter.",
-						enumValue.get().name(), key));
+					logger.config(
+						() -> "Using ArgumentCountValidationMode '%s' set via the '%s' configuration parameter.".formatted(
+							enumValue.get().name(), key));
 					return enumValue.get();
 				}
 				else {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
@@ -86,7 +86,7 @@ class EvaluatedArgumentSet {
 
 	private static Object[] dropSurplus(Object[] arguments, int newLength) {
 		Preconditions.condition(newLength <= arguments.length,
-			() -> String.format("New length %d must be less than or equal to the total length %d", newLength,
+			() -> "New length %d must be less than or equal to the total length %d".formatted(newLength,
 				arguments.length));
 		return arguments.length > newLength ? Arrays.copyOf(arguments, newLength) : arguments;
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/EvaluatedArgumentSet.java
@@ -92,8 +92,8 @@ class EvaluatedArgumentSet {
 	}
 
 	private static Optional<String> determineName(Arguments arguments) {
-		if (arguments instanceof ArgumentSet) {
-			return Optional.of(((ArgumentSet) arguments).getName());
+		if (arguments instanceof ArgumentSet set) {
+			return Optional.of(set.getName());
 		}
 		return Optional.empty();
 	}
@@ -105,7 +105,7 @@ class EvaluatedArgumentSet {
 	}
 
 	private static Object extractFromNamed(Object argument, Function<Named<?>, Object> mapper) {
-		return argument instanceof Named ? mapper.apply((Named<?>) argument) : argument;
+		return argument instanceof Named<?> named ? mapper.apply(named) : argument;
 	}
 
 }

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClassExtension.java
@@ -97,7 +97,7 @@ class ParameterizedClassExtension extends ParameterizedInvocationContextProvider
 
 		Optional<ParameterizedClass> annotation = findAnnotation(extensionContext.getTestClass(),
 			ParameterizedClass.class);
-		if (!annotation.isPresent()) {
+		if (annotation.isEmpty()) {
 			return false;
 		}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationContextProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationContextProvider.java
@@ -55,8 +55,7 @@ class ParameterizedInvocationContextProvider<T> {
 	private static <T> void validateInvokedAtLeastOnce(long invocationCount,
 			ParameterizedDeclarationContext<T> declarationContext) {
 		if (invocationCount == 0 && !declarationContext.isAllowingZeroInvocations()) {
-			String message = String.format(
-				"Configuration error: You must configure at least one set of arguments for this @%s",
+			String message = "Configuration error: You must configure at least one set of arguments for this @%s".formatted(
 				declarationContext.getAnnotationName());
 			throw new TemplateInvocationValidationException(message);
 		}
@@ -67,7 +66,7 @@ class ParameterizedInvocationContextProvider<T> {
 			ArgumentsSource.class);
 
 		Preconditions.notEmpty(argumentsSources,
-			() -> String.format("Configuration error: You must configure at least one arguments source for this @%s",
+			() -> "Configuration error: You must configure at least one arguments source for this @%s".formatted(
 				declarationContext.getAnnotationName()));
 
 		return argumentsSources;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
@@ -59,10 +59,10 @@ class ParameterizedInvocationNameFormatter {
 				? extensionContext.getConfigurationParameter(DISPLAY_NAME_PATTERN_KEY) //
 						.orElse(DEFAULT_DISPLAY_NAME_PATTERN)
 				: name;
-		pattern = Preconditions.notBlank(pattern.trim(), () -> String.format(
-			"Configuration error: @%s on %s must be declared with a non-empty name.",
-			declarationContext.getAnnotationName(),
-			declarationContext.getResolverFacade().getIndexedParameterDeclarations().getSourceElementDescription()));
+		pattern = Preconditions.notBlank(pattern.trim(),
+			() -> "Configuration error: @%s on %s must be declared with a non-empty name.".formatted(
+				declarationContext.getAnnotationName(),
+				declarationContext.getResolverFacade().getIndexedParameterDeclarations().getSourceElementDescription()));
 
 		int argumentMaxLength = extensionContext.getConfigurationParameter(ARGUMENT_MAX_LENGTH_KEY, Integer::parseInt) //
 				.orElse(512);
@@ -243,9 +243,9 @@ class ParameterizedInvocationNameFormatter {
 				result.append(context.argumentSetName.get());
 				return;
 			}
-			throw new ExtensionConfigurationException(String.format(
-				"When the display name pattern for a @%s contains %s, the arguments must be supplied as an ArgumentSet.",
-				this.annotationName, ARGUMENT_SET_NAME_PLACEHOLDER));
+			throw new ExtensionConfigurationException(
+				"When the display name pattern for a @%s contains %s, the arguments must be supplied as an ArgumentSet.".formatted(
+					this.annotationName, ARGUMENT_SET_NAME_PLACEHOLDER));
 		}
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestExtension.java
@@ -31,7 +31,7 @@ class ParameterizedTestExtension extends ParameterizedInvocationContextProvider<
 	@Override
 	public boolean supportsTestTemplate(ExtensionContext context) {
 		Optional<ParameterizedTest> annotation = findAnnotation(context.getTestMethod(), ParameterizedTest.class);
-		if (!annotation.isPresent()) {
+		if (annotation.isEmpty()) {
 			return false;
 		}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestSpiInstantiator.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTestSpiInstantiator.java
@@ -49,7 +49,7 @@ class ParameterizedTestSpiInstantiator {
 			Class<? extends T> implementationClass) {
 
 		Preconditions.condition(!ReflectionUtils.isInnerClass(implementationClass),
-			() -> String.format("The %s [%s] must be either a top-level class or a static nested class",
+			() -> "The %s [%s] must be either a top-level class or a static nested class".formatted(
 				spiInterface.getSimpleName(), implementationClass.getName()));
 
 		Constructor<?>[] constructors = implementationClass.getDeclaredConstructors();

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
@@ -710,7 +710,7 @@ class ResolverFacade {
 		private ParameterContext toParameterContext(ExtensionContext extensionContext,
 				Optional<ParameterContext> originalParameterContext) {
 			Optional<Object> target = originalParameterContext.flatMap(ParameterContext::getTarget);
-			if (!target.isPresent()) {
+			if (target.isEmpty()) {
 				target = extensionContext.getTestInstance();
 			}
 			return toParameterContext(target);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
@@ -592,14 +592,14 @@ class ResolverFacade {
 		}
 
 		static String describe(AnnotatedElement sourceElement) {
-			if (sourceElement instanceof Method) {
-				return String.format("method [%s]", ((Method) sourceElement).toGenericString());
+			if (sourceElement instanceof Method method) {
+				return "method [%s]".formatted(method.toGenericString());
 			}
-			if (sourceElement instanceof Constructor) {
-				return String.format("constructor [%s]", ((Constructor<?>) sourceElement).toGenericString());
+			if (sourceElement instanceof Constructor<?> constructor) {
+				return "constructor [%s]".formatted(constructor.toGenericString());
 			}
-			if (sourceElement instanceof Class) {
-				return String.format("class [%s]", ((Class<?>) sourceElement).getName());
+			if (sourceElement instanceof Class<?> clazz) {
+				return "class [%s]".formatted(clazz.getName());
 			}
 			return sourceElement.toString();
 		}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
@@ -242,7 +242,7 @@ class ResolverFacade {
 					() -> new DefaultArgumentSetLifecycleMethodParameterResolver(originalResolverFacade,
 						lifecycleMethodResolverFacade, parameterDeclarationMapping))) //
 				.getOrThrow(cause -> new ExtensionConfigurationException(
-					String.format("Invalid @%s lifecycle method declaration: %s",
+					"Invalid @%s lifecycle method declaration: %s".formatted(
 						annotation.annotationType().getSimpleName(), method.toGenericString()),
 					cause));
 	}
@@ -347,13 +347,13 @@ class ResolverFacade {
 				break;
 			}
 			if (!actualDeclaration.getParameterType().equals(originalDeclaration.getParameterType())) {
-				errors.add(String.format(
-					"parameter%s with index %d is incompatible with the parameter declared on the parameterized class: expected type '%s' but found '%s'",
-					parameterName(actualDeclaration), parameterIndex, originalDeclaration.getParameterType(),
-					actualDeclaration.getParameterType()));
+				errors.add(
+					"parameter%s with index %d is incompatible with the parameter declared on the parameterized class: expected type '%s' but found '%s'".formatted(
+						parameterName(actualDeclaration), parameterIndex, originalDeclaration.getParameterType(),
+						actualDeclaration.getParameterType()));
 			}
 			else if (findAnnotation(actualDeclaration.getAnnotatedElement(), ConvertWith.class).isPresent()) {
-				errors.add(String.format("parameter%s with index %d must not be annotated with @ConvertWith",
+				errors.add("parameter%s with index %d must not be annotated with @ConvertWith".formatted(
 					parameterName(actualDeclaration), parameterIndex));
 			}
 			else if (errors.isEmpty()) {
@@ -375,7 +375,7 @@ class ResolverFacade {
 			throw new PreconditionViolationException("Configuration error: " + errors.get(0) + ".");
 		}
 		else {
-			throw new PreconditionViolationException(String.format("%d configuration errors:%n%s", errors.size(),
+			throw new PreconditionViolationException("%d configuration errors:%n%s".formatted(errors.size(),
 				errors.stream().collect(joining(lineSeparator() + "- ", "- ", ""))));
 		}
 	}
@@ -392,7 +392,7 @@ class ResolverFacade {
 
 		for (int index = 0; index <= indexedParameters.lastKey(); index++) {
 			if (!indexedParameters.containsKey(index)) {
-				errors.add(String.format("no field annotated with @Parameter(%d) declared", index));
+				errors.add("no field annotated with @Parameter(%d) declared".formatted(index));
 			}
 		}
 	}
@@ -402,18 +402,17 @@ class ResolverFacade {
 		List<Field> fields = declarations.stream().map(FieldParameterDeclaration::getField).collect(toList());
 		if (index < 0) {
 			declarations.stream() //
-					.map(declaration -> String.format(
-						"index must be greater than or equal to zero in @Parameter(%d) annotation on field [%s]", index,
-						declaration.getField())) //
+					.map(
+						declaration -> "index must be greater than or equal to zero in @Parameter(%d) annotation on field [%s]".formatted(
+							index, declaration.getField())) //
 					.forEach(errors::add);
 		}
 		else if (declarations.size() > 1) {
-			errors.add(
-				String.format("duplicate index declared in @Parameter(%d) annotation on fields %s", index, fields));
+			errors.add("duplicate index declared in @Parameter(%d) annotation on fields %s".formatted(index, fields));
 		}
 		fields.stream() //
 				.filter(ModifierSupport::isFinal) //
-				.map(field -> String.format("@Parameter field [%s] must not be declared as final", field)) //
+				.map(field -> "@Parameter field [%s] must not be declared as final".formatted(field)) //
 				.forEach(errors::add);
 	}
 
@@ -421,9 +420,9 @@ class ResolverFacade {
 			List<String> errors) {
 		aggregatorParameters.stream() //
 				.filter(declaration -> declaration.getParameterIndex() != Parameter.UNSET_INDEX) //
-				.map(declaration -> String.format(
-					"no index may be declared in @Parameter(%d) annotation on aggregator field [%s]",
-					declaration.getParameterIndex(), declaration.getField())) //
+				.map(
+					declaration -> "no index may be declared in @Parameter(%d) annotation on aggregator field [%s]".formatted(
+						declaration.getParameterIndex(), declaration.getField())) //
 				.forEach(errors::add);
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentAccessException.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentAccessException.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.params.aggregator;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -26,6 +28,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = STABLE, since = "5.7")
 public class ArgumentAccessException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public ArgumentAccessException(String message) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAggregationException.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/ArgumentsAggregationException.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.params.aggregator;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -26,6 +28,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = STABLE, since = "5.7")
 public class ArgumentsAggregationException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public ArgumentsAggregationException(String message) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessor.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/aggregator/DefaultArgumentsAccessor.java
@@ -10,7 +10,6 @@
 
 package org.junit.jupiter.params.aggregator;
 
-import static java.lang.String.format;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Arrays;
@@ -61,7 +60,7 @@ public class DefaultArgumentsAccessor implements ArgumentsAccessor {
 	@Override
 	public Object get(int index) {
 		Preconditions.condition(index >= 0 && index < this.arguments.length,
-			() -> format("index must be >= 0 and < %d", this.arguments.length));
+			() -> "index must be >= 0 and < %d".formatted(this.arguments.length));
 		return this.arguments[index];
 	}
 
@@ -74,8 +73,7 @@ public class DefaultArgumentsAccessor implements ArgumentsAccessor {
 			return requiredType.cast(convertedValue);
 		}
 		catch (Exception ex) {
-			String message = format(
-				"Argument at index [%d] with value [%s] and type [%s] could not be converted or cast to type [%s].",
+			String message = "Argument at index [%d] with value [%s] and type [%s] could not be converted or cast to type [%s].".formatted(
 				index, value, ClassUtils.nullSafeToString(value == null ? null : value.getClass()),
 				requiredType.getName());
 			throw new ArgumentAccessException(message, ex);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ArgumentConversionException.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ArgumentConversionException.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.params.converter;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -26,6 +28,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = STABLE, since = "5.7")
 public class ArgumentConversionException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public ArgumentConversionException(String message) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -106,13 +106,13 @@ public class DefaultArgumentConverter implements ArgumentConverter {
 			return source;
 		}
 
-		if (source instanceof String) {
+		if (source instanceof String string) {
 			if (targetType == Locale.class && getLocaleConversionFormat() == LocaleConversionFormat.BCP_47) {
-				return Locale.forLanguageTag((String) source);
+				return Locale.forLanguageTag(string);
 			}
 
 			try {
-				return convert((String) source, targetType, classLoader);
+				return convert(string, targetType, classLoader);
 			}
 			catch (ConversionException ex) {
 				throw new ArgumentConversionException(ex.getMessage(), ex);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -119,9 +119,8 @@ public class DefaultArgumentConverter implements ArgumentConverter {
 			}
 		}
 
-		throw new ArgumentConversionException(
-			String.format("No built-in converter for source type %s and target type %s",
-				source.getClass().getTypeName(), targetType.getTypeName()));
+		throw new ArgumentConversionException("No built-in converter for source type %s and target type %s".formatted(
+			source.getClass().getTypeName(), targetType.getTypeName()));
 	}
 
 	private LocaleConversionFormat getLocaleConversionFormat() {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/TypedArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/TypedArgumentConverter.java
@@ -62,13 +62,12 @@ public abstract class TypedArgumentConverter<S, T> implements ArgumentConverter 
 			return convert(null);
 		}
 		if (!this.sourceType.isInstance(source)) {
-			String message = String.format(
-				"%s cannot convert objects of type [%s]. Only source objects of type [%s] are supported.",
+			String message = "%s cannot convert objects of type [%s]. Only source objects of type [%s] are supported.".formatted(
 				getClass().getSimpleName(), source.getClass().getName(), this.sourceType.getName());
 			throw new ArgumentConversionException(message);
 		}
 		if (!ReflectionUtils.isAssignableTo(this.targetType, actualTargetType)) {
-			String message = String.format("%s cannot convert to type [%s]. Only target type [%s] is supported.",
+			String message = "%s cannot convert to type [%s]. Only target type [%s] is supported.".formatted(
 				getClass().getSimpleName(), actualTargetType.getName(), this.targetType.getName());
 			throw new ArgumentConversionException(message);
 		}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsUtils.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsUtils.java
@@ -30,8 +30,8 @@ final class ArgumentsUtils {
 	 */
 	static Arguments toArguments(Object item) {
 		// Nothing to do except cast.
-		if (item instanceof Arguments) {
-			return (Arguments) item;
+		if (item instanceof Arguments arguments) {
+			return arguments;
 		}
 
 		// Pass all multidimensional arrays "as is", in contrast to Object[].
@@ -42,8 +42,8 @@ final class ArgumentsUtils {
 
 		// Special treatment for one-dimensional reference arrays.
 		// See https://github.com/junit-team/junit5/issues/1665
-		if (item instanceof Object[]) {
-			return arguments((Object[]) item);
+		if (item instanceof Object[] objects) {
+			return arguments(objects);
 		}
 
 		// Pass everything else "as is".

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -125,8 +125,7 @@ class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 		}
 
 		Preconditions.condition(!useHeadersInDisplayName || (csvRecord.length <= headers.length),
-			() -> String.format(
-				"The number of columns (%d) exceeds the number of supplied headers (%d) in CSV record: %s",
+			() -> "The number of columns (%d) exceeds the number of supplied headers (%d) in CSV record: %s".formatted(
 				csvRecord.length, headers.length, Arrays.toString(csvRecord)));
 
 		Object[] arguments = new Object[csvRecord.length];

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -149,8 +149,8 @@ class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 	 */
 	static RuntimeException handleCsvException(Throwable throwable, Annotation annotation) {
 		UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
-		if (throwable instanceof PreconditionViolationException) {
-			throw (PreconditionViolationException) throwable;
+		if (throwable instanceof PreconditionViolationException exception) {
+			throw exception;
 		}
 		throw new CsvParsingException("Failed to parse CSV input configured via " + annotation, throwable);
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -201,7 +201,7 @@ class CsvFileArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvFileS
 		public InputStream openFile(String path) {
 			Preconditions.notBlank(path, () -> "File [" + path + "] must not be null or blank");
 			try {
-				return Files.newInputStream(Paths.get(path));
+				return Files.newInputStream(Path.of(path));
 			}
 			catch (IOException e) {
 				throw new JUnitException("File [" + path + "] could not be read", e);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvParsingException.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvParsingException.java
@@ -12,6 +12,8 @@ package org.junit.jupiter.params.provider;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -25,6 +27,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = STABLE, since = "5.7")
 public class CsvParsingException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public CsvParsingException(String message) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyArgumentsProvider.java
@@ -45,7 +45,7 @@ class EmptyArgumentsProvider implements ArgumentsProvider {
 		Optional<ParameterDeclaration> firstParameter = parameters.getFirst();
 
 		Preconditions.condition(firstParameter.isPresent(),
-			() -> String.format("@EmptySource cannot provide an empty argument to %s: no formal parameters declared.",
+			() -> "@EmptySource cannot provide an empty argument to %s: no formal parameters declared.".formatted(
 				parameters.getSourceElementDescription()));
 
 		Class<?> parameterType = firstParameter.get().getParameterType();
@@ -89,7 +89,7 @@ class EmptyArgumentsProvider implements ArgumentsProvider {
 		}
 		// else
 		throw new PreconditionViolationException(
-			String.format("@EmptySource cannot provide an empty argument to %s: [%s] is not a supported type.",
+			"@EmptySource cannot provide an empty argument to %s: [%s] is not a supported type.".formatted(
 				parameters.getSourceElementDescription(), parameterType.getName()));
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumArgumentsProvider.java
@@ -56,8 +56,7 @@ class EnumArgumentsProvider extends AnnotationBasedArgumentsProvider<EnumSource>
 		E from = enumSource.from().isEmpty() ? constants[0] : Enum.valueOf(enumClass, enumSource.from());
 		E to = enumSource.to().isEmpty() ? constants[constants.length - 1] : Enum.valueOf(enumClass, enumSource.to());
 		Preconditions.condition(from.compareTo(to) <= 0,
-			() -> String.format(
-				"Invalid enum range: 'from' (%s) must come before 'to' (%s) in the natural order of enum constants.",
+			() -> "Invalid enum range: 'from' (%s) must come before 'to' (%s) in the natural order of enum constants.".formatted(
 				from, to));
 		return EnumSet.range(from, to);
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldArgumentsProvider.java
@@ -90,8 +90,8 @@ class FieldArgumentsProvider extends AnnotationBasedArgumentsProvider<FieldSourc
 				.findFirst()//
 				.orElse(null);
 
-		Preconditions.notNull(field,
-			() -> format("Could not find field named [%s] in class [%s]", resolvedFieldName, resolvedClass.getName()));
+		Preconditions.notNull(field, () -> "Could not find field named [%s] in class [%s]".formatted(resolvedFieldName,
+			resolvedClass.getName()));
 		return field;
 	}
 
@@ -106,22 +106,22 @@ class FieldArgumentsProvider extends AnnotationBasedArgumentsProvider<FieldSourc
 
 	private static Object readField(Field field, Object testInstance) {
 		Object value = ReflectionSupport.tryToReadFieldValue(field, testInstance).getOrThrow(
-			cause -> new JUnitException(format("Could not read field [%s]", field.getName()), cause));
+			cause -> new JUnitException("Could not read field [%s]".formatted(field.getName()), cause));
 
 		String fieldName = field.getName();
 		String declaringClass = field.getDeclaringClass().getName();
 
 		Preconditions.notNull(value,
-			() -> format("The value of field [%s] in class [%s] must not be null", fieldName, declaringClass));
+			() -> "The value of field [%s] in class [%s] must not be null".formatted(fieldName, declaringClass));
 
 		Preconditions.condition(!(value instanceof BaseStream),
-			() -> format("The value of field [%s] in class [%s] must not be a stream", fieldName, declaringClass));
+			() -> "The value of field [%s] in class [%s] must not be a stream".formatted(fieldName, declaringClass));
 
 		Preconditions.condition(!(value instanceof Iterator),
-			() -> format("The value of field [%s] in class [%s] must not be an Iterator", fieldName, declaringClass));
+			() -> "The value of field [%s] in class [%s] must not be an Iterator".formatted(fieldName, declaringClass));
 
 		Preconditions.condition(isConvertibleToStream(field, value),
-			() -> format("The value of field [%s] in class [%s] must be convertible to a Stream", fieldName,
+			() -> "The value of field [%s] in class [%s] must be convertible to a Stream".formatted(fieldName,
 				declaringClass));
 
 		return value;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/FieldArgumentsProvider.java
@@ -60,8 +60,8 @@ class FieldArgumentsProvider extends AnnotationBasedArgumentsProvider<FieldSourc
 				.map(field -> validateField(field, testInstance))
 				.map(field -> readField(field, testInstance))
 				.flatMap(fieldValue -> {
-					if (fieldValue instanceof Supplier<?>) {
-						fieldValue = ((Supplier<?>) fieldValue).get();
+					if (fieldValue instanceof Supplier<?> supplier) {
+						fieldValue = supplier.get();
 					}
 					return CollectionUtils.toStream(fieldValue);
 				})
@@ -141,21 +141,18 @@ class FieldArgumentsProvider extends AnnotationBasedArgumentsProvider<FieldSourc
 		// Check declared type T of Supplier<T>.
 		if (Supplier.class.isAssignableFrom(field.getType())) {
 			Type genericType = field.getGenericType();
-			if (genericType instanceof ParameterizedType) {
-				ParameterizedType parameterizedType = (ParameterizedType) genericType;
+			if (genericType instanceof ParameterizedType parameterizedType) {
 				Type[] typeArguments = parameterizedType.getActualTypeArguments();
 				if (typeArguments.length == 1) {
 					Type type = typeArguments[0];
 					// Handle cases such as Supplier<IntStream>
-					if (type instanceof Class) {
-						Class<?> clazz = (Class<?>) type;
+					if (type instanceof Class<?> clazz) {
 						return CollectionUtils.isConvertibleToStream(clazz);
 					}
 					// Handle cases such as Supplier<Stream<String>>
-					if (type instanceof ParameterizedType) {
-						Type rawType = ((ParameterizedType) type).getRawType();
-						if (rawType instanceof Class<?>) {
-							Class<?> clazz = (Class<?>) rawType;
+					if (type instanceof ParameterizedType innerParameterizedType) {
+						Type rawType = innerParameterizedType.getRawType();
+						if (rawType instanceof Class<?> clazz) {
 							return CollectionUtils.isConvertibleToStream(clazz);
 						}
 					}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -80,9 +80,9 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 		Method factoryMethod = findFactoryMethodByFullyQualifiedName(testClass, testMethod, factoryMethodName);
 
 		// Ensure factory method has a valid return type and is not a test method.
-		Preconditions.condition(isFactoryMethod.test(factoryMethod), () -> format(
-			"Could not find valid factory method [%s] for test class [%s] but found the following invalid candidate: %s",
-			originalFactoryMethodName, testClass.getName(), factoryMethod));
+		Preconditions.condition(isFactoryMethod.test(factoryMethod),
+			() -> "Could not find valid factory method [%s] for test class [%s] but found the following invalid candidate: %s".formatted(
+				originalFactoryMethodName, testClass.getName(), factoryMethod));
 
 		return factoryMethod;
 	}
@@ -129,7 +129,7 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 		// If we didn't find an exact match but an explicit parameter list was specified,
 		// that's a user configuration error.
 		Preconditions.condition(!explicitParameterListSpecified,
-			() -> format("Could not find factory method [%s(%s)] in class [%s]", methodName, methodParameters,
+			() -> "Could not find factory method [%s(%s)] in class [%s]".formatted(methodName, methodParameters,
 				className));
 
 		// Otherwise, fall back to the same lenient search semantics that are used
@@ -158,17 +158,16 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 		Preconditions.notEmpty(factoryMethods, () -> {
 			if (candidates.isEmpty()) {
 				// Report that we didn't find anything.
-				return format("Could not find factory method [%s] in class [%s]", factoryMethodName, clazz.getName());
+				return "Could not find factory method [%s] in class [%s]".formatted(factoryMethodName, clazz.getName());
 			}
 			// If we didn't find the factory method using the isFactoryMethod Predicate, perhaps
 			// the specified factory method has an invalid return type or is a test method.
 			// In that case, we report the invalid candidates that were found.
-			return format(
-				"Could not find valid factory method [%s] in class [%s] but found the following invalid candidates: %s",
+			return "Could not find valid factory method [%s] in class [%s] but found the following invalid candidates: %s".formatted(
 				factoryMethodName, clazz.getName(), candidates);
 		});
 		Preconditions.condition(factoryMethods.size() == 1,
-			() -> format("%d factory methods named [%s] were found in class [%s]: %s", factoryMethods.size(),
+			() -> "%d factory methods named [%s] were found in class [%s]: %s".formatted(factoryMethods.size(),
 				factoryMethodName, clazz.getName(), factoryMethods));
 		return factoryMethods.get(0);
 	}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullArgumentsProvider.java
@@ -29,7 +29,7 @@ class NullArgumentsProvider implements ArgumentsProvider {
 	@Override
 	public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
 		Preconditions.condition(parameters.getFirst().isPresent(),
-			() -> String.format("@NullSource cannot provide a null argument to %s: no formal parameters declared.",
+			() -> "@NullSource cannot provide a null argument to %s: no formal parameters declared.".formatted(
 				parameters.getSourceElementDescription()));
 
 		return Stream.of(nullArguments);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumerInitializer.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumerInitializer.java
@@ -49,7 +49,7 @@ public final class AnnotationConsumerInitializer {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static <T> T initialize(AnnotatedElement annotatedElement, T annotationConsumerInstance) {
-		if (annotationConsumerInstance instanceof AnnotationConsumer) {
+		if (annotationConsumerInstance instanceof AnnotationConsumer consumer) {
 			Class<? extends Annotation> annotationType = findConsumedAnnotationType(annotationConsumerInstance);
 			List<? extends Annotation> annotations = findAnnotations(annotatedElement, annotationType);
 
@@ -58,8 +58,7 @@ public final class AnnotationConsumerInitializer {
 						+ " must be used with an annotation of type " + annotationType.getName());
 			}
 
-			annotations.forEach(annotation -> initializeAnnotationConsumer(
-				(AnnotationConsumer) annotationConsumerInstance, annotation));
+			annotations.forEach(annotation -> initializeAnnotationConsumer(consumer, annotation));
 		}
 		return annotationConsumerInstance;
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/JUnitException.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/JUnitException.java
@@ -13,6 +13,8 @@ package org.junit.platform.commons;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 
 /**
@@ -24,6 +26,7 @@ import org.apiguardian.api.API;
 @API(status = STABLE, since = "1.5")
 public class JUnitException extends RuntimeException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public JUnitException(String message) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/PreconditionViolationException.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/PreconditionViolationException.java
@@ -12,6 +12,8 @@ package org.junit.platform.commons;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 
 /**
@@ -22,6 +24,7 @@ import org.apiguardian.api.API;
 @API(status = STABLE, since = "1.5")
 public class PreconditionViolationException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public PreconditionViolationException(String message) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -220,7 +220,7 @@ public final class AnnotationSupport {
 		Preconditions.notNull(enclosingInstanceTypes, "enclosingInstanceTypes must not be null");
 
 		Optional<A> annotation = findAnnotation(clazz, annotationType);
-		if (!annotation.isPresent()) {
+		if (annotation.isEmpty()) {
 			ListIterator<Class<?>> iterator = enclosingInstanceTypes.listIterator(enclosingInstanceTypes.size());
 			while (iterator.hasPrevious()) {
 				annotation = findAnnotation(iterator.previous(), annotationType);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionException.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionException.java
@@ -12,6 +12,8 @@ package org.junit.platform.commons.support.conversion;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -24,6 +26,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = EXPERIMENTAL, since = "1.11")
 public class ConversionException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public ConversionException(String message) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionSupport.java
@@ -122,9 +122,9 @@ public final class ConversionSupport {
 				return (T) converter.get().convert(source, targetTypeToUse, classLoaderToUse);
 			}
 			catch (Exception ex) {
-				if (ex instanceof ConversionException) {
+				if (ex instanceof ConversionException conversionException) {
 					// simply rethrow it
-					throw (ConversionException) ex;
+					throw conversionException;
 				}
 				// else
 				throw new ConversionException(

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionSupport.java
@@ -128,7 +128,7 @@ public final class ConversionSupport {
 				}
 				// else
 				throw new ConversionException(
-					String.format("Failed to convert String \"%s\" to type %s", source, targetType.getTypeName()), ex);
+					"Failed to convert String \"%s\" to type %s".formatted(source, targetType.getTypeName()), ex);
 			}
 		}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/CloseablePath.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/CloseablePath.java
@@ -20,7 +20,6 @@ import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,7 +64,7 @@ final class CloseablePath implements Closeable {
 			return createForJarFileSystem(new URI(JAR_URI_SCHEME + ':' + uri),
 				fileSystem -> fileSystem.getRootDirectories().iterator().next(), fileSystemProvider);
 		}
-		return new CloseablePath(Paths.get(uri), NULL_CLOSEABLE);
+		return new CloseablePath(Path.of(uri), NULL_CLOSEABLE);
 	}
 
 	private static CloseablePath createForJarFileSystem(URI jarUri, Function<FileSystem, Path> pathProvider,

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/DefaultClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/scanning/DefaultClasspathScanner.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.commons.support.scanning;
 
-import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -297,8 +296,9 @@ public class DefaultClasspathScanner implements ClasspathScanner {
 
 	private void logMalformedClassName(Path classFile, String fullyQualifiedClassName, InternalError ex) {
 		try {
-			logger.debug(ex, () -> format("The java.lang.Class loaded from path [%s] has a malformed class name [%s].",
-				classFile.toAbsolutePath(), fullyQualifiedClassName));
+			logger.debug(ex,
+				() -> "The java.lang.Class loaded from path [%s] has a malformed class name [%s].".formatted(
+					classFile.toAbsolutePath(), fullyQualifiedClassName));
 		}
 		catch (Throwable t) {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(t);
@@ -309,7 +309,7 @@ public class DefaultClasspathScanner implements ClasspathScanner {
 
 	private void logGenericFileProcessingException(Path classpathFile, Throwable throwable) {
 		logger.debug(throwable,
-			() -> format("Failed to load [%s] during classpath scanning.", classpathFile.toAbsolutePath()));
+			() -> "Failed to load [%s] during classpath scanning.".formatted(classpathFile.toAbsolutePath()));
 	}
 
 	private ClassLoader getClassLoader() {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -111,7 +111,7 @@ public final class AnnotationUtils {
 	public static <A extends Annotation> Optional<A> findAnnotation(Optional<? extends AnnotatedElement> element,
 			Class<A> annotationType) {
 
-		if (element == null || !element.isPresent()) {
+		if (element == null || element.isEmpty()) {
 			return Optional.empty();
 		}
 
@@ -251,7 +251,7 @@ public final class AnnotationUtils {
 	public static <A extends Annotation> List<A> findRepeatableAnnotations(Optional<? extends AnnotatedElement> element,
 			Class<A> annotationType) {
 
-		if (element == null || !element.isPresent()) {
+		if (element == null || element.isEmpty()) {
 			return Collections.emptyList();
 		}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -342,9 +342,10 @@ public final class AnnotationUtils {
 					// a 'value' attribute that returns an array of the contained annotation type.
 					// See https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.6.3
 					Method method = ReflectionUtils.tryToGetMethod(containerType, "value").getOrThrow(
-						cause -> new JUnitException(String.format(
-							"Container annotation type '%s' must declare a 'value' attribute of type %s[].",
-							containerType, annotationType), cause));
+						cause -> new JUnitException(
+							"Container annotation type '%s' must declare a 'value' attribute of type %s[].".formatted(
+								containerType, annotationType),
+							cause));
 
 					Annotation[] containedAnnotations = (Annotation[]) ReflectionUtils.invokeMethod(method, candidate);
 					found.addAll((Collection<? extends A>) asList(containedAnnotations));

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -159,8 +159,7 @@ public final class AnnotationUtils {
 			return directMetaAnnotation;
 		}
 
-		if (element instanceof Class) {
-			Class<?> clazz = (Class<?>) element;
+		if (element instanceof Class<?> clazz) {
 
 			// Search on interfaces
 			for (Class<?> ifc : clazz.getInterfaces()) {
@@ -297,8 +296,7 @@ public final class AnnotationUtils {
 			Class<A> annotationType, Class<? extends Annotation> containerType, boolean inherited, Set<A> found,
 			Set<Annotation> visited) {
 
-		if (element instanceof Class) {
-			Class<?> clazz = (Class<?>) element;
+		if (element instanceof Class<?> clazz) {
 
 			// Recurse first in order to support top-down semantics for inherited, repeatable annotations.
 			if (inherited) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScannerLoader.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClasspathScannerLoader.java
@@ -36,9 +36,9 @@ class ClasspathScannerLoader {
 		}
 
 		if (classpathScanners.size() > 1) {
-			throw new JUnitException(String.format(
-				"There should not be more than one ClasspathScanner implementation present on the classpath but there were %d: %s",
-				classpathScanners.size(), classpathScanners));
+			throw new JUnitException(
+				"There should not be more than one ClasspathScanner implementation present on the classpath but there were %d: %s".formatted(
+					classpathScanners.size(), classpathScanners));
 		}
 
 		return new DefaultClasspathScanner(ClassLoaderUtils::getDefaultClassLoader, ReflectionUtils::tryToLoadClass);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
@@ -194,38 +194,38 @@ public final class CollectionUtils {
 	 */
 	public static Stream<?> toStream(Object object) {
 		Preconditions.notNull(object, "Object must not be null");
-		if (object instanceof Stream) {
-			return (Stream<?>) object;
+		if (object instanceof Stream<?> stream) {
+			return stream;
 		}
-		if (object instanceof DoubleStream) {
-			return ((DoubleStream) object).boxed();
+		if (object instanceof DoubleStream stream) {
+			return stream.boxed();
 		}
-		if (object instanceof IntStream) {
-			return ((IntStream) object).boxed();
+		if (object instanceof IntStream stream) {
+			return stream.boxed();
 		}
-		if (object instanceof LongStream) {
-			return ((LongStream) object).boxed();
+		if (object instanceof LongStream stream) {
+			return stream.boxed();
 		}
-		if (object instanceof Collection) {
-			return ((Collection<?>) object).stream();
+		if (object instanceof Collection<?> collection) {
+			return collection.stream();
 		}
-		if (object instanceof Iterable) {
-			return stream(((Iterable<?>) object).spliterator(), false);
+		if (object instanceof Iterable<?> iterable) {
+			return stream(iterable.spliterator(), false);
 		}
-		if (object instanceof Iterator) {
-			return stream(spliteratorUnknownSize((Iterator<?>) object, ORDERED), false);
+		if (object instanceof Iterator<?> iterator) {
+			return stream(spliteratorUnknownSize(iterator, ORDERED), false);
 		}
-		if (object instanceof Object[]) {
-			return Arrays.stream((Object[]) object);
+		if (object instanceof Object[] array) {
+			return Arrays.stream(array);
 		}
-		if (object instanceof double[]) {
-			return DoubleStream.of((double[]) object).boxed();
+		if (object instanceof double[] array) {
+			return DoubleStream.of(array).boxed();
 		}
-		if (object instanceof int[]) {
-			return IntStream.of((int[]) object).boxed();
+		if (object instanceof int[] array) {
+			return IntStream.of(array).boxed();
 		}
-		if (object instanceof long[]) {
-			return LongStream.of((long[]) object).boxed();
+		if (object instanceof long[] array) {
+			return LongStream.of(array).boxed();
 		}
 		if (object.getClass().isArray() && object.getClass().getComponentType().isPrimitive()) {
 			return IntStream.range(0, Array.getLength(object)).mapToObj(i -> Array.get(object, i));

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
@@ -238,8 +238,8 @@ public final class CollectionUtils {
 				.map(method -> (Iterator<?>) invokeMethod(method, object)) //
 				.map(iterator -> spliteratorUnknownSize(iterator, ORDERED)) //
 				.map(spliterator -> stream(spliterator, false)) //
-				.orElseThrow(() -> new PreconditionViolationException(String.format(
-					"Cannot convert instance of %s into a Stream: %s", object.getClass().getName(), object)));
+				.orElseThrow(() -> new PreconditionViolationException(
+					"Cannot convert instance of %s into a Stream: %s".formatted(object.getClass().getName(), object)));
 	}
 
 	private static Optional<Method> findIteratorMethod(Class<?> type) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/LruCache.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/LruCache.java
@@ -12,6 +12,7 @@ package org.junit.platform.commons.util;
 
 import static org.apiguardian.api.API.Status.INTERNAL;
 
+import java.io.Serial;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ import org.apiguardian.api.API;
 @API(status = INTERNAL, since = "1.6")
 public class LruCache<K, V> extends LinkedHashMap<K, V> {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final int maxSize;

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/RuntimeUtils.java
@@ -52,7 +52,7 @@ public final class RuntimeUtils {
 	static Optional<List<String>> getInputArguments() {
 		Optional<Class<?>> managementFactoryClass = ReflectionUtils.tryToLoadClass(
 			"java.lang.management.ManagementFactory").toOptional();
-		if (!managementFactoryClass.isPresent()) {
+		if (managementFactoryClass.isEmpty()) {
 			return Optional.empty();
 		}
 		// Can't use "java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()"

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/StringUtils.java
@@ -165,29 +165,29 @@ public final class StringUtils {
 		try {
 			if (obj.getClass().isArray()) {
 				if (obj.getClass().getComponentType().isPrimitive()) {
-					if (obj instanceof boolean[]) {
-						return Arrays.toString((boolean[]) obj);
+					if (obj instanceof boolean[] booleans) {
+						return Arrays.toString(booleans);
 					}
-					if (obj instanceof char[]) {
-						return Arrays.toString((char[]) obj);
+					if (obj instanceof char[] chars) {
+						return Arrays.toString(chars);
 					}
-					if (obj instanceof short[]) {
-						return Arrays.toString((short[]) obj);
+					if (obj instanceof short[] shorts) {
+						return Arrays.toString(shorts);
 					}
-					if (obj instanceof byte[]) {
-						return Arrays.toString((byte[]) obj);
+					if (obj instanceof byte[] bytes) {
+						return Arrays.toString(bytes);
 					}
-					if (obj instanceof int[]) {
-						return Arrays.toString((int[]) obj);
+					if (obj instanceof int[] ints) {
+						return Arrays.toString(ints);
 					}
-					if (obj instanceof long[]) {
-						return Arrays.toString((long[]) obj);
+					if (obj instanceof long[] longs) {
+						return Arrays.toString(longs);
 					}
-					if (obj instanceof float[]) {
-						return Arrays.toString((float[]) obj);
+					if (obj instanceof float[] floats) {
+						return Arrays.toString(floats);
 					}
-					if (obj instanceof double[]) {
-						return Arrays.toString((double[]) obj);
+					if (obj instanceof double[] doubles) {
+						return Arrays.toString(doubles);
 					}
 				}
 				return Arrays.deepToString((Object[]) obj);

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/ListTestEnginesCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/ListTestEnginesCommand.java
@@ -46,7 +46,7 @@ class ListTestEnginesCommand extends BaseCommand<Void> {
 		engine.getGroupId().ifPresent(details::add);
 		engine.getArtifactId().ifPresent(details::add);
 		engine.getVersion().ifPresent(details::add);
-		out.println(getColorScheme().string(String.format("@|bold %s|@%s", engine.getId(), details)));
+		out.println(getColorScheme().string("@|bold %s|@%s".formatted(engine.getId(), details)));
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/ManifestVersionProvider.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/ManifestVersionProvider.java
@@ -25,8 +25,7 @@ class ManifestVersionProvider implements CommandLine.IVersionProvider {
 	@Override
 	public String[] getVersion() {
 		return new String[] { //
-				String.format("@|bold JUnit Platform Console Launcher %s|@",
-					getImplementationVersion().orElse("<unknown>")), //
+				"@|bold JUnit Platform Console Launcher %s|@".formatted(getImplementationVersion().orElse("<unknown>")), //
 				"JVM: ${java.version} (${java.vendor} ${java.vm.name} ${java.vm.version})", //
 				"OS: ${os.name} ${os.version} ${os.arch}" //
 		};

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptionsMixin.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptionsMixin.java
@@ -240,7 +240,7 @@ class TestDiscoveryOptionsMixin {
 			String existing = configurationParameters.get(key);
 			if (existing != null && !existing.equals(newValue)) {
 				throw new CommandLine.ParameterException(spec.commandLine(),
-					String.format("Duplicate key '%s' for values '%s' and '%s'.", key, existing, newValue));
+					"Duplicate key '%s' for values '%s' and '%s'.".formatted(key, existing, newValue));
 			}
 		}
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ColorPalette.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/ColorPalette.java
@@ -122,7 +122,7 @@ class ColorPalette {
 	}
 
 	private String getAnsiFormatter(Style style) {
-		return String.format("\u001B[%sm", this.colorsToAnsiSequences.get(style));
+		return "\u001B[%sm".formatted(this.colorsToAnsiSequences.get(style));
 	}
 
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/CustomClassLoaderCloseStrategy.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/CustomClassLoaderCloseStrategy.java
@@ -31,8 +31,8 @@ public enum CustomClassLoaderCloseStrategy {
 
 		@Override
 		public void handle(ClassLoader customClassLoader) {
-			if (customClassLoader instanceof AutoCloseable) {
-				close((AutoCloseable) customClassLoader);
+			if (customClassLoader instanceof AutoCloseable closeable) {
+				close(closeable);
 			}
 		}
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/DiscoveryRequestCreator.java
@@ -137,15 +137,15 @@ class DiscoveryRequestCreator {
 		Stream<String> patternStreams = Stream.concat( //
 			options.getIncludedClassNamePatterns().stream(), //
 			selectors.stream() //
-					.map(selector -> selector instanceof IterationSelector
-							? ((IterationSelector) selector).getParentSelector()
+					.map(selector -> selector instanceof IterationSelector iterationSelector
+							? iterationSelector.getParentSelector()
 							: selector) //
 					.map(selector -> {
-						if (selector instanceof ClassSelector) {
-							return ((ClassSelector) selector).getClassName();
+						if (selector instanceof ClassSelector classSelector) {
+							return classSelector.getClassName();
 						}
-						if (selector instanceof MethodSelector) {
-							return ((MethodSelector) selector).getClassName();
+						if (selector instanceof MethodSelector methodSelector) {
+							return methodSelector.getClassName();
 						}
 						return null;
 					}) //

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/FlatPrintingListener.java
@@ -93,7 +93,7 @@ class FlatPrintingListener implements DetailsPrintingListener {
 	}
 
 	private void println(Style style, String format, Object... args) {
-		this.out.println(colorPalette.paint(style, String.format(format, args)));
+		this.out.println(colorPalette.paint(style, format.formatted(args)));
 	}
 
 	/**

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TestFeedPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TestFeedPrintingListener.java
@@ -50,7 +50,7 @@ class TestFeedPrintingListener implements DetailsPrintingListener {
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
 		if (shouldPrint(testIdentifier)) {
 			String msg = formatTestIdentifier(testIdentifier);
-			String indentedReason = indented(String.format("Reason: %s", reason));
+			String indentedReason = indented("Reason: %s".formatted(reason));
 			println(Style.SKIPPED,
 				String.format("%s" + STATUS_SEPARATOR + "SKIPPED%n" + INDENTATION + "%s", msg, indentedReason));
 		}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrinter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/tasks/TreePrinter.java
@@ -80,7 +80,7 @@ class TreePrinter {
 			out.print(" ");
 			out.print(duration);
 		}
-		boolean nodeIsBeingListed = node.duration == 0 && !node.result().isPresent() && !node.reason().isPresent();
+		boolean nodeIsBeingListed = node.duration == 0 && node.result().isEmpty() && node.reason().isEmpty();
 		if (!nodeIsBeingListed) {
 			out.print(" ");
 			out.print(icon);
@@ -120,7 +120,7 @@ class TreePrinter {
 	}
 
 	private void printThrowable(String indent, TestExecutionResult result) {
-		if (!result.getThrowable().isPresent()) {
+		if (result.getThrowable().isEmpty()) {
 			return;
 		}
 		Throwable throwable = result.getThrowable().get();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/CompositeFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/CompositeFilter.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.engine;
 
-import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static org.junit.platform.engine.FilterResult.included;
 
@@ -82,7 +81,7 @@ class CompositeFilter<T> implements Filter<T> {
 		// @formatter:off
 		return filters.stream()
 				.map(Object::toString)
-				.map(value -> format("(%s)", value))
+				.map(value -> "(%s)".formatted(value))
 				.collect(joining(" and "));
 		// @formatter:on
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/ConfigurationParameters.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/ConfigurationParameters.java
@@ -123,8 +123,8 @@ public interface ConfigurationParameters {
 				return transformer.apply(input);
 			}
 			catch (Exception ex) {
-				String message = String.format(
-					"Failed to transform configuration parameter with key '%s' and initial value '%s'", key, input);
+				String message = "Failed to transform configuration parameter with key '%s' and initial value '%s'".formatted(
+					key, input);
 				throw new JUnitException(message, ex);
 			}
 		});

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoverySelectorIdentifier.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/DiscoverySelectorIdentifier.java
@@ -108,7 +108,7 @@ public final class DiscoverySelectorIdentifier {
 	 */
 	@Override
 	public String toString() {
-		return String.format("%s:%s", this.prefix, this.value);
+		return "%s:%s".formatted(this.prefix, this.value);
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -120,7 +120,7 @@ public interface TestDescriptor {
 	 */
 	@API(status = STABLE, since = "1.10")
 	default Set<? extends TestDescriptor> getAncestors() {
-		if (!getParent().isPresent()) {
+		if (getParent().isEmpty()) {
 			return Collections.emptySet();
 		}
 		TestDescriptor parent = getParent().get();
@@ -215,7 +215,7 @@ public interface TestDescriptor {
 	 * <p>A <em>root</em> descriptor is a descriptor without a parent.
 	 */
 	default boolean isRoot() {
-		return !getParent().isPresent();
+		return getParent().isEmpty();
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestTag.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestTag.java
@@ -118,7 +118,7 @@ public final class TestTag implements Serializable {
 
 	private TestTag(String name) {
 		Preconditions.condition(TestTag.isValid(name),
-			() -> String.format("Tag name [%s] must be syntactically valid", name));
+			() -> "Tag name [%s] must be syntactically valid".formatted(name));
 		this.name = name.trim();
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestTag.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestTag.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +36,7 @@ import org.junit.platform.commons.util.StringUtils;
 @API(status = STABLE, since = "1.0")
 public final class TestTag implements Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final String name;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestTag.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestTag.java
@@ -135,8 +135,7 @@ public final class TestTag implements Serializable {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof TestTag) {
-			TestTag that = (TestTag) obj;
+		if (obj instanceof TestTag that) {
 			return Objects.equals(this.name, that.name);
 		}
 		return false;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -14,6 +14,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.ref.SoftReference;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = STABLE, since = "1.0")
 public class UniqueId implements Cloneable, Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private static final String ENGINE_SEGMENT_TYPE = "engine";
@@ -296,6 +298,7 @@ public class UniqueId implements Cloneable, Serializable {
 	@API(status = STABLE, since = "1.0")
 	public static class Segment implements Serializable {
 
+		@Serial
 		private static final long serialVersionUID = 1L;
 
 		private final String type;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
@@ -70,7 +70,7 @@ class UniqueIdFormat implements Serializable {
 		this.closeSegment = closeSegment;
 		this.segmentDelimiter = segmentDelimiter;
 		this.segmentPattern = Pattern.compile(
-			String.format("%s(.+)%s(.+)%s", quote(openSegment), quote(typeValueSeparator), quote(closeSegment)),
+			"%s(.+)%s(.+)%s".formatted(quote(openSegment), quote(typeValueSeparator), quote(closeSegment)),
 			Pattern.DOTALL);
 
 		// Compute "forbidden" character encoding map.
@@ -99,7 +99,7 @@ class UniqueIdFormat implements Serializable {
 	private Segment createSegment(String segmentString) throws JUnitException {
 		Matcher segmentMatcher = this.segmentPattern.matcher(segmentString);
 		if (!segmentMatcher.matches()) {
-			throw new JUnitException(String.format("'%s' is not a well-formed UniqueId segment", segmentString));
+			throw new JUnitException("'%s' is not a well-formed UniqueId segment".formatted(segmentString));
 		}
 		String type = decode(checkAllowed(segmentMatcher.group(1)));
 		String value = decode(checkAllowed(segmentMatcher.group(2)));
@@ -116,7 +116,7 @@ class UniqueIdFormat implements Serializable {
 
 	private void checkDoesNotContain(String typeOrValue, char forbiddenCharacter) {
 		Preconditions.condition(typeOrValue.indexOf(forbiddenCharacter) < 0,
-			() -> String.format("type or value '%s' must not contain '%s'", typeOrValue, forbiddenCharacter));
+			() -> "type or value '%s' must not contain '%s'".formatted(typeOrValue, forbiddenCharacter));
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -36,6 +37,7 @@ import org.junit.platform.engine.UniqueId.Segment;
  */
 class UniqueIdFormat implements Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private static final UniqueIdFormat defaultFormat = new UniqueIdFormat('[', ':', ']', '/');

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
@@ -159,7 +159,7 @@ public class ClasspathResourceSelector implements DiscoverySelector {
 		}
 		else {
 			return Optional.of(DiscoverySelectorIdentifier.create(IdentifierParser.PREFIX,
-				String.format("%s?%s", this.classpathResourceName, this.position.toQueryPart())));
+				"%s?%s".formatted(this.classpathResourceName, this.position.toQueryPart())));
 		}
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathRootSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathRootSelector.java
@@ -17,7 +17,6 @@ import static org.junit.platform.commons.util.CollectionUtils.getFirstElement;
 
 import java.net.URI;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -114,7 +113,7 @@ public class ClasspathRootSelector implements DiscoverySelector {
 
 		@Override
 		public Optional<ClasspathRootSelector> parse(DiscoverySelectorIdentifier identifier, Context context) {
-			Path path = Paths.get(URI.create(identifier.getValue()));
+			Path path = Path.of(URI.create(identifier.getValue()));
 			return getFirstElement(DiscoverySelectors.selectClasspathRoots(singleton(path)));
 		}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DirectorySelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DirectorySelector.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -67,7 +66,7 @@ public class DirectorySelector implements DiscoverySelector {
 	 * @see #getRawPath()
 	 */
 	public Path getPath() {
-		return Paths.get(this.path);
+		return Path.of(this.path);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectorIdentifierParsers.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectorIdentifierParsers.java
@@ -75,7 +75,7 @@ class DiscoverySelectorIdentifierParsers {
 			for (DiscoverySelectorIdentifierParser parser : loadedParsers) {
 				DiscoverySelectorIdentifierParser previous = parsersByPrefix.put(parser.getPrefix(), parser);
 				Preconditions.condition(previous == null,
-					() -> String.format("Duplicate parser for prefix: [%s]; candidate a: [%s]; candidate b: [%s]",
+					() -> "Duplicate parser for prefix: [%s]; candidate a: [%s]; candidate b: [%s]".formatted(
 						parser.getPrefix(), requireNonNull(previous).getClass().getName(),
 						parser.getClass().getName()));
 			}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectorIdentifierParsers.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectorIdentifierParsers.java
@@ -37,16 +37,14 @@ class DiscoverySelectorIdentifierParsers {
 		Preconditions.notNull(identifiers, "identifiers must not be null");
 		return Stream.of(identifiers) //
 				.map(DiscoverySelectorIdentifierParsers::parse) //
-				.filter(Optional::isPresent) //
-				.map(Optional::get);
+				.flatMap(Optional::stream);
 	}
 
 	static Stream<? extends DiscoverySelector> parseAll(Collection<DiscoverySelectorIdentifier> identifiers) {
 		Preconditions.notNull(identifiers, "identifiers must not be null");
 		return identifiers.stream() //
 				.map(DiscoverySelectorIdentifierParsers::parse) //
-				.filter(Optional::isPresent) //
-				.map(Optional::get);
+				.flatMap(Optional::stream);
 	}
 
 	static Optional<? extends DiscoverySelector> parse(String identifier) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectors.java
@@ -177,7 +177,7 @@ public final class DiscoverySelectors {
 	public static FileSelector selectFile(File file, FilePosition position) {
 		Preconditions.notNull(file, "File must not be null");
 		Preconditions.condition(file.isFile(),
-			() -> String.format("The supplied java.io.File [%s] must represent an existing file", file));
+			() -> "The supplied java.io.File [%s] must represent an existing file".formatted(file));
 		try {
 			return new FileSelector(file.getCanonicalPath(), position);
 		}
@@ -219,7 +219,7 @@ public final class DiscoverySelectors {
 	public static DirectorySelector selectDirectory(File directory) {
 		Preconditions.notNull(directory, "Directory must not be null");
 		Preconditions.condition(directory.isDirectory(),
-			() -> String.format("The supplied java.io.File [%s] must represent an existing directory", directory));
+			() -> "The supplied java.io.File [%s] must represent an existing directory".formatted(directory));
 		try {
 			return new DirectorySelector(directory.getCanonicalPath());
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludeClassNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludeClassNameFilter.java
@@ -41,11 +41,11 @@ class ExcludeClassNameFilter extends AbstractClassNameFilter {
 	}
 
 	private String formatInclusionReason(String className) {
-		return String.format("Class name [%s] does not match any excluded pattern: %s", className, patternDescription);
+		return "Class name [%s] does not match any excluded pattern: %s".formatted(className, patternDescription);
 	}
 
 	private String formatExclusionReason(String className, Pattern pattern) {
-		return String.format("Class name [%s] matches excluded pattern: '%s'", className, pattern);
+		return "Class name [%s] matches excluded pattern: '%s'".formatted(className, pattern);
 	}
 
 	@Override
@@ -55,7 +55,7 @@ class ExcludeClassNameFilter extends AbstractClassNameFilter {
 
 	@Override
 	public String toString() {
-		return String.format("%s that excludes class names that match one of the following regular expressions: %s",
+		return "%s that excludes class names that match one of the following regular expressions: %s".formatted(
 			getClass().getSimpleName(), this.patternDescription);
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludeClassNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludeClassNameFilter.java
@@ -50,7 +50,7 @@ class ExcludeClassNameFilter extends AbstractClassNameFilter {
 
 	@Override
 	public Predicate<String> toPredicate() {
-		return className -> !findMatchingPattern(className).isPresent();
+		return className -> findMatchingPattern(className).isEmpty();
 	}
 
 	@Override

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludePackageNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludePackageNameFilter.java
@@ -61,7 +61,7 @@ class ExcludePackageNameFilter implements PackageNameFilter {
 
 	@Override
 	public Predicate<String> toPredicate() {
-		return packageName -> !findMatchingName(packageName).isPresent();
+		return packageName -> findMatchingName(packageName).isEmpty();
 	}
 
 	private Optional<String> findMatchingName(String packageName) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludePackageNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ExcludePackageNameFilter.java
@@ -51,12 +51,12 @@ class ExcludePackageNameFilter implements PackageNameFilter {
 	}
 
 	private String formatInclusionReason(String packageName) {
-		return String.format("Package name [%s] does not match any excluded names: %s", packageName,
+		return "Package name [%s] does not match any excluded names: %s".formatted(packageName,
 			this.patternDescription);
 	}
 
 	private String formatExclusionReason(String packageName, String matchedName) {
-		return String.format("Package name [%s] matches excluded name: '%s'", packageName, matchedName);
+		return "Package name [%s] matches excluded name: '%s'".formatted(packageName, matchedName);
 	}
 
 	@Override
@@ -71,8 +71,7 @@ class ExcludePackageNameFilter implements PackageNameFilter {
 
 	@Override
 	public String toString() {
-		return String.format(
-			"%s that excludes packages whose names are either equal to or start with one of the following: %s",
+		return "%s that excludes packages whose names are either equal to or start with one of the following: %s".formatted(
 			getClass().getSimpleName(), this.patternDescription);
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FilePosition.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FilePosition.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.discovery;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
@@ -37,6 +38,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = STABLE, since = "1.7")
 public class FilePosition implements Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private static final Logger logger = LoggerFactory.getLogger(FilePosition.class);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FileSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FileSelector.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -70,7 +69,7 @@ public class FileSelector implements DiscoverySelector {
 	 * @see #getRawPath()
 	 */
 	public Path getPath() {
-		return Paths.get(this.path);
+		return Path.of(this.path);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FileSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FileSelector.java
@@ -127,7 +127,7 @@ public class FileSelector implements DiscoverySelector {
 		}
 		else {
 			return Optional.of(DiscoverySelectorIdentifier.create(IdentifierParser.PREFIX,
-				String.format("%s?%s", this.path, this.position.toQueryPart())));
+				"%s?%s".formatted(this.path, this.position.toQueryPart())));
 		}
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IncludeClassNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IncludeClassNameFilter.java
@@ -41,12 +41,11 @@ class IncludeClassNameFilter extends AbstractClassNameFilter {
 	}
 
 	private String formatInclusionReason(String className, Pattern pattern) {
-		return String.format("Class name [%s] matches included pattern: '%s'", className, pattern);
+		return "Class name [%s] matches included pattern: '%s'".formatted(className, pattern);
 	}
 
 	private String formatExclusionReason(String className) {
-		return String.format("Class name [%s] does not match any included pattern: %s", className,
-			this.patternDescription);
+		return "Class name [%s] does not match any included pattern: %s".formatted(className, this.patternDescription);
 	}
 
 	@Override
@@ -56,7 +55,7 @@ class IncludeClassNameFilter extends AbstractClassNameFilter {
 
 	@Override
 	public String toString() {
-		return String.format("%s that includes class names that match one of the following regular expressions: %s",
+		return "%s that includes class names that match one of the following regular expressions: %s".formatted(
 			getClass().getSimpleName(), this.patternDescription);
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IncludePackageNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IncludePackageNameFilter.java
@@ -51,11 +51,11 @@ class IncludePackageNameFilter implements PackageNameFilter {
 	}
 
 	private String formatInclusionReason(String packageName, String matchedName) {
-		return String.format("Package name [%s] matches included name: '%s'", packageName, matchedName);
+		return "Package name [%s] matches included name: '%s'".formatted(packageName, matchedName);
 	}
 
 	private String formatExclusionReason(String packageName) {
-		return String.format("Package name [%s] does not match any included names: %s", packageName,
+		return "Package name [%s] does not match any included names: %s".formatted(packageName,
 			this.patternDescription);
 	}
 
@@ -71,8 +71,7 @@ class IncludePackageNameFilter implements PackageNameFilter {
 
 	@Override
 	public String toString() {
-		return String.format(
-			"%s that includes packages whose names are either equal to or start with one of the following: %s",
+		return "%s that includes packages whose names are either equal to or start with one of the following: %s".formatted(
 			getClass().getSimpleName(), this.patternDescription);
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IterationSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IterationSelector.java
@@ -106,7 +106,7 @@ public class IterationSelector implements DiscoverySelector {
 	public Optional<DiscoverySelectorIdentifier> toIdentifier() {
 		return this.parentSelector.toIdentifier().map(parentSelectorString -> DiscoverySelectorIdentifier.create( //
 			IdentifierParser.PREFIX, //
-			String.format("%s[%s]", parentSelectorString, formatIterationIndicesAsRanges())) //
+			"%s[%s]".formatted(parentSelectorString, formatIterationIndicesAsRanges())) //
 		);
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/MethodSelector.java
@@ -234,14 +234,14 @@ public class MethodSelector implements DiscoverySelector {
 			if (this.parameterTypes.length > 0) {
 				this.javaMethod = ReflectionSupport.findMethod(this.javaClass, this.methodName,
 					this.parameterTypes).orElseThrow(
-						() -> new PreconditionViolationException(String.format(
-							"Could not find method with name [%s] and parameter types [%s] in class [%s].",
-							this.methodName, this.parameterTypeNames, this.javaClass.getName())));
+						() -> new PreconditionViolationException(
+							"Could not find method with name [%s] and parameter types [%s] in class [%s].".formatted(
+								this.methodName, this.parameterTypeNames, this.javaClass.getName())));
 			}
 			else {
 				this.javaMethod = ReflectionSupport.findMethod(this.javaClass, this.methodName).orElseThrow(
 					() -> new PreconditionViolationException(
-						String.format("Could not find method with name [%s] in class [%s].", this.methodName,
+						"Could not find method with name [%s] in class [%s].".formatted(this.methodName,
 							this.javaClass.getName())));
 			}
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.support.descriptor;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
@@ -43,6 +44,7 @@ import org.junit.platform.engine.TestSource;
 @API(status = STABLE, since = "1.0")
 public class ClassSource implements TestSource {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.support.descriptor;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,6 +34,7 @@ import org.junit.platform.engine.TestSource;
 @API(status = STABLE, since = "1.0")
 public class ClasspathResourceSource implements TestSource {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/CompositeTestSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/CompositeTestSource.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine.support.descriptor;
 import static java.util.Collections.unmodifiableList;
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.junit.platform.engine.TestSource;
 @API(status = STABLE, since = "1.0")
 public class CompositeTestSource implements TestSource {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DefaultUriSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DefaultUriSource.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.engine.support.descriptor;
 
+import java.io.Serial;
 import java.net.URI;
 import java.util.Objects;
 
@@ -23,6 +24,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
  */
 class DefaultUriSource implements UriSource {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final URI uri;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DirectorySource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/DirectorySource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URI;
 
 import org.apiguardian.api.API;
@@ -30,6 +31,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = STABLE, since = "1.0")
 public class DirectorySource implements FileSystemSource {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FilePosition.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FilePosition.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.support.descriptor;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
@@ -32,6 +33,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = STABLE, since = "1.0")
 public class FilePosition implements Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private static final Logger logger = LoggerFactory.getLogger(FilePosition.class);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FileSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/FileSource.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,6 +34,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 @API(status = STABLE, since = "1.0")
 public class FileSource implements FileSystemSource {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
@@ -208,14 +208,14 @@ public class MethodSource implements TestSource {
 			if (StringUtils.isNotBlank(this.methodParameterTypes)) {
 				this.javaMethod = ReflectionSupport.findMethod(this.javaClass, this.methodName,
 					this.methodParameterTypes).orElseThrow(
-						() -> new PreconditionViolationException(String.format(
-							"Could not find method with name [%s] and parameter types [%s] in class [%s].",
-							this.methodName, this.methodParameterTypes, this.javaClass.getName())));
+						() -> new PreconditionViolationException(
+							"Could not find method with name [%s] and parameter types [%s] in class [%s].".formatted(
+								this.methodName, this.methodParameterTypes, this.javaClass.getName())));
 			}
 			else {
 				this.javaMethod = ReflectionSupport.findMethod(this.javaClass, this.methodName).orElseThrow(
 					() -> new PreconditionViolationException(
-						String.format("Could not find method with name [%s] in class [%s].", this.methodName,
+						"Could not find method with name [%s] in class [%s].".formatted(this.methodName,
 							this.javaClass.getName())));
 			}
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
@@ -13,6 +13,7 @@ package org.junit.platform.engine.support.descriptor;
 import static org.apiguardian.api.API.Status.STABLE;
 import static org.junit.platform.commons.util.ClassUtils.nullSafeToString;
 
+import java.io.Serial;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
@@ -36,6 +37,7 @@ import org.junit.platform.engine.TestSource;
 @API(status = STABLE, since = "1.0")
 public class MethodSource implements TestSource {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
@@ -12,6 +12,7 @@ package org.junit.platform.engine.support.descriptor;
 
 import static org.apiguardian.api.API.Status.STABLE;
 
+import java.io.Serial;
 import java.util.Objects;
 
 import org.apiguardian.api.API;
@@ -31,6 +32,7 @@ import org.junit.platform.engine.TestSource;
 @API(status = STABLE, since = "1.0")
 public class PackageSource implements TestSource {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
@@ -68,8 +68,9 @@ public interface UriSource extends TestSource {
 			}
 		}
 		catch (RuntimeException ex) {
-			LoggerFactory.getLogger(UriSource.class).debug(ex, () -> String.format(
-				"The supplied URI [%s] is not path-based. Falling back to default UriSource implementation.", uri));
+			LoggerFactory.getLogger(UriSource.class).debug(ex,
+				() -> "The supplied URI [%s] is not path-based. Falling back to default UriSource implementation.".formatted(
+					uri));
 		}
 
 		// Store supplied URI as-is

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
@@ -15,7 +15,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.logging.LoggerFactory;
@@ -59,7 +58,7 @@ public interface UriSource extends TestSource {
 
 		try {
 			URI uriWithoutQuery = ResourceUtils.stripQueryComponent(uri);
-			Path path = Paths.get(uriWithoutQuery);
+			Path path = Path.of(uriWithoutQuery);
 			if (Files.isRegularFile(path)) {
 				return FileSource.from(path.toFile(), FilePosition.fromQuery(uri.getQuery()).orElse(null));
 			}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolution.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolution.java
@@ -120,46 +120,46 @@ class EngineDiscoveryRequestResolution {
 		if (resolvedSelectors.containsKey(selector)) {
 			return Optional.of(resolvedSelectors.get(selector));
 		}
-		if (selector instanceof UniqueIdSelector) {
-			return resolveUniqueId((UniqueIdSelector) selector);
+		if (selector instanceof UniqueIdSelector uniqueIdSelector) {
+			return resolveUniqueId(uniqueIdSelector);
 		}
 		return resolve(selector, resolver -> {
 			Context context = getContext(selector);
-			if (selector instanceof ClasspathResourceSelector) {
-				return resolver.resolve((ClasspathResourceSelector) selector, context);
+			if (selector instanceof ClasspathResourceSelector classpathResourceSelector) {
+				return resolver.resolve(classpathResourceSelector, context);
 			}
-			if (selector instanceof ClasspathRootSelector) {
-				return resolver.resolve((ClasspathRootSelector) selector, context);
+			if (selector instanceof ClasspathRootSelector classpathRootSelector) {
+				return resolver.resolve(classpathRootSelector, context);
 			}
-			if (selector instanceof ClassSelector) {
-				return resolver.resolve((ClassSelector) selector, context);
+			if (selector instanceof ClassSelector classSelector) {
+				return resolver.resolve(classSelector, context);
 			}
-			if (selector instanceof IterationSelector) {
-				return resolver.resolve((IterationSelector) selector, context);
+			if (selector instanceof IterationSelector iterationSelector) {
+				return resolver.resolve(iterationSelector, context);
 			}
-			if (selector instanceof NestedClassSelector) {
-				return resolver.resolve((NestedClassSelector) selector, context);
+			if (selector instanceof NestedClassSelector nestedClassSelector) {
+				return resolver.resolve(nestedClassSelector, context);
 			}
-			if (selector instanceof DirectorySelector) {
-				return resolver.resolve((DirectorySelector) selector, context);
+			if (selector instanceof DirectorySelector directorySelector) {
+				return resolver.resolve(directorySelector, context);
 			}
-			if (selector instanceof FileSelector) {
-				return resolver.resolve((FileSelector) selector, context);
+			if (selector instanceof FileSelector fileSelector) {
+				return resolver.resolve(fileSelector, context);
 			}
-			if (selector instanceof MethodSelector) {
-				return resolver.resolve((MethodSelector) selector, context);
+			if (selector instanceof MethodSelector methodSelector) {
+				return resolver.resolve(methodSelector, context);
 			}
-			if (selector instanceof NestedMethodSelector) {
-				return resolver.resolve((NestedMethodSelector) selector, context);
+			if (selector instanceof NestedMethodSelector nestedMethodSelector) {
+				return resolver.resolve(nestedMethodSelector, context);
 			}
-			if (selector instanceof ModuleSelector) {
-				return resolver.resolve((ModuleSelector) selector, context);
+			if (selector instanceof ModuleSelector moduleSelector) {
+				return resolver.resolve(moduleSelector, context);
 			}
-			if (selector instanceof PackageSelector) {
-				return resolver.resolve((PackageSelector) selector, context);
+			if (selector instanceof PackageSelector packageSelector) {
+				return resolver.resolve(packageSelector, context);
 			}
-			if (selector instanceof UriSelector) {
-				return resolver.resolve((UriSelector) selector, context);
+			if (selector instanceof UriSelector uriSelector) {
+				return resolver.resolve(uriSelector, context);
 			}
 			return resolver.resolve(selector, context);
 		});

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
@@ -40,8 +40,8 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 		public ParallelExecutionConfiguration createConfiguration(ConfigurationParameters configurationParameters) {
 			int parallelism = configurationParameters.get(CONFIG_FIXED_PARALLELISM_PROPERTY_NAME,
 				Integer::valueOf).orElseThrow(
-					() -> new JUnitException(String.format("Configuration parameter '%s' must be set",
-						CONFIG_FIXED_PARALLELISM_PROPERTY_NAME)));
+					() -> new JUnitException(
+						"Configuration parameter '%s' must be set".formatted(CONFIG_FIXED_PARALLELISM_PROPERTY_NAME)));
 
 			int maxPoolSize = configurationParameters.get(CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME,
 				Integer::valueOf).orElse(parallelism + 256);
@@ -66,8 +66,8 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 				BigDecimal::new).orElse(BigDecimal.ONE);
 
 			Preconditions.condition(factor.compareTo(BigDecimal.ZERO) > 0,
-				() -> String.format("Factor '%s' specified via configuration parameter '%s' must be greater than 0",
-					factor, CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME));
+				() -> "Factor '%s' specified via configuration parameter '%s' must be greater than 0".formatted(factor,
+					CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME));
 
 			int parallelism = Math.max(1,
 				factor.multiply(BigDecimal.valueOf(Runtime.getRuntime().availableProcessors())).intValue());
@@ -75,8 +75,7 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 			int maxPoolSize = configurationParameters.get(CONFIG_DYNAMIC_MAX_POOL_SIZE_FACTOR_PROPERTY_NAME,
 				BigDecimal::new).map(maxPoolSizeFactor -> {
 					Preconditions.condition(maxPoolSizeFactor.compareTo(BigDecimal.ONE) >= 0,
-						() -> String.format(
-							"Factor '%s' specified via configuration parameter '%s' must be greater than or equal to 1",
+						() -> "Factor '%s' specified via configuration parameter '%s' must be greater than or equal to 1".formatted(
 							factor, CONFIG_DYNAMIC_MAX_POOL_SIZE_FACTOR_PROPERTY_NAME));
 					return maxPoolSizeFactor.multiply(BigDecimal.valueOf(parallelism)).intValue();
 				}).orElseGet(() -> 256 + parallelism);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -181,7 +181,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 			catch (Throwable throwable) {
 				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 				logger.debug(throwable,
-					() -> String.format("Failed to invoke nodeSkipped() on Node %s", testDescriptor.getUniqueId()));
+					() -> "Failed to invoke nodeSkipped() on Node %s".formatted(testDescriptor.getUniqueId()));
 			}
 			taskContext.getListener().executionSkipped(testDescriptor, skipResult.getReason().orElse("<unknown>"));
 			return;
@@ -196,7 +196,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 		catch (Throwable throwable) {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 			logger.debug(throwable,
-				() -> String.format("Failed to invoke nodeFinished() on Node %s", testDescriptor.getUniqueId()));
+				() -> "Failed to invoke nodeFinished() on Node %s".formatted(testDescriptor.getUniqueId()));
 		}
 		taskContext.getListener().executionFinished(testDescriptor, throwableCollector.toTestExecutionResult());
 		throwableCollector = null;

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
@@ -424,8 +424,8 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 			if (this.value == NO_VALUE_SET) {
 				computeValue();
 			}
-			if (this.value instanceof Failure) {
-				throw ExceptionUtils.throwAsUncheckedException(((Failure) this.value).throwable);
+			if (this.value instanceof Failure failure) {
+				throw ExceptionUtils.throwAsUncheckedException(failure.throwable);
 			}
 			return this.value;
 		}
@@ -464,8 +464,8 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 		@API(status = EXPERIMENTAL, since = "1.13")
 		static <N> CloseAction<N> closeAutoCloseables() {
 			return (__, ___, value) -> {
-				if (value instanceof AutoCloseable) {
-					((AutoCloseable) value).close();
+				if (value instanceof AutoCloseable closeable) {
+					closeable.close();
 				}
 			};
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
@@ -308,7 +308,7 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 		}
 		// else
 		throw new NamespacedHierarchicalStoreException(
-			String.format("Object stored under key [%s] is not of required type [%s], but was [%s]: %s", key,
+			"Object stored under key [%s] is not of required type [%s], but was [%s]: %s".formatted(key,
 				requiredType.getName(), value.getClass().getName(), value));
 	}
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreException.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreException.java
@@ -12,6 +12,8 @@ package org.junit.platform.engine.support.store;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -23,6 +25,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = EXPERIMENTAL, since = "1.10")
 public class NamespacedHierarchicalStoreException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public NamespacedHierarchicalStoreException(String message) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/EngineFilter.java
@@ -128,20 +128,19 @@ public class EngineFilter implements Filter<TestEngine> {
 
 		if (this.type == Type.INCLUDE) {
 			return includedIf(this.engineIds.stream().anyMatch(engineId::equals), //
-				() -> String.format("Engine ID [%s] is in included list [%s]", engineId, this.engineIds), //
-				() -> String.format("Engine ID [%s] is not in included list [%s]", engineId, this.engineIds));
+				() -> "Engine ID [%s] is in included list [%s]".formatted(engineId, this.engineIds), //
+				() -> "Engine ID [%s] is not in included list [%s]".formatted(engineId, this.engineIds));
 		}
 		else {
 			return includedIf(this.engineIds.stream().noneMatch(engineId::equals), //
-				() -> String.format("Engine ID [%s] is not in excluded list [%s]", engineId, this.engineIds), //
-				() -> String.format("Engine ID [%s] is in excluded list [%s]", engineId, this.engineIds));
+				() -> "Engine ID [%s] is not in excluded list [%s]".formatted(engineId, this.engineIds), //
+				() -> "Engine ID [%s] is in excluded list [%s]".formatted(engineId, this.engineIds));
 		}
 	}
 
 	@Override
 	public String toString() {
-		return String.format("%s that %s engines with IDs %s", getClass().getSimpleName(), this.type.verb,
-			this.engineIds);
+		return "%s that %s engines with IDs %s".formatted(getClass().getSimpleName(), this.type.verb, this.engineIds);
 	}
 
 	private static List<String> validateAndTrim(List<String> engineIds) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/ExcludeMethodFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/ExcludeMethodFilter.java
@@ -42,17 +42,16 @@ class ExcludeMethodFilter extends AbstractMethodFilter {
 	}
 
 	private String formatInclusionReason(String methodName) {
-		return String.format("Method name [%s] does not match any excluded pattern: %s", methodName,
-			patternDescription);
+		return "Method name [%s] does not match any excluded pattern: %s".formatted(methodName, patternDescription);
 	}
 
 	private String formatExclusionReason(String methodName, Pattern pattern) {
-		return String.format("Method name [%s] matches excluded pattern: '%s'", methodName, pattern);
+		return "Method name [%s] matches excluded pattern: '%s'".formatted(methodName, pattern);
 	}
 
 	@Override
 	public String toString() {
-		return String.format("%s that excludes method names that match one of the following regular expressions: %s",
+		return "%s that excludes method names that match one of the following regular expressions: %s".formatted(
 			getClass().getSimpleName(), patternDescription);
 	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/IncludeMethodFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/IncludeMethodFilter.java
@@ -42,17 +42,16 @@ class IncludeMethodFilter extends AbstractMethodFilter {
 	}
 
 	private String formatInclusionReason(String methodName, Pattern pattern) {
-		return String.format("Method name [%s] matches included pattern: '%s'", methodName, pattern);
+		return "Method name [%s] matches included pattern: '%s'".formatted(methodName, pattern);
 	}
 
 	private String formatExclusionReason(String methodName) {
-		return String.format("Method name [%s] does not match any included pattern: %s", methodName,
-			patternDescription);
+		return "Method name [%s] does not match any included pattern: %s".formatted(methodName, patternDescription);
 	}
 
 	@Override
 	public String toString() {
-		return String.format("%s that includes method names that match one of the following regular expressions: %s",
+		return "%s that includes method names that match one of the following regular expressions: %s".formatted(
 			getClass().getSimpleName(), patternDescription);
 	}
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
@@ -140,12 +140,11 @@ public final class TagFilter {
 	}
 
 	private static String inclusionReasonExpressionSatisfy(List<String> tagExpressions) {
-		return String.format("included because tags match expression(s): [%s]", formatToString(tagExpressions));
+		return "included because tags match expression(s): [%s]".formatted(formatToString(tagExpressions));
 	}
 
 	private static String exclusionReasonExpressionNotSatisfy(List<String> tagExpressions) {
-		return String.format("excluded because tags do not match tag expression(s): [%s]",
-			formatToString(tagExpressions));
+		return "excluded because tags do not match tag expression(s): [%s]".formatted(formatToString(tagExpressions));
 	}
 
 	private static PostDiscoveryFilter excludeMatching(List<String> tagExpressions) {
@@ -161,11 +160,11 @@ public final class TagFilter {
 	}
 
 	private static String inclusionReasonExpressionNotSatisfy(List<String> tagExpressions) {
-		return String.format("included because tags do not match expression(s): [%s]", formatToString(tagExpressions));
+		return "included because tags do not match expression(s): [%s]".formatted(formatToString(tagExpressions));
 	}
 
 	private static String exclusionReasonExpressionSatisfy(List<String> tagExpressions) {
-		return String.format("excluded because tags match tag expression(s): [%s]", formatToString(tagExpressions));
+		return "excluded because tags match tag expression(s): [%s]".formatted(formatToString(tagExpressions));
 	}
 
 	private static String formatToString(List<String> tagExpressions) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -22,6 +22,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.ObjectStreamField;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -47,7 +48,9 @@ import org.junit.platform.engine.UniqueId;
 @API(status = STABLE, since = "1.0")
 public final class TestIdentifier implements Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
+	@Serial
 	private static final ObjectStreamField[] serialPersistentFields = ObjectStreamClass.lookup(
 		SerializedForm.class).getFields();
 
@@ -272,11 +275,13 @@ public final class TestIdentifier implements Serializable {
 		// @formatter:on
 	}
 
+	@Serial
 	private void writeObject(ObjectOutputStream s) throws IOException {
 		SerializedForm serializedForm = new SerializedForm(this);
 		serializedForm.serialize(s);
 	}
 
+	@Serial
 	private void readObject(ObjectInputStream s) throws ClassNotFoundException, IOException {
 		SerializedForm serializedForm = SerializedForm.deserialize(s);
 		uniqueId = UniqueId.parse(serializedForm.uniqueId);
@@ -295,6 +300,7 @@ public final class TestIdentifier implements Serializable {
 	 */
 	private static class SerializedForm implements Serializable {
 
+		@Serial
 		private static final long serialVersionUID = 1L;
 
 		private final String uniqueId;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -248,8 +248,7 @@ public final class TestIdentifier implements Serializable {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof TestIdentifier) {
-			TestIdentifier that = (TestIdentifier) obj;
+		if (obj instanceof TestIdentifier that) {
 			return Objects.equals(this.uniqueId, that.uniqueId);
 		}
 		return false;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -110,7 +110,7 @@ public class TestPlan {
 		allIdentifiers.put(testIdentifier.getUniqueIdObject(), testIdentifier);
 
 		// Root identifiers. Typically, a test engine.
-		if (!testIdentifier.getParentIdObject().isPresent()) {
+		if (testIdentifier.getParentIdObject().isEmpty()) {
 			roots.add(testIdentifier);
 			return;
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ClasspathAlignmentChecker.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ClasspathAlignmentChecker.java
@@ -86,7 +86,7 @@ class ClasspathAlignmentChecker {
 			packagesByVersions.values().stream() //
 					.flatMap(List::stream) //
 					.sorted(comparing(Package::getName)) //
-					.map(pkg -> String.format("- %s: %s%n", pkg.getName(), pkg.getImplementationVersion())) //
+					.map(pkg -> "- %s: %s%n".formatted(pkg.getName(), pkg.getImplementationVersion())) //
 					.forEach(message::append);
 			return Optional.of(new JUnitException(message.toString(), error));
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/CompositeEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/CompositeEngineExecutionListener.java
@@ -83,9 +83,8 @@ class CompositeEngineExecutionListener implements EngineExecutionListener {
 			}
 			catch (Throwable throwable) {
 				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
-				logger.warn(throwable,
-					() -> String.format("EngineExecutionListener [%s] threw exception for method: %s",
-						listener.getClass().getName(), description.get()));
+				logger.warn(throwable, () -> "EngineExecutionListener [%s] threw exception for method: %s".formatted(
+					listener.getClass().getName(), description.get()));
 			}
 		});
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/CompositeTestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/CompositeTestExecutionListener.java
@@ -111,7 +111,7 @@ class CompositeTestExecutionListener implements TestExecutionListener {
 			}
 			catch (Throwable throwable) {
 				UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
-				logger.warn(throwable, () -> String.format("TestExecutionListener [%s] threw exception for method: %s",
+				logger.warn(throwable, () -> "TestExecutionListener [%s] threw exception for method: %s".formatted(
 					listener.getClass().getName(), description.get()));
 			}
 		});

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueCollector.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueCollector.java
@@ -69,8 +69,8 @@ class DiscoveryIssueCollector implements LauncherDiscoveryListener {
 					.source(toSource(selector)) //
 					.build());
 		}
-		else if (result.getStatus() == UNRESOLVED && selector instanceof UniqueIdSelector) {
-			UniqueId uniqueId = ((UniqueIdSelector) selector).getUniqueId();
+		else if (result.getStatus() == UNRESOLVED && selector instanceof UniqueIdSelector uniqueIdSelector) {
+			UniqueId uniqueId = uniqueIdSelector.getUniqueId();
 			if (uniqueId.hasPrefix(engineId)) {
 				this.issues.add(DiscoveryIssue.create(Severity.ERROR, selector + " could not be resolved"));
 			}
@@ -78,37 +78,34 @@ class DiscoveryIssueCollector implements LauncherDiscoveryListener {
 	}
 
 	static TestSource toSource(DiscoverySelector selector) {
-		if (selector instanceof ClassSelector) {
-			return ClassSource.from(((ClassSelector) selector).getClassName());
+		if (selector instanceof ClassSelector classSelector) {
+			return ClassSource.from(classSelector.getClassName());
 		}
-		if (selector instanceof MethodSelector) {
-			MethodSelector methodSelector = (MethodSelector) selector;
+		if (selector instanceof MethodSelector methodSelector) {
 			return MethodSource.from(methodSelector.getClassName(), methodSelector.getMethodName(),
 				methodSelector.getParameterTypeNames());
 		}
-		if (selector instanceof ClasspathResourceSelector) {
-			ClasspathResourceSelector resourceSelector = (ClasspathResourceSelector) selector;
+		if (selector instanceof ClasspathResourceSelector resourceSelector) {
 			String resourceName = resourceSelector.getClasspathResourceName();
 			return resourceSelector.getPosition() //
 					.map(DiscoveryIssueCollector::convert) //
 					.map(position -> ClasspathResourceSource.from(resourceName, position)) //
 					.orElseGet(() -> ClasspathResourceSource.from(resourceName));
 		}
-		if (selector instanceof PackageSelector) {
-			return PackageSource.from(((PackageSelector) selector).getPackageName());
+		if (selector instanceof PackageSelector packageSelector) {
+			return PackageSource.from(packageSelector.getPackageName());
 		}
-		if (selector instanceof FileSelector) {
-			FileSelector fileSelector = (FileSelector) selector;
+		if (selector instanceof FileSelector fileSelector) {
 			return fileSelector.getPosition() //
 					.map(DiscoveryIssueCollector::convert) //
 					.map(position -> FileSource.from(fileSelector.getFile(), position)) //
 					.orElseGet(() -> FileSource.from(fileSelector.getFile()));
 		}
-		if (selector instanceof DirectorySelector) {
-			return DirectorySource.from(((DirectorySelector) selector).getDirectory());
+		if (selector instanceof DirectorySelector directorySelector) {
+			return DirectorySource.from(directorySelector.getDirectory());
 		}
-		if (selector instanceof UriSelector) {
-			return UriSource.from(((UriSelector) selector).getUri());
+		if (selector instanceof UriSelector uriSelector) {
+			return UriSource.from(uriSelector.getUri());
 		}
 		return null;
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueException.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueException.java
@@ -12,6 +12,8 @@ package org.junit.platform.launcher.core;
 
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
+import java.io.Serial;
+
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
 
@@ -24,6 +26,7 @@ import org.junit.platform.commons.JUnitException;
 @API(status = EXPERIMENTAL, since = "1.13")
 public class DiscoveryIssueException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	DiscoveryIssueException(String message) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
@@ -123,12 +123,10 @@ class DiscoveryIssueNotifier {
 				issue.message());
 			issue.source().ifPresent(source -> {
 				message.append("\n    Source: ").append(source);
-				if (source instanceof MethodSource) {
-					MethodSource methodSource = (MethodSource) source;
+				if (source instanceof MethodSource methodSource) {
 					appendIdeCompatibleLink(message, methodSource.getClassName(), methodSource.getMethodName());
 				}
-				else if (source instanceof ClassSource) {
-					ClassSource classSource = (ClassSource) source;
+				else if (source instanceof ClassSource classSource) {
 					appendIdeCompatibleLink(message, classSource.getClassName(), "<no-method>");
 				}
 			});

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -200,8 +200,8 @@ public class EngineDiscoveryOrchestrator {
 		catch (Throwable throwable) {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 			JUnitException cause = null;
-			if (throwable instanceof LinkageError) {
-				cause = ClasspathAlignmentChecker.check((LinkageError) throwable).orElse(null);
+			if (throwable instanceof LinkageError error) {
+				cause = ClasspathAlignmentChecker.check(error).orElse(null);
 			}
 			if (cause == null) {
 				String message = "TestEngine with ID '%s' failed to discover tests".formatted(testEngine.getId());

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -163,13 +163,13 @@ public class EngineDiscoveryOrchestrator {
 			boolean engineIsExcluded = engineFilterer.isExcluded(testEngine);
 
 			if (engineIsExcluded) {
-				logger.debug(() -> String.format("Test discovery for engine '%s' was skipped due to an EngineFilter%s.",
-					testEngine.getId(), phase.map(it -> String.format(" in %s phase", it)).orElse("")));
+				logger.debug(() -> "Test discovery for engine '%s' was skipped due to an EngineFilter%s.".formatted(
+					testEngine.getId(), phase.map(it -> " in %s phase".formatted(it)).orElse("")));
 				continue;
 			}
 
-			logger.debug(() -> String.format("Discovering tests%s in engine '%s'.",
-				phase.map(it -> String.format(" during Launcher %s phase", it)).orElse(""), testEngine.getId()));
+			logger.debug(() -> "Discovering tests%s in engine '%s'.".formatted(
+				phase.map(it -> " during Launcher %s phase".formatted(it)).orElse(""), testEngine.getId()));
 
 			EngineResultInfo engineResult = discoverEngineRoot(testEngine, request, issueCollector, uniqueIdCreator);
 			testEngineDescriptors.put(testEngine, engineResult);
@@ -204,7 +204,7 @@ public class EngineDiscoveryOrchestrator {
 				cause = ClasspathAlignmentChecker.check((LinkageError) throwable).orElse(null);
 			}
 			if (cause == null) {
-				String message = String.format("TestEngine with ID '%s' failed to discover tests", testEngine.getId());
+				String message = "TestEngine with ID '%s' failed to discover tests".formatted(testEngine.getId());
 				cause = new JUnitException(message, throwable);
 			}
 			listener.engineDiscoveryFinished(uniqueEngineId, EngineDiscoveryResult.failed(cause));
@@ -247,10 +247,10 @@ public class EngineDiscoveryOrchestrator {
 			String displayNames = testDescriptors.stream().map(TestDescriptor::getDisplayName).collect(joining(", "));
 			long containerCount = testDescriptors.stream().filter(TestDescriptor::isContainer).count();
 			long methodCount = testDescriptors.stream().filter(TestDescriptor::isTest).count();
-			logger.config(() -> String.format("%d containers and %d tests were %s", containerCount, methodCount,
-				exclusionReason));
+			logger.config(
+				() -> "%d containers and %d tests were %s".formatted(containerCount, methodCount, exclusionReason));
 			logger.debug(
-				() -> String.format("The following containers and tests were %s: %s", exclusionReason, displayNames));
+				() -> "The following containers and tests were %s: %s".formatted(exclusionReason, displayNames));
 		});
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryResultValidator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryResultValidator.java
@@ -39,12 +39,11 @@ class EngineDiscoveryResultValidator {
 	 */
 	void validate(TestEngine testEngine, TestDescriptor root) {
 		Preconditions.notNull(root,
-			() -> String.format(
-				"The discover() method for TestEngine with ID '%s' must return a non-null root TestDescriptor.",
+			() -> "The discover() method for TestEngine with ID '%s' must return a non-null root TestDescriptor.".formatted(
 				testEngine.getId()));
 		Optional<String> cyclicGraphInfo = getCyclicGraphInfo(root);
-		Preconditions.condition(!cyclicGraphInfo.isPresent(),
-			() -> String.format("The discover() method for TestEngine with ID '%s' returned a cyclic graph; %s",
+		Preconditions.condition(cyclicGraphInfo.isEmpty(),
+			() -> "The discover() method for TestEngine with ID '%s' returned a cyclic graph; %s".formatted(
 				testEngine.getId(), cyclicGraphInfo.get()));
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryResultValidator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryResultValidator.java
@@ -69,7 +69,7 @@ class EngineDiscoveryResultValidator {
 					List<UniqueId> path2 = findPath(visited, parent.getUniqueId());
 					path2.add(uid);
 
-					return Optional.of(String.format("%s exists in at least two paths:\n(1) %s\n(2) %s", uid,
+					return Optional.of("%s exists in at least two paths:\n(1) %s\n(2) %s".formatted(uid,
 						formatted(path1), formatted(path2)));
 				}
 				else {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -235,8 +235,8 @@ public class EngineExecutionOrchestrator {
 		catch (Throwable throwable) {
 			UnrecoverableExceptions.rethrowIfUnrecoverable(throwable);
 			JUnitException cause = null;
-			if (throwable instanceof LinkageError) {
-				cause = ClasspathAlignmentChecker.check((LinkageError) throwable).orElse(null);
+			if (throwable instanceof LinkageError error) {
+				cause = ClasspathAlignmentChecker.check(error).orElse(null);
 			}
 			if (cause == null) {
 				String message = "TestEngine with ID '%s' failed to execute tests".formatted(testEngine.getId());

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -239,7 +239,7 @@ public class EngineExecutionOrchestrator {
 				cause = ClasspathAlignmentChecker.check((LinkageError) throwable).orElse(null);
 			}
 			if (cause == null) {
-				String message = String.format("TestEngine with ID '%s' failed to execute tests", testEngine.getId());
+				String message = "TestEngine with ID '%s' failed to execute tests".formatted(testEngine.getId());
 				cause = new JUnitException(message, throwable);
 			}
 			delayingListener.reportEngineStartIfNecessary();

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineIdValidator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineIdValidator.java
@@ -32,15 +32,15 @@ class EngineIdValidator {
 		for (TestEngine testEngine : testEngines) {
 			// check usage of reserved ID prefix
 			if (!validateReservedIds(testEngine)) {
-				getLogger().warn(() -> String.format(
-					"Third-party TestEngine implementations are forbidden to use the reserved 'junit-' prefix for their ID: '%s'",
-					testEngine.getId()));
+				getLogger().warn(
+					() -> "Third-party TestEngine implementations are forbidden to use the reserved 'junit-' prefix for their ID: '%s'".formatted(
+						testEngine.getId()));
 			}
 
 			// check uniqueness
 			if (!ids.add(testEngine.getId())) {
-				throw new JUnitException(String.format(
-					"Cannot create Launcher for multiple engines with the same ID '%s'.", testEngine.getId()));
+				throw new JUnitException(
+					"Cannot create Launcher for multiple engines with the same ID '%s'.".formatted(testEngine.getId()));
 			}
 		}
 		return testEngines;
@@ -54,7 +54,7 @@ class EngineIdValidator {
 	// https://github.com/junit-team/junit5/issues/1557
 	private static boolean validateReservedIds(TestEngine testEngine) {
 		String engineId = Preconditions.notBlank(testEngine.getId(),
-			() -> String.format("ID for TestEngine [%s] must not be null or blank", testEngine.getClass().getName()));
+			() -> "ID for TestEngine [%s] must not be null or blank".formatted(testEngine.getClass().getName()));
 		if (!engineId.startsWith("junit-")) {
 			return true;
 		}
@@ -82,7 +82,7 @@ class EngineIdValidator {
 			return;
 		}
 		throw new JUnitException(
-			String.format("Third-party TestEngine '%s' is forbidden to use the reserved '%s' TestEngine ID.",
+			"Third-party TestEngine '%s' is forbidden to use the reserved '%s' TestEngine ID.".formatted(
 				actualClassName, testEngine.getId()));
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/HierarchicalOutputDirectoryProvider.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/HierarchicalOutputDirectoryProvider.java
@@ -13,7 +13,6 @@ package org.junit.platform.launcher.core;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -62,7 +61,7 @@ class HierarchicalOutputDirectoryProvider implements OutputDirectoryProvider {
 	}
 
 	private static Path toSanitizedPath(Segment segment) {
-		return Paths.get(sanitizeName(segment.getValue()));
+		return Path.of(sanitizeName(segment.getValue()));
 	}
 
 	private static String sanitizeName(String value) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -270,14 +270,14 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 							Stream.of(configFileUrl + " (*)"), //
 							resources.stream().skip(1).map(URL::toString) //
 						).collect(joining("\n- ", "\n- ", ""));
-						return String.format(
-							"Discovered %d '%s' configuration files on the classpath (see below); only the first (*) will be used.%s",
+						return "Discovered %d '%s' configuration files on the classpath (see below); only the first (*) will be used.%s".formatted(
 							resources.size(), configFileName, formattedResourceList);
 					});
 				}
 
-				logger.config(() -> String.format(
-					"Loading JUnit Platform configuration parameters from classpath resource [%s].", configFileUrl));
+				logger.config(
+					() -> "Loading JUnit Platform configuration parameters from classpath resource [%s].".formatted(
+						configFileUrl));
 				URLConnection urlConnection = configFileUrl.openConnection();
 				urlConnection.setUseCaches(false);
 				try (InputStream inputStream = urlConnection.getInputStream()) {
@@ -287,8 +287,7 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 		}
 		catch (Exception ex) {
 			logger.warn(ex,
-				() -> String.format(
-					"Failed to load JUnit Platform configuration parameters from classpath resource [%s].",
+				() -> "Failed to load JUnit Platform configuration parameters from classpath resource [%s].".formatted(
 					configFileName));
 		}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -315,7 +315,7 @@ public final class LauncherDiscoveryRequestBuilder {
 		}
 		else {
 			throw new PreconditionViolationException(
-				String.format("Filter [%s] must implement %s, %s, or %s.", filter, EngineFilter.class.getSimpleName(),
+				"Filter [%s] must implement %s, %s, or %s.".formatted(filter, EngineFilter.class.getSimpleName(),
 					PostDiscoveryFilter.class.getSimpleName(), DiscoveryFilter.class.getSimpleName()));
 		}
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -304,14 +304,14 @@ public final class LauncherDiscoveryRequestBuilder {
 	}
 
 	private void storeFilter(Filter<?> filter) {
-		if (filter instanceof EngineFilter) {
-			this.engineFilters.add((EngineFilter) filter);
+		if (filter instanceof EngineFilter engineFilter) {
+			this.engineFilters.add(engineFilter);
 		}
-		else if (filter instanceof PostDiscoveryFilter) {
-			this.postDiscoveryFilters.add((PostDiscoveryFilter) filter);
+		else if (filter instanceof PostDiscoveryFilter postDiscoveryFilter) {
+			this.postDiscoveryFilters.add(postDiscoveryFilter);
 		}
-		else if (filter instanceof DiscoveryFilter<?>) {
-			this.discoveryFilters.add((DiscoveryFilter<?>) filter);
+		else if (filter instanceof DiscoveryFilter<?> discoveryFilter) {
+			this.discoveryFilters.add(discoveryFilter);
 		}
 		else {
 			throw new PreconditionViolationException(

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherPhase.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherPhase.java
@@ -37,7 +37,7 @@ enum LauncherPhase {
 			}
 			catch (Exception e) {
 				logger.warn(
-					() -> String.format("Ignoring invalid LauncherPhase '%s' set via the '%s' configuration parameter.",
+					() -> "Ignoring invalid LauncherPhase '%s' set via the '%s' configuration parameter.".formatted(
 						value, DISCOVERY_ISSUE_FAILURE_PHASE_PROPERTY_NAME));
 				return null;
 			}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderRegistry.java
@@ -48,9 +48,9 @@ class ServiceLoaderRegistry {
 	private static <T> String logLoadedInstances(Class<T> type, List<T> instances, List<String> exclusions) {
 		String typeName = type.getSimpleName();
 		if (exclusions == null) {
-			return String.format("Loaded %s instances: %s", typeName, instances);
+			return "Loaded %s instances: %s".formatted(typeName, instances);
 		}
-		return String.format("Loaded %s instances: %s (excluded classes: %s)", typeName, instances, exclusions);
+		return "Loaded %s instances: %s (excluded classes: %s)".formatted(typeName, instances, exclusions);
 	}
 
 	private static <T> List<T> load(Class<T> type, Predicate<String> classNameFilter,

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
@@ -50,8 +50,7 @@ class StackTracePruningEngineExecutionListener extends DelegatingEngineExecution
 		return testDescriptor.getAncestors() //
 				.stream() //
 				.map(TestDescriptor::getSource) //
-				.filter(Optional::isPresent) //
-				.map(Optional::get) //
+				.flatMap(Optional::stream) //
 				.map(source -> {
 					if (source instanceof ClassSource) {
 						return ((ClassSource) source).getClassName();

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
@@ -52,11 +52,11 @@ class StackTracePruningEngineExecutionListener extends DelegatingEngineExecution
 				.map(TestDescriptor::getSource) //
 				.flatMap(Optional::stream) //
 				.map(source -> {
-					if (source instanceof ClassSource) {
-						return ((ClassSource) source).getClassName();
+					if (source instanceof ClassSource classSource) {
+						return classSource.getClassName();
 					}
-					else if (source instanceof MethodSource) {
-						return ((MethodSource) source).getClassName();
+					else if (source instanceof MethodSource methodSource) {
+						return methodSource.getClassName();
 					}
 					else {
 						return null;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListener.java
@@ -55,7 +55,7 @@ class StreamInterceptingTestExecutionListener implements EagerTestExecutionListe
 		Optional<StreamInterceptor> stderrInterceptor = captureStderr ? StreamInterceptor.registerStderr(maxSize)
 				: Optional.empty();
 
-		if ((!stdoutInterceptor.isPresent() && captureStdout) || (!stderrInterceptor.isPresent() && captureStderr)) {
+		if ((stdoutInterceptor.isEmpty() && captureStdout) || (stderrInterceptor.isEmpty() && captureStderr)) {
 			stdoutInterceptor.ifPresent(StreamInterceptor::unregister);
 			stderrInterceptor.ifPresent(StreamInterceptor::unregister);
 			return Optional.empty();

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestEngineFormatter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestEngineFormatter.java
@@ -33,7 +33,7 @@ class TestEngineFormatter {
 
 	private static String format(String title, Stream<TestEngine> testEngines) {
 		String details = testEngines //
-				.map(engine -> String.format("- %s (%s)", engine.getId(), join(", ", computeAttributes(engine)))) //
+				.map(engine -> "- %s (%s)".formatted(engine.getId(), join(", ", computeAttributes(engine)))) //
 				.collect(joining("\n"));
 		return title + ":" + (details.isEmpty() ? " <none>" : "\n" + details);
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LoggingListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LoggingListener.java
@@ -124,7 +124,7 @@ public class LoggingListener implements TestExecutionListener {
 	}
 
 	private void logWithThrowable(String message, Throwable t, Object... args) {
-		this.logger.accept(t, () -> String.format(message, args));
+		this.logger.accept(t, () -> message.formatted(args));
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
@@ -98,7 +98,7 @@ public class OutputDir {
 	}
 
 	public Path createFile(String prefix, String extension) throws UncheckedIOException {
-		String filename = String.format("%s-%d.%s", prefix, Math.abs(random.nextLong()), extension);
+		String filename = "%s-%d.%s".formatted(prefix, Math.abs(random.nextLong()), extension);
 		Path outputFile = path.resolve(filename);
 
 		try {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/OutputDir.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.SecureRandom;
 import java.util.Optional;
@@ -36,7 +35,7 @@ public class OutputDir {
 		Pattern.quote(OUTPUT_DIR_UNIQUE_NUMBER_PLACEHOLDER));
 
 	public static OutputDir create(Optional<String> customDir) {
-		return create(customDir, () -> Paths.get("."));
+		return create(customDir, () -> Path.of("."));
 	}
 
 	static OutputDir create(Optional<String> customDir, Supplier<Path> currentWorkingDir) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListener.java
@@ -206,7 +206,7 @@ public class UniqueIdTrackingListener implements TestExecutionListener {
 		String prefix = configurationParameters.get(OUTPUT_FILE_PREFIX_PROPERTY_NAME) //
 				.orElse(DEFAULT_OUTPUT_FILE_PREFIX);
 		Supplier<Path> workingDirSupplier = () -> configurationParameters.get(WORKING_DIR_PROPERTY_NAME).map(
-			Paths::get).orElseGet(() -> Paths.get("."));
+			Paths::get).orElseGet(() -> Path.of("."));
 		return OutputDir.create(configurationParameters.get(OUTPUT_DIR_PROPERTY_NAME), workingDirSupplier) //
 				.createFile(prefix, "txt");
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/discovery/LoggingLauncherDiscoveryListener.java
@@ -78,8 +78,8 @@ class LoggingLauncherDiscoveryListener implements LauncherDiscoveryListener {
 				break;
 			case UNRESOLVED:
 				Consumer<Supplier<String>> loggingConsumer = logger::debug;
-				if (selector instanceof UniqueIdSelector) {
-					UniqueId uniqueId = ((UniqueIdSelector) selector).getUniqueId();
+				if (selector instanceof UniqueIdSelector uniqueIdSelector) {
+					UniqueId uniqueId = uniqueIdSelector.getUniqueId();
 					if (uniqueId.hasPrefix(engineId)) {
 						loggingConsumer = logger::warn;
 					}

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -17,7 +17,6 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Clock;
 
 import javax.xml.stream.XMLStreamException;
@@ -57,7 +56,7 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 
 	// For tests only
 	LegacyXmlReportGeneratingListener(String reportsDir, PrintWriter out, Clock clock) {
-		this(Paths.get(reportsDir), out, clock);
+		this(Path.of(reportsDir), out, clock);
 	}
 
 	private LegacyXmlReportGeneratingListener(Path reportsDir, PrintWriter out, Clock clock) {

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListener.java
@@ -121,7 +121,7 @@ public class LegacyXmlReportGeneratingListener implements TestExecutionListener 
 	}
 
 	private boolean isRoot(TestIdentifier testIdentifier) {
-		return !testIdentifier.getParentIdObject().isPresent();
+		return testIdentifier.getParentIdObject().isEmpty();
 	}
 
 	private void printException(String message, Exception exception) {

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
@@ -303,17 +303,15 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 	}
 
 	private void addTestSource(TestSource source, Sources sources) {
-		if (source instanceof CompositeTestSource) {
-			((CompositeTestSource) source).getSources().forEach(it -> addTestSource(it, sources));
+		if (source instanceof CompositeTestSource compositeSource) {
+			compositeSource.getSources().forEach(it -> addTestSource(it, sources));
 		}
-		else if (source instanceof ClassSource) {
-			ClassSource classSource = (ClassSource) source;
+		else if (source instanceof ClassSource classSource) {
 			sources.append(classSource(classSource.getClassName()), //
 				element -> classSource.getPosition().ifPresent(
 					filePosition -> element.addFilePosition(filePosition.getLine(), filePosition.getColumn())));
 		}
-		else if (source instanceof MethodSource) {
-			MethodSource methodSource = (MethodSource) source;
+		else if (source instanceof MethodSource methodSource) {
 			sources.append(methodSource(methodSource.getClassName(), methodSource.getMethodName()), element -> {
 				String methodParameterTypes = methodSource.getMethodParameterTypes();
 				if (methodParameterTypes != null) {
@@ -321,26 +319,24 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 				}
 			});
 		}
-		else if (source instanceof ClasspathResourceSource) {
-			ClasspathResourceSource classpathResourceSource = (ClasspathResourceSource) source;
+		else if (source instanceof ClasspathResourceSource classpathResourceSource) {
 			sources.append(classpathResourceSource(classpathResourceSource.getClasspathResourceName()), //
 				element -> classpathResourceSource.getPosition().ifPresent(
 					filePosition -> element.addFilePosition(filePosition.getLine(), filePosition.getColumn())));
 		}
-		else if (source instanceof PackageSource) {
-			sources.append(packageSource(((PackageSource) source).getPackageName()));
+		else if (source instanceof PackageSource packageSource) {
+			sources.append(packageSource(packageSource.getPackageName()));
 		}
-		else if (source instanceof FileSource) {
-			FileSource fileSource = (FileSource) source;
+		else if (source instanceof FileSource fileSource) {
 			sources.append(fileSource(fileSource.getFile()), //
 				element -> fileSource.getPosition().ifPresent(
 					filePosition -> element.addFilePosition(filePosition.getLine(), filePosition.getColumn())));
 		}
-		else if (source instanceof DirectorySource) {
-			sources.append(directorySource(((DirectorySource) source).getFile()));
+		else if (source instanceof DirectorySource directorySource) {
+			sources.append(directorySource(directorySource.getFile()));
 		}
-		else if (source instanceof UriSource) {
-			sources.append(uriSource(((UriSource) source).getUri()));
+		else if (source instanceof UriSource uriSource) {
+			sources.append(uriSource(uriSource.getUri()));
 		}
 	}
 

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
@@ -61,7 +61,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -119,7 +118,7 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 
 	@SuppressWarnings("unused") // Used via ServiceLoader
 	public OpenTestReportGeneratingListener() {
-		this(Paths.get(".").toAbsolutePath());
+		this(Path.of(".").toAbsolutePath());
 	}
 
 	OpenTestReportGeneratingListener(Path workingDir) {

--- a/junit-platform-suite-commons/src/main/java/org/junit/platform/suite/commons/SuiteLauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-suite-commons/src/main/java/org/junit/platform/suite/commons/SuiteLauncherDiscoveryRequestBuilder.java
@@ -463,7 +463,7 @@ public final class SuiteLauncherDiscoveryRequestBuilder {
 
 	private static Stream<ClassSelector> toClassSelectors(Class<?> suiteClass, SelectClasses annotation) {
 		Preconditions.condition(annotation.value().length > 0 || annotation.names().length > 0,
-			() -> String.format("@SelectClasses on class [%s] must declare at least one class reference or name",
+			() -> "@SelectClasses on class [%s] must declare at least one class reference or name".formatted(
 				suiteClass.getName()));
 		return Stream.concat(//
 			AdditionalDiscoverySelectors.selectClasses(annotation.value()), //
@@ -535,7 +535,7 @@ public final class SuiteLauncherDiscoveryRequestBuilder {
 	}
 
 	private static String prefixErrorMessageForInvalidSelectMethodUsage(Class<?> suiteClass, String detailMessage) {
-		return String.format("@SelectMethod on class [%s]: %s", suiteClass.getName(), detailMessage);
+		return "@SelectMethod on class [%s]: %s".formatted(suiteClass.getName(), detailMessage);
 	}
 
 	private ClassNameFilter createIncludeClassNameFilter(String... patterns) {

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/ClassSelectorResolver.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/ClassSelectorResolver.java
@@ -133,8 +133,7 @@ final class ClassSelectorResolver implements SelectorResolver {
 	}
 
 	private static String createConfigContainsCycleMessage(Class<?> suiteClass, UniqueId suiteId) {
-		return String.format(
-			"The suite configuration of [%s] resulted in a cycle [%s] and will not be discovered a second time.",
+		return "The suite configuration of [%s] resulted in a cycle [%s] and will not be discovered a second time.".formatted(
 			suiteClass.getName(), suiteId);
 	}
 

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/IsSuiteClass.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/IsSuiteClass.java
@@ -65,8 +65,7 @@ final class IsSuiteClass implements Predicate<Class<?>> {
 	}
 
 	private static DiscoveryIssue createIssue(Class<?> testClass, String detailMessage) {
-		String message = String.format("@Suite class '%s' %s It will not be executed.", testClass.getName(),
-			detailMessage);
+		String message = "@Suite class '%s' %s It will not be executed.".formatted(testClass.getName(), detailMessage);
 		return DiscoveryIssue.builder(DiscoveryIssue.Severity.WARNING, message) //
 				.source(ClassSource.from(testClass)) //
 				.build();

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/LifecycleMethodUtils.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/LifecycleMethodUtils.java
@@ -65,7 +65,7 @@ final class LifecycleMethodUtils {
 	private static DiscoveryIssueReporter.Condition<Method> isStatic(Class<? extends Annotation> annotationType,
 			DiscoveryIssueReporter issueReporter) {
 		return issueReporter.createReportingCondition(ModifierSupport::isStatic, method -> {
-			String message = String.format("@%s method '%s' must be static.", annotationType.getSimpleName(),
+			String message = "@%s method '%s' must be static.".formatted(annotationType.getSimpleName(),
 				method.toGenericString());
 			return createError(message, method);
 		});
@@ -74,7 +74,7 @@ final class LifecycleMethodUtils {
 	private static DiscoveryIssueReporter.Condition<Method> isNotPrivate(Class<? extends Annotation> annotationType,
 			DiscoveryIssueReporter issueReporter) {
 		return issueReporter.createReportingCondition(ModifierSupport::isNotPrivate, method -> {
-			String message = String.format("@%s method '%s' must not be private.", annotationType.getSimpleName(),
+			String message = "@%s method '%s' must not be private.".formatted(annotationType.getSimpleName(),
 				method.toGenericString());
 			return createError(message, method);
 		});
@@ -83,7 +83,7 @@ final class LifecycleMethodUtils {
 	private static DiscoveryIssueReporter.Condition<Method> returnsPrimitiveVoid(
 			Class<? extends Annotation> annotationType, DiscoveryIssueReporter issueReporter) {
 		return issueReporter.createReportingCondition(ReflectionUtils::returnsPrimitiveVoid, method -> {
-			String message = String.format("@%s method '%s' must not return a value.", annotationType.getSimpleName(),
+			String message = "@%s method '%s' must not return a value.".formatted(annotationType.getSimpleName(),
 				method.toGenericString());
 			return createError(message, method);
 		});
@@ -92,8 +92,8 @@ final class LifecycleMethodUtils {
 	private static DiscoveryIssueReporter.Condition<Method> hasNoParameters(Class<? extends Annotation> annotationType,
 			DiscoveryIssueReporter issueReporter) {
 		return issueReporter.createReportingCondition(method -> method.getParameterCount() == 0, method -> {
-			String message = String.format("@%s method '%s' must not accept parameters.",
-				annotationType.getSimpleName(), method.toGenericString());
+			String message = "@%s method '%s' must not accept parameters.".formatted(annotationType.getSimpleName(),
+				method.toGenericString());
 			return createError(message, method);
 		});
 	}

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/NoTestsDiscoveredException.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/NoTestsDiscoveredException.java
@@ -10,10 +10,13 @@
 
 package org.junit.platform.suite.engine;
 
+import java.io.Serial;
+
 import org.junit.platform.commons.JUnitException;
 
 class NoTestsDiscoveredException extends JUnitException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	NoTestsDiscoveredException(Class<?> suiteClass) {

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/NoTestsDiscoveredException.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/NoTestsDiscoveredException.java
@@ -17,7 +17,7 @@ class NoTestsDiscoveredException extends JUnitException {
 	private static final long serialVersionUID = 1L;
 
 	NoTestsDiscoveredException(Class<?> suiteClass) {
-		super(String.format("Suite [%s] did not discover any tests", suiteClass.getName()));
+		super("Suite [%s] did not discover any tests".formatted(suiteClass.getName()));
 	}
 
 }

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
@@ -90,7 +90,7 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 		// @formatter:off
 		return findAnnotation(suiteClass, Suite.class)
 				.map(Suite::failIfNoTests)
-				.orElseThrow(() -> new JUnitException(String.format("Suite [%s] was not annotated with @Suite", suiteClass.getName())));
+				.orElseThrow(() -> new JUnitException("Suite [%s] was not annotated with @Suite".formatted(suiteClass.getName())));
 		// @formatter:on
 	}
 
@@ -246,7 +246,7 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 					if (message.endsWith(".")) {
 						message = message.substring(0, message.length() - 1);
 					}
-					return String.format("[%s] %s (via @Suite %s).", engineId, message, suitePath);
+					return "[%s] %s (via @Suite %s).".formatted(engineId, message, suitePath);
 				}));
 		}
 

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Assertions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Assertions.java
@@ -82,7 +82,7 @@ class Assertions {
 	}
 
 	private static String formatValues(long expected, long actual) {
-		return String.format("expected: <%d> but was: <%d>", expected, actual);
+		return "expected: <%d> but was: <%d>".formatted(expected, actual);
 	}
 
 }

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -293,7 +293,7 @@ public final class EngineTestKit {
 				.filter((TestEngine engine) -> engineId.equals(engine.getId()))//
 				.findFirst()//
 				.orElseThrow(() -> new PreconditionViolationException(
-					String.format("Failed to load TestEngine with ID [%s]", engineId)));
+					"Failed to load TestEngine with ID [%s]".formatted(engineId)));
 	}
 
 	private EngineTestKit() {

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
@@ -476,7 +476,7 @@ public final class Events {
 				.findFirst();
 		// @formatter:on
 
-		if (!matchedEvent.isPresent()) {
+		if (matchedEvent.isEmpty()) {
 			softly.fail("Condition did not match any event: " + condition);
 		}
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -85,10 +85,10 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 	}
 
 	private boolean tryToFilterRunner(Description description) {
-		if (runner instanceof Filterable) {
+		if (runner instanceof Filterable filterable) {
 			ExcludeDescriptionFilter filter = new ExcludeDescriptionFilter(description);
 			try {
-				((Filterable) runner).filter(filter);
+				filterable.filter(filter);
 			}
 			catch (NoTestsRemainException ignore) {
 				// it's safe to ignore this exception because childless TestDescriptors will get pruned
@@ -163,7 +163,7 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 	}
 
 	private Runner getRunnerToReport() {
-		return (runner instanceof RunnerDecorator) ? ((RunnerDecorator) runner).getDecoratedRunner() : runner;
+		return (runner instanceof RunnerDecorator decorator) ? decorator.getDecoratedRunner() : runner;
 	}
 
 	public boolean isIgnored() {
@@ -172,8 +172,8 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 
 	public void setExecutorService(ExecutorService executorService) {
 		Runner runner = getRunnerToReport();
-		if (runner instanceof ParentRunner) {
-			((ParentRunner<?>) runner).setScheduler(new RunnerScheduler() {
+		if (runner instanceof ParentRunner<?> parentRunner) {
+			parentRunner.setScheduler(new RunnerScheduler() {
 
 				private final List<Future<?>> futures = new CopyOnWriteArrayList<>();
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
@@ -59,8 +59,7 @@ class MethodSelectorResolver implements SelectorResolver {
 
 	private Optional<RunnerTestDescriptor> addFilter(TestDescriptor parent,
 			Function<RunnerTestDescriptor, Filter> filterCreator) {
-		if (parent instanceof RunnerTestDescriptor) {
-			RunnerTestDescriptor runnerTestDescriptor = (RunnerTestDescriptor) parent;
+		if (parent instanceof RunnerTestDescriptor runnerTestDescriptor) {
 			runnerTestDescriptor.getFilters().ifPresent(
 				filters -> filters.add(filterCreator.apply(runnerTestDescriptor)));
 			return Optional.of(runnerTestDescriptor);

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/MethodSelectorResolver.java
@@ -113,7 +113,7 @@ class MethodSelectorResolver implements SelectorResolver {
 
 			@Override
 			public String describe() {
-				return String.format("Method %s", desiredDescription.getDisplayName());
+				return "Method %s".formatted(desiredDescription.getDisplayName());
 			}
 		};
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunListenerAdapter.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/RunListenerAdapter.java
@@ -216,7 +216,7 @@ class RunListenerAdapter extends RunListener {
 
 	private boolean isAncestor(TestDescriptor candidate, TestDescriptor testDescriptor) {
 		Optional<TestDescriptor> parent = testDescriptor.getParent();
-		if (!parent.isPresent()) {
+		if (parent.isEmpty()) {
 			return false;
 		}
 		if (parent.get().equals(candidate)) {

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -122,8 +122,7 @@ class TestRun {
 
 	void markSkipped(TestDescriptor testDescriptor) {
 		skippedDescriptors.add(testDescriptor);
-		if (testDescriptor instanceof VintageTestDescriptor) {
-			VintageTestDescriptor vintageDescriptor = (VintageTestDescriptor) testDescriptor;
+		if (testDescriptor instanceof VintageTestDescriptor vintageDescriptor) {
 			descriptionToDescriptors.get(vintageDescriptor.getDescription()).incrementSkippedOrStarted();
 		}
 	}
@@ -139,8 +138,7 @@ class TestRun {
 	void markStarted(TestDescriptor testDescriptor, EventType eventType) {
 		inProgressDescriptors.put(testDescriptor, eventType);
 		startedDescriptors.add(testDescriptor);
-		if (testDescriptor instanceof VintageTestDescriptor) {
-			VintageTestDescriptor vintageDescriptor = (VintageTestDescriptor) testDescriptor;
+		if (testDescriptor instanceof VintageTestDescriptor vintageDescriptor) {
 			inProgressDescriptorsByStartingThread.get().addLast(vintageDescriptor);
 			descriptionToDescriptors.get(vintageDescriptor.getDescription()).incrementSkippedOrStarted();
 		}
@@ -153,8 +151,7 @@ class TestRun {
 	void markFinished(TestDescriptor testDescriptor) {
 		inProgressDescriptors.remove(testDescriptor);
 		finishedDescriptors.add(testDescriptor);
-		if (testDescriptor instanceof VintageTestDescriptor) {
-			VintageTestDescriptor descriptor = (VintageTestDescriptor) testDescriptor;
+		if (testDescriptor instanceof VintageTestDescriptor descriptor) {
 			inProgressDescriptorsByStartingThread.get().removeLastOccurrence(descriptor);
 		}
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -114,7 +114,7 @@ class TestRun {
 		VintageDescriptors vintageDescriptors = descriptionToDescriptors.getOrDefault(description,
 			VintageDescriptors.NONE);
 		Optional<VintageTestDescriptor> result = vintageDescriptors.getUnambiguously(description);
-		if (!result.isPresent()) {
+		if (result.isEmpty()) {
 			result = fallback.apply(vintageDescriptors);
 		}
 		return result;

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/support/UniqueIdReader.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/support/UniqueIdReader.java
@@ -10,7 +10,6 @@
 
 package org.junit.vintage.engine.support;
 
-import static java.lang.String.format;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue;
 
@@ -47,7 +46,7 @@ public class UniqueIdReader implements Function<Description, Serializable> {
 		return tryToReadFieldValue(Description.class, fieldName, description)
 				.andThenTry(Serializable.class::cast)
 				.ifFailure(cause -> logger.warn(cause, () ->
-						format("Could not read unique ID for Description; using display name instead: %s", description)))
+						"Could not read unique ID for Description; using display name instead: %s".formatted(description)))
 				.toOptional()
 				.orElseGet(description::getDisplayName);
 		// @formatter:on

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
@@ -33,7 +33,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -271,7 +270,7 @@ class VintageTestEngineDiscoveryTests {
 	@Test
 	void resolvesClasspathSelectorForJarFile() throws Exception {
 		var jarUrl = getClass().getResource("/vintage-testjar.jar");
-		var jarFile = Paths.get(jarUrl.toURI());
+		var jarFile = Path.of(jarUrl.toURI());
 
 		var originalClassLoader = Thread.currentThread().getContextClassLoader();
 		try (var classLoader = new URLClassLoader(new URL[] { jarUrl })) {
@@ -721,7 +720,7 @@ class VintageTestEngineDiscoveryTests {
 
 	private Path getClasspathRoot(Class<?> testClass) throws Exception {
 		var location = testClass.getProtectionDomain().getCodeSource().getLocation();
-		return Paths.get(location.toURI());
+		return Path.of(location.toURI());
 	}
 
 	private void assertYieldsNoDescriptors(Class<?> testClass) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertInstanceOfAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertInstanceOfAssertionsTests.java
@@ -93,7 +93,7 @@ class AssertInstanceOfAssertionsTests {
 
 	private void assertInstanceOfFails(Class<?> expectedType, Object actualValue, String unexpectedSort) {
 		String valueType = actualValue == null ? "null" : actualValue.getClass().getCanonicalName();
-		String expectedMessage = String.format("Unexpected %s, expected: <%s> but was: <%s>", unexpectedSort,
+		String expectedMessage = "Unexpected %s, expected: <%s> but was: <%s>".formatted(unexpectedSort,
 			expectedType.getCanonicalName(), valueType);
 
 		assertThrowsWithMessage(expectedMessage, () -> assertInstanceOf(expectedType, actualValue));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledOnOsConditionTests.java
@@ -74,7 +74,7 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	void disabledOnEveryOs() {
 		evaluateCondition();
 		assertDisabled();
-		assertReasonContains(String.format("Disabled on operating system: %s ==> Disabled on every OS", OS_NAME));
+		assertReasonContains("Disabled on operating system: %s ==> Disabled on every OS".formatted(OS_NAME));
 	}
 
 	/**
@@ -234,33 +234,33 @@ class DisabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	private void assertDisabledOnCurrentOsIf(boolean condition) {
 		if (condition) {
 			assertDisabled();
-			assertReasonContains(String.format("Disabled on operating system: %s", OS_NAME));
+			assertReasonContains("Disabled on operating system: %s".formatted(OS_NAME));
 		}
 		else {
 			assertEnabled();
-			assertReasonContains(String.format("Enabled on operating system: %s", OS_NAME));
+			assertReasonContains("Enabled on operating system: %s".formatted(OS_NAME));
 		}
 	}
 
 	private void assertDisabledOnCurrentArchitectureIf(boolean condition) {
 		if (condition) {
 			assertDisabled();
-			assertReasonContains(String.format("Disabled on architecture: %s", ARCH));
+			assertReasonContains("Disabled on architecture: %s".formatted(ARCH));
 		}
 		else {
 			assertEnabled();
-			assertReasonContains(String.format("Enabled on architecture: %s", ARCH));
+			assertReasonContains("Enabled on architecture: %s".formatted(ARCH));
 		}
 	}
 
 	private void assertDisabledOnCurrentOsAndArchitectureIf(boolean condition) {
 		if (condition) {
 			assertDisabled();
-			assertReasonContains(String.format("Disabled on operating system: %s (%s)", OS_NAME, ARCH));
+			assertReasonContains("Disabled on operating system: %s (%s)".formatted(OS_NAME, ARCH));
 		}
 		else {
 			assertEnabled();
-			assertReasonContains(String.format("Enabled on operating system: %s (%s)", OS_NAME, ARCH));
+			assertReasonContains("Enabled on operating system: %s (%s)".formatted(OS_NAME, ARCH));
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledOnOsConditionTests.java
@@ -234,33 +234,33 @@ class EnabledOnOsConditionTests extends AbstractExecutionConditionTests {
 	private void assertEnabledOnCurrentOsIf(boolean condition) {
 		if (condition) {
 			assertEnabled();
-			assertReasonContains(String.format("Enabled on operating system: %s", OS_NAME));
+			assertReasonContains("Enabled on operating system: %s".formatted(OS_NAME));
 		}
 		else {
 			assertDisabled();
-			assertReasonContains(String.format("Disabled on operating system: %s", OS_NAME));
+			assertReasonContains("Disabled on operating system: %s".formatted(OS_NAME));
 		}
 	}
 
 	private void assertEnabledOnCurrentArchitectureIf(boolean condition) {
 		if (condition) {
 			assertEnabled();
-			assertReasonContains(String.format("Enabled on architecture: %s", ARCH));
+			assertReasonContains("Enabled on architecture: %s".formatted(ARCH));
 		}
 		else {
 			assertDisabled();
-			assertReasonContains(String.format("Disabled on architecture: %s", ARCH));
+			assertReasonContains("Disabled on architecture: %s".formatted(ARCH));
 		}
 	}
 
 	private void assertEnabledOnCurrentOsAndArchitectureIf(boolean condition) {
 		if (condition) {
 			assertEnabled();
-			assertReasonContains(String.format("Enabled on operating system: %s (%s)", OS_NAME, ARCH));
+			assertReasonContains("Enabled on operating system: %s (%s)".formatted(OS_NAME, ARCH));
 		}
 		else {
 			assertDisabled();
-			assertReasonContains(String.format("Disabled on operating system: %s (%s)", OS_NAME, ARCH));
+			assertReasonContains("Disabled on operating system: %s (%s)".formatted(OS_NAME, ARCH));
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/ExtensionComposabilityTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/ExtensionComposabilityTests.java
@@ -150,7 +150,7 @@ class ExtensionComposabilityTests {
 	}
 
 	private String methodSignature(Method method) {
-		return String.format("%s(%s)", method.getName(),
+		return "%s(%s)".formatted(method.getName(),
 			ClassUtils.nullSafeToString(Class::getSimpleName, method.getParameterTypes()));
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolverTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/support/TypeBasedParameterResolverTests.java
@@ -119,7 +119,7 @@ class TypeBasedParameterResolverTests {
 		public String resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
 				throws ParameterResolutionException {
 			Class<?> parameterAnnotation = parameterContext.getParameter().getAnnotations()[0].annotationType();
-			return String.format("%s %s", extensionContext.getDisplayName(), parameterAnnotation.getSimpleName());
+			return "%s %s".formatted(extensionContext.getDisplayName(), parameterAnnotation.getSimpleName());
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -208,8 +208,7 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 
 	private void assertNestedCycle(Class<?> start, Class<?> from, Class<?> to) {
 		var results = executeTestsForClass(start);
-		var expectedMessage = String.format(
-			"Cause: org.junit.platform.commons.JUnitException: Detected cycle in inner class hierarchy between %s and %s",
+		var expectedMessage = "Cause: org.junit.platform.commons.JUnitException: Detected cycle in inner class hierarchy between %s and %s".formatted(
 			from.getName(), to.getName());
 		results.containerEvents().assertThatEvents() //
 				.haveExactly(1, finishedWithFailure(message(it -> it.contains(expectedMessage))));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoverySelectorResolverTests.java
@@ -49,7 +49,6 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
@@ -522,7 +521,7 @@ class DiscoverySelectorResolverTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void classpathResolution() throws Exception {
-		Path classpath = Paths.get(
+		Path classpath = Path.of(
 			DiscoverySelectorResolverTests.class.getProtectionDomain().getCodeSource().getLocation().toURI());
 
 		List<ClasspathRootSelector> selectors = selectClasspathRoots(singleton(classpath));
@@ -549,7 +548,7 @@ class DiscoverySelectorResolverTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void classpathResolutionForJarFiles() throws Exception {
 		URL jarUrl = requireNonNull(getClass().getResource("/jupiter-testjar.jar"));
-		Path path = Paths.get(jarUrl.toURI());
+		Path path = Path.of(jarUrl.toURI());
 		List<ClasspathRootSelector> selectors = selectClasspathRoots(singleton(path));
 
 		ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/injection/sample/LongParameterResolver.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/injection/sample/LongParameterResolver.java
@@ -43,8 +43,8 @@ public class LongParameterResolver implements ParameterResolver {
 		for (TypeVariable<?> typeVariable : parameterContext.getDeclaringExecutable().getDeclaringClass().getTypeParameters()) {
 			boolean namesMatch = typeInMethod.getTypeName().equals(typeVariable.getName());
 			boolean typesAreCompatible = typeVariable.getBounds().length == 1 && //
-					typeVariable.getBounds()[0] instanceof Class && //
-					((Class<?>) typeVariable.getBounds()[0]).isAssignableFrom(Long.class);
+					typeVariable.getBounds()[0] instanceof Class<?> clazz && //
+					clazz.isAssignableFrom(Long.class);
 
 			if (namesMatch && typesAreCompatible) {
 				return true;

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/AutoCloseTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/AutoCloseTests.java
@@ -61,8 +61,7 @@ class AutoCloseTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void blankCloseMethodName() {
 		Class<?> testClass = BlankCloseMethodNameTestCase.class;
-		String msg = String.format("@AutoClose on field %s.field must specify a method name.",
-			testClass.getCanonicalName());
+		String msg = "@AutoClose on field %s.field must specify a method name.".formatted(testClass.getCanonicalName());
 		Events tests = executeTestsForClass(testClass).testEvents();
 		assertFailingWithMessage(tests, msg);
 	}
@@ -70,8 +69,7 @@ class AutoCloseTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void primitiveTypeCannotBeClosed() {
 		Class<?> testClass = PrimitiveFieldTestCase.class;
-		String msg = String.format("@AutoClose is not supported on primitive field %s.x.",
-			testClass.getCanonicalName());
+		String msg = "@AutoClose is not supported on primitive field %s.x.".formatted(testClass.getCanonicalName());
 		Events tests = executeTestsForClass(testClass).testEvents();
 		assertFailingWithMessage(tests, msg);
 	}
@@ -79,7 +77,7 @@ class AutoCloseTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void arrayCannotBeClosed() {
 		Class<?> testClass = ArrayFieldTestCase.class;
-		String msg = String.format("@AutoClose is not supported on array field %s.x.", testClass.getCanonicalName());
+		String msg = "@AutoClose is not supported on array field %s.x.".formatted(testClass.getCanonicalName());
 		Events tests = executeTestsForClass(testClass).testEvents();
 		assertFailingWithMessage(tests, msg);
 	}
@@ -87,8 +85,7 @@ class AutoCloseTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void nullCannotBeClosed(@TrackLogRecords LogRecordListener listener) {
 		Class<?> testClass = NullCloseableFieldTestCase.class;
-		String msg = String.format("Cannot @AutoClose field %s.field because it is null.",
-			testClass.getCanonicalName());
+		String msg = "Cannot @AutoClose field %s.field because it is null.".formatted(testClass.getCanonicalName());
 		Events tests = executeTestsForClass(testClass).testEvents();
 		tests.assertStatistics(stats -> stats.succeeded(1).failed(0));
 		assertThat(listener.stream(Level.WARNING)).map(LogRecord::getMessage).anyMatch(msg::equals);
@@ -394,7 +391,7 @@ class AutoCloseTests extends AbstractJupiterTestEngineTests {
 	}
 
 	private void assertMissingCloseMethod(Class<?> testClass, String methodName) {
-		String msg = String.format("Cannot @AutoClose field %s.field because %s does not define method %s().",
+		String msg = "Cannot @AutoClose field %s.field because %s does not define method %s().".formatted(
 			testClass.getCanonicalName(), String.class.getName(), methodName);
 		Events tests = executeTestsForClass(testClass).testEvents();
 		assertFailingWithMessage(tests, msg);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -853,7 +853,7 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 			String name = declaringExecutable instanceof Constructor
 					? declaringExecutable.getDeclaringClass().getSimpleName()
 					: declaringExecutable.getName();
-			return String.format("%s-%d-%s", name, parameterContext.getIndex(), text);
+			return "%s-%d-%s".formatted(name, parameterContext.getIndex(), text);
 		}
 	}
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -402,7 +402,7 @@ class OrderedMethodTests {
 		@BeforeEach
 		void trackInvocations(TestInfo testInfo) {
 			var method = testInfo.getTestMethod().orElseThrow(AssertionError::new);
-			var signature = String.format("%s(%s)", method.getName(),
+			var signature = "%s(%s)".formatted(method.getName(),
 				ClassUtils.nullSafeToString(method.getParameterTypes()));
 
 			callSequence.add(signature);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ParameterResolverTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ParameterResolverTests.java
@@ -227,7 +227,7 @@ class ParameterResolverTests extends AbstractJupiterTestEngineTests {
 	void executeTestsForParameterizedTypesSelectingByFullyQualifiedMethodNameContainingGenericInfo() throws Exception {
 		Method method = ParameterizedTypeTestCase.class.getDeclaredMethod("testMapOfStrings", Map.class);
 		String genericParameterTypeName = method.getGenericParameterTypes()[0].getTypeName();
-		String fqmn = String.format("%s#%s(%s)", ParameterizedTypeTestCase.class.getName(), "testMapOfStrings",
+		String fqmn = "%s#%s(%s)".formatted(ParameterizedTypeTestCase.class.getName(), "testMapOfStrings",
 			genericParameterTypeName);
 
 		assertEventsForParameterizedTypes(executeTests(selectMethod(fqmn)));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPreconditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryPreconditionTests.java
@@ -20,7 +20,6 @@ import static org.junit.platform.testkit.engine.TestExecutionResultConditions.me
 
 import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -102,7 +101,7 @@ class TempDirectoryPreconditionTests extends AbstractJupiterTestEngineTests {
 	@SuppressWarnings("JUnitMalformedDeclaration")
 	static class FinalStaticFieldTestCase {
 
-		static final @TempDir Path path = Paths.get(".");
+		static final @TempDir Path path = Path.of(".");
 
 		@Test
 		void test() {
@@ -112,7 +111,7 @@ class TempDirectoryPreconditionTests extends AbstractJupiterTestEngineTests {
 	@SuppressWarnings("JUnitMalformedDeclaration")
 	static class FinalInstanceFieldTestCase {
 
-		final @TempDir Path path = Paths.get(".");
+		final @TempDir Path path = Path.of(".");
 
 		@Test
 		void test() {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TempDirectoryTests.java
@@ -1402,7 +1402,7 @@ class TempDirectoryTests extends AbstractJupiterTestEngineTests {
 			}
 
 			private static String getName(AnnotatedElement element) {
-				return element instanceof Field ? ((Field) element).getName() : ((Parameter) element).getName();
+				return element instanceof Field field ? field.getName() : ((Parameter) element).getName();
 			}
 
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstancePostProcessorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstancePostProcessorTests.java
@@ -189,8 +189,8 @@ class TestInstancePostProcessorTests extends AbstractJupiterTestEngineTests {
 
 		@Override
 		public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
-			if (testInstance instanceof Named) {
-				((Named) testInstance).setName(name, context.getRequiredTestClass().getSimpleName());
+			if (testInstance instanceof Named named) {
+				named.setName(name, context.getRequiredTestClass().getSimpleName());
 			}
 			String instanceType = testInstance.getClass().getSimpleName();
 			callSequence.add(name + ":" + instanceType);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstancePreDestroyCallbackTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstancePreDestroyCallbackTests.java
@@ -187,8 +187,8 @@ class TestInstancePreDestroyCallbackTests extends AbstractJupiterTestEngineTests
 		public void preDestroyTestInstance(ExtensionContext context) {
 			assertThat(context.getTestInstance()).isPresent();
 			Object testInstance = context.getTestInstance().get();
-			if (testInstance instanceof Destroyable) {
-				((Destroyable) testInstance).setDestroyed();
+			if (testInstance instanceof Destroyable destroyable) {
+				destroyable.setDestroyed();
 			}
 			callSequence.add(name + "PreDestroyCallbackTestInstance:" + testInstance.getClass().getSimpleName());
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/sub/SystemPropertyCondition.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/sub/SystemPropertyCondition.java
@@ -56,7 +56,7 @@ public class SystemPropertyCondition implements ExecutionCondition {
 
 			if (!Objects.equals(expected, actual)) {
 				return ConditionEvaluationResult.disabled(
-					String.format("System property [%s] has a value of [%s] instead of [%s]", key, actual, expected));
+					"System property [%s] has a value of [%s] instead of [%s]".formatted(key, actual, expected));
 			}
 		}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -182,9 +182,9 @@ class ParameterizedTestExtensionTests {
 		var exception = assertThrows(JUnitException.class, stream::toArray);
 
 		assertThat(exception) //
-				.hasMessage(String.format(
-					"The ArgumentsProvider [%s] must be either a top-level class or a static nested class",
-					NonStaticArgumentsProvider.class.getName()));
+				.hasMessage(
+					"The ArgumentsProvider [%s] must be either a top-level class or a static nested class".formatted(
+						NonStaticArgumentsProvider.class.getName()));
 	}
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -1175,8 +1175,8 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 			var results = execute(ArgumentCountValidationMode.STRICT, UnusedArgumentsTestCase.class,
 				"testWithTwoUnusedStringArgumentsProvider", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(finishedWithFailure(message(String.format(
-						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused1]")))));
+					.haveExactly(1, event(finishedWithFailure(message(
+						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused1]".formatted()))));
 		}
 
 		@Test
@@ -1184,8 +1184,8 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 			var results = execute(ArgumentCountValidationMode.STRICT, UnusedArgumentsTestCase.class,
 				"testWithMethodSourceProvidingUnusedArguments", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(finishedWithFailure(message(String.format(
-						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused1]")))));
+					.haveExactly(1, event(finishedWithFailure(message(
+						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused1]".formatted()))));
 		}
 
 		@Test
@@ -1193,8 +1193,8 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 			var results = execute(ArgumentCountValidationMode.NONE, UnusedArgumentsTestCase.class,
 				"testWithStrictArgumentCountValidation", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(finishedWithFailure(message(String.format(
-						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused1]")))));
+					.haveExactly(1, event(finishedWithFailure(message(
+						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused1]".formatted()))));
 		}
 
 		@Test
@@ -1202,8 +1202,8 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 			var results = execute(ArgumentCountValidationMode.STRICT, UnusedArgumentsTestCase.class,
 				"testWithCsvSourceContainingDifferentNumbersOfArguments", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(finishedWithFailure(message(String.format(
-						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused1]"))))) //
+					.haveExactly(1, event(finishedWithFailure(message(
+						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused1]".formatted())))) //
 					.haveExactly(1,
 						event(test(), displayName("[2] argument=bar"), finishedWithFailure(message("bar"))));
 		}
@@ -1231,8 +1231,8 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 			var results = execute(ArgumentCountValidationMode.STRICT, UnusedArgumentsTestCase.class,
 				"testWithEvaluationReportingArgumentsProvider", String.class);
 			results.allEvents().assertThatEvents() //
-					.haveExactly(1, event(finishedWithFailure(message(String.format(
-						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused]")))));
+					.haveExactly(1, event(finishedWithFailure(message(
+						"Configuration error: @ParameterizedTest consumes 1 parameter but there were 2 arguments provided.%nNote: the provided arguments were [foo, unused]".formatted()))));
 			results.allEvents().reportingEntryPublished().assertThatEvents() //
 					.haveExactly(1, event(EventConditions.reportEntry(Map.of("evaluated", "true"))));
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
@@ -212,8 +212,8 @@ class EnumArgumentsProviderTests {
 		when(annotation.mode()).thenReturn(mode);
 		when(annotation.names()).thenReturn(names);
 		when(annotation.toString()).thenReturn(
-			String.format("@EnumSource(value=%s.class, from=%s, to=%s, mode=%s, names=%s)", enumClass.getSimpleName(),
-				from, to, mode, Arrays.toString(names)));
+			"@EnumSource(value=%s.class, from=%s, to=%s, mode=%s, names=%s)".formatted(enumClass.getSimpleName(), from,
+				to, mode, Arrays.toString(names)));
 
 		var provider = new EnumArgumentsProvider();
 		provider.accept(annotation);

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java
@@ -22,7 +22,6 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -202,9 +201,9 @@ class ConversionSupportTests {
 
 	@Test
 	void convertsStringToPath() {
-		assertConverts("path", Path.class, Paths.get("path"));
-		assertConverts("/path", Path.class, Paths.get("/path"));
-		assertConverts("/some/path", Path.class, Paths.get("/some/path"));
+		assertConverts("path", Path.class, Path.of("path"));
+		assertConverts("/path", Path.class, Path.of("/path"));
+		assertConverts("/some/path", Path.class, Path.of("/some/path"));
 	}
 
 	// --- java.lang -----------------------------------------------------------

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/scanning/DefaultClasspathScannerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/scanning/DefaultClasspathScannerTests.java
@@ -31,7 +31,6 @@ import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -558,7 +557,7 @@ class DefaultClasspathScannerTests {
 	@Test
 	void findAllClassesInClasspathRootForNonExistingRoot() {
 		assertThrows(PreconditionViolationException.class,
-			() -> classpathScanner.scanForClassesInClasspathRoot(Paths.get("does_not_exist").toUri(), allClasses));
+			() -> classpathScanner.scanForClassesInClasspathRoot(Path.of("does_not_exist").toUri(), allClasses));
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -1135,7 +1135,7 @@ class ReflectionUtilsTests {
 			assertThatExceptionOfType(JUnitException.class)//
 					.as("expected cycle from %s to %s", from.getSimpleName(), to.getSimpleName())//
 					.isThrownBy(() -> findNestedClasses(start))//
-					.withMessageMatching(String.format("Detected cycle in inner class hierarchy between .+%s and .+%s",
+					.withMessageMatching("Detected cycle in inner class hierarchy between .+%s and .+%s".formatted(
 						from.getSimpleName(), to.getSimpleName()));
 		}
 
@@ -1785,7 +1785,7 @@ class ReflectionUtilsTests {
 		private static List<String> signaturesOf(List<Method> methods) {
 			// @formatter:off
 			return methods.stream()
-					.map(m -> String.format("%s(%s)", m.getName(), ClassUtils.nullSafeToString(m.getParameterTypes())))
+					.map(m -> "%s(%s)".formatted(m.getName(), ClassUtils.nullSafeToString(m.getParameterTypes())))
 					.toList();
 			// @formatter:on
 		}

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/StringUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/StringUtilsTests.java
@@ -150,27 +150,26 @@ class StringUtilsTests {
 	}
 
 	private void shouldContainWhitespace(String str) {
-		assertTrue(containsWhitespace(str), () -> String.format("'%s' should contain whitespace", str));
-		assertFalse(doesNotContainWhitespace(str), () -> String.format("'%s' should contain whitespace", str));
+		assertTrue(containsWhitespace(str), () -> "'%s' should contain whitespace".formatted(str));
+		assertFalse(doesNotContainWhitespace(str), () -> "'%s' should contain whitespace".formatted(str));
 	}
 
 	private void shouldNotContainWhitespace(String str) {
-		assertTrue(doesNotContainWhitespace(str), () -> String.format("'%s' should not contain whitespace", str));
-		assertFalse(containsWhitespace(str), () -> String.format("'%s' should not contain whitespace", str));
+		assertTrue(doesNotContainWhitespace(str), () -> "'%s' should not contain whitespace".formatted(str));
+		assertFalse(containsWhitespace(str), () -> "'%s' should not contain whitespace".formatted(str));
 	}
 
 	private void shouldContainIsoControlCharacter(String str) {
-		assertTrue(containsIsoControlCharacter(str),
-			() -> String.format("'%s' should contain ISO control character", str));
+		assertTrue(containsIsoControlCharacter(str), () -> "'%s' should contain ISO control character".formatted(str));
 		assertFalse(doesNotContainIsoControlCharacter(str),
-			() -> String.format("'%s' should contain ISO control character", str));
+			() -> "'%s' should contain ISO control character".formatted(str));
 	}
 
 	private void shouldNotContainIsoControlCharacter(String str) {
 		assertTrue(doesNotContainIsoControlCharacter(str),
-			() -> String.format("'%s' should not contain ISO control character", str));
+			() -> "'%s' should not contain ISO control character".formatted(str));
 		assertFalse(containsIsoControlCharacter(str),
-			() -> String.format("'%s' should not contain ISO control character", str));
+			() -> "'%s' should not contain ISO control character".formatted(str));
 	}
 
 	private static class ToStringReturnsNull {

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
@@ -209,7 +209,7 @@ class ConsoleDetailsTests {
 			if (optionalUri.isEmpty()) {
 				if (Boolean.getBoolean("org.junit.platform.console.ConsoleDetailsTests.writeResultOut")) {
 					// do not use Files.createTempDirectory(prefix) as we want one folder for one container
-					var temp = Paths.get(System.getProperty("java.io.tmpdir"), dirName.replace('/', '-'));
+					var temp = Path.of(System.getProperty("java.io.tmpdir"), dirName.replace('/', '-'));
 					Files.createDirectories(temp);
 					var path = Files.writeString(temp.resolve(outName), result.out);
 					throw new TestAbortedException(
@@ -218,7 +218,7 @@ class ConsoleDetailsTests {
 				fail("could not load resource named `" + dirName + "/" + outName + "`");
 			}
 
-			var path = Paths.get(optionalUri.get());
+			var path = Path.of(optionalUri.get());
 			assumeTrue(Files.exists(path), "path does not exist: " + path);
 			assumeTrue(Files.isReadable(path), "can not read: " + path);
 

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.console;
 
-import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -214,7 +213,7 @@ class ConsoleDetailsTests {
 					Files.createDirectories(temp);
 					var path = Files.writeString(temp.resolve(outName), result.out);
 					throw new TestAbortedException(
-						format("resource `%s` not found\nwrote console stdout to: %s/%s", dirName, outName, path));
+						"resource `%s` not found\nwrote console stdout to: %s/%s".formatted(dirName, outName, path));
 				}
 				fail("could not load resource named `" + dirName + "/" + outName + "`");
 			}

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherIntegrationTests.java
@@ -97,7 +97,7 @@ class ConsoleLauncherIntegrationTests {
 			throws IOException {
 
 		var outputFile = tempDir.resolve("output.txt");
-		var line = String.format("execute -e junit-jupiter --select-class %s %s %s", StdStreamTestCase.class.getName(),
+		var line = "execute -e junit-jupiter --select-class %s %s %s".formatted(StdStreamTestCase.class.getName(),
 			redirectedStream, outputFile);
 		var args = line.split(" ");
 		new ConsoleLauncherWrapper().execute(args);
@@ -113,7 +113,7 @@ class ConsoleLauncherIntegrationTests {
 	@Test
 	void executeWithRedirectedStdStreamsToSameFile(@TempDir Path tempDir) throws IOException {
 		var outputFile = tempDir.resolve("output.txt");
-		var line = String.format("execute -e junit-jupiter --select-class %s --redirect-stdout %s --redirect-stderr %s",
+		var line = "execute -e junit-jupiter --select-class %s --redirect-stdout %s --redirect-stderr %s".formatted(
 			StdStreamTestCase.class.getName(), outputFile, outputFile);
 		var args = line.split(" ");
 		new ConsoleLauncherWrapper().execute(args);

--- a/platform-tests/src/test/java/org/junit/platform/console/options/CommandLineOptionsParsingTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/CommandLineOptionsParsingTests.java
@@ -34,7 +34,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -318,7 +317,7 @@ class CommandLineOptionsParsingTests {
 	@ParameterizedTest
 	@EnumSource
 	void parseValidAdditionalClasspathEntries(ArgsType type) {
-		var dir = Paths.get(".");
+		var dir = Path.of(".");
 		// @formatter:off
 		assertAll(
 			() -> assertEquals(List.of(dir), type.parseArgLine("-cp .").discovery.getAdditionalClasspathEntries()),
@@ -553,7 +552,7 @@ class CommandLineOptionsParsingTests {
 	@ParameterizedTest
 	@EnumSource
 	void parseClasspathScanningEntries(ArgsType type) {
-		var dir = Paths.get(".");
+		var dir = Path.of(".");
 		// @formatter:off
 		assertAll(
 			() -> assertTrue(type.parseArgLine("--scan-class-path").discovery.isScanClasspath()),
@@ -563,8 +562,8 @@ class CommandLineOptionsParsingTests {
 			() -> assertTrue(type.parseArgLine("--scan-class-path .").discovery.isScanClasspath()),
 			() -> assertEquals(List.of(dir), type.parseArgLine("--scan-class-path .").discovery.getSelectedClasspathEntries()),
 			() -> assertEquals(List.of(dir), type.parseArgLine("--scan-class-path=.").discovery.getSelectedClasspathEntries()),
-			() -> assertEquals(List.of(dir, Paths.get("src/test/java")), type.parseArgLine("--scan-class-path . --scan-class-path src/test/java").discovery.getSelectedClasspathEntries()),
-			() -> assertEquals(List.of(dir, Paths.get("src/test/java")), type.parseArgLine("--scan-class-path ." + File.pathSeparator + "src/test/java").discovery.getSelectedClasspathEntries())
+			() -> assertEquals(List.of(dir, Path.of("src/test/java")), type.parseArgLine("--scan-class-path . --scan-class-path src/test/java").discovery.getSelectedClasspathEntries()),
+			() -> assertEquals(List.of(dir, Path.of("src/test/java")), type.parseArgLine("--scan-class-path ." + File.pathSeparator + "src/test/java").discovery.getSelectedClasspathEntries())
 		);
 		// @formatter:on
 	}
@@ -605,7 +604,7 @@ class CommandLineOptionsParsingTests {
 	@ParameterizedTest
 	@EnumSource
 	void parseValidStdoutRedirectionFile(ArgsType type) {
-		var file = Paths.get("foo.txt");
+		var file = Path.of("foo.txt");
 		// @formatter:off
 		assertAll(
 			() -> assertNull(type.parseArgLine("").output.getStdoutPath()),
@@ -619,7 +618,7 @@ class CommandLineOptionsParsingTests {
 	@ParameterizedTest
 	@EnumSource
 	void parseValidStderrRedirectionFile(ArgsType type) {
-		var file = Paths.get("foo.txt");
+		var file = Path.of("foo.txt");
 		// @formatter:off
 		assertAll(
 			() -> assertNull(type.parseArgLine("").output.getStderrPath()),

--- a/platform-tests/src/test/java/org/junit/platform/console/options/ExecuteTestsCommandTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/options/ExecuteTestsCommandTests.java
@@ -17,7 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -96,7 +96,7 @@ class ExecuteTestsCommandTests {
 
 	@Test
 	void parseValidXmlReportsDirs() {
-		var dir = Paths.get("build", "test-results");
+		var dir = Path.of("build", "test-results");
 		// @formatter:off
 		assertAll(
 				() -> assertEquals(Optional.empty(), parseArgs().getReportsDir()),

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/ConsoleTestExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/ConsoleTestExecutorTests.java
@@ -19,7 +19,7 @@ import static org.junit.platform.launcher.core.LauncherFactoryForTestingPurposes
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -98,7 +98,7 @@ class ConsoleTestExecutorTests {
 
 	@Test
 	void usesCustomClassLoaderIfAdditionalClassPathEntriesArePresent() {
-		discoveryOptions.setAdditionalClasspathEntries(List.of(Paths.get(".")));
+		discoveryOptions.setAdditionalClasspathEntries(List.of(Path.of(".")));
 
 		var oldClassLoader = getDefaultClassLoader();
 		dummyTestEngine.addTest("failingTest",

--- a/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/tasks/DiscoveryRequestCreatorTests.java
@@ -26,7 +26,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUri;
 
 import java.io.File;
 import java.net.URI;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -73,7 +73,7 @@ class DiscoveryRequestCreatorTests {
 	@Test
 	void convertsScanClasspathOptionWithExplicitRootDirectories() {
 		options.setScanClasspath(true);
-		options.setSelectedClasspathEntries(List.of(Paths.get("."), Paths.get("..")));
+		options.setSelectedClasspathEntries(List.of(Path.of("."), Path.of("..")));
 
 		var request = convert();
 
@@ -87,7 +87,7 @@ class DiscoveryRequestCreatorTests {
 	@Test
 	void convertsScanClasspathOptionWithAdditionalClasspathEntries() {
 		options.setScanClasspath(true);
-		options.setAdditionalClasspathEntries(List.of(Paths.get("."), Paths.get("..")));
+		options.setAdditionalClasspathEntries(List.of(Path.of("."), Path.of("..")));
 
 		var request = convert();
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/TestTagTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/TestTagTests.java
@@ -89,11 +89,11 @@ class TestTagTests {
 	}
 
 	private static void yep(String tag) {
-		assertTrue(TestTag.isValid(tag), () -> String.format("'%s' should be a valid tag", tag));
+		assertTrue(TestTag.isValid(tag), () -> "'%s' should be a valid tag".formatted(tag));
 	}
 
 	private static void nope(String tag) {
-		assertFalse(TestTag.isValid(tag), () -> String.format("'%s' should not be a valid tag", tag));
+		assertFalse(TestTag.isValid(tag), () -> "'%s' should not be a valid tag".formatted(tag));
 	}
 
 	private void assertSyntaxViolation(String tag) {

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
@@ -824,7 +824,7 @@ class DiscoverySelectorsTests {
 			var className = "org.example.CalculatorSpec";
 			var methodName = "#a plus #b equals #c";
 			var methodParameters = "int, int, int";
-			var fqmn = String.format("%s#%s(%s)", className, methodName, methodParameters);
+			var fqmn = "%s#%s(%s)".formatted(className, methodName, methodParameters);
 
 			var selector = selectMethod(fqmn);
 			assertEquals(className, selector.getClassName());
@@ -875,7 +875,7 @@ class DiscoverySelectorsTests {
 			var className = "org.example.KotlinTestCase";
 			var methodName = "test name ends with parentheses()";
 			var methodParameters = "int, int, int";
-			var fqmn = String.format("%s#%s(%s)", className, methodName, methodParameters);
+			var fqmn = "%s#%s(%s)".formatted(className, methodName, methodParameters);
 
 			var selector = selectMethod(fqmn);
 
@@ -1440,7 +1440,7 @@ class DiscoverySelectorsTests {
 	}
 
 	private static String fqmnWithParamNames(String... params) {
-		return String.format("%s#%s(%s)", DiscoverySelectorsTests.class.getName(), "myTest", join(", ", params));
+		return "%s#%s(%s)".formatted(DiscoverySelectorsTests.class.getName(), "myTest", join(", ", params));
 	}
 
 	interface TestInterface {

--- a/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/discovery/DiscoverySelectorsTests.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -118,7 +117,7 @@ class DiscoverySelectorsTests {
 			var selector = selectFile(path);
 			assertEquals(path, selector.getRawPath());
 			assertEquals(new File(path), selector.getFile());
-			assertEquals(Paths.get(path), selector.getPath());
+			assertEquals(Path.of(path), selector.getPath());
 		}
 
 		@Test
@@ -132,7 +131,7 @@ class DiscoverySelectorsTests {
 			var selector = selectFile(path, filePosition);
 			assertEquals(path, selector.getRawPath());
 			assertEquals(new File(path), selector.getFile());
-			assertEquals(Paths.get(path), selector.getPath());
+			assertEquals(Path.of(path), selector.getPath());
 			assertEquals(filePosition, selector.getPosition().orElseThrow());
 		}
 
@@ -149,7 +148,7 @@ class DiscoverySelectorsTests {
 			var selector = selectFile(file);
 			assertEquals(path, selector.getRawPath());
 			assertEquals(file.getCanonicalFile(), selector.getFile());
-			assertEquals(Paths.get(path), selector.getPath());
+			assertEquals(Path.of(path), selector.getPath());
 		}
 
 		@Test
@@ -166,7 +165,7 @@ class DiscoverySelectorsTests {
 			var selector = selectFile(file, filePosition);
 			assertEquals(path, selector.getRawPath());
 			assertEquals(file.getCanonicalFile(), selector.getFile());
-			assertEquals(Paths.get(path), selector.getPath());
+			assertEquals(Path.of(path), selector.getPath());
 			assertEquals(FilePosition.from(12, 34), selector.getPosition().orElseThrow());
 		}
 
@@ -184,7 +183,7 @@ class DiscoverySelectorsTests {
 					.asInstanceOf(type(FileSelector.class)) //
 					.extracting(FileSelector::getRawPath, FileSelector::getFile, FileSelector::getPath,
 						FileSelector::getPosition) //
-					.containsExactly(path, new File(path), Paths.get(path), Optional.empty());
+					.containsExactly(path, new File(path), Path.of(path), Optional.empty());
 		}
 
 		@Test
@@ -197,7 +196,7 @@ class DiscoverySelectorsTests {
 					.asInstanceOf(type(FileSelector.class)) //
 					.extracting(FileSelector::getRawPath, FileSelector::getFile, FileSelector::getPath,
 						FileSelector::getPosition) //
-					.containsExactly(absolutePath, new File(absolutePath), Paths.get(absolutePath), Optional.empty());
+					.containsExactly(absolutePath, new File(absolutePath), Path.of(absolutePath), Optional.empty());
 		}
 
 		@Test
@@ -210,7 +209,7 @@ class DiscoverySelectorsTests {
 					.asInstanceOf(type(FileSelector.class)) //
 					.extracting(FileSelector::getRawPath, FileSelector::getFile, FileSelector::getPath,
 						FileSelector::getPosition) //
-					.containsExactly(path, new File(path), Paths.get(path), Optional.of(filePosition));
+					.containsExactly(path, new File(path), Path.of(path), Optional.of(filePosition));
 		}
 
 		@Test
@@ -224,7 +223,7 @@ class DiscoverySelectorsTests {
 					.asInstanceOf(type(FileSelector.class)) //
 					.extracting(FileSelector::getRawPath, FileSelector::getFile, FileSelector::getPath,
 						FileSelector::getPosition) //
-					.containsExactly(absolutePath, new File(absolutePath), Paths.get(absolutePath),
+					.containsExactly(absolutePath, new File(absolutePath), Path.of(absolutePath),
 						Optional.of(filePosition));
 		}
 
@@ -238,7 +237,7 @@ class DiscoverySelectorsTests {
 			var selector = selectDirectory(path);
 			assertEquals(path, selector.getRawPath());
 			assertEquals(new File(path), selector.getDirectory());
-			assertEquals(Paths.get(path), selector.getPath());
+			assertEquals(Path.of(path), selector.getPath());
 		}
 
 		@Test
@@ -254,7 +253,7 @@ class DiscoverySelectorsTests {
 			var selector = selectDirectory(directory);
 			assertEquals(path, selector.getRawPath());
 			assertEquals(directory.getCanonicalFile(), selector.getDirectory());
-			assertEquals(Paths.get(path), selector.getPath());
+			assertEquals(Path.of(path), selector.getPath());
 		}
 
 	}
@@ -272,7 +271,7 @@ class DiscoverySelectorsTests {
 					.asInstanceOf(type(DirectorySelector.class)) //
 					.extracting(DirectorySelector::getRawPath, DirectorySelector::getDirectory,
 						DirectorySelector::getPath) //
-					.containsExactly(path, new File(path), Paths.get(path));
+					.containsExactly(path, new File(path), Path.of(path));
 		}
 
 		@Test
@@ -285,7 +284,7 @@ class DiscoverySelectorsTests {
 					.asInstanceOf(type(DirectorySelector.class)) //
 					.extracting(DirectorySelector::getRawPath, DirectorySelector::getDirectory,
 						DirectorySelector::getPath) //
-					.containsExactly(path, new File(path), Paths.get(path));
+					.containsExactly(path, new File(path), Path.of(path));
 		}
 
 		@Test
@@ -468,14 +467,14 @@ class DiscoverySelectorsTests {
 
 		@Test
 		void selectClasspathRootsWithNonExistingDirectory() {
-			var selectors = selectClasspathRoots(Set.of(Paths.get("some", "local", "path")));
+			var selectors = selectClasspathRoots(Set.of(Path.of("some", "local", "path")));
 
 			assertThat(selectors).isEmpty();
 		}
 
 		@Test
 		void selectClasspathRootsWithNonExistingJarFile() {
-			var selectors = selectClasspathRoots(Set.of(Paths.get("some.jar")));
+			var selectors = selectClasspathRoots(Set.of(Path.of("some.jar")));
 
 			assertThat(selectors).isEmpty();
 		}
@@ -490,7 +489,7 @@ class DiscoverySelectorsTests {
 		@Test
 		void selectClasspathRootsWithExistingJarFile() throws Exception {
 			var jarUri = requireNonNull(getClass().getResource("/jartest.jar")).toURI();
-			var jarFile = Paths.get(jarUri);
+			var jarFile = Path.of(jarUri);
 
 			var selectors = selectClasspathRoots(Set.of(jarFile));
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoMethodTestDescriptor.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/DemoMethodTestDescriptor.java
@@ -32,7 +32,7 @@ public class DemoMethodTestDescriptor extends AbstractTestDescriptor {
 
 	public DemoMethodTestDescriptor(UniqueId uniqueId, Method testMethod) {
 		super(uniqueId,
-			String.format("%s(%s)", Preconditions.notNull(testMethod, "Method must not be null").getName(),
+			"%s(%s)".formatted(Preconditions.notNull(testMethod, "Method must not be null").getName(),
 				ClassUtils.nullSafeToString(Class::getSimpleName, testMethod.getParameterTypes())),
 			MethodSource.from(testMethod));
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ParallelExecutionIntegrationTests.java
@@ -265,8 +265,8 @@ class ParallelExecutionIntegrationTests {
 		List<Event> parallelTestMethodEvents = events.reportingEntryPublished() //
 				.filter(e -> e.getTestDescriptor().getSource() //
 						.filter(it -> //
-						it instanceof MethodSource
-								&& SuccessfulParallelTestCase.class.equals(((MethodSource) it).getJavaClass()) //
+						it instanceof MethodSource methodSource
+								&& SuccessfulParallelTestCase.class.equals(methodSource.getJavaClass()) //
 						).isPresent() //
 				) //
 				.toList();

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockSupport.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/hierarchical/ResourceLockSupport.java
@@ -19,8 +19,8 @@ class ResourceLockSupport {
 		if (resourceLock instanceof NopLock) {
 			return List.of();
 		}
-		if (resourceLock instanceof SingleLock) {
-			return List.of(((SingleLock) resourceLock).getLock());
+		if (resourceLock instanceof SingleLock lock) {
+			return List.of(lock.getLock());
 		}
 		return ((CompositeLock) resourceLock).getLocks();
 	}

--- a/platform-tests/src/test/java/org/junit/platform/launcher/MethodFilterTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/MethodFilterTests.java
@@ -58,14 +58,14 @@ class MethodFilterTests {
 		var filter = includeMethodNamePatterns(regex);
 
 		assertIncluded(filter.apply(CLASS1_TEST1),
-			String.format("Method name [%s] matches included pattern: '%s'", CLASS1_TEST1_NAME, regex));
+			"Method name [%s] matches included pattern: '%s'".formatted(CLASS1_TEST1_NAME, regex));
 		assertIncluded(filter.apply(CLASS1_TEST2),
-			String.format("Method name [%s] matches included pattern: '%s'", CLASS1_TEST2_NAME, regex));
+			"Method name [%s] matches included pattern: '%s'".formatted(CLASS1_TEST2_NAME, regex));
 
 		assertExcluded(filter.apply(CLASS2_TEST1),
-			String.format("Method name [%s] does not match any included pattern: '%s'", CLASS2_TEST1_NAME, regex));
+			"Method name [%s] does not match any included pattern: '%s'".formatted(CLASS2_TEST1_NAME, regex));
 		assertExcluded(filter.apply(CLASS2_TEST2),
-			String.format("Method name [%s] does not match any included pattern: '%s'", CLASS2_TEST2_NAME, regex));
+			"Method name [%s] does not match any included pattern: '%s'".formatted(CLASS2_TEST2_NAME, regex));
 	}
 
 	@Test
@@ -75,14 +75,14 @@ class MethodFilterTests {
 		var filter = includeMethodNamePatterns(firstRegex, secondRegex);
 
 		assertIncluded(filter.apply(CLASS1_TEST1),
-			String.format("Method name [%s] matches included pattern: '%s'", CLASS1_TEST1_NAME, firstRegex));
+			"Method name [%s] matches included pattern: '%s'".formatted(CLASS1_TEST1_NAME, firstRegex));
 		assertIncluded(filter.apply(CLASS1_TEST2),
-			String.format("Method name [%s] matches included pattern: '%s'", CLASS1_TEST2_NAME, firstRegex));
+			"Method name [%s] matches included pattern: '%s'".formatted(CLASS1_TEST2_NAME, firstRegex));
 		assertIncluded(filter.apply(CLASS2_TEST1),
-			String.format("Method name [%s] matches included pattern: '%s'", CLASS2_TEST1_NAME, secondRegex));
+			"Method name [%s] matches included pattern: '%s'".formatted(CLASS2_TEST1_NAME, secondRegex));
 
 		assertExcluded(filter.apply(CLASS2_TEST2),
-			String.format("Method name [%s] does not match any included pattern: '%s' OR '%s'", CLASS2_TEST2_NAME,
+			"Method name [%s] does not match any included pattern: '%s' OR '%s'".formatted(CLASS2_TEST2_NAME,
 				firstRegex, secondRegex));
 	}
 
@@ -105,14 +105,14 @@ class MethodFilterTests {
 		var filter = excludeMethodNamePatterns(regex);
 
 		assertExcluded(filter.apply(CLASS1_TEST1),
-			String.format("Method name [%s] matches excluded pattern: '%s'", CLASS1_TEST1_NAME, regex));
+			"Method name [%s] matches excluded pattern: '%s'".formatted(CLASS1_TEST1_NAME, regex));
 		assertExcluded(filter.apply(CLASS1_TEST2),
-			String.format("Method name [%s] matches excluded pattern: '%s'", CLASS1_TEST2_NAME, regex));
+			"Method name [%s] matches excluded pattern: '%s'".formatted(CLASS1_TEST2_NAME, regex));
 
 		assertIncluded(filter.apply(CLASS2_TEST1),
-			String.format("Method name [%s] does not match any excluded pattern: '%s'", CLASS2_TEST1_NAME, regex));
+			"Method name [%s] does not match any excluded pattern: '%s'".formatted(CLASS2_TEST1_NAME, regex));
 		assertIncluded(filter.apply(CLASS2_TEST2),
-			String.format("Method name [%s] does not match any excluded pattern: '%s'", CLASS2_TEST2_NAME, regex));
+			"Method name [%s] does not match any excluded pattern: '%s'".formatted(CLASS2_TEST2_NAME, regex));
 	}
 
 	@Test
@@ -122,14 +122,14 @@ class MethodFilterTests {
 		var filter = excludeMethodNamePatterns(firstRegex, secondRegex);
 
 		assertExcluded(filter.apply(CLASS1_TEST1),
-			String.format("Method name [%s] matches excluded pattern: '%s'", CLASS1_TEST1_NAME, firstRegex));
+			"Method name [%s] matches excluded pattern: '%s'".formatted(CLASS1_TEST1_NAME, firstRegex));
 		assertExcluded(filter.apply(CLASS1_TEST2),
-			String.format("Method name [%s] matches excluded pattern: '%s'", CLASS1_TEST2_NAME, firstRegex));
+			"Method name [%s] matches excluded pattern: '%s'".formatted(CLASS1_TEST2_NAME, firstRegex));
 		assertExcluded(filter.apply(CLASS2_TEST1),
-			String.format("Method name [%s] matches excluded pattern: '%s'", CLASS2_TEST1_NAME, secondRegex));
+			"Method name [%s] matches excluded pattern: '%s'".formatted(CLASS2_TEST1_NAME, secondRegex));
 
 		assertIncluded(filter.apply(CLASS2_TEST2),
-			String.format("Method name [%s] does not match any excluded pattern: '%s' OR '%s'", CLASS2_TEST2_NAME,
+			"Method name [%s] does not match any excluded pattern: '%s' OR '%s'".formatted(CLASS2_TEST2_NAME,
 				firstRegex, secondRegex));
 	}
 

--- a/platform-tests/src/test/java/org/junit/platform/suite/commons/SuiteLauncherDiscoveryRequestBuilderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/suite/commons/SuiteLauncherDiscoveryRequestBuilderTests.java
@@ -22,7 +22,7 @@ import static org.junit.platform.suite.commons.SuiteLauncherDiscoveryRequestBuil
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.URI;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -487,7 +487,7 @@ class SuiteLauncherDiscoveryRequestBuilderTests {
 
 		LauncherDiscoveryRequest request = builder.applySelectorsAndFiltersFromSuite(Suite.class).build();
 		List<DirectorySelector> selectors = request.getSelectorsByType(DirectorySelector.class);
-		assertEquals(Paths.get("path/to/root"), exactlyOne(selectors).getPath());
+		assertEquals(Path.of("path/to/root"), exactlyOne(selectors).getPath());
 	}
 
 	@Test
@@ -508,7 +508,7 @@ class SuiteLauncherDiscoveryRequestBuilderTests {
 
 		LauncherDiscoveryRequest request = builder.applySelectorsAndFiltersFromSuite(Suite.class).build();
 		List<FileSelector> selectors = request.getSelectorsByType(FileSelector.class);
-		assertEquals(Paths.get("path/to/root"), exactlyOne(selectors).getPath());
+		assertEquals(Path.of("path/to/root"), exactlyOne(selectors).getPath());
 	}
 
 	@Test

--- a/platform-tooling-support-tests/src/main/java/platform/tooling/support/Helper.java
+++ b/platform-tooling-support-tests/src/main/java/platform/tooling/support/Helper.java
@@ -12,7 +12,6 @@ package platform.tooling.support;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,7 +25,7 @@ import java.util.stream.Stream;
  */
 public class Helper {
 
-	private static final Path ROOT = Paths.get("..");
+	private static final Path ROOT = Path.of("..");
 	private static final Path GRADLE_PROPERTIES = ROOT.resolve("gradle.properties");
 	private static final Path SETTINGS_GRADLE = ROOT.resolve("settings.gradle.kts");
 

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManifestTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManifestTests.java
@@ -86,6 +86,6 @@ class ManifestTests {
 	private static void assertValue(Attributes attributes, String name, String expected) {
 		var actual = attributes.getValue(name);
 		assertEquals(expected, actual,
-			String.format("Manifest attribute %s expected to be %s, but is: %s", name, expected, actual));
+			"Manifest attribute %s expected to be %s, but is: %s".formatted(name, expected, actual));
 	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/XmlAssertions.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/XmlAssertions.java
@@ -73,8 +73,8 @@ class XmlAssertions {
 			UnaryOperator<String> obfuscator) {
 		return testResult -> {
 			Object obfuscatedTestResult = testResult;
-			if (testResult instanceof String) {
-				obfuscatedTestResult = obfuscator.apply((String) testResult);
+			if (testResult instanceof String string) {
+				obfuscatedTestResult = obfuscator.apply(string);
 			}
 			return delegate.serialize(obfuscatedTestResult);
 		};


### PR DESCRIPTION
## Overview

- **Use `String.formatted` instead of `String.format`**
- **Use `@Serial` annotation**
- **Use `Path.of` instead of `Paths.get`**
- **Use `Optional.stream`**
- **Use `Optional.isEmpty()` instead of `!Optional.isPresent()`**
- **Use `instanceof` pattern matching**

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
