### PR TITLE
Stop reporting discovery issues for synthetic methods

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.1.adoc
@@ -45,6 +45,8 @@ repository on GitHub.
   to avoid conflicts with other control characters.
 * Fix `IllegalAccessError` thrown when using the Kotlin-specific `assertDoesNotThrow`
   assertion.
+* Stop reporting discovery issues for synthetic methods, particularly in conjunction with
+  Kotlin suspend functions.
 
 [[release-notes-6.0.1-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestableMethod.java
@@ -45,7 +45,7 @@ abstract class IsTestableMethod implements Predicate<Method> {
 
 	@Override
 	public boolean test(Method candidate) {
-		if (isAnnotated(candidate, this.annotationType)) {
+		if (!candidate.isSynthetic() && isAnnotated(candidate, this.annotationType)) {
 			return condition.check(candidate) && isNotAbstract(candidate);
 		}
 		return false;

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
@@ -67,7 +67,7 @@ public class KotlinReflectionUtils {
 	 */
 	@API(status = INTERNAL, since = "6.0")
 	public static boolean isKotlinSuspendingFunction(Method method) {
-		if (kotlinCoroutineContinuation != null && isKotlinType(method.getDeclaringClass())) {
+		if (!method.isSynthetic() && kotlinCoroutineContinuation != null && isKotlinType(method.getDeclaringClass())) {
 			int parameterCount = method.getParameterCount();
 			return parameterCount > 0 //
 					&& method.getParameterTypes()[parameterCount - 1] == kotlinCoroutineContinuation;

--- a/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/kotlin/KotlinSuspendFunctionsTests.kt
+++ b/jupiter-tests/src/test/kotlin/org/junit/jupiter/api/kotlin/KotlinSuspendFunctionsTests.kt
@@ -42,6 +42,13 @@ class KotlinSuspendFunctionsTests : AbstractJupiterTestEngineTests() {
     }
 
     @Test
+    fun suspendingOpenTestMethodsAreSupported() {
+        val results = executeTestsForClass(OpenTestMethodTestCase::class)
+        assertAllTestsPassed(results, 1)
+        assertThat(getPublishedEvents(results)).containsExactly("test")
+    }
+
+    @Test
     fun suspendingTestTemplateMethodsAreSupported() {
         val results = executeTestsForClass(TestTemplateTestCase::class)
         assertAllTestsPassed(results, 2)
@@ -184,6 +191,14 @@ class KotlinSuspendFunctionsTests : AbstractJupiterTestEngineTests() {
         @Test
         suspend fun test(reporter: TestReporter) {
             suspendingPublish(reporter, "test[$parameter]")
+        }
+    }
+
+    @Suppress("JUnitMalformedDeclaration")
+    open class OpenTestMethodTestCase {
+        @Test // https://github.com/junit-team/junit-framework/issues/5102
+        open suspend fun `check getRandomPositiveInt`(reporter: TestReporter) {
+            suspendingPublish(reporter, "test")
         }
     }
 

--- a/platform-tests/platform-tests.gradle.kts
+++ b/platform-tests/platform-tests.gradle.kts
@@ -5,7 +5,7 @@ import org.gradle.plugins.ide.eclipse.model.Classpath
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 plugins {
-	id("junitbuild.java-library-conventions")
+	id("junitbuild.kotlin-library-conventions")
 	id("junitbuild.junit4-compatibility")
 	id("junitbuild.testing-conventions")
 	id("junitbuild.jmh-conventions")
@@ -54,6 +54,7 @@ dependencies {
 	testImplementation(libs.openTestReporting.tooling.core)
 	testImplementation(libs.picocli)
 	testImplementation(libs.bundles.xmlunit)
+	testImplementation(kotlin("stdlib"))
 	testImplementation(testFixtures(projects.junitJupiterApi))
 	testImplementation(testFixtures(projects.junitPlatformReporting))
 	testImplementation(projects.platformTests) {

--- a/platform-tests/src/test/kotlin/org/junit/platform/commons/util/KotlinReflectionUtilsTests.kt
+++ b/platform-tests/src/test/kotlin/org/junit/platform/commons/util/KotlinReflectionUtilsTests.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.platform.commons.util
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.platform.commons.support.ModifierSupport
+import kotlin.coroutines.Continuation
+
+class KotlinReflectionUtilsTests {
+    @Test
+    fun recognizesSuspendFunction() {
+        val method =
+            OpenTestMethodTestCase::class.java.getDeclaredMethod(
+                "test",
+                Continuation::class.java
+            )
+
+        assertFalse(ModifierSupport.isStatic(method))
+        assertFalse(method.isSynthetic)
+
+        assertTrue(KotlinReflectionUtils.isKotlinSuspendingFunction(method))
+    }
+
+    @Test
+    fun doesNotRecognizeSyntheticMethodAsSuspendFunction() {
+        val method =
+            OpenTestMethodTestCase::class.java.getDeclaredMethod(
+                "test\$suspendImpl",
+                OpenTestMethodTestCase::class.java,
+                Continuation::class.java
+            )
+
+        assertTrue(ModifierSupport.isStatic(method))
+        assertTrue(method.isSynthetic)
+
+        assertFalse(KotlinReflectionUtils.isKotlinSuspendingFunction(method))
+    }
+
+    @Suppress("JUnitMalformedDeclaration")
+    open class OpenTestMethodTestCase {
+        @Test
+        open suspend fun test() {
+        }
+    }
+}


### PR DESCRIPTION
Prior to this commit, _all_ methods of a potential test class were
checked for being test methods, including synthetic ones. However, when
resolving a test class only non-synthetic methods were taken into
account.

Since the Kotlin compiler generates a synthetic, static method suffixed
with `$suspendImpl` for every open (i.e. non-final) method and copies
its annotations, such methods were included in the check.

In addition to filtering out synthetic methods from being checked,
`KotlinReflectionUtils` no longer recognizes them as suspend functions.

Fixes #5102.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
