### PR TITLE
added null checks

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/CallbackSupport.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/CallbackSupport.java
@@ -8,6 +8,7 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import java.util.Objects;
 package org.junit.jupiter.engine.descriptor;
 
 import static org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder;
@@ -25,6 +26,10 @@ class CallbackSupport {
 
 	static <T extends Extension> void invokeBeforeCallbacks(Class<T> type, JupiterEngineExecutionContext context,
 			CallbackInvoker<T> callbackInvoker) {
+		
+		Objects.requireNonNull(type, "type must not be null");
+		Objects.requireNonNull(context, "context must not be null");
+		Objects.requireNonNull(callbackInvoker, "callbackInvoker must not be null");
 
 		ExtensionRegistry registry = context.getExtensionRegistry();
 		ExtensionContext extensionContext = context.getExtensionContext();
@@ -40,7 +45,11 @@ class CallbackSupport {
 
 	static <T extends Extension> void invokeAfterCallbacks(Class<T> type, JupiterEngineExecutionContext context,
 			CallbackInvoker<T> callbackInvoker) {
-
+		
+		Objects.requireNonNull(type, "type must not be null");
+		Objects.requireNonNull(context, "context must not be null");
+		Objects.requireNonNull(callbackInvoker, "callbackInvoker must not be null");
+		
 		ExtensionRegistry registry = context.getExtensionRegistry();
 		ExtensionContext extensionContext = context.getExtensionContext();
 		ThrowableCollector throwableCollector = context.getThrowableCollector();


### PR DESCRIPTION
## Overview

I placed  the `Objects.requireNonNull` (null checks) at the start of each public-facing method to ensure that critical inputs are not null before proceeding with the logic.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
