### PR TITLE
Remove short-circuiting to ensure all classes are checked for cycles

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -1142,17 +1143,9 @@ public final class ReflectionUtils {
 		Preconditions.notNull(clazz, "Class must not be null");
 		Preconditions.notNull(predicate, "Predicate must not be null");
 
-		class Tracker implements Consumer<Class<?>> {
-			boolean foundNestedClass = false;
-			@Override
-			public void accept(Class<?> __) {
-				foundNestedClass = true;
-			}
-		}
-		Tracker tracker = new Tracker();
-
-		visitAllNestedClasses(clazz, predicate, tracker);
-		return tracker.foundNestedClass;
+		AtomicBoolean foundNestedClass = new AtomicBoolean(false);
+		visitAllNestedClasses(clazz, predicate, __ -> foundNestedClass.setPlain(true));
+		return foundNestedClass.getPlain();
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1119,10 +1120,7 @@ public final class ReflectionUtils {
 		Preconditions.notNull(predicate, "Predicate must not be null");
 
 		Set<Class<?>> candidates = new LinkedHashSet<>();
-		visitNestedClasses(clazz, predicate, nestedClass -> {
-			candidates.add(nestedClass);
-			return true;
-		});
+		visitAllNestedClasses(clazz, predicate, candidates::add);
 		return List.copyOf(candidates);
 	}
 
@@ -1144,8 +1142,17 @@ public final class ReflectionUtils {
 		Preconditions.notNull(clazz, "Class must not be null");
 		Preconditions.notNull(predicate, "Predicate must not be null");
 
-		boolean visitorWasNotCalled = visitNestedClasses(clazz, predicate, __ -> false);
-		return !visitorWasNotCalled;
+		class Tracker implements Consumer<Class<?>> {
+			boolean foundNestedClass = false;
+			@Override
+			public void accept(Class<?> __) {
+				foundNestedClass = true;
+			}
+		}
+		Tracker tracker = new Tracker();
+
+		visitAllNestedClasses(clazz, predicate, tracker);
+		return tracker.foundNestedClass;
 	}
 
 	/**
@@ -1156,10 +1163,15 @@ public final class ReflectionUtils {
 		return findNestedClasses(clazz, predicate).stream();
 	}
 
-	private static boolean visitNestedClasses(Class<?> clazz, Predicate<Class<?>> predicate,
-			Visitor<Class<?>> visitor) {
+	/**
+	 * Visit <em>all</em> nested classes without support for short-circuiting
+	 * in order to ensure all of them are checked for class cycles.
+	 */
+	private static void visitAllNestedClasses(Class<?> clazz, Predicate<Class<?>> predicate,
+			Consumer<Class<?>> consumer) {
+
 		if (!isSearchable(clazz)) {
-			return true;
+			return;
 		}
 
 		if (isInnerClass(clazz) && predicate.test(clazz)) {
@@ -1171,10 +1183,7 @@ public final class ReflectionUtils {
 			for (Class<?> nestedClass : clazz.getDeclaredClasses()) {
 				if (predicate.test(nestedClass)) {
 					detectInnerClassCycle(nestedClass);
-					boolean shouldContinue = visitor.accept(nestedClass);
-					if (!shouldContinue) {
-						return false;
-					}
+					consumer.accept(nestedClass);
 				}
 			}
 		}
@@ -1183,20 +1192,12 @@ public final class ReflectionUtils {
 		}
 
 		// Search class hierarchy
-		boolean shouldContinue = visitNestedClasses(clazz.getSuperclass(), predicate, visitor);
-		if (!shouldContinue) {
-			return false;
-		}
+		visitAllNestedClasses(clazz.getSuperclass(), predicate, consumer);
 
 		// Search interface hierarchy
 		for (Class<?> ifc : clazz.getInterfaces()) {
-			shouldContinue = visitNestedClasses(ifc, predicate, visitor);
-			if (!shouldContinue) {
-				return false;
-			}
+			visitAllNestedClasses(ifc, predicate, consumer);
 		}
-
-		return true;
 	}
 
 	/**
@@ -1934,16 +1935,6 @@ public final class ReflectionUtils {
 			return getUnderlyingCause(((InvocationTargetException) t).getTargetException());
 		}
 		return t;
-	}
-
-	private interface Visitor<T> {
-
-		/**
-		 * @return {@code true} if the visitor should continue searching;
-		 * {@code false} if the visitor should stop
-		 */
-		boolean accept(T value);
-
 	}
 
 }


### PR DESCRIPTION
## Overview

Resolves #4597.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
