### PR TITLE
Enhance assertEquals() failure messages with string diffs including c…

### DIFF
--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertArrayEqualsAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertArrayEqualsAssertionsTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEndsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
@@ -1942,7 +1943,7 @@ class AssertArrayEqualsAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageStartsWith(ex, "message");
-			assertMessageEndsWith(ex, "array contents differ at index [3][3][0], expected: <2> but was: <99>");
+			assertMessageContains(ex, "array contents differ at index [3][3][0], expected: <2> but was: <99>");
 		}
 
 		try {
@@ -1952,7 +1953,7 @@ class AssertArrayEqualsAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageStartsWith(ex, "message");
-			assertMessageEndsWith(ex, "array contents differ at index [3][3][0], expected: <2> but was: <99>");
+			assertMessageContains(ex, "array contents differ at index [3][3][0], expected: <2> but was: <99>");
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.api;
 
 import static org.junit.jupiter.api.AssertionTestUtils.assertExpectedAndActualValues;
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEndsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
@@ -48,6 +49,21 @@ class AssertEqualsAssertionsTests {
 		catch (AssertionFailedError ex) {
 			assertMessageEquals(ex, "expected: <1> but was: <2>");
 			assertExpectedAndActualValues(ex, expected, actual);
+		}
+	}
+
+	@Test
+	void assertEqualsStringWithUnequalSpaceTabs() {
+		String expected = "a			c";
+		String actual = "a	c";
+		try {
+			assertEquals(expected, actual, "message");
+			expectAssertionFailedError();
+		}
+		catch (AssertionFailedError ex) {
+			assertMessageStartsWith(ex, "message");
+			assertMessageContains(ex, "expected: <a			c> but was: <a	c>");
+			assertMessageContains(ex, "diff: a[\\t\\t\\t]c");
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertIterableEqualsAssertionsTests.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.api;
 
+import static org.junit.jupiter.api.AssertionTestUtils.assertMessageContains;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEndsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
@@ -394,7 +395,7 @@ class AssertIterableEqualsAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageStartsWith(ex, "message");
-			assertMessageEndsWith(ex, "iterable contents differ at index [3][3][0], expected: <2> but was: <99>");
+			assertMessageContains(ex, "iterable contents differ at index [3][3][0], expected: <2> but was: <99>");
 		}
 
 		try {
@@ -404,7 +405,7 @@ class AssertIterableEqualsAssertionsTests {
 		}
 		catch (AssertionFailedError ex) {
 			assertMessageStartsWith(ex, "message");
-			assertMessageEndsWith(ex, "iterable contents differ at index [3][3][0], expected: <2> but was: <99>");
+			assertMessageContains(ex, "iterable contents differ at index [3][3][0], expected: <2> but was: <99>");
 		}
 	}
 


### PR DESCRIPTION
…ontrol characters

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
