### PR TITLE
Enrich `assertInstanceOf` failure with cause

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.1.0-M1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.1.0-M1.adoc
@@ -51,7 +51,9 @@ repository on GitHub.
 * Introduce new `dynamicContainer(Consumer<? super Configuration>)` factory method for
   dynamic containers. It allows configuring the `ExecutionMode` of the dynamic container
   and/or its children in addition to its display name, test source URI, and children.
-
+* Enrich `assertInstanceOf` failure using the test subject `Throwable` as cause. It
+  results in the stack trace of the test subject `Throwable` to get reported along with
+  the failure.
 
 [[release-notes-6.1.0-M1-junit-vintage]]
 === JUnit Vintage

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertInstanceOf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertInstanceOf.java
@@ -55,6 +55,7 @@ class AssertInstanceOf {
 					.reason(actualValue == null ? "Unexpected null value" : "Unexpected type") //
 					.expected(expectedType) //
 					.actual(actualValue == null ? null : actualValue.getClass()) //
+					.cause(actualValue instanceof Throwable t ? t : null) //
 					.buildAndThrow();
 		}
 		return expectedType.cast(actualValue);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertInstanceOfAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertInstanceOfAssertionsTests.java
@@ -96,15 +96,19 @@ class AssertInstanceOfAssertionsTests {
 		String valueType = actualValue == null ? "null" : actualValue.getClass().getCanonicalName();
 		String expectedMessage = "Unexpected %s, expected: <%s> but was: <%s>".formatted(unexpectedSort,
 			expectedType.getCanonicalName(), valueType);
+		Throwable expectedCause = actualValue instanceof Throwable throwable ? throwable : null;
 
-		assertThrowsWithMessage(expectedMessage, () -> assertInstanceOf(expectedType, actualValue));
-		assertThrowsWithMessage("extra ==> " + expectedMessage,
+		assertThrowsWithMessage(expectedMessage, expectedCause, () -> assertInstanceOf(expectedType, actualValue));
+		assertThrowsWithMessage("extra ==> " + expectedMessage, expectedCause,
 			() -> assertInstanceOf(expectedType, actualValue, "extra"));
-		assertThrowsWithMessage("extra ==> " + expectedMessage,
+		assertThrowsWithMessage("extra ==> " + expectedMessage, expectedCause,
 			() -> assertInstanceOf(expectedType, actualValue, () -> "extra"));
 	}
 
-	private void assertThrowsWithMessage(String expectedMessage, Executable executable) {
-		assertEquals(expectedMessage, assertThrows(AssertionFailedError.class, executable).getMessage());
+	private void assertThrowsWithMessage(String expectedMessage, @Nullable Throwable expectedCause,
+			Executable executable) {
+		Throwable throwable = assertThrows(AssertionFailedError.class, executable);
+		assertEquals(expectedMessage, throwable.getMessage());
+		assertSame(expectedCause, throwable.getCause());
 	}
 }


### PR DESCRIPTION
As agreed in this [discussion], enrich `assertInstanceOf` failure with cause.

### `jshell` demonstration

```
$ jshell --class-path opentest4j-1.3.0.jar:junit-platform-commons-6.1.0-SNAPSHOT.jar:junit-jupiter-api-6.1.0-SNAPSHOT.jar
|  Welcome to JShell -- Version 25
|  For an introduction type: /help intro

jshell> org.junit.jupiter.api.Assertions.assertInstanceOf(RuntimeException.class, new java.io.IOException())
|  Exception org.opentest4j.AssertionFailedError: Unexpected type, expected: <java.lang.RuntimeException> but was: <java.io.IOException>
|        at AssertionFailureBuilder.build (AssertionFailureBuilder.java:158)
|        at AssertionFailureBuilder.buildAndThrow (AssertionFailureBuilder.java:139)
|        at AssertInstanceOf.assertInstanceOf (AssertInstanceOf.java:59)
|        at AssertInstanceOf.assertInstanceOf (AssertInstanceOf.java:35)
|        at Assertions.assertInstanceOf (Assertions.java:3688)
|        at (#1:1)
|  Caused by: java.io.IOException
|        ...
```

Note the `Caused by: java.io.IOException` at the end, which is added by this PR.

[discussion]: https://github.com/junit-team/junit-framework/discussions/5014