### PR TITLE
Stabilize asciidoctorPdf task

### DIFF
--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -363,7 +363,9 @@ tasks {
 	}
 
 	asciidoctorPdf {
-		setExecutionMode(JAVA_EXEC) // Avoid classpath conflicts with other Gradle plugins (e.g. JReleaser)
+		// Avoid classpath conflicts with other Gradle plugins (e.g. JReleaser)
+		// Avoid propagating apparent memory leaks in Asciidoctor/JRuby to Gradle daemon.
+		setExecutionMode(JAVA_EXEC)
 		jvm {
 			maxHeapSize = "512M"
 		}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,7 @@ version = 6.1.0-SNAPSHOT
 # For backward compatibility checks
 apiBaselineVersion = 6.0.1
 
-# We need more metaspace due to apparent memory leak in Asciidoctor/JRuby
-org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configuration-cache.parallel=true


### PR DESCRIPTION
`gradlew ascPdf` never completed for me on `main`, due to OOM:

(unrelated warnings trimmed, e.g. https://github.com/junit-team/junit-framework/pull/5131)
```
> Task :documentation:asciidoctorPdf
Picked up JAVA_TOOL_OPTIONS: -Xms32M -Xmx256M -XX:+UseG1GC -D-XX:+PrintCommandLineFlags
...
Nov 02, 2025 12:31:10 PM uri:classloader:/gems/asciidoctor-pdf-2.3.23/lib/asciidoctor/pdf/converter.rb convert_code
...
Exception in thread "main" org.asciidoctor.gradle.remote.AsciidoctorRemoteExecutionException: Error running Asciidoctor whilst attempting to process P:\projects\contrib\github-junit-jupiter\documentation\src\
docs\asciidoc\user-guide\index.adoc using backend pdf
        at org.asciidoctor.gradle.remote.AsciidoctorJavaExec$_convertFiles_closure4.doCall(AsciidoctorJavaExec.groovy:91)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
        at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:280)
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1007)
        at groovy.lang.Closure.call(Closure.java:433)
        at groovy.lang.Closure.call(Closure.java:422)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2394)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2379)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2432)
        at org.asciidoctor.gradle.remote.AsciidoctorJavaExec.convertFiles(AsciidoctorJavaExec.groovy:82)
        at org.asciidoctor.gradle.remote.AsciidoctorJavaExec.access$0(AsciidoctorJavaExec.groovy)
        at org.asciidoctor.gradle.remote.AsciidoctorJavaExec$_run_closure3.doCall(AsciidoctorJavaExec.groovy:73)
        at org.asciidoctor.gradle.remote.AsciidoctorJavaExec$_run_closure3.call(AsciidoctorJavaExec.groovy)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2394)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2379)
        at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2420)
        at org.asciidoctor.gradle.remote.AsciidoctorJavaExec.run(AsciidoctorJavaExec.groovy:68)
        at org.asciidoctor.gradle.remote.AsciidoctorJavaExec.main(AsciidoctorJavaExec.groovy:49)
Caused by: java.lang.OutOfMemoryError: Java heap space
        at org.jruby.ext.zlib.JZlibInflate.run(JZlibInflate.java:263)
        at org.jruby.ext.zlib.JZlibInflate.internalFinish(JZlibInflate.java:310)
        at org.jruby.ext.zlib.ZStream.finish(ZStream.java:136)
        at org.jruby.ext.zlib.JZlibInflate.s_inflate(JZlibInflate.java:68)
        at org.jruby.ext.zlib.JZlibInflate$INVOKER$s$1$0$s_inflate.call(JZlibInflate$INVOKER$s$1$0$s_inflate.gen)
        at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:242)
        at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:314)
        at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
        at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:82)
        at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:201)
        at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:188)
        at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:257)
        at org.jruby.RubyClass.newInstance(RubyClass.java:923)
        at org.jruby.RubyClass$INVOKER$i$newInstance.call(RubyClass$INVOKER$i$newInstance.gen)
        at org.jruby.internal.runtime.methods.JavaMethod$JavaMethodZeroOrOneOrNBlock.call(JavaMethod.java:355)
        at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:242)
        at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:314)
        at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
        at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:82)
        at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:201)
        at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:188)
        at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:220)
        at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:242)
        at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:314)
        at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:66)
        at org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:118)
        at org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:136)
        at org.jruby.runtime.IRBlockBody.doYield(IRBlockBody.java:169)
        at org.jruby.runtime.BlockBody.yield(BlockBody.java:108)
        at org.jruby.runtime.Block.yield(Block.java:189)
        at org.jruby.RubyIO.ensureYieldClose(RubyIO.java:1204)
        at org.jruby.RubyIO.open(RubyIO.java:1198)

> Task :documentation:asciidoctorPdf FAILED

BUILD FAILED in 52s
107 actionable tasks: 18 executed, 1 from cache, 88 up-to-date
```
This is due to not having a specific memory allocation for this Java process. The default is 1/4 of total RAM, so I have to set `JAVA_TOOL_OPTIONS` locally to avoid huge heaps (I have 96GB). But 256M is not enough for this process. I explicitly hardcoded a value that makes the task complete, here's the effect of it (gradlew :ascPdf --info):

<img width="1666" height="385" alt="image" src="https://github.com/user-attachments/assets/50543b14-33e7-4be5-91b9-d02533f9b289" />

512M is arbitrary, I tested with 10G as well, just to make sure it's not too low. No significant difference in runtime.

---

While figuring out what's wrong, I also noticed that the metaspace workaround is no longer necessary.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
