### PR TITLE
Fix support for pre-5.13 `AnnotationBasedArgumentsProviders`

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.1.adoc
@@ -35,7 +35,8 @@ on GitHub.
 [[release-notes-5.13.1-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Fix support for `AnnotationBasedArgumentsProvider` implementations that override the
+  deprecated `provideArguments(ExtensionContext, Annotation)` method.
 
 [[release-notes-5.13.1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumerInitializer.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumerInitializer.java
@@ -41,6 +41,7 @@ public final class AnnotationConsumerInitializer {
 	private static final List<AnnotationConsumingMethodSignature> annotationConsumingMethodSignatures = asList( //
 		new AnnotationConsumingMethodSignature("accept", 1, 0), //
 		new AnnotationConsumingMethodSignature("provideArguments", 3, 2), //
+		new AnnotationConsumingMethodSignature("provideArguments", 2, 1), //
 		new AnnotationConsumingMethodSignature("convert", 3, 2));
 
 	private AnnotationConsumerInitializer() {


### PR DESCRIPTION
## Overview

The `provideArguments(ExtensionContext, Annotation)` was deprecated in
5.13 and no longer taken into account when determining the consumed
annotation. Now, it is checked for again if the new method overload
couldn't be found.

Fixes #4610.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
