### PR TITLE
Add OutputFormat utility for vertical side-by-side collection formatting for assertion failure outputAdd OutputFormat utility for vertical side-by-side collection formatting for assertion failure outputCreate OutputFormat.java

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/OutputFormat.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/OutputFormat.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.api;
+
+import static org.apiguardian.api.API.Status.INTERNAL;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apiguardian.api.API;
+
+/**
+ * {@code OutputFormat} provides utility methods for formatting collections
+ * and other data structures for display in assertion failure messages.
+ *
+ * <p>This class is primarily used internally by the JUnit Jupiter API
+ * to format output in assertion failures, providing clear and readable
+ * representations of expected vs actual values.
+ *
+ * @since 5.11
+ */
+@API(status = INTERNAL, since = "5.11")
+public final class OutputFormat {
+
+	private OutputFormat() {
+		/* no-op */
+	}
+
+	/**
+	 * Creates a supplier that formats two collections vertically side-by-side
+	 * for comparison in assertion failure output.
+	 *
+	 * <p>The formatting displays the expected collection on the left and the
+	 * actual collection on the right, with elements aligned for easy comparison.
+	 * This format is particularly useful for assertion failures where collections
+	 * differ and need to be visually compared.
+	 *
+	 * <p>Example output format:
+	 * <pre>
+	 * Expected                  Actual
+	 * ========                  ======
+	 * [element1]                [element1]
+	 * [element2]                [differentElement]
+	 * [element3]                [element3]
+	 * </pre>
+	 *
+	 * @param expected the expected collection
+	 * @param actual the actual collection
+	 * @return a supplier that provides the formatted string when called
+	 */
+	public static Supplier<String> ofVertical(Collection<?> expected, Collection<?> actual) {
+		return () -> {
+			if (expected == null && actual == null) {
+				return "Expected: null\nActual:   null";
+			}
+			if (expected == null) {
+				return "Expected: null\nActual:   " + formatCollection(actual);
+			}
+			if (actual == null) {
+				return "Expected: " + formatCollection(expected) + "\nActual:   null";
+			}
+
+			List<String> expectedStrings = expected.stream()
+					.map(String::valueOf)
+					.collect(Collectors.toList());
+			List<String> actualStrings = actual.stream()
+					.map(String::valueOf)
+					.collect(Collectors.toList());
+
+			int maxExpectedWidth = expectedStrings.stream()
+					.mapToInt(String::length)
+					.max()
+					.orElse(0);
+			maxExpectedWidth = Math.max(maxExpectedWidth, "Expected".length());
+
+			StringBuilder result = new StringBuilder();
+			
+			// Header line
+			result.append(String.format("%-" + maxExpectedWidth + "s  %s%n", "Expected", "Actual"));
+			result.append(String.format("%-" + maxExpectedWidth + "s  %s%n", "=".repeat(Math.min(maxExpectedWidth, "Expected".length())), "=".repeat("Actual".length())));
+
+			// Format side-by-side comparison
+			int maxSize = Math.max(expectedStrings.size(), actualStrings.size());
+			for (int i = 0; i < maxSize; i++) {
+				String expectedItem = i < expectedStrings.size() ? "[" + expectedStrings.get(i) + "]" : "";
+				String actualItem = i < actualStrings.size() ? "[" + actualStrings.get(i) + "]" : "";
+				result.append(String.format("%-" + maxExpectedWidth + "s  %s%n", expectedItem, actualItem));
+			}
+
+			return result.toString().trim();
+		};
+	}
+
+	/**
+	 * Formats a collection into a string representation.
+	 *
+	 * @param collection the collection to format
+	 * @return the formatted string representation
+	 */
+	private static String formatCollection(Collection<?> collection) {
+		if (collection == null) {
+			return "null";
+		}
+		if (collection.isEmpty()) {
+			return "[]";
+		}
+		return collection.stream()
+				.map(String::valueOf)
+				.collect(Collectors.joining(", ", "[", "]"));
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds a new `OutputFormat` utility class to the JUnit Jupiter API that provides enhanced formatting capabilities for assertion failure messages. This addresses issue #3593 by introducing vertical side-by-side collection formatting as a building block for improved assertion diff output.

## Changes
- **New Class**: `OutputFormat` in `org.junit.jupiter.api` package
- **Key Method**: `ofVertical(Collection<?> expected, Collection<?> actual)` - creates a Supplier<String> that formats two collections side-by-side vertically
- **Features**:
  - Vertical alignment of expected vs actual collections
  - Proper handling of null collections and empty collections
  - Lazy evaluation through Supplier pattern
  - Clear visual separation with headers and padding

## Usage
The `OutputFormat.ofVertical()` method serves as a building block for improved assertion diff output, making it easier to visually compare collections in test failures.

## Related Issue
References #3593

---
I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done
- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)Add OutputFormat utility class for JUnit Jupiter API

This class provides formatting utilities for assertion failure output, specifically:
- ofVertical() static method that formats two collections side-by-side vertically
- Returns Supplier<String> for lazy evaluation of formatted output
- Suitable for use in assertion failure messages when comparing collections
- Includes proper handling of null collections and empty collections
- Follows JUnit Jupiter API patterns and conventions

The vertical format makes it easy to visually compare expected vs actual collections in test failures.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
