### PR TITLE
Avoid reporting discovery warnings for abstract methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.2.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.2.adoc
@@ -39,6 +39,9 @@ repository on GitHub.
   `@Nested`.
 * Stop reporting discovery issues for _abstract_ inner classes that contain test methods
   but are not annotated with `@Nested`.
+* Stop reporting discovery issues for _abstract_ test methods. While they won't be
+  executed, it's a valid pattern to annotate them with `@Test` for documentation purposes
+  and override them in subclasses while re-declaring the `@Test` annotation.
 
 [[release-notes-5.13.2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.discovery.predicates;
 
 import static org.junit.jupiter.engine.support.MethodReflectionUtils.getReturnType;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
+import static org.junit.platform.commons.support.ModifierSupport.isNotAbstract;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -39,14 +40,13 @@ abstract class IsTestableMethod implements Predicate<Method> {
 		this.annotationType = annotationType;
 		this.condition = isNotStatic(annotationType, issueReporter) //
 				.and(isNotPrivate(annotationType, issueReporter)) //
-				.and(isNotAbstract(annotationType, issueReporter)) //
 				.and(returnTypeConditionFactory.apply(annotationType, issueReporter));
 	}
 
 	@Override
 	public boolean test(Method candidate) {
 		if (isAnnotated(candidate, this.annotationType)) {
-			return condition.check(candidate);
+			return condition.check(candidate) && isNotAbstract(candidate);
 		}
 		return false;
 	}
@@ -61,12 +61,6 @@ abstract class IsTestableMethod implements Predicate<Method> {
 			DiscoveryIssueReporter issueReporter) {
 		return issueReporter.createReportingCondition(ModifierSupport::isNotPrivate,
 			method -> createIssue(annotationType, method, "must not be private"));
-	}
-
-	private static Condition<Method> isNotAbstract(Class<? extends Annotation> annotationType,
-			DiscoveryIssueReporter issueReporter) {
-		return issueReporter.createReportingCondition(ModifierSupport::isNotAbstract,
-			method -> createIssue(annotationType, method, "must not be abstract"));
 	}
 
 	protected static Condition<Method> hasVoidReturnType(Class<? extends Annotation> annotationType,

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
@@ -63,14 +63,14 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void discoverTestClass() {
 		LauncherDiscoveryRequest request = defaultRequest().selectors(selectClass(LocalTestCase.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 		assertEquals(7, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	@Test
 	void doNotDiscoverAbstractTestClass() {
 		LauncherDiscoveryRequest request = defaultRequest().selectors(selectClass(AbstractTestCase.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 		assertEquals(0, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -78,7 +78,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	void discoverMethodByUniqueId() {
 		LauncherDiscoveryRequest request = defaultRequest().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test1()"))).build();
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -86,7 +86,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 	void discoverMethodByUniqueIdForOverloadedMethod() {
 		LauncherDiscoveryRequest request = defaultRequest().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class, "test4()"))).build();
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -95,7 +95,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest request = defaultRequest().selectors(
 			selectUniqueId(JupiterUniqueIdBuilder.uniqueIdForMethod(LocalTestCase.class,
 				"test4(" + TestInfo.class.getName() + ")"))).build();
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -105,7 +105,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 
 		LauncherDiscoveryRequest request = defaultRequest().selectors(
 			selectMethod(LocalTestCase.class, testMethod)).build();
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 		assertEquals(2, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -114,7 +114,7 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 		LauncherDiscoveryRequest request = defaultRequest().selectors(selectMethod(LocalTestCase.class, "test1"),
 			selectMethod(LocalTestCase.class, "test2")).build();
 
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 
 		assertThat(engineDescriptor.getChildren()).hasSize(1);
 		TestDescriptor classDescriptor = getOnlyElement(engineDescriptor.getChildren());
@@ -361,14 +361,23 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 				.contains(org.junit.platform.engine.support.descriptor.MethodSource.from(method));
 	}
 
+	private TestDescriptor discoverTestsWithoutIssues(LauncherDiscoveryRequest request) {
+		var results = super.discoverTests(request);
+		assertThat(results.getDiscoveryIssues()).isEmpty();
+		return results.getEngineDescriptor();
+	}
+
 	// -------------------------------------------------------------------
 
 	@SuppressWarnings("unused")
-	private static abstract class AbstractTestCase {
+	static abstract class AbstractTestCase {
 
 		@Test
-		void abstractTest() {
+		void test() {
 		}
+
+		@Test
+		abstract void abstractTest();
 	}
 
 	@SuppressWarnings("JUnitMalformedDeclaration")

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/predicates/IsTestMethodTests.java
@@ -72,12 +72,7 @@ class IsTestMethodTests {
 		var method = abstractMethod("bogusAbstractTestMethod");
 
 		assertThat(isTestMethod).rejects(method);
-
-		var issue = getOnlyElement(discoveryIssues);
-		assertThat(issue.severity()).isEqualTo(Severity.WARNING);
-		assertThat(issue.message()).isEqualTo("@Test method '%s' must not be abstract. It will not be executed.",
-			method.toGenericString());
-		assertThat(issue.source()).contains(MethodSource.from(method));
+		assertThat(discoveryIssues).isEmpty();
 	}
 
 	@Test
@@ -86,12 +81,8 @@ class IsTestMethodTests {
 
 		assertThat(isTestMethod).rejects(method);
 
-		assertThat(discoveryIssues).hasSize(2);
-		discoveryIssues.sort(comparing(DiscoveryIssue::message));
-		assertThat(discoveryIssues.getFirst().message()) //
-				.isEqualTo("@Test method '%s' must not be abstract. It will not be executed.",
-					method.toGenericString());
-		assertThat(discoveryIssues.getLast().message()) //
+		var issue = getOnlyElement(discoveryIssues);
+		assertThat(issue.message()) //
 				.isEqualTo("@Test method '%s' must not return a value. It will not be executed.",
 					method.toGenericString());
 	}


### PR DESCRIPTION
## Overview

Resolves #4636.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit5/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit5/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
