### PR TITLE
Make dependency on open-test-reporting-tooling-spi non-optional

### DIFF
--- a/junit-platform-reporting/junit-platform-reporting.gradle.kts
+++ b/junit-platform-reporting/junit-platform-reporting.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 	api(platform(projects.junitBom))
 	api(projects.junitPlatformLauncher)
 
+	implementation(libs.openTestReporting.tooling.spi)
+
 	compileOnlyApi(libs.apiguardian)
 	compileOnly(libs.jspecify)
-
-	compileOnlyApi(libs.openTestReporting.tooling.spi)
 
 	shadowed(libs.openTestReporting.events)
 

--- a/platform-tooling-support-tests/projects/graalvm-starter/settings.gradle.kts
+++ b/platform-tooling-support-tests/projects/graalvm-starter/settings.gradle.kts
@@ -28,6 +28,12 @@ dependencyResolutionManagement {
 					snapshotsOnly()
 				}
 			}
+			maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
+				mavenContent {
+					snapshotsOnly()
+					includeGroup("org.opentest4j.reporting")
+				}
+			}
 		}
 	}
 }

--- a/platform-tooling-support-tests/projects/jupiter-starter/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/jupiter-starter/build.gradle.kts
@@ -7,6 +7,12 @@ val junitVersion: String by project
 repositories {
 	maven { url = uri(file(System.getProperty("maven.repo"))) }
 	mavenCentral()
+	maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
+		mavenContent {
+			snapshotsOnly()
+			includeGroup("org.opentest4j.reporting")
+		}
+	}
 }
 
 dependencies {

--- a/platform-tooling-support-tests/projects/reflection-tests/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/reflection-tests/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 dependencies {
 	testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
 	testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-	testRuntimeOnly("org.junit.platform:junit-platform-reporting:$junitVersion")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junitVersion")
 }
 
 java {
@@ -30,13 +30,5 @@ tasks.test {
 
 	reports {
 		html.required = true
-	}
-
-	val outputDir = reports.junitXml.outputLocation
-	jvmArgumentProviders += CommandLineArgumentProvider {
-		listOf(
-			"-Djunit.platform.reporting.open.xml.enabled=true",
-			"-Djunit.platform.reporting.output.dir=${outputDir.get().asFile.absolutePath}"
-		)
 	}
 }

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GraalVmStarterTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/GraalVmStarterTests.java
@@ -50,7 +50,7 @@ class GraalVmStarterTests {
 					graalVmHome.orElseThrow(TestAbortedException::new).toString()).addArguments(
 						"-Dmaven.repo=" + MavenRepo.dir()) //
 				.addArguments("javaToolchains", "nativeTest", "--no-daemon", "--stacktrace", "--no-build-cache",
-					"--warning-mode=fail") //
+					"--warning-mode=fail", "--refresh-dependencies") //
 				.redirectOutput(outputFiles) //
 				.startAndWait();
 


### PR DESCRIPTION
## Overview

Since the module descriptor requires it, it cannot be optional but must
be a regular dependency. Otherwise, using junit-platform-reporting on
the module path will fail.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
