### PR TITLE
Disable `LexicographicalAnnotationAttributeListing`

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-nullability-conventions.gradle.kts
@@ -38,10 +38,10 @@ tasks.withType<JavaCompile>().configureEach {
 				"UnnecessaryLambda", // The findings of this check are subjective because a named constant can be more readable in many cases.
 				// picnic (https://error-prone.picnic.tech)
 				"ConstantNaming",
-				"DirectReturn", // https://github.com/junit-team/junit-framework/pull/5006#discussion_r2403984446
+				"DirectReturn", // We don`t want to use this: https://github.com/junit-team/junit-framework/pull/5006#discussion_r2403984446
 				"FormatStringConcatenation",
 				"IdentityConversion",
-				"LexicographicalAnnotationAttributeListing",
+				"LexicographicalAnnotationAttributeListing", // We don`t want to use this: https://github.com/junit-team/junit-framework/pull/5043#pullrequestreview-3330615838
 				"LexicographicalAnnotationListing",
 				"MissingTestCall",
 				"NestedOptionals",


### PR DESCRIPTION

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
