### PR TITLE
Deprecate JUnit 4 related modules

### DIFF
--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -165,7 +165,7 @@ tasks {
 		args.addAll("--config=junit.platform.reporting.open.xml.enabled=true")
 		args.addAll("--config=junit.platform.output.capture.stdout=true")
 		args.addAll("--config=junit.platform.output.capture.stderr=true")
-		args.addAll("--config=junit.platform.discovery.issue.severity.critical=info")
+		args.addAll("--config=junit.platform.discovery.issue.severity.critical=warn")
 		outputs.dir(consoleLauncherTestReportsDir)
 		argumentProviders.add(CommandLineArgumentProvider {
 			listOf(
@@ -202,6 +202,7 @@ tasks {
 		(options as JUnitPlatformOptions).apply {
 			includeEngines("junit-vintage")
 			includeTags("timeout")
+			systemProperty("junit.platform.discovery.issue.severity.critical", "warn")
 		}
 	}
 

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
@@ -132,7 +132,11 @@ repository on GitHub.
 [[release-notes-6.0.0-M1-junit-vintage-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes
 
-* ❓
+* The JUnit Vintage engine is now deprecated and will report an INFO level discovery issue
+  when it finds at least one JUnit 4 test class. For now, the intent of the deprecation is
+  not to signal removal in the next major version but to clarify the intended purpose of
+  the engine. It should only be used temporarily while migrating tests to JUnit Jupiter or
+  another testing framework with native JUnit Platform support.
 
 [[release-notes-6.0.0-M1-junit-vintage-new-features-and-improvements]]
 ==== New Features and Improvements

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
@@ -110,6 +110,8 @@ repository on GitHub.
 * The contracts for the `Executable` parameters of Kotlin-specific `assertTimeout`
   functions were changed from `callsInPlace(executable, EXACTLY_ONCE)` to
   `callsInPlace(executable, AT_MOST_ONCE)` which might result in compilation errors.
+* The `junit-jupiter-migrationsupport` artifact and its contained classes are now
+  deprecated and will be removed in the next major version.
 
 [[release-notes-6.0.0-M1-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements

--- a/documentation/src/docs/asciidoc/user-guide/appendix.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/appendix.adoc
@@ -108,8 +108,8 @@ Please refer to the corresponding sections for <<running-tests-build-maven-bom, 
   `junit-jupiter-params`::
     Support for <<writing-tests-parameterized-tests>> in JUnit Jupiter.
   `junit-jupiter-migrationsupport`::
-    Support for migrating from JUnit 4 to JUnit Jupiter; only required for support for
-    JUnit 4's `@Ignore` annotation and for running selected JUnit 4 rules.
+    _Deprecated_ support for migrating from JUnit 4 to JUnit Jupiter; only required for
+    support for JUnit 4's `@Ignore` annotation and for running selected JUnit 4 rules.
 
 [[dependency-metadata-junit-vintage]]
 ==== JUnit Vintage

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -256,6 +256,9 @@ include::{testDir}/example/ParameterizedMigrationDemo.java[tags=after]
 [[migrating-from-junit4-rule-support]]
 === Limited JUnit 4 Rule Support
 
+WARNING: _JUnit 4 rule support_ is deprecated for removal since version 6.0.0. Please
+migrate to the corresponding APIs and extensions provided by JUnit Jupiter.
+
 As stated above, JUnit Jupiter does not and will not support JUnit 4 rules natively. The
 JUnit team realizes, however, that many organizations, especially large ones, are likely
 to have large JUnit 4 code bases that make use of custom rules. To serve these
@@ -289,6 +292,9 @@ extension model of JUnit Jupiter instead of the rule-based model of JUnit 4.
 
 [[migrating-from-junit4-ignore-annotation-support]]
 === JUnit 4 @Ignore Support
+
+WARNING: _JUnit 4 `@Ignore` support_ is deprecated for removal since version 6.0.0. Please
+use JUnit Jupiter's `@Disabled` annotation instead.
 
 In order to provide a smooth migration path from JUnit 4 to JUnit Jupiter, the
 `junit-jupiter-migrationsupport` module provides support for JUnit 4's `@Ignore`

--- a/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/migration-from-junit4.adoc
@@ -21,6 +21,10 @@ plenty of time to migrate to JUnit Jupiter on their own schedule.
 [[migrating-from-junit4-running]]
 === Running JUnit 4 Tests on the JUnit Platform
 
+WARNING: The JUnit Vintage engine is deprecated and should only be used temporarily while
+migrating tests to JUnit Jupiter or another testing framework with native JUnit Platform
+support.
+
 Make sure that the `junit-vintage-engine` artifact is in your test runtime path. In that
 case JUnit 3 and JUnit 4 tests will automatically be picked up by the JUnit Platform
 launcher.

--- a/documentation/src/test/java/example/IgnoredTestsDemo.java
+++ b/documentation/src/test/java/example/IgnoredTestsDemo.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.EnableJUnit4MigrationSupport;
 
 // @ExtendWith(IgnoreCondition.class)
+@SuppressWarnings("removal")
 @EnableJUnit4MigrationSupport
 class IgnoredTestsDemo {
 

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/EnableJUnit4MigrationSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/EnableJUnit4MigrationSupport.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.migrationsupport;
 
-import static org.apiguardian.api.API.Status.STABLE;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -47,10 +47,14 @@ import org.junit.jupiter.migrationsupport.rules.VerifierSupport;
  * @see ExpectedExceptionSupport
  * @see IgnoreCondition
  * @see EnableRuleMigrationSupport
+ * @deprecated Please migrate to Jupiter extensions and use
+ * {@link org.junit.jupiter.api.Disabled @Disabled} instead.
  */
+@SuppressWarnings("removal")
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@API(status = STABLE, since = "5.7")
+@API(status = DEPRECATED, since = "6.0")
+@Deprecated(since = "6.0", forRemoval = true)
 @EnableRuleMigrationSupport
 @ExtendWith(IgnoreCondition.class)
 public @interface EnableJUnit4MigrationSupport {

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/conditions/IgnoreCondition.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/conditions/IgnoreCondition.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.migrationsupport.conditions;
 
-import static org.apiguardian.api.API.Status.STABLE;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 
 import java.lang.reflect.AnnotatedElement;
@@ -32,8 +32,10 @@ import org.junit.platform.commons.util.StringUtils;
  * @see org.junit.jupiter.api.Disabled @Disabled
  * @see #evaluateExecutionCondition(ExtensionContext)
  * @see org.junit.jupiter.migrationsupport.EnableJUnit4MigrationSupport
+ * @deprecated Please use {@link org.junit.jupiter.api.Disabled @Disabled} instead.
  */
-@API(status = STABLE, since = "5.7")
+@API(status = DEPRECATED, since = "6.0")
+@Deprecated(since = "6.0", forRemoval = true)
 public class IgnoreCondition implements ExecutionCondition {
 
 	private static final ConditionEvaluationResult ENABLED = //

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/conditions/package-info.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/conditions/package-info.java
@@ -1,7 +1,7 @@
 /**
- * Extensions which provide support for conditional test execution features of
- * JUnit 4 (e.g., the {@link org.junit.Ignore @Ignore} annotation) within JUnit
- * Jupiter.
+ * <em>Deprecated</em> extensions that provide support for conditional test
+ * execution features of JUnit 4 (e.g., the {@link org.junit.Ignore @Ignore}
+ * annotation) within JUnit Jupiter.
  */
 
 @NullMarked

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/package-info.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Support for migrating from JUnit 4 to JUnit Jupiter.
+ * <em>Deprecated</em> support for migrating from JUnit 4 to JUnit Jupiter.
  */
 
 @NullMarked

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/EnableRuleMigrationSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/EnableRuleMigrationSupport.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.migrationsupport.rules;
 
-import static org.apiguardian.api.API.Status.STABLE;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -36,10 +36,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see VerifierSupport
  * @see ExpectedExceptionSupport
  * @see org.junit.jupiter.migrationsupport.EnableJUnit4MigrationSupport
+ * @deprecated Please migrate to Jupiter extensions.
  */
+@SuppressWarnings("removal")
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@API(status = STABLE, since = "5.7")
+@API(status = DEPRECATED, since = "6.0")
+@Deprecated(since = "6.0", forRemoval = true)
 @ExtendWith(ExternalResourceSupport.class)
 @ExtendWith(VerifierSupport.class)
 @ExtendWith(ExpectedExceptionSupport.class)

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
@@ -12,7 +12,7 @@ package org.junit.jupiter.migrationsupport.rules;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static org.apiguardian.api.API.Status.STABLE;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.migrationsupport.rules.adapter.ExpectedExceptionAdapter;
 import org.junit.rules.ExpectedException;
 
@@ -38,8 +39,13 @@ import org.junit.rules.ExpectedException;
  * @see org.junit.rules.ExpectedException
  * @see org.junit.rules.TestRule
  * @see org.junit.Rule
+ * @deprecated Please use
+ * {@link org.junit.jupiter.api.Assertions#assertThrows(Class, Executable)}
+ * instead.
  */
-@API(status = STABLE, since = "5.7")
+@SuppressWarnings("removal")
+@API(status = DEPRECATED, since = "6.0")
+@Deprecated(since = "6.0", forRemoval = true)
 public class ExpectedExceptionSupport implements AfterEachCallback, TestExecutionExceptionHandler {
 
 	private static final String EXCEPTION_WAS_HANDLED = "exceptionWasHandled";

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupport.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.migrationsupport.rules;
 
-import static org.apiguardian.api.API.Status.STABLE;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -37,8 +37,11 @@ import org.junit.rules.ExternalResource;
  * @see org.junit.rules.ExternalResource
  * @see org.junit.rules.TestRule
  * @see org.junit.Rule
+ * @deprecated Please use {@link org.junit.jupiter.api.AutoClose @AutoClose} instead.
  */
-@API(status = STABLE, since = "5.7")
+@SuppressWarnings("removal")
+@API(status = DEPRECATED, since = "6.0")
+@Deprecated(since = "6.0", forRemoval = true)
 public class ExternalResourceSupport implements BeforeEachCallback, AfterEachCallback {
 
 	private final TestRuleSupport support = new TestRuleSupport(ExternalResourceAdapter::new, ExternalResource.class);

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/VerifierSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/VerifierSupport.java
@@ -10,7 +10,7 @@
 
 package org.junit.jupiter.migrationsupport.rules;
 
-import static org.apiguardian.api.API.Status.STABLE;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 
 import org.apiguardian.api.API;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -36,8 +36,11 @@ import org.junit.rules.Verifier;
  * @see org.junit.rules.Verifier
  * @see org.junit.rules.TestRule
  * @see org.junit.Rule
+ * @deprecated Please implement {@link org.junit.jupiter.api.extension.AfterTestExecutionCallback} instead.
  */
-@API(status = STABLE, since = "5.7")
+@SuppressWarnings("removal")
+@API(status = DEPRECATED, since = "6.0")
+@Deprecated(since = "6.0", forRemoval = true)
 public class VerifierSupport implements AfterEachCallback {
 
 	private final TestRuleSupport support = new TestRuleSupport(VerifierAdapter::new, Verifier.class);

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/adapter/package-info.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/adapter/package-info.java
@@ -1,5 +1,6 @@
 /**
- * Simple wrappers for JUnit 4 rules to overcome visibility limitations of the JUnit 4 implementations.
+ * <em>Internal</em> wrappers for JUnit 4 rules to overcome visibility
+ * limitations of the JUnit 4 implementations.
  */
 
 @NullMarked

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/member/TestRuleAnnotatedMember.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/member/TestRuleAnnotatedMember.java
@@ -18,7 +18,7 @@ import org.junit.rules.TestRule;
 /**
  * @since 5.0
  */
-@API(status = INTERNAL, since = "5.0")
+@API(status = INTERNAL, since = "5.1")
 public interface TestRuleAnnotatedMember {
 
 	TestRule getTestRule();

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/member/package-info.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/member/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Abstractions for members which can be targets of JUnit 4 rule annotations.
+ * <em>Internal</em> abstractions for members which can be targets of JUnit 4 rule annotations.
  */
 
 @NullMarked

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/package-info.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/package-info.java
@@ -1,5 +1,6 @@
 /**
- * Extensions which provide (limited) support for JUnit 4 rules within JUnit Jupiter.
+ * <em>Deprecated</em> extensions which provide (limited) support for JUnit 4
+ * rules within JUnit Jupiter.
  */
 
 @NullMarked

--- a/junit-vintage-engine/src/main/java/module-info.java
+++ b/junit-vintage-engine/src/main/java/module-info.java
@@ -16,6 +16,7 @@
  * @provides org.junit.platform.engine.TestEngine The {@code VintageTestEngine}
  * runs JUnit 3 and 4 based tests on the platform.
  */
+@SuppressWarnings("deprecation")
 module org.junit.vintage.engine {
 
 	requires static org.apiguardian.api;

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/Constants.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/Constants.java
@@ -10,17 +10,19 @@
 
 package org.junit.vintage.engine;
 
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
-import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
 
 /**
  * Collection of constants related to the {@link VintageTestEngine}.
  *
- * @since 5.12
+ * @deprecated Should only be used temporarily while migrating tests to JUnit
+ * Jupiter or another testing framework with native JUnit Platform support
  */
-@API(status = STABLE, since = "5.12")
+@Deprecated(since = "6.0")
+@API(status = DEPRECATED, since = "6.0")
 public final class Constants {
 
 	/**

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/VintageTestEngine.java
@@ -10,7 +10,7 @@
 
 package org.junit.vintage.engine;
 
-import static org.apiguardian.api.API.Status.INTERNAL;
+import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.junit.platform.engine.TestExecutionResult.successful;
 import static org.junit.vintage.engine.descriptor.VintageTestDescriptor.ENGINE_ID;
 
@@ -31,8 +31,11 @@ import org.junit.vintage.engine.execution.VintageExecutor;
  * The JUnit Vintage {@link TestEngine}.
  *
  * @since 4.12
+ * @deprecated Should only be used temporarily while migrating tests to JUnit
+ * Jupiter or another testing framework with native JUnit Platform support
  */
-@API(status = INTERNAL, since = "4.12")
+@Deprecated(since = "6.0")
+@API(status = DEPRECATED, since = "6.0")
 public final class VintageTestEngine implements TestEngine {
 
 	@Override

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/VintageDiscoverer.java
@@ -14,6 +14,7 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.support.scanning.ClassFilter;
+import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
@@ -44,6 +45,13 @@ public class VintageDiscoverer {
 		for (TestDescriptor testDescriptor : engineDescriptor.getChildren()) {
 			RunnerTestDescriptor runnerTestDescriptor = (RunnerTestDescriptor) testDescriptor;
 			postProcessor.applyFiltersAndCreateDescendants(runnerTestDescriptor);
+		}
+		if (!engineDescriptor.getChildren().isEmpty()) {
+			var issue = DiscoveryIssue.create(DiscoveryIssue.Severity.INFO, //
+				"The JUnit Vintage engine is deprecated and should only be " //
+						+ "used temporarily while migrating tests to JUnit Jupiter or another testing " //
+						+ "framework with native JUnit Platform support.");
+			discoveryRequest.getDiscoveryListener().issueEncountered(uniqueId, issue);
 		}
 		return engineDescriptor;
 	}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
@@ -12,10 +12,6 @@ package org.junit.vintage.engine.execution;
 
 import static java.util.Objects.requireNonNullElse;
 import static org.apiguardian.api.API.Status.INTERNAL;
-import static org.junit.vintage.engine.Constants.PARALLEL_CLASS_EXECUTION;
-import static org.junit.vintage.engine.Constants.PARALLEL_EXECUTION_ENABLED;
-import static org.junit.vintage.engine.Constants.PARALLEL_METHOD_EXECUTION;
-import static org.junit.vintage.engine.Constants.PARALLEL_POOL_SIZE;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -34,12 +30,14 @@ import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.vintage.engine.Constants;
 import org.junit.vintage.engine.descriptor.RunnerTestDescriptor;
 import org.junit.vintage.engine.descriptor.VintageEngineDescriptor;
 
 /**
  * @since 5.12
  */
+@SuppressWarnings({ "deprecation", "RedundantSuppression" })
 @API(status = INTERNAL, since = "5.12")
 public class VintageExecutor {
 
@@ -62,9 +60,11 @@ public class VintageExecutor {
 		this.engineExecutionListener = engineExecutionListener;
 		this.request = request;
 		this.parallelExecutionEnabled = request.getConfigurationParameters().getBoolean(
-			PARALLEL_EXECUTION_ENABLED).orElse(false);
-		this.classes = request.getConfigurationParameters().getBoolean(PARALLEL_CLASS_EXECUTION).orElse(false);
-		this.methods = request.getConfigurationParameters().getBoolean(PARALLEL_METHOD_EXECUTION).orElse(false);
+			Constants.PARALLEL_EXECUTION_ENABLED).orElse(false);
+		this.classes = request.getConfigurationParameters().getBoolean(Constants.PARALLEL_CLASS_EXECUTION).orElse(
+			false);
+		this.methods = request.getConfigurationParameters().getBoolean(Constants.PARALLEL_METHOD_EXECUTION).orElse(
+			false);
 	}
 
 	public void executeAllChildren() {
@@ -110,7 +110,7 @@ public class VintageExecutor {
 	}
 
 	private int getThreadPoolSize() {
-		Optional<String> optionalPoolSize = request.getConfigurationParameters().get(PARALLEL_POOL_SIZE);
+		Optional<String> optionalPoolSize = request.getConfigurationParameters().get(Constants.PARALLEL_POOL_SIZE);
 		if (optionalPoolSize.isPresent()) {
 			try {
 				int poolSize = Integer.parseInt(optionalPoolSize.get());

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTests.java
@@ -63,6 +63,7 @@ class JUnit4ParameterizedTests {
 			request()
 				.selectors(selector)
 				.filters(includeEngines("junit-vintage"))
+				.enableImplicitConfigurationParameters(false)
 				.build()
 		);
 		// @formatter:on

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageLauncherIntegrationTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageLauncherIntegrationTests.java
@@ -280,7 +280,9 @@ class VintageLauncherIntegrationTests {
 	}
 
 	private LauncherDiscoveryRequest toRequest(LauncherDiscoveryRequestBuilder requestBuilder) {
-		return requestBuilder.filters(includeEngines(ENGINE_ID)).build();
+		return requestBuilder.filters(includeEngines(ENGINE_ID)) //
+				.enableImplicitConfigurationParameters(false) //
+				.build();
 	}
 
 }

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineBasicTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineBasicTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 4.12
  */
+@SuppressWarnings("deprecation")
 class VintageTestEngineBasicTests {
 
 	private final VintageTestEngine vintage = new VintageTestEngine();

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineExecutionTests.java
@@ -787,8 +787,10 @@ class VintageTestEngineExecutionTests {
 	@Test
 	void executesCompletelyDynamicTestCaseDiscoveredByUniqueId() {
 		Class<?> testClass = CompletelyDynamicTestCase.class;
-		var request = LauncherDiscoveryRequestBuilder.request().selectors(
-			selectUniqueId(VintageUniqueIdBuilder.uniqueIdForClass(testClass))).build();
+		var request = LauncherDiscoveryRequestBuilder.request() //
+				.selectors(selectUniqueId(VintageUniqueIdBuilder.uniqueIdForClass(testClass))) //
+				.enableImplicitConfigurationParameters(false) //
+				.build();
 
 		execute(request).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
@@ -868,8 +870,10 @@ class VintageTestEngineExecutionTests {
 		// Load Groovy class via reflection to avoid compilation errors in Eclipse IDE.
 		String testClassName = "org.junit.vintage.engine.samples.spock.SpockTestCaseWithUnrolledAndRegularFeatureMethods";
 		Class<?> testClass = ReflectionUtils.loadRequiredClass(testClassName, getClass().getClassLoader());
-		var request = LauncherDiscoveryRequestBuilder.request().selectors(
-			selectMethod(testClass, "unrolled feature for #input")).build();
+		var request = LauncherDiscoveryRequestBuilder.request() //
+				.selectors(selectMethod(testClass, "unrolled feature for #input"))//
+				.enableImplicitConfigurationParameters(false) //
+				.build();
 		execute(request).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(uniqueIdSubstring(testClassName), started()), //
@@ -889,7 +893,10 @@ class VintageTestEngineExecutionTests {
 		// Load Groovy class via reflection to avoid compilation errors in Eclipse IDE.
 		String testClassName = "org.junit.vintage.engine.samples.spock.SpockTestCaseWithUnrolledAndRegularFeatureMethods";
 		Class<?> testClass = ReflectionUtils.loadRequiredClass(testClassName, getClass().getClassLoader());
-		var request = LauncherDiscoveryRequestBuilder.request().selectors(selectMethod(testClass, "regular")).build();
+		var request = LauncherDiscoveryRequestBuilder.request() //
+				.selectors(selectMethod(testClass, "regular")) //
+				.enableImplicitConfigurationParameters(false) //
+				.build();
 		execute(request).allEvents().assertEventsMatchExactly( //
 			event(engine(), started()), //
 			event(container(testClass), started()), //
@@ -924,10 +931,12 @@ class VintageTestEngineExecutionTests {
 		return execute(request(testClass));
 	}
 
+	@SuppressWarnings("deprecation")
 	private static EngineExecutionResults execute(LauncherDiscoveryRequest request) {
 		return EngineTestKit.execute(new VintageTestEngine(), request);
 	}
 
+	@SuppressWarnings("deprecation")
 	private static void execute(Class<?> testClass, EngineExecutionListener listener) {
 		TestEngine testEngine = new VintageTestEngine();
 		var discoveryRequest = request(testClass);
@@ -938,7 +947,10 @@ class VintageTestEngineExecutionTests {
 	}
 
 	private static LauncherDiscoveryRequest request(Class<?> testClass) {
-		return LauncherDiscoveryRequestBuilder.request().selectors(selectClass(testClass)).build();
+		return LauncherDiscoveryRequestBuilder.request() //
+				.selectors(selectClass(testClass)) //
+				.enableImplicitConfigurationParameters(false) //
+				.build();
 	}
 
 	private static boolean atLeastJUnit4_13() {

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/execution/ParallelExecutionIntegrationTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/execution/ParallelExecutionIntegrationTests.java
@@ -17,10 +17,6 @@ import static org.junit.platform.testkit.engine.EventConditions.event;
 import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
 import static org.junit.platform.testkit.engine.EventConditions.started;
 import static org.junit.platform.testkit.engine.EventConditions.test;
-import static org.junit.vintage.engine.Constants.PARALLEL_CLASS_EXECUTION;
-import static org.junit.vintage.engine.Constants.PARALLEL_EXECUTION_ENABLED;
-import static org.junit.vintage.engine.Constants.PARALLEL_METHOD_EXECUTION;
-import static org.junit.vintage.engine.Constants.PARALLEL_POOL_SIZE;
 import static org.junit.vintage.engine.descriptor.VintageTestDescriptor.SEGMENT_TYPE_RUNNER;
 import static org.junit.vintage.engine.descriptor.VintageTestDescriptor.SEGMENT_TYPE_TEST;
 import static org.junit.vintage.engine.samples.junit4.JUnit4ParallelClassesTestCase.FirstClassTestCase;
@@ -51,6 +47,7 @@ import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
 import org.junit.platform.testkit.engine.Event;
 import org.junit.platform.testkit.engine.Events;
+import org.junit.vintage.engine.Constants;
 import org.junit.vintage.engine.VintageTestEngine;
 import org.junit.vintage.engine.samples.junit4.JUnit4ParallelClassesTestCase;
 import org.junit.vintage.engine.samples.junit4.JUnit4ParallelMethodsTestCase;
@@ -180,12 +177,14 @@ class ParallelExecutionIntegrationTests {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	private static EngineExecutionResults execute(int poolSize, boolean parallelClasses, boolean parallelMethods,
 			Class<?>... testClass) {
 		return EngineTestKit.execute(new VintageTestEngine(),
 			request(poolSize, parallelClasses, parallelMethods, testClass));
 	}
 
+	@SuppressWarnings("deprecation")
 	private static LauncherDiscoveryRequest request(int poolSize, boolean parallelClasses, boolean parallelMethods,
 			Class<?>... testClasses) {
 		var classSelectors = Arrays.stream(testClasses) //
@@ -194,10 +193,11 @@ class ParallelExecutionIntegrationTests {
 
 		return LauncherDiscoveryRequestBuilder.request() //
 				.selectors(classSelectors) //
-				.configurationParameter(PARALLEL_EXECUTION_ENABLED, String.valueOf(true)) //
-				.configurationParameter(PARALLEL_POOL_SIZE, String.valueOf(poolSize)) //
-				.configurationParameter(PARALLEL_CLASS_EXECUTION, String.valueOf(parallelClasses)) //
-				.configurationParameter(PARALLEL_METHOD_EXECUTION, String.valueOf(parallelMethods)) //
+				.configurationParameter(Constants.PARALLEL_EXECUTION_ENABLED, String.valueOf(true)) //
+				.configurationParameter(Constants.PARALLEL_POOL_SIZE, String.valueOf(poolSize)) //
+				.configurationParameter(Constants.PARALLEL_CLASS_EXECUTION, String.valueOf(parallelClasses)) //
+				.configurationParameter(Constants.PARALLEL_METHOD_EXECUTION, String.valueOf(parallelMethods)) //
+				.enableImplicitConfigurationParameters(false) //
 				.build();
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/conditions/IgnoreAnnotationIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/conditions/IgnoreAnnotationIntegrationTests.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.migrationsupport.EnableJUnit4MigrationSupport;
  * @since 5.4
  * @see IgnoreConditionTests
  */
+@SuppressWarnings("removal")
 class IgnoreAnnotationIntegrationTests {
 
 	@Nested

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/conditions/IgnoreConditionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/conditions/IgnoreConditionTests.java
@@ -35,6 +35,7 @@ import org.junit.platform.testkit.engine.Events;
  * @since 5.4
  * @see IgnoreAnnotationIntegrationTests
  */
+@SuppressWarnings("removal")
 class IgnoreConditionTests {
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/AbstractTestRuleAdapterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/AbstractTestRuleAdapterTests.java
@@ -26,6 +26,7 @@ import org.junit.rules.Verifier;
 /**
  * @since 5.0
  */
+@SuppressWarnings("removal")
 public class AbstractTestRuleAdapterTests {
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/EnableRuleMigrationSupportWithBothRuleTypesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/EnableRuleMigrationSupportWithBothRuleTypesTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.Verifier;
 
+@SuppressWarnings("removal")
 @EnableRuleMigrationSupport
 public class EnableRuleMigrationSupportWithBothRuleTypesTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupportTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupportTests.java
@@ -34,6 +34,7 @@ import org.junit.rules.ExpectedException;
  *
  * @since 5.0
  */
+@SuppressWarnings("removal")
 class ExpectedExceptionSupportTests {
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForDifferentDeclaredReturnTypesRulesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForDifferentDeclaredReturnTypesRulesTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
 
+@SuppressWarnings("removal")
 @ExtendWith(ExternalResourceSupport.class)
 class ExternalResourceSupportForDifferentDeclaredReturnTypesRulesTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForMixedMethodAndFieldRulesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForMixedMethodAndFieldRulesTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.ExternalResource;
 
+@SuppressWarnings("removal")
 @ExtendWith(ExternalResourceSupport.class)
 public class ExternalResourceSupportForMixedMethodAndFieldRulesTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForMultipleFieldRulesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForMultipleFieldRulesTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.ExternalResource;
 
+@SuppressWarnings("removal")
 @ExtendWith(ExternalResourceSupport.class)
 public class ExternalResourceSupportForMultipleFieldRulesTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForMultipleMethodRulesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForMultipleMethodRulesTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.ExternalResource;
 
+@SuppressWarnings("removal")
 @ExtendWith(ExternalResourceSupport.class)
 public class ExternalResourceSupportForMultipleMethodRulesTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForTemporaryFolderFieldTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupportForTemporaryFolderFieldTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.TemporaryFolder;
 
+@SuppressWarnings("removal")
 @ExtendWith(ExternalResourceSupport.class)
 public class ExternalResourceSupportForTemporaryFolderFieldTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/LauncherBasedEnableRuleMigrationSupportTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/LauncherBasedEnableRuleMigrationSupportTests.java
@@ -23,6 +23,7 @@ import org.junit.rules.ErrorCollector;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.Verifier;
 
+@SuppressWarnings("removal")
 class LauncherBasedEnableRuleMigrationSupportTests {
 
 	@Test

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/VerifierSupportForMixedMethodAndFieldRulesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/VerifierSupportForMixedMethodAndFieldRulesTests.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.Verifier;
 
+@SuppressWarnings("removal")
 @ExtendWith(VerifierSupport.class)
 public class VerifierSupportForMixedMethodAndFieldRulesTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/WrongExtendWithForVerifierFieldTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/WrongExtendWithForVerifierFieldTests.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.Verifier;
 
+@SuppressWarnings("removal")
 @ExtendWith(ExternalResourceSupport.class)
 public class WrongExtendWithForVerifierFieldTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/WrongExtendWithForVerifierMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/WrongExtendWithForVerifierMethodTests.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.Verifier;
 
+@SuppressWarnings("removal")
 @ExtendWith(ExternalResourceSupport.class)
 public class WrongExtendWithForVerifierMethodTests {
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
@@ -441,6 +441,7 @@ class LauncherFactoryTests {
 		return request()
 				.selectors(selectClass(JUnit4Example.class))
 				.selectors(selectClass(JUnit5Example.class))
+				.enableImplicitConfigurationParameters(false)
 				.build();
 		// @formatter:on
 	}

--- a/platform-tooling-support-tests/projects/graalvm-starter/build.gradle.kts
+++ b/platform-tooling-support-tests/projects/graalvm-starter/build.gradle.kts
@@ -52,6 +52,7 @@ val initializeAtBuildTime = mapOf(
 	// These need to be added to native-build-tools
 	"6.0" to listOf(
 		"org.junit.platform.commons.util.KotlinReflectionUtils",
+		"org.junit.platform.launcher.core.DiscoveryIssueNotifier\$1",
 	)
 )
 

--- a/platform-tooling-support-tests/projects/standalone/expected-err.txt
+++ b/platform-tooling-support-tests/projects/standalone/expected-err.txt
@@ -18,3 +18,7 @@
 - junit-platform-suite .+
 - junit-jupiter .+
 - junit-vintage .+
+>> LOGGER >>
+INFO: TestEngine with ID 'junit-vintage' encountered a non-critical issue during test discovery:
+
+(1) [INFO] The JUnit Vintage engine is deprecated and should only be used temporarily while migrating tests to JUnit Jupiter or another testing framework with native JUnit Platform support.


### PR DESCRIPTION
## Overview

- **Deprecate junit-jupiter-migrationsupport for removal in 7.0**
- **Deprecate junit-vintage-engine to clarify its purpose**

Resolves #4580..

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
