### PR TITLE
Remove NullAway custom contract annotations option

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
@@ -69,7 +69,6 @@ tasks.withType<JavaCompile>().configureEach {
 			}
 			onlyNullMarked = true
 			isJSpecifyMode = true
-			customContractAnnotations.add("org.junit.platform.commons.annotation.Contract")
 			checkContracts = true
 			suppressionNameAliases.add("DataFlowIssue")
 		}


### PR DESCRIPTION
Since version [0.12.11](https://github.com/uber/NullAway/releases/tag/v0.12.11), NullAway accepts any annotation with `Contract` simple name.

See https://github.com/uber/NullAway/pull/1295.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
