### PR TITLE
Fix HTML entity warnings in asciidoctorPdf

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -1011,13 +1011,13 @@ expressions can be useful.
 | `+++catalog \| shipping+++`
 | all tests for *catalog* plus all tests for *shipping*
 
-| `+++catalog & shipping+++`
+| `+++catalog &amp; shipping+++`
 | all tests for the intersection between *catalog* and *shipping*
 
-| `+++product & !end-to-end+++`
+| `+++product &amp; !end-to-end+++`
 | all tests for *product*, but not the _end-to-end_ tests
 
-| `+++(micro \| integration) & (product \| shipping)+++`
+| `+++(micro \| integration) &amp; (product \| shipping)+++`
 | all _micro_ or _integration_ tests for *product* or *shipping*
 |===
 


### PR DESCRIPTION
## Fixes

```
> Task :documentation:asciidoctorPdf
failed to parse formatted text: <code>catalog & shipping</code> (reason: Expected one of #, #x, amp, apos, gt, lt, nbsp, quot after <code>catalog & at byte 16)
failed to parse formatted text: <code>catalog & shipping</code> (reason: Expected one of '#', '#x', 'amp', 'apos', 'gt', 'lt', 'nbsp', 'quot' after <code>catalog & at byte 16) (uri:classloader:/gems/prawn-table-0.2.2/lib/prawn/table.rb:set_row_heights)
failed to parse formatted text: <code>product & !end-to-end</code> (reason: Expected one of #, #x, amp, apos, gt, lt, nbsp, quot after <code>product & at byte 16)
failed to parse formatted text: <code>product & !end-to-end</code> (reason: Expected one of '#', '#x', 'amp', 'apos', 'gt', 'lt', 'nbsp', 'quot' after <code>product & at byte 16) (uri:classloader:/gems/prawn-table-0.2.2/lib/prawn/table.rb:set_row_heights)
failed to parse formatted text: <code>(micro | integration) & (product | shipping)</code> (reason: Expected one of #, #x, amp, apos, gt, lt, nbsp, quot after <code>(micro | integration) & at byte 30)
failed to parse formatted text: <code>(micro | integration) & (product | shipping)</code> (reason: Expected one of '#', '#x', 'amp', 'apos', 'gt', 'lt', 'nbsp', 'quot' after <code>(micro | integration) & at byte 30) (uri:classloader:/gems/prawn-table-0.2.2/lib/prawn/table.rb:set_row_heights)
failed to parse formatted text: <code>catalog & shipping</code> (reason: Expected one of #, #x, amp, apos, gt, lt, nbsp, quot after <code>catalog & at byte 16)
failed to parse formatted text: <code>catalog & shipping</code> (reason: Expected one of '#', '#x', 'amp', 'apos', 'gt', 'lt', 'nbsp', 'quot' after <code>catalog & at byte 16) (uri:classloader:/gems/prawn-table-0.2.2/lib/prawn/table.rb:ink_and_draw_cells)
failed to parse formatted text: <code>product & !end-to-end</code> (reason: Expected one of #, #x, amp, apos, gt, lt, nbsp, quot after <code>product & at byte 16)
failed to parse formatted text: <code>product & !end-to-end</code> (reason: Expected one of '#', '#x', 'amp', 'apos', 'gt', 'lt', 'nbsp', 'quot' after <code>product & at byte 16) (uri:classloader:/gems/prawn-table-0.2.2/lib/prawn/table.rb:ink_and_draw_cells)
failed to parse formatted text: <code>(micro | integration) & (product | shipping)</code> (reason: Expected one of #, #x, amp, apos, gt, lt, nbsp, quot after <code>(micro | integration) & at byte 30)
failed to parse formatted text: <code>(micro | integration) & (product | shipping)</code> (reason: Expected one of '#', '#x', 'amp', 'apos', 'gt', 'lt', 'nbsp', 'quot' after <code>(micro | integration) & at byte 30) (uri:classloader:/gems/prawn-table-0.2.2/lib/prawn/table.rb:ink_and_draw_cells)
```

## Tests

`gradlew :documentation:asciidoctorPdf :documentation:asciidoctor`

pdf:
<img width="690" height="187" alt="image" src="https://github.com/user-attachments/assets/49e5d025-909c-41da-9183-9de43d94ba95" />

html:
<img width="995" height="316" alt="image" src="https://github.com/user-attachments/assets/59a7e83a-74e7-41a7-8620-2ad264698a88" />


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
