### PR TITLE
Make `targetType` parameter easier to use with class literals

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.1.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-6.0.1.adoc
@@ -60,6 +60,8 @@ repository on GitHub.
   a custom comment character using the new `commentCharacter` attribute.
 * Improve error message when using `@ParameterizedClass` with field injection and not
   providing enough arguments.
+* Allow calling `TypedArgumentConverter` constructor for `@Nullable T` target types
+  without having to cast class literals to `Class<@Nullable T>`.
 
 
 [[release-notes-6.0.1-junit-vintage]]

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/TypedArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/TypedArgumentConverter.java
@@ -13,6 +13,7 @@ package org.junit.jupiter.params.converter;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.support.FieldContext;
@@ -43,7 +44,8 @@ public abstract class TypedArgumentConverter<S, T extends @Nullable Object> impl
 	 * @param targetType the type of the target object to create from the source;
 	 * never {@code null}
 	 */
-	protected TypedArgumentConverter(Class<S> sourceType, Class<T> targetType) {
+	protected TypedArgumentConverter(Class<S> sourceType,
+			@SuppressWarnings("NullableProblems") Class<@NonNull T> targetType) {
 		this.sourceType = Preconditions.notNull(sourceType, "sourceType must not be null");
 		this.targetType = Preconditions.notNull(targetType, "targetType must not be null");
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
@@ -57,6 +57,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Condition;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -972,7 +973,8 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 		}
 	}
 
-	private static class CustomIntegerToStringConverter extends TypedArgumentConverter<Integer, String> {
+	@NullMarked
+	private static class CustomIntegerToStringConverter extends TypedArgumentConverter<Integer, @Nullable String> {
 
 		CustomIntegerToStringConverter() {
 			super(Integer.class, String.class);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -63,6 +63,7 @@ import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -2629,6 +2630,7 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 			assertEquals("", locale.getCountry());
 		}
 
+		@NullMarked
 		static class Iso639Converter extends TypedArgumentConverter<String, Locale> {
 
 			Iso639Converter() {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/TypedArgumentConverterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/converter/TypedArgumentConverterTests.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -203,6 +204,7 @@ class TypedArgumentConverterTests {
 	private @interface StringLength {
 	}
 
+	@NullMarked
 	private static class StringLengthArgumentConverter extends TypedArgumentConverter<String, Integer> {
 
 		StringLengthArgumentConverter() {

--- a/jupiter-tests/src/test/kotlin/org/junit/jupiter/params/converter/TypedArgumentConverterKotlinTests.kt
+++ b/jupiter-tests/src/test/kotlin/org/junit/jupiter/params/converter/TypedArgumentConverterKotlinTests.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package org.junit.jupiter.params.converter
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.extension.ParameterContext
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class TypedArgumentConverterKotlinTests {
+    @Test
+    fun converts() {
+        val parameterContext = mock(ParameterContext::class.java)
+        val parameter = this.javaClass.getDeclaredMethod("foo", String::class.java).parameters[0]
+        `when`(parameterContext.parameter).thenReturn(parameter)
+
+        assertNull(NullableTypeConverter().convert(null, parameterContext))
+        assertEquals("null", NonNullableTypeConverter().convert(null, parameterContext))
+    }
+
+    @Suppress("unused")
+    private fun foo(param: String) = Unit
+
+    class NullableTypeConverter : TypedArgumentConverter<String, String?>(String::class.java, String::class.java) {
+        override fun convert(source: String?) = source
+    }
+
+    class NonNullableTypeConverter : TypedArgumentConverter<String, String>(String::class.java, String::class.java) {
+        override fun convert(source: String?) = source.toString()
+    }
+}


### PR DESCRIPTION
Resolves #5105.

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
