### PR TITLE
Remove `null` support from `getWrapperType` input, add test coverage

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -238,7 +238,7 @@ public final class ReflectionUtils {
 
 		classNameToTypeMap = Collections.unmodifiableMap(classNamesToTypes);
 
-		Map<Class<?>, Class<?>> primitivesToWrappers = new IdentityHashMap<>(9);
+		Map<Class<?>, Class<?>> primitivesToWrappers = new IdentityHashMap<>(8);
 
 		primitivesToWrappers.put(boolean.class, Boolean.class);
 		primitivesToWrappers.put(byte.class, Byte.class);
@@ -564,7 +564,7 @@ public final class ReflectionUtils {
 	 *
 	 * @param type the primitive type for which to retrieve the wrapper type
 	 * @return the corresponding wrapper type or {@code null} if the
-	 * supplied type is {@code null} or not a primitive type
+	 * supplied type is not a primitive type
 	 */
 	public static @Nullable Class<?> getWrapperType(Class<?> type) {
 		return primitiveToWrapperMap.get(type);

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -211,6 +212,19 @@ class ReflectionUtilsTests {
 			assertFalse(isWideningConversion(float.class, int.class)); // narrowing
 			assertFalse(isWideningConversion(int.class, int.class)); // direct match
 			assertFalse(isWideningConversion(String.class, int.class)); // neither a primitive nor a wrapper
+		}
+
+		@Test
+		void getWrapperType() {
+			assertEquals(Boolean.class, ReflectionUtils.getWrapperType(boolean.class));
+			assertEquals(Byte.class, ReflectionUtils.getWrapperType(byte.class));
+			assertEquals(Character.class, ReflectionUtils.getWrapperType(char.class));
+			assertEquals(Short.class, ReflectionUtils.getWrapperType(short.class));
+			assertEquals(Integer.class, ReflectionUtils.getWrapperType(int.class));
+			assertEquals(Long.class, ReflectionUtils.getWrapperType(long.class));
+			assertEquals(Float.class, ReflectionUtils.getWrapperType(float.class));
+			assertEquals(Double.class, ReflectionUtils.getWrapperType(double.class));
+			assertNull(ReflectionUtils.getWrapperType(Object.class));
 		}
 
 		@Test


### PR DESCRIPTION
## Overview

Initially triggered by https://github.com/junit-team/junit5/pull/4557#discussion_r2105731215.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
