### PR TITLE
Add JAVA_26 to JRE enum

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -24,6 +24,8 @@ jobs:
         jdk:
         - version: 25
           type: ea
+        - version: 26
+          type: ea
     name: "OpenJDK ${{ matrix.jdk.version }} (${{ matrix.jdk.release || matrix.jdk.type }})"
     runs-on: ubuntu-latest
     steps:

--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-M1.adoc
@@ -129,6 +129,7 @@ repository on GitHub.
 * Kotlin's `suspend` modifier may now be applied to test and lifecycle methods.
 * The `Arguments` interface for parameterized tests is now officially a
   `@FunctionalInterface`.
+* `JAVA_26` has been added to the `JRE` enum for use with JRE-based execution conditions.
 
 
 [[release-notes-6.0.0-M1-junit-vintage]]

--- a/gradle/base/code-generator-model/src/main/resources/jre.yaml
+++ b/gradle/base/code-generator-model/src/main/resources/jre.yaml
@@ -30,3 +30,5 @@
   since: '5.11'
 - version: 25
   since: '5.11.4'
+- version: 26
+  since: '6.0.0'


### PR DESCRIPTION
## Overview

Add `JRE.JAVA_26` constant and introduce JDK 26-ea CI build

Closes #4642

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://junit.org/junit5/docs/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://junit.org/junit5/docs/snapshot/user-guide/) and [Release Notes](https://junit.org/junit5/docs/snapshot/user-guide/#release-notes)
