### PR TITLE
Require GraalVM as vendor for JDK used in `GraalVmStarterTests`

### DIFF
--- a/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
+++ b/platform-tooling-support-tests/platform-tooling-support-tests.gradle.kts
@@ -2,6 +2,7 @@ import com.gradle.develocity.agent.gradle.internal.test.TestDistributionConfigur
 import junitbuild.extensions.capitalized
 import junitbuild.extensions.dependencyProject
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.jvm.toolchain.JvmVendorSpec.GRAAL_VM
 import org.gradle.kotlin.dsl.support.listFilesOrdered
 import java.time.Duration
 
@@ -227,7 +228,7 @@ val test by testing.suites.getting(JvmTestSuite::class) {
 
 				val gradleJavaVersion = 21
 				jvmArgumentProviders += JavaHomeDir(project, gradleJavaVersion, develocity.testDistribution.enabled)
-				jvmArgumentProviders += JavaHomeDir(project, gradleJavaVersion, develocity.testDistribution.enabled, nativeImage = true)
+				jvmArgumentProviders += JavaHomeDir(project, gradleJavaVersion, develocity.testDistribution.enabled, graalvm = true)
 				systemProperty("gradle.java.version", gradleJavaVersion)
 			}
 		}
@@ -254,7 +255,7 @@ class MavenRepo(project: Project, @get:Internal val repoDir: Provider<File>) : C
 	override fun asArguments() = listOf("-Dmaven.repo=${repoDir.get().absolutePath}")
 }
 
-class JavaHomeDir(project: Project, @Input val version: Int, testDistributionEnabled: Provider<Boolean>, @Input val nativeImage: Boolean = false) : CommandLineArgumentProvider {
+class JavaHomeDir(project: Project, @Input val version: Int, testDistributionEnabled: Provider<Boolean>, @Input val graalvm: Boolean = false) : CommandLineArgumentProvider {
 
 	@Internal
 	val javaLauncher: Property<JavaLauncher> = project.objects.property<JavaLauncher>()
@@ -262,7 +263,10 @@ class JavaHomeDir(project: Project, @Input val version: Int, testDistributionEna
 				try {
 					project.javaToolchains.launcherFor {
 						languageVersion = JavaLanguageVersion.of(version)
-						nativeImageCapable = nativeImage
+						if (graalvm) {
+							vendor = GRAAL_VM
+							nativeImageCapable = true
+						}
 					}.get()
 				} catch (e: Exception) {
 					null
@@ -278,7 +282,7 @@ class JavaHomeDir(project: Project, @Input val version: Int, testDistributionEna
 		}
 		val metadata = javaLauncher.map { it.metadata }
 		val javaHome = metadata.map { it.installationPath.asFile.absolutePath }.orNull
-		return javaHome?.let { listOf("-Djava.home.$version${if (nativeImage) ".nativeImage" else ""}=$it") } ?: emptyList()
+		return javaHome?.let { listOf("-Djava.home.$version${if (graalvm) ".nativeImage" else ""}=$it") } ?: emptyList()
 	}
 }
 


### PR DESCRIPTION
To solve problems such as https://github.com/junit-team/junit-framework/pull/4737#issuecomment-3052895656

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
