### PR TITLE
Fix #5169 - Mark ArgumentsProvider provideArguments(ParameterDeclarations) as MAINTAINED instead of EXPERIMENTAL.

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsProvider.java
@@ -11,7 +11,7 @@
 package org.junit.jupiter.params.provider;
 
 import static org.apiguardian.api.API.Status.DEPRECATED;
-import static org.apiguardian.api.API.Status.EXPERIMENTAL;
+import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.stream.Stream;
@@ -72,7 +72,7 @@ public interface ArgumentsProvider {
 	 * @return a stream of arguments; never {@code null}
 	 * @since 5.13
 	 */
-	@API(status = EXPERIMENTAL, since = "6.0")
+	@API(status = MAINTAINED, since = "6.0")
 	default Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context)
 			throws Exception {
 		try {


### PR DESCRIPTION
Fixes #5169

This PR updates the API status of the new overload of
ArgumentsProvider.provideArguments(ParameterDeclarations, ExtensionContext)
from EXPERIMENTAL to MAINTAINED.

**Background**

In JUnit Jupiter 6.0.1, the new provideArguments(ParameterDeclarations, ExtensionContext) method is marked as @API(status = EXPERIMENTAL) while the older provideArguments(ExtensionContext) method is already deprecated.

This creates a mismatch:

- Users are encouraged to migrate to the new method
- But the new method is still labeled experimental
- Spring Boot 4.0.0 surfaced this inconsistency during upgrade

As noted in the issue discussion, the maintainers confirmed that the new API is stable and should be treated as maintained starting with JUnit 6.0.2.

**Summary of Changes**

Update the annotation on
provideArguments(ParameterDeclarations parameters, ExtensionContext context)
from:

`@API(status = EXPERIMENTAL, since = "6.0")
`

to:

`@API(status = MAINTAINED, since = "6.0")
`

This aligns the API status with the maintainer guidance and resolves the confusion around the intended stability level of the new method.

**Rationale**
- The new overload is the recommended migration target, replacing the deprecated method
- Marking it as MAINTAINED ensures tools, users, and downstream projects treat it as stable
- Brings the declaration in line with the milestone notes for 6.0.2)
