### PR TITLE
Fix #4896 in AbstractExtensionContext (jupiter-engine:)

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/AbstractExtensionContext.java
@@ -142,9 +142,15 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 		this.engineExecutionListener.reportingEntryPublished(this.testDescriptor, ReportEntry.from(values));
 	}
 
+	private static void validateArtifactName(String name) {
+		Preconditions.notBlank(name, "name must not be null or blank");
+		Preconditions.condition(name.indexOf('/') < 0 && name.indexOf('\\') < 0,
+			() -> "name must not contain any path separators: " + name);
+	}
+
 	@Override
 	public void publishFile(String name, MediaType mediaType, ThrowingConsumer<Path> action) {
-		Preconditions.notNull(name, "name must not be null");
+		validateArtifactName(name);
 		Preconditions.notNull(mediaType, "mediaType must not be null");
 		Preconditions.notNull(action, "action must not be null");
 
@@ -156,7 +162,7 @@ abstract class AbstractExtensionContext<T extends TestDescriptor> implements Ext
 
 	@Override
 	public void publishDirectory(String name, ThrowingConsumer<Path> action) {
-		Preconditions.notNull(name, "name must not be null");
+		validateArtifactName(name);
 		Preconditions.notNull(action, "action must not be null");
 
 		ThrowingConsumer<Path> enhancedAction = path -> {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/ExtensionContextTests.java
@@ -328,7 +328,7 @@ public class ExtensionContextTests {
 
 		var exception = assertThrows(PreconditionViolationException.class, () -> extensionContext.publishFile(name,
 			MediaType.APPLICATION_OCTET_STREAM, __ -> fail("should not be called")));
-		assertThat(exception).hasMessage("name must not contain path separators: " + name);
+		assertThat(exception).hasMessage("name must not contain any path separators: " + name);
 	}
 
 	@Test
@@ -338,7 +338,7 @@ public class ExtensionContextTests {
 
 		var exception = assertThrows(PreconditionViolationException.class,
 			() -> extensionContext.publishDirectory(name, __ -> fail("should not be called")));
-		assertThat(exception).hasMessage("name must not contain path separators: " + name);
+		assertThat(exception).hasMessage("name must not contain any path separators: " + name);
 	}
 
 	@Test
@@ -449,6 +449,96 @@ public class ExtensionContextTests {
 		assertEquals(parentValue, childStore.computeIfAbsent(parentKey, k -> "a different value"));
 		assertEquals(parentValue, childStore.getOrComputeIfAbsent(parentKey, k -> "a different value"));
 		assertEquals(parentValue, childStore.get(parentKey));
+	}
+
+	@Test
+	@SuppressWarnings("NullAway")
+	void failsWhenAttemptingToPublishFileWithNullName(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+
+		var exception = assertThrows(PreconditionViolationException.class, () -> extensionContext.publishFile(null,
+			MediaType.APPLICATION_OCTET_STREAM, __ -> fail("should not be called")));
+		assertThat(exception).hasMessage("name must not be null or blank");
+	}
+
+	@Test
+	void failsWhenAttemptingToPublishFileWithBlankName(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+
+		assertAll(() -> {
+			var ex = assertThrows(PreconditionViolationException.class, () -> extensionContext.publishFile("",
+				MediaType.APPLICATION_OCTET_STREAM, __ -> fail("should not be called")));
+			assertThat(ex).hasMessage("name must not be null or blank");
+		}, () -> {
+			var ex = assertThrows(PreconditionViolationException.class, () -> extensionContext.publishFile("   ",
+				MediaType.APPLICATION_OCTET_STREAM, __ -> fail("should not be called")));
+			assertThat(ex).hasMessage("name must not be null or blank");
+		});
+	}
+
+	@Test
+	@SuppressWarnings("NullAway")
+	void failsWhenAttemptingToPublishDirectoryWithNullName(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+
+		var exception = assertThrows(PreconditionViolationException.class,
+			() -> extensionContext.publishDirectory(null, __ -> fail("should not be called")));
+		assertThat(exception).hasMessage("name must not be null or blank");
+	}
+
+	@Test
+	void failsWhenAttemptingToPublishDirectoryWithBlankName(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+
+		assertAll(() -> {
+			var ex = assertThrows(PreconditionViolationException.class,
+				() -> extensionContext.publishDirectory("", __ -> fail("should not be called")));
+			assertThat(ex).hasMessage("name must not be null or blank");
+		}, () -> {
+			var ex = assertThrows(PreconditionViolationException.class,
+				() -> extensionContext.publishDirectory("   ", __ -> fail("should not be called")));
+			assertThat(ex).hasMessage("name must not be null or blank");
+		});
+	}
+
+	@Test
+	void failsWhenAttemptingToPublishFileWithForwardSlashInName(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+		var name = "test/subDir";
+
+		var exception = assertThrows(PreconditionViolationException.class, () -> extensionContext.publishFile(name,
+			MediaType.APPLICATION_OCTET_STREAM, __ -> fail("should not be called")));
+		assertThat(exception).hasMessage("name must not contain any path separators: " + name);
+	}
+
+	@Test
+	void failsWhenAttemptingToPublishDirectoryWithForwardSlashInName(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+		var name = "test/subDir";
+
+		var exception = assertThrows(PreconditionViolationException.class,
+			() -> extensionContext.publishDirectory(name, __ -> fail("should not be called")));
+		assertThat(exception).hasMessage("name must not contain any path separators: " + name);
+	}
+
+	@Test
+	void failsWhenAttemptingToPublishFileWithBackslashInName(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+		var name = "test\\subDir";
+
+		var exception = assertThrows(PreconditionViolationException.class, () -> extensionContext.publishFile(name,
+			MediaType.APPLICATION_OCTET_STREAM, __ -> fail("should not be called")));
+		assertThat(exception).hasMessage("name must not contain any path separators: " + name);
+	}
+
+	@Test
+	void failsWhenAttemptingToPublishDirectoryWithBackslashInName(@TempDir Path tempDir) {
+		var extensionContext = createExtensionContextForFilePublishing(tempDir);
+		var name = "test\\subDir";
+
+		var exception = assertThrows(PreconditionViolationException.class,
+			() -> extensionContext.publishDirectory(name, __ -> fail("should not be called")));
+		assertThat(exception).hasMessage("name must not contain any path separators: " + name);
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
validate blank names and path separators in `publishFile`, `publishDirectory` and added test cases.

```java
    private static void validateArtifactName(String name) {
		Preconditions.notBlank(name, "name must not be null or blank");
		Preconditions.condition(name.indexOf('/') < 0 && name.indexOf('\\') < 0,
			() -> "name must not contain any path separators: " + name);
	}

	@Override
	public void publishFile(String name, MediaType mediaType, ThrowingConsumer<Path> action) {
		validateArtifactName(name);
		Preconditions.notNull(mediaType, "mediaType must not be null");
		Preconditions.notNull(action, "action must not be null");

		publishFileEntry(name, action, file -> {
			Preconditions.condition(Files.isRegularFile(file), () -> "Published path must be a regular file: " + file);
			return FileEntry.from(file, mediaType.toString());
		});
	}
	
	@Override
	public void publishDirectory(String name, ThrowingConsumer<Path> action) {
		validateArtifactName(name);
		Preconditions.notNull(action, "action must not be null");

		ThrowingConsumer<Path> enhancedAction = path -> {
			if (!Files.isDirectory(path)) {
				Files.createDirectory(path);
			}
			action.accept(path);
		};
		publishFileEntry(name, enhancedAction, file -> {
			Preconditions.condition(Files.isDirectory(file), () -> "Published path must be a directory: " + file);
			return FileEntry.from(file, null);
		});
	}
```

fix #4896 