### PR TITLE
Allow publishing files to an existing directory

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.0.adoc
@@ -188,6 +188,8 @@ to start reporting discovery issues.
   failures.
 * Add support for Kotlin `Sequence` to `@MethodSource`, `@FieldSource`, and
   `@TestFactory`.
+* Allow publishing files to an existing directory via `TestReporter` and
+  `ExtensionContext`, for example, when re-running a test class.
 
 
 [[release-notes-5.13.0-junit-vintage]]

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -419,7 +419,7 @@ public interface ExtensionContext {
 	 * and attach it to the current test or container.
 	 *
 	 * <p>The directory will be resolved and created in the report output directory
-	 * prior to invoking the supplied action.
+	 * prior to invoking the supplied action, if it doesn't already exist.
 	 *
 	 * @param name the name of the directory to be attached; never {@code null}
 	 * or blank and must not contain any path separators

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -161,7 +161,9 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 		Preconditions.notNull(action, "action must not be null");
 
 		ThrowingConsumer<Path> enhancedAction = path -> {
-			Files.createDirectory(path);
+			if (!Files.isDirectory(path)) {
+				Files.createDirectory(path);
+			}
 			action.accept(path);
 		};
 		publishFileEntry(name, enhancedAction, file -> {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
@@ -382,6 +382,19 @@ public class ExtensionContextTests {
 			"Published path must be a directory: " + tempDir.resolve("OuterClass").resolve("test"));
 	}
 
+	@Test
+	void allowsPublishingToTheSameDirectoryTwice(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+
+		extensionContext.publishDirectory("test",
+			dir -> Files.writeString(dir.resolve("nested1.txt"), "Nested content 1"));
+		extensionContext.publishDirectory("test",
+			dir -> Files.writeString(dir.resolve("nested2.txt"), "Nested content 2"));
+
+		assertThat(tempDir.resolve("OuterClass/test/nested1.txt")).hasContent("Nested content 1");
+		assertThat(tempDir.resolve("OuterClass/test/nested2.txt")).hasContent("Nested content 2");
+	}
+
 	private ExtensionContext createExtensionContextForFilePublishing(Path tempDir) {
 		return createExtensionContextForFilePublishing(tempDir, mock(EngineExecutionListener.class),
 			outerClassDescriptor(null));


### PR DESCRIPTION
## Overview

Prior to this commit, both `TestReporter` and `ExtensionContext` threw
an exception when `publishDirectory` was called with an existing
directory. Now, they only attempt to create the directory if it doesn't
already exist.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
