### PR TITLE
Add self-tests for `assert[Not]Equals()` with arrays

### DIFF
--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionUtils.java
@@ -17,9 +17,8 @@ import java.util.Deque;
 import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.annotation.Contract;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.commons.util.UnrecoverableExceptions;
 
 /**
@@ -29,9 +28,6 @@ import org.junit.platform.commons.util.UnrecoverableExceptions;
  * @since 5.0
  */
 class AssertionUtils {
-
-	private static final Logger logger = LoggerFactory.getLogger(AssertionUtils.class);
-
 	private AssertionUtils() {
 		/* no-op */
 	}
@@ -133,9 +129,14 @@ class AssertionUtils {
 		if (obj1 == null) {
 			return (obj2 == null);
 		}
-		if (obj1.getClass().isArray() && (obj2 != null && obj2.getClass().isArray())) {
-			// TODO Find first method in user's code, i.e. non-framework code.
-			logger.debug(() -> "Should have used `assertArrayEquals()` in method: <TODO>");
+		if (obj2 == null) {
+			return false;
+		}
+		if (Boolean.getBoolean("junit.jupiter.disallow.arrays.in.equals.checks")) {
+			if (obj1.getClass().isArray() && obj2.getClass().isArray()) {
+				throw new JUnitException(
+					"Detected array arguments:" + " " + obj1.getClass() + " and " + obj2.getClass());
+			}
 		}
 		return obj1.equals(obj2);
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertNotEqualsAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertNotEqualsAssertionsTests.java
@@ -14,14 +14,16 @@ import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEndsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageEquals;
 import static org.junit.jupiter.api.AssertionTestUtils.assertMessageStartsWith;
 import static org.junit.jupiter.api.AssertionTestUtils.expectAssertionFailedError;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.logging.LogRecord;
+import java.util.Arrays;
 
-import org.junit.jupiter.api.fixtures.TrackLogRecords;
-import org.junit.platform.commons.logging.LogRecordListener;
+import org.junit.platform.commons.JUnitException;
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -632,14 +634,24 @@ class AssertNotEqualsAssertionsTests {
 	@Nested
 	class AssertNotEqualsArrays {
 		@Test
-		void objects(@TrackLogRecords LogRecordListener listener) {
+		void objects() {
 			Object object = new Object();
 			Object array1 = new Object[] { object };
 			Object array2 = new Object[] { object };
-			assertNotEquals(array1, array2);
-			assertLinesMatch("""
-					Should have used `assertArrayEquals()` in method: <TODO>
-					""".lines(), listener.stream(AssertionUtils.class).map(LogRecord::getMessage));
+			assertThrows(AssertionFailedError.class, () -> assertSame(array1, array2));
+			assertThrows(AssertionFailedError.class, () -> assertEquals(array1, array2));
+			assertNotEquals(array1, array2); // succeeds
+			assertTrue(Arrays.deepEquals((Object[]) array1, (Object[]) array2));
+			assertArrayEquals((Object[]) array1, (Object[]) array2);
+			try {
+				System.setProperty("junit.jupiter.disallow.arrays.in.equals.checks", "true");
+				var exception = assertThrows(JUnitException.class, () -> assertNotEquals(array1, array2));
+				assertEquals("Detected array arguments: class [Ljava.lang.Object; and class [Ljava.lang.Object;",
+					exception.getMessage());
+			}
+			finally {
+				System.clearProperty("junit.jupiter.disallow.arrays.in.equals.checks");
+			}
 		}
 	}
 


### PR DESCRIPTION
_work in progess..._

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
