### PR TITLE
chore: replace List<@Nullable Object> with List<?>

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -450,7 +450,9 @@ public final class AnnotationSupport {
 		List<Field> fields = findAnnotatedFields(instance.getClass(), annotationType, ModifierSupport::isNotStatic,
 			HierarchyTraversalMode.TOP_DOWN);
 
-		return ReflectionUtils.readFieldValues(fields, instance);
+		@SuppressWarnings("unchecked")
+		List<@Nullable Object> result = (List<@Nullable Object>) ReflectionUtils.readFieldValues(fields, instance);
+		return result;
 	}
 
 	/**
@@ -482,7 +484,9 @@ public final class AnnotationSupport {
 		List<Field> fields = findAnnotatedFields(clazz, annotationType, ModifierSupport::isStatic,
 			HierarchyTraversalMode.TOP_DOWN);
 
-		return ReflectionUtils.readFieldValues(fields, null);
+		@SuppressWarnings("unchecked")
+		List<@Nullable Object> result = (List<@Nullable Object>) ReflectionUtils.readFieldValues(fields, null);
+		return result;
 	}
 
 	/**

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -657,7 +657,7 @@ public final class ReflectionUtils {
 	 * @return an immutable list of the values of the specified fields; never
 	 * {@code null} but may be empty or contain {@code null} entries
 	 */
-	public static List<@Nullable Object> readFieldValues(List<Field> fields, @Nullable Object instance) {
+	public static List<?> readFieldValues(List<Field> fields, @Nullable Object instance) {
 		return readFieldValues(fields, instance, field -> true);
 	}
 
@@ -674,9 +674,7 @@ public final class ReflectionUtils {
 	 * @return an immutable list of the values of the specified fields; never
 	 * {@code null} but may be empty or contain {@code null} entries
 	 */
-	@SuppressWarnings("NullAway")
-	public static List<@Nullable Object> readFieldValues(List<Field> fields, @Nullable Object instance,
-			Predicate<Field> predicate) {
+	public static List<?> readFieldValues(List<Field> fields, @Nullable Object instance, Predicate<Field> predicate) {
 		Preconditions.notNull(fields, "fields list must not be null");
 		Preconditions.notNull(predicate, "Predicate must not be null");
 

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -60,6 +60,7 @@ import java.util.logging.LogRecord;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -1952,7 +1953,8 @@ class ReflectionUtilsTests {
 
 			var values = readFieldValues(fields, new ClassWithFields());
 
-			assertThat(values).containsExactly("enigma", 3.14, "text", 2.5, null, 42, "constant", 99);
+			Assertions.<Object> assertThat(values).containsExactly("enigma", 3.14, "text", 2.5, null, 42, "constant",
+				99);
 		}
 
 		@Test
@@ -1961,7 +1963,7 @@ class ReflectionUtilsTests {
 
 			var values = readFieldValues(fields, null);
 
-			assertThat(values).containsExactly(2.5, "constant", 99);
+			Assertions.<Object> assertThat(values).containsExactly(2.5, "constant", 99);
 		}
 
 		/**
@@ -1972,15 +1974,15 @@ class ReflectionUtilsTests {
 		void readFieldValuesFromInterfacesAndClassesInTypeHierarchy() {
 			var fields = findFields(InterfaceWithField.class, ReflectionUtils::isStatic, TOP_DOWN);
 			var values = readFieldValues(fields, null);
-			assertThat(values).containsOnly("ifc");
+			Assertions.<Object> assertThat(values).containsOnly("ifc");
 
 			fields = findFields(SuperclassWithFieldAndFieldFromInterface.class, ReflectionUtils::isStatic, TOP_DOWN);
 			values = readFieldValues(fields, null);
-			assertThat(values).containsExactly("ifc", "super");
+			Assertions.<Object> assertThat(values).containsExactly("ifc", "super");
 
 			fields = findFields(SubclassWithFieldAndFieldFromInterface.class, ReflectionUtils::isStatic, TOP_DOWN);
 			values = readFieldValues(fields, null);
-			assertThat(values).containsExactly("ifc", "super", "sub");
+			Assertions.<Object> assertThat(values).containsExactly("ifc", "super", "sub");
 		}
 
 		@Test
@@ -1989,7 +1991,7 @@ class ReflectionUtilsTests {
 
 			var values = readFieldValues(fields, new ClassWithFields(), isA(String.class));
 
-			assertThat(values).containsExactly("enigma", "text", null, "constant");
+			Assertions.<Object> assertThat(values).containsExactly("enigma", "text", null, "constant");
 		}
 
 		@Test
@@ -1998,7 +2000,7 @@ class ReflectionUtilsTests {
 
 			var values = readFieldValues(fields, null, isA(String.class));
 
-			assertThat(values).containsExactly("constant");
+			Assertions.<Object> assertThat(values).containsExactly("constant");
 		}
 
 		@Test
@@ -2007,7 +2009,7 @@ class ReflectionUtilsTests {
 
 			var values = readFieldValues(fields, new ClassWithFields(), isA(int.class));
 
-			assertThat(values).containsExactly(42);
+			Assertions.<Object> assertThat(values).containsExactly(42);
 		}
 
 		@Test
@@ -2016,7 +2018,7 @@ class ReflectionUtilsTests {
 
 			var values = readFieldValues(fields, null, isA(Integer.class));
 
-			assertThat(values).containsExactly(99);
+			Assertions.<Object> assertThat(values).containsExactly(99);
 		}
 
 		@Test
@@ -2025,7 +2027,7 @@ class ReflectionUtilsTests {
 
 			var values = readFieldValues(fields, new ClassWithFields(), isA(double.class));
 
-			assertThat(values).containsExactly(3.14);
+			Assertions.<Object> assertThat(values).containsExactly(3.14);
 		}
 
 		@Test
@@ -2034,7 +2036,7 @@ class ReflectionUtilsTests {
 
 			var values = readFieldValues(fields, null, isA(Double.class));
 
-			assertThat(values).containsExactly(2.5);
+			Assertions.<Object> assertThat(values).containsExactly(2.5);
 		}
 
 		private static Predicate<Field> isA(Class<?> type) {


### PR DESCRIPTION
## Overview

The latter is easier to read, and it forbids list.add(...) at the compile-time.

See https://jspecify.dev/docs/user-guide/#wildcard-bounds

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
