### PR TITLE
Ensure `@Nested` classes are executed after sibling test methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.1.adoc
@@ -35,7 +35,13 @@ on GitHub.
 [[release-notes-5.13.1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* The 5.13.0 release introduced a regression regarding the execution order in test classes
+  containing both test methods and `@Nested` test classes. When classpath scanning was
+  used during test discovery -- for example, when resolving a package selector for a
+  `@Suite` class -- test methods in `@Nested` classes were executed _before_ test methods
+  in their enclosing class. This undesired change in behavior has now been reverted so
+  that tests in `@Nested` test classes are always executed _after_ tests in enclosing test
+  classes again.
 
 [[release-notes-5.13.1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -71,7 +71,7 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 		assertEquals(2, tests.succeeded().count(), "# tests succeeded");
 		assertEquals(1, tests.failed().count(), "# tests failed");
 
-		assertThat(tests.started().map(it -> it.getTestDescriptor().getDisplayName()).toList()) //
+		assertThat(tests.started().map(it -> it.getTestDescriptor().getDisplayName())) //
 				.containsExactlyInAnyOrder("someTest()", "successful()", "failing()") //
 				.containsSubsequence("someTest()", "successful()") //
 				.containsSubsequence("someTest()", "failing()");

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -30,12 +30,9 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass.RecursiveNestedClass;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass.RecursiveNestedSiblingClass;
@@ -73,8 +70,11 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 		assertEquals(3, tests.started().count(), "# tests started");
 		assertEquals(2, tests.succeeded().count(), "# tests succeeded");
 		assertEquals(1, tests.failed().count(), "# tests failed");
-		assertThat(tests.started().map(it -> it.getTestDescriptor().getDisplayName())) //
-				.containsExactly("someTest()", "successful()", "failing()");
+
+		assertThat(tests.started().map(it -> it.getTestDescriptor().getDisplayName()).toList()) //
+				.containsExactlyInAnyOrder("someTest()", "successful()", "failing()") //
+				.containsSubsequence("someTest()", "successful()") //
+				.containsSubsequence("someTest()", "failing()");
 
 		Events containers = executionResults.containerEvents();
 		assertEquals(3, containers.started().count(), "# containers started");
@@ -248,15 +248,12 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Nested
-		@TestMethodOrder(OrderAnnotation.class)
 		class NestedTestCase {
 
-			@Order(1)
 			@Test
 			void successful() {
 			}
 
-			@Order(2)
 			@Test
 			void failing() {
 				Assertions.fail("Something went horribly wrong");

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -13,8 +13,10 @@ package org.junit.jupiter.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.ClassNameFilter.includeClassNamePatterns;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.LauncherConstants.CRITICAL_DISCOVERY_ISSUE_SEVERITY_PROPERTY_NAME;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
@@ -22,19 +24,28 @@ import static org.junit.platform.testkit.engine.EventConditions.finishedWithFail
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass.RecursiveNestedClass;
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass.RecursiveNestedSiblingClass;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.Events;
 
@@ -53,18 +64,31 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 		assertEquals(5, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
-	@Test
-	void nestedTestsAreExecuted() {
-		EngineExecutionResults executionResults = executeTestsForClass(TestCaseWithNesting.class);
-		Events containers = executionResults.containerEvents();
-		Events tests = executionResults.testEvents();
+	@ParameterizedTest(name = "{0}")
+	@MethodSource
+	void nestedTestsAreExecutedInTheRightOrder(Consumer<LauncherDiscoveryRequestBuilder> configurer) {
+		EngineExecutionResults executionResults = executeTests(configurer);
 
+		Events tests = executionResults.testEvents();
 		assertEquals(3, tests.started().count(), "# tests started");
 		assertEquals(2, tests.succeeded().count(), "# tests succeeded");
 		assertEquals(1, tests.failed().count(), "# tests failed");
+		assertThat(tests.started().map(it -> it.getTestDescriptor().getDisplayName())) //
+				.containsExactly("someTest()", "successful()", "failing()");
 
+		Events containers = executionResults.containerEvents();
 		assertEquals(3, containers.started().count(), "# containers started");
 		assertEquals(3, containers.finished().count(), "# containers finished");
+	}
+
+	static List<Named<Consumer<LauncherDiscoveryRequestBuilder>>> nestedTestsAreExecutedInTheRightOrder() {
+		return List.of( //
+			Named.of("class selector", request -> request //
+					.selectors(selectClass(TestCaseWithNesting.class))),
+			Named.of("package selector", request -> request //
+					.selectors(selectPackage(TestCaseWithNesting.class.getPackageName())) //
+					.filters(includeClassNamePatterns(Pattern.quote(TestCaseWithNesting.class.getName()) + ".*"))) //
+		);
 	}
 
 	@Test
@@ -224,12 +248,15 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 		}
 
 		@Nested
+		@TestMethodOrder(OrderAnnotation.class)
 		class NestedTestCase {
 
+			@Order(1)
 			@Test
 			void successful() {
 			}
 
+			@Order(2)
 			@Test
 			void failing() {
 				Assertions.fail("Something went horribly wrong");


### PR DESCRIPTION
## Overview

In order to validate them, classpath scanning was changed to find them
in 5.13.0. However, that caused `@Nested` classes to be added to their
parent descriptors before their sibling test methods. This made the
order of execution in classes containing nested test classes dependent
on how they were discovered unless a `MethodOrderer` was configured in
which case `MethodOrderingVisitor` ensured test methods came before
`@Nested` test classes on the same level.

This commit changes `MethodOrderingVisitor` to also ensure this
ordering constraint in case no `MethodOrderer` is configured.

Resolves #4600.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
