### PR TITLE
Make all tables scrollable (if necessary)

### DIFF
--- a/documentation/src/docs/asciidoc/docinfos/docinfo.html
+++ b/documentation/src/docs/asciidoc/docinfos/docinfo.html
@@ -11,8 +11,8 @@
     .is-collapsible{ max-height:3000px; overflow:hidden; }
     .is-collapsed{ max-height:0 }
     .is-active-link{ font-weight:700 }
-    table.scrollable {
-      overflow-x: scroll;
+    table {
+      overflow-x: auto;
       display: block;
       border-width: 0;
     }

--- a/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/running-tests.adoc
@@ -849,7 +849,6 @@ generically as strings via their identifiers.
 
 The following discovery selectors are provided out of the box:
 
-[.scrollable]
 |===
 | Java Type                     | API                                            | Annotation                  | Console Launcher                                 | Identifier
 

--- a/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/writing-tests.adoc
@@ -3479,7 +3479,7 @@ strategies.
 The following table lists relevant properties for configuring parallel execution. See
 <<running-tests-config-params>> for details on how to set such properties.
 
-[.scrollable, cols="d,d,a,d"]
+[cols="d,d,a,d"]
 |===
 |Property |Description |Supported Values |Default Value
 


### PR DESCRIPTION
Re-fixes #5129
There are more tables that kept doing the same (e.g. package tables at the bottom), and also noticed the same happens on desktop too:
<img width="1724" height="737" alt="image" src="https://github.com/user-attachments/assets/8cee50bc-1d2c-4862-a565-7638a99350d8" />

Had to change from `: scroll;` to `: auto;` to make sure that narrow tables don't get a disabled scrollbar.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
