### PR TITLE
Support `CharSequence` argument for Fallback String-to-Object Conversion

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.0-RC1.adoc
@@ -27,6 +27,10 @@ repository on GitHub.
 ==== New Features and Improvements
 
 * Prune stack traces up to test or lifecycle method
+* Convention-based conversion in `ConversionSupport` now supports factory methods and
+  factory constructors that accept a single `CharSequence` argument in addition to the
+  existing support for factories that accept a single `String` argument.
+
 
 [[release-notes-6.0.0-RC1-junit-jupiter]]
 === JUnit Jupiter
@@ -52,6 +56,10 @@ repository on GitHub.
   In addition, special characters are escaped within quoted text. Please refer to the
   <<../user-guide/index.adoc#writing-tests-parameterized-tests-display-names-quoted-text,
   User Guide>> for details.
+* <<../user-guide/index.adoc#writing-tests-parameterized-tests-argument-conversion-implicit-fallback,
+  Fallback String-to-Object Conversion>> for parameterized tests now supports factory
+  methods and factory constructors that accept a single `CharSequence` argument in
+  addition to the existing support for factories that accept a single `String` argument.
 
 
 [[release-notes-6.0.0-RC1-junit-vintage]]

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -2519,11 +2519,12 @@ table, JUnit Jupiter also provides a fallback mechanism for automatic conversion
 method_ or a _factory constructor_ as defined below.
 
 - __factory method__: a non-private, `static` method declared in the target type that
-  accepts a single `String` argument and returns an instance of the target type. The name
-  of the method can be arbitrary and need not follow any particular convention.
+  accepts either a single `String` argument or a single `CharSequence` argument and
+  returns an instance of the target type. The name of the method can be arbitrary and need
+  not follow any particular convention.
 - __factory constructor__: a non-private constructor in the target type that accepts a
-  single `String` argument. Note that the target type must be declared as either a
-  top-level class or as a `static` nested class.
+  either a single `String` argument or a single `CharSequence` argument. Note that the
+  target type must be declared as either a top-level class or as a `static` nested class.
 
 NOTE: If multiple _factory methods_ are discovered, they will be ignored. If a _factory
 method_ and a _factory constructor_ are discovered, the factory method will be used

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/ConversionSupport.java
@@ -75,15 +75,20 @@ public final class ConversionSupport {
 	 *
 	 * <ol>
 	 * <li>Search for a single, non-private static factory method in the target
-	 * type that converts from a String to the target type. Use the factory method
-	 * if present.</li>
+	 * type that converts from a {@link String} to the target type. Use the
+	 * factory method if present.</li>
 	 * <li>Search for a single, non-private constructor in the target type that
-	 * accepts a String. Use the constructor if present.</li>
+	 * accepts a {@link String}. Use the constructor if present.</li>
+	 * <li>Search for a single, non-private static factory method in the target
+	 * type that converts from a {@link CharSequence} to the target type. Use the
+	 * factory method if present.</li>
+	 * <li>Search for a single, non-private constructor in the target type that
+	 * accepts a {@link CharSequence}. Use the constructor if present.</li>
 	 * </ol>
 	 *
-	 * <p>If multiple suitable factory methods are discovered they will be ignored.
-	 * If neither a single factory method nor a single constructor is found, the
-	 * convention-based conversion strategy will not apply.
+	 * <p>If multiple suitable factory methods or constructors are discovered they
+	 * will be ignored. If neither a single factory method nor a single constructor
+	 * is found, the convention-based conversion strategy will not apply.
 	 *
 	 * @param source the source {@code String} to convert; may be {@code null}
 	 * but only if the target type is a reference type

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -311,6 +311,17 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 					event(test(), displayName("[2] book = book 2"), finishedWithFailure(message("book 2"))));
 	}
 
+	/**
+	 * @since 6.0
+	 */
+	@Test
+	void executesWithImplicitGenericConverterWithCharSequenceConstructor() {
+		var results = execute("testWithImplicitGenericConverterWithCharSequenceConstructor", Record.class);
+		results.testEvents().assertThatEvents() //
+				.haveExactly(1, event(displayName("\"record 1\""), finishedWithFailure(message("record 1")))) //
+				.haveExactly(1, event(displayName("\"record 2\""), finishedWithFailure(message("record 2"))));
+	}
+
 	@Test
 	void legacyReportingNames() {
 		var results = execute("testWithCustomName", String.class, int.class);
@@ -1458,6 +1469,12 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 		@ValueSource(strings = { "book 1", "book 2" })
 		void testWithImplicitGenericConverter(Book book) {
 			fail(book.title);
+		}
+
+		@ParameterizedTest(name = "{0}")
+		@ValueSource(strings = { "record 1", "record 2" })
+		void testWithImplicitGenericConverterWithCharSequenceConstructor(Record record) {
+			fail(record.title.toString());
 		}
 
 		@ParameterizedTest(quoteTextArguments = false)
@@ -2671,6 +2688,9 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 		static Book factory(String title) {
 			return new Book(title);
 		}
+	}
+
+	record Record(CharSequence title) {
 	}
 
 	static class FailureInBeforeEachTestCase {


### PR DESCRIPTION
Prior to this commit, the ["Fallback String-to-Object Conversion"](https://docs.junit.org/current/user-guide/#writing-tests-parameterized-tests-argument-conversion-implicit-fallback) support for parameterized tests supported factory constructors and methods that accepted a single `String` argument.

This commit relaxes that restriction to support factory constructors and methods that accept either a single `String` argument or a single `CharSequence` argument, since the original source `String` can always be supplied to an `Executable` that accepts a `CharSequence`.

Note that this change is available to third parties via `ConversionSupport` in `junit-platform-commons`, which `junit-jupiter-params` utilizes.

- Closes #4815

