### PR TITLE
Avoid reporting discovery issues for composed `@Nested` annotations

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.3.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-5.13.3.adoc
@@ -35,7 +35,8 @@ repository on GitHub.
 [[release-notes-5.13.3-junit-jupiter-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* Stop reporting discovery issues for composed annotation classes that are meta-annotated
+  with `@Nested`.
 
 [[release-notes-5.13.3-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicates.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicates.java
@@ -19,6 +19,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.isInnerClass;
 import static org.junit.platform.commons.util.ReflectionUtils.isMethodPresent;
 import static org.junit.platform.commons.util.ReflectionUtils.isNestedClassPresent;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
@@ -42,8 +43,9 @@ import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter.Condit
 @API(status = INTERNAL, since = "5.13")
 public class TestClassPredicates {
 
-	public final Predicate<Class<?>> isAnnotatedWithNested = testClass -> isAnnotated(testClass, Nested.class);
-	public final Predicate<Class<?>> isAnnotatedWithClassTemplate = testClass -> isAnnotated(testClass,
+	public final Predicate<Class<?>> isAnnotatedWithNested = candidate -> isAnnotatedButNotComposed(candidate,
+		Nested.class);
+	public final Predicate<Class<?>> isAnnotatedWithClassTemplate = candidate -> isAnnotatedButNotComposed(candidate,
 		ClassTemplate.class);
 
 	public final Predicate<Class<?>> isAnnotatedWithNestedAndValid = candidate -> this.isAnnotatedWithNested.test(
@@ -143,5 +145,9 @@ public class TestClassPredicates {
 		return DiscoveryIssue.builder(DiscoveryIssue.Severity.WARNING, message) //
 				.source(ClassSource.from(testClass)) //
 				.build();
+	}
+
+	private static boolean isAnnotatedButNotComposed(Class<?> candidate, Class<? extends Annotation> annotationType) {
+		return !candidate.isAnnotation() && isAnnotated(candidate, annotationType);
 	}
 }

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine;
 
 import static kotlin.jvm.JvmClassMappingKt.getJavaClass;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
@@ -23,6 +24,7 @@ import java.util.function.Consumer;
 
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
@@ -65,6 +67,12 @@ public abstract class AbstractJupiterTestEngineTests {
 
 	protected EngineExecutionResults executeTests(LauncherDiscoveryRequest request) {
 		return EngineTestKit.execute(this.engine, request);
+	}
+
+	protected TestDescriptor discoverTestsWithoutIssues(LauncherDiscoveryRequest request) {
+		var results = discoverTests(request);
+		assertThat(results.getDiscoveryIssues()).isEmpty();
+		return results.getEngineDescriptor();
 	}
 
 	protected EngineDiscoveryResults discoverTestsForClass(Class<?> testClass) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/ClassTemplateInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/ClassTemplateInvocationTests.java
@@ -88,6 +88,7 @@ import org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestTemplateInvocationTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.engine.TestTag;
@@ -979,8 +980,10 @@ public class ClassTemplateInvocationTests extends AbstractJupiterTestEngineTests
 
 	@Test
 	void propagatesTagsFromEnclosingClassesToNestedClassTemplates() {
-		var engineDescriptor = discoverTestsForClass(
-			NestedClassTemplateWithTagOnEnclosingClassTestCase.class).getEngineDescriptor();
+		var request = defaultRequest() //
+				.selectors(selectClass(NestedClassTemplateWithTagOnEnclosingClassTestCase.class)) //
+				.build();
+		var engineDescriptor = discoverTestsWithoutIssues(request);
 		var classDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		var nestedClassTemplateDescriptor = getOnlyElement(classDescriptor.getChildren());
 
@@ -988,6 +991,17 @@ public class ClassTemplateInvocationTests extends AbstractJupiterTestEngineTests
 				.containsExactly("top-level");
 		assertThat(nestedClassTemplateDescriptor.getTags()).extracting(TestTag::getName) //
 				.containsExactlyInAnyOrder("top-level", "nested");
+	}
+
+	@Test
+	void ignoresComposedAnnotations() {
+		var request = defaultRequest() //
+				.selectors(selectClass(ParameterizedClass.class)) //
+				.build();
+
+		var engineDescriptor = discoverTestsWithoutIssues(request);
+
+		assertThat(engineDescriptor.getDescendants()).isEmpty();
 	}
 
 	// -------------------------------------------------------------------

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/NestedTestClassesTests.java
@@ -19,10 +19,13 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMetho
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.LauncherConstants.CRITICAL_DISCOVERY_ISSUE_SEVERITY_PROPERTY_NAME;
-import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -38,6 +41,7 @@ import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass.Re
 import org.junit.jupiter.engine.NestedTestClassesTests.OuterClass.NestedClass.RecursiveNestedSiblingClass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.engine.DiscoveryIssue.Severity;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
@@ -56,8 +60,8 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void nestedTestsAreCorrectlyDiscovered() {
-		LauncherDiscoveryRequest request = request().selectors(selectClass(TestCaseWithNesting.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		LauncherDiscoveryRequest request = defaultRequest().selectors(selectClass(TestCaseWithNesting.class)).build();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 		assertEquals(5, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -93,8 +97,9 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 
 	@Test
 	void doublyNestedTestsAreCorrectlyDiscovered() {
-		LauncherDiscoveryRequest request = request().selectors(selectClass(TestCaseWithDoubleNesting.class)).build();
-		TestDescriptor engineDescriptor = discoverTests(request).getEngineDescriptor();
+		LauncherDiscoveryRequest request = defaultRequest().selectors(
+			selectClass(TestCaseWithDoubleNesting.class)).build();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
 		assertEquals(8, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
@@ -243,6 +248,22 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 			AbstractBaseWithInnerClassTestCase.AbstractInnerClass.class).getDiscoveryIssues();
 
 		assertThat(discoveryIssues).isEmpty();
+	}
+
+	@Test
+	void nestedTestsWithCustomAnnotationAreCorrectlyDiscovered() {
+		LauncherDiscoveryRequest request = defaultRequest().selectors(
+			selectClass(CustomAnnotationTestCase.class)).build();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
+		assertEquals(3, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
+	}
+
+	@ParameterizedTest
+	@ValueSource(classes = { TopLevelComposedNested.class, CustomAnnotationTestCase.MyNested.class })
+	void ignoresComposedAnnotations(Class<?> annotationType) {
+		LauncherDiscoveryRequest request = defaultRequest().selectors(selectClass(annotationType)).build();
+		TestDescriptor engineDescriptor = discoverTestsWithoutIssues(request);
+		assertEquals(0, engineDescriptor.getDescendants().size(), "# resolved test descriptors");
 	}
 
 	private void assertNestedCycle(Class<?> start, Class<?> from, Class<?> to) {
@@ -447,6 +468,25 @@ class NestedTestClassesTests extends AbstractJupiterTestEngineTests {
 	static class ConcreteWithExtendedInnerClassTestCase extends AbstractBaseWithInnerClassTestCase {
 		@Nested
 		class NestedTests extends AbstractInnerClass {
+		}
+	}
+
+	static class CustomAnnotationTestCase {
+
+		@Nested
+		@Retention(RetentionPolicy.RUNTIME)
+		@Target(ElementType.TYPE)
+		@interface MyNested {
+		}
+
+		@SuppressWarnings({ "JUnitMalformedDeclaration", "InnerClassMayBeStatic" })
+		@MyNested
+		class Inner {
+
+			@Test
+			void test() {
+
+			}
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TopLevelComposedNested.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TopLevelComposedNested.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.jupiter.engine;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Nested;
+
+@Nested
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TopLevelComposedNested {
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/discovery/DiscoveryTests.java
@@ -361,12 +361,6 @@ class DiscoveryTests extends AbstractJupiterTestEngineTests {
 				.contains(org.junit.platform.engine.support.descriptor.MethodSource.from(method));
 	}
 
-	private TestDescriptor discoverTestsWithoutIssues(LauncherDiscoveryRequest request) {
-		var results = super.discoverTests(request);
-		assertThat(results.getDiscoveryIssues()).isEmpty();
-		return results.getEngineDescriptor();
-	}
-
 	// -------------------------------------------------------------------
 
 	@SuppressWarnings("unused")


### PR DESCRIPTION
## Overview

Fixes #4681.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
