### PR TITLE
[prone] fix `UnnecessarilyFullyQualified`

### DIFF
--- a/documentation/src/test/java/example/AssertionsDemo.java
+++ b/documentation/src/test/java/example/AssertionsDemo.java
@@ -27,6 +27,8 @@ import java.util.concurrent.CountDownLatch;
 import example.domain.Person;
 import example.util.Calculator;
 
+import extensions.DisabledOnOpenJ9;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -87,7 +89,7 @@ class AssertionsDemo {
 	}
 
 	// end::user_guide[]
-	@extensions.DisabledOnOpenJ9
+	@DisabledOnOpenJ9
 	// tag::user_guide[]
 	@Test
 	void exceptionTesting() {

--- a/documentation/src/test/java/example/RepeatedTestsDemo.java
+++ b/documentation/src/test/java/example/RepeatedTestsDemo.java
@@ -17,14 +17,17 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 // end::user_guide[]
 // Use fully qualified names to avoid having them show up in the imports.
-@org.junit.jupiter.api.parallel.Execution(org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD)
+@Execution(ExecutionMode.SAME_THREAD)
 // tag::user_guide[]
 class RepeatedTestsDemo {
 
@@ -54,7 +57,7 @@ class RepeatedTestsDemo {
 
 	// end::user_guide[]
 	// Use fully qualified name to avoid having it show up in the imports.
-	@org.junit.jupiter.api.Disabled("intentional failures would break the build")
+	@Disabled("intentional failures would break the build")
 	// tag::user_guide[]
 	@RepeatedTest(value = 8, failureThreshold = 2)
 	void repeatedTestWithFailureThreshold(RepetitionInfo repetitionInfo) {

--- a/documentation/src/test/java/example/StandardTests.java
+++ b/documentation/src/test/java/example/StandardTests.java
@@ -14,6 +14,8 @@ package example;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import extensions.ExpectToFail;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,7 +38,7 @@ class StandardTests {
 	}
 
 	// end::user_guide[]
-	@extensions.ExpectToFail
+	@ExpectToFail
 	// tag::user_guide[]
 	@Test
 	void failingTest() {

--- a/documentation/src/test/java/example/SuiteDemo.java
+++ b/documentation/src/test/java/example/SuiteDemo.java
@@ -11,6 +11,7 @@
 package example;
 
 //tag::user_guide[]
+import org.junit.platform.suite.api.ExcludeTags;
 import org.junit.platform.suite.api.IncludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
@@ -21,7 +22,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SelectPackages("example")
 @IncludeClassNamePatterns(".*Tests")
 //end::user_guide[]
-@org.junit.platform.suite.api.ExcludeTags("exclude")
+@ExcludeTags("exclude")
 //tag::user_guide[]
 class SuiteDemo {
 }

--- a/documentation/src/test/java/example/UsingTheLauncherForDiscoveryDemo.java
+++ b/documentation/src/test/java/example/UsingTheLauncherForDiscoveryDemo.java
@@ -16,6 +16,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPackage;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.discoveryRequest;
 
+import org.junit.jupiter.api.Test;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.TestPlan;
@@ -27,7 +28,7 @@ import org.junit.platform.launcher.core.LauncherFactory;
  */
 class UsingTheLauncherForDiscoveryDemo {
 
-	@org.junit.jupiter.api.Test
+	@Test
 	@SuppressWarnings("unused")
 	void discovery() {
 		// @formatter:off

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
@@ -1,6 +1,7 @@
 import junitbuild.extensions.dependencyFromLibs
 import net.ltgt.gradle.errorprone.errorprone
 import net.ltgt.gradle.nullaway.nullaway
+import org.gradle.jvm.toolchain.JvmImplementation.J9
 
 plugins {
 	`java-library`
@@ -16,17 +17,10 @@ dependencies {
 
 tasks.withType<JavaCompile>().configureEach {
 	options.errorprone {
-		val shouldDisableErrorProne = java.toolchain.implementation.orNull == JvmImplementation.J9
-		if (name == "compileJava" && !shouldDisableErrorProne) {
-			disable(
-				"AnnotateFormatMethod", // We don`t want to use ErrorProne's annotations.
-				"BadImport", // This check is opinionated wrt. which method names it considers unsuitable for import which includes a few of our own methods in `ReflectionUtils` etc.
-				"DoNotCallSuggester", // We don`t want to use ErrorProne's annotations.
-				"ImmutableEnumChecker", // We don`t want to use ErrorProne's annotations.
-				"InlineMeSuggester", // We don`t want to use ErrorProne's annotations.
-				"MissingSummary", // Produces a lot of findings that we consider to be false positives, for example for package-private classes and methods.
-				"StringSplitter", // We don`t want to use Guava.
-				"UnnecessaryLambda", // The findings of this check are subjective because a named constant can be more readable in many cases.
+		val enableErrorProne = java.toolchain.implementation.orNull != J9
+		if (name == "compileJava" && enableErrorProne) {
+			disableAllWarnings = true // considering this immense spam burden, remove this once to fix dedicated flaw. https://github.com/diffplug/spotless/pull/2766
+			disable( // We don`t want to use ErrorProne's annotations.
 				// picnic (https://error-prone.picnic.tech)
 				"ConstantNaming",
 				"DirectReturn", // We don`t want to use this: https://github.com/junit-team/junit-framework/pull/5006#discussion_r2403984446
@@ -45,18 +39,23 @@ tasks.withType<JavaCompile>().configureEach {
 			error(
 				"CanonicalAnnotationSyntax",
 				"IsInstanceLambdaUsage",
+				"MissingOverride",
 				"PackageLocation",
 				"RedundantStringConversion",
 				"RedundantStringEscape",
+				"SelfAssignment",
+				"StringCharset",
+				"StringJoin",
+				"UnnecessarilyFullyQualified",
 			)
 		} else {
 			disableAllChecks = true
 		}
 		nullaway {
-			if (shouldDisableErrorProne) {
-				disable()
-			} else {
+			if (enableErrorProne) {
 				enable()
+			} else {
+				disable()
 			}
 			onlyNullMarked = true
 			isJSpecifyMode = true

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -69,7 +69,7 @@ public interface ClassOrderer {
 	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values include fully qualified class names for types that
-	 * implement {@link org.junit.jupiter.api.ClassOrderer}.
+	 * implement {@link ClassOrderer}.
 	 *
 	 * <p>If not specified, test classes are not ordered unless test classes are
 	 * annotated with {@link TestClassOrder @TestClassOrder}.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -66,7 +66,7 @@ public interface MethodOrderer {
 	 * <h4>Supported Values</h4>
 	 *
 	 * <p>Supported values include fully qualified class names for types that
-	 * implement {@link org.junit.jupiter.api.MethodOrderer}.
+	 * implement {@link MethodOrderer}.
 	 *
 	 * <p>If not specified, test methods will be ordered using an algorithm that
 	 * is deterministic but intentionally non-obvious.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Named.java
@@ -36,7 +36,7 @@ public interface Named<T extends @Nullable Object> {
 	 * depending on the use case
 	 * @param <T> the type of the payload
 	 * @return an instance of {@code Named}; never {@code null}
-	 * @see #named(String, java.lang.Object)
+	 * @see #named(String, Object)
 	 */
 	static <T extends @Nullable Object> Named<T> of(String name, T payload) {
 		Preconditions.notBlank(name, "name must not be null or blank");

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/TestInstance.java
@@ -113,13 +113,13 @@ public @interface TestInstance {
 		 * <h4>Supported Values</h4>
 		 *
 		 * <p>Supported values include names of enum constants defined in
-		 * {@link org.junit.jupiter.api.TestInstance.Lifecycle}, ignoring case.
+		 * {@link TestInstance.Lifecycle}, ignoring case.
 		 *
 		 * <p>If not specified, the default is "per_method" which corresponds to
 		 * {@code @TestInstance(Lifecycle.PER_METHOD)}.
 		 *
 		 * @since 5.0
-		 * @see org.junit.jupiter.api.TestInstance
+		 * @see TestInstance
 		 */
 		@API(status = STABLE, since = "5.9")
 		public static final String DEFAULT_LIFECYCLE_PROPERTY_NAME = "junit.jupiter.testinstance.lifecycle.default";

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledForJreRange.java
@@ -63,19 +63,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 5.6
  * @see JRE
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIf.java
@@ -57,19 +57,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * {@code @Disabled*} annotations in this package.
  *
  * @since 5.7
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfEnvironmentVariable.java
@@ -58,19 +58,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * indirectly present, or meta-present on a given element.
  *
  * @since 5.1
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledIfSystemProperty.java
@@ -58,19 +58,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * indirectly present, or meta-present on a given element.
  *
  * @since 5.1
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledInNativeImage.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledInNativeImage.java
@@ -58,19 +58,19 @@ import org.apiguardian.api.API;
  * <a href="https://www.graalvm.org/reference-manual/native-image/metadata/AutomaticMetadataCollection/">tracing agent</a>.
  *
  * @since 5.9.1
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnJre.java
@@ -62,19 +62,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 5.1
  * @see JRE
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOs.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOs.java
@@ -63,19 +63,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 5.1
  * @see OS
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledForJreRange.java
@@ -63,19 +63,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 5.6
  * @see JRE
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIf.java
@@ -57,19 +57,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * {@code @Disabled*} annotations in this package.
  *
  * @since 5.7
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfEnvironmentVariable.java
@@ -57,19 +57,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * indirectly present, or meta-present on a given element.
  *
  * @since 5.1
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledIfSystemProperty.java
@@ -57,19 +57,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * indirectly present, or meta-present on a given element.
  *
  * @since 5.1
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledInNativeImage.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledInNativeImage.java
@@ -58,19 +58,19 @@ import org.apiguardian.api.API;
  * <a href="https://www.graalvm.org/reference-manual/native-image/metadata/AutomaticMetadataCollection/">tracing agent</a>.
  *
  * @since 5.9.1
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnJre.java
@@ -62,19 +62,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 5.1
  * @see JRE
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.EnabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see EnabledOnOs
+ * @see DisabledOnOs
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOs.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOs.java
@@ -63,19 +63,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 5.1
  * @see OS
- * @see org.junit.jupiter.api.condition.EnabledIf
- * @see org.junit.jupiter.api.condition.DisabledIf
- * @see org.junit.jupiter.api.condition.DisabledOnOs
- * @see org.junit.jupiter.api.condition.EnabledOnJre
- * @see org.junit.jupiter.api.condition.DisabledOnJre
- * @see org.junit.jupiter.api.condition.EnabledForJreRange
- * @see org.junit.jupiter.api.condition.DisabledForJreRange
- * @see org.junit.jupiter.api.condition.EnabledInNativeImage
- * @see org.junit.jupiter.api.condition.DisabledInNativeImage
- * @see org.junit.jupiter.api.condition.EnabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.DisabledIfSystemProperty
- * @see org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
- * @see org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+ * @see EnabledIf
+ * @see DisabledIf
+ * @see DisabledOnOs
+ * @see EnabledOnJre
+ * @see DisabledOnJre
+ * @see EnabledForJreRange
+ * @see DisabledForJreRange
+ * @see EnabledInNativeImage
+ * @see DisabledInNativeImage
+ * @see EnabledIfSystemProperty
+ * @see DisabledIfSystemProperty
+ * @see EnabledIfEnvironmentVariable
+ * @see DisabledIfEnvironmentVariable
  * @see org.junit.jupiter.api.Disabled
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -506,7 +506,7 @@ public interface ExtensionContext {
 	 * @return the {@code ExecutionMode} of the test; never {@code null}
 	 *
 	 * @since 5.8.1
-	 * @see org.junit.jupiter.api.parallel.ExecutionMode {@code @ExecutionMode}
+	 * @see ExecutionMode {@code @ExecutionMode}
 	 */
 	@API(status = STABLE, since = "5.8.1")
 	ExecutionMode getExecutionMode();

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ParameterContext.java
@@ -32,8 +32,8 @@ import org.apiguardian.api.API;
  *
  * @since 5.0
  * @see ParameterResolver
- * @see java.lang.reflect.Parameter
- * @see java.lang.reflect.Executable
+ * @see Parameter
+ * @see Executable
  * @see java.lang.reflect.Method
  * @see java.lang.reflect.Constructor
  */

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/Executable.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/Executable.java
@@ -19,14 +19,14 @@ import org.apiguardian.api.API;
  * implement any generic block of code that potentially throws a
  * {@link Throwable}.
  *
- * <p>The {@code Executable} interface is similar to {@link java.lang.Runnable},
+ * <p>The {@code Executable} interface is similar to {@link Runnable},
  * except that an {@code Executable} can throw any kind of exception.
  *
  * <h2>Rationale for throwing {@code Throwable} instead of {@code Exception}</h2>
  *
  * <p>Although Java applications typically throw exceptions that are instances
- * of {@link java.lang.Exception}, {@link java.lang.RuntimeException},
- * {@link java.lang.Error}, or {@link java.lang.AssertionError} (in testing
+ * of {@link Exception}, {@link RuntimeException},
+ * {@link Error}, or {@link AssertionError} (in testing
  * scenarios), there may be use cases where an {@code Executable} needs to
  * explicitly throw a {@code Throwable}. In order to support such specialized
  * use cases, {@link #execute()} is declared to throw {@code Throwable}.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/ThrowingConsumer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/function/ThrowingConsumer.java
@@ -27,8 +27,8 @@ import org.jspecify.annotations.Nullable;
  * <h2>Rationale for throwing {@code Throwable} instead of {@code Exception}</h2>
  *
  * <p>Although Java applications typically throw exceptions that are instances
- * of {@link java.lang.Exception}, {@link java.lang.RuntimeException},
- * {@link java.lang.Error}, or {@link java.lang.AssertionError} (in testing
+ * of {@link Exception}, {@link RuntimeException},
+ * {@link Error}, or {@link AssertionError} (in testing
  * scenarios), there may be use cases where a {@code ThrowingConsumer} needs to
  * explicitly throw a {@code Throwable}. In order to support such specialized
  * use cases, {@link #accept} is declared to throw {@code Throwable}.

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/io/TempDirFactory.java
@@ -78,7 +78,7 @@ public interface TempDirFactory extends Closeable {
 	 * <p>The created temporary directory is always created in the default
 	 * file system with the system's default temporary directory as its parent.
 	 *
-	 * @see Files#createTempDirectory(java.lang.String, java.nio.file.attribute.FileAttribute[])
+	 * @see Files#createTempDirectory(String, java.nio.file.attribute.FileAttribute[])
 	 */
 	class Standard implements TempDirFactory {
 

--- a/junit-jupiter-engine/src/main/java/module-info.java
+++ b/junit-jupiter-engine/src/main/java/module-info.java
@@ -8,13 +8,17 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.engine.JupiterTestEngine;
+import org.junit.platform.engine.TestEngine;
+
 /**
- * Provides the JUnit Jupiter {@link org.junit.platform.engine.TestEngine}
+ * Provides the JUnit Jupiter {@link TestEngine}
  * implementation.
  *
  * @since 5.0
- * @uses org.junit.jupiter.api.extension.Extension
- * @provides org.junit.platform.engine.TestEngine The {@code JupiterTestEngine}
+ * @uses Extension
+ * @provides TestEngine The {@code JupiterTestEngine}
  * runs Jupiter based tests on the platform.
  */
 module org.junit.jupiter.engine {
@@ -29,10 +33,10 @@ module org.junit.jupiter.engine {
 
 	// exports org.junit.jupiter.engine; // Constants...
 
-	uses org.junit.jupiter.api.extension.Extension;
+	uses Extension;
 
-	provides org.junit.platform.engine.TestEngine
-			with org.junit.jupiter.engine.JupiterTestEngine;
+	provides TestEngine
+			with JupiterTestEngine;
 
 	opens org.junit.jupiter.engine.extension to org.junit.platform.commons;
 }

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -47,7 +47,7 @@ import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
 import org.junit.platform.engine.support.descriptor.UriSource;
 
 /**
- * {@link org.junit.platform.engine.TestDescriptor TestDescriptor} for
+ * {@link TestDescriptor TestDescriptor} for
  * {@link org.junit.jupiter.api.TestFactory @TestFactory} methods.
  *
  * @since 5.0

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.java
@@ -32,7 +32,7 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 
 /**
- * {@link TestDescriptor} for {@link org.junit.jupiter.api.TestTemplate @TestTemplate}
+ * {@link TestDescriptor} for {@link TestTemplate @TestTemplate}
  * methods.
  *
  * @since 5.0

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.engine.extension.ExtensionRegistry;
 
 /**
  * {@code InterceptingExecutableInvoker} encapsulates the invocation of a
- * {@link java.lang.reflect.Executable} (i.e., method or constructor),
+ * {@link Executable} (i.e., method or constructor),
  * including support for dynamic resolution of method parameters via
  * {@link ParameterResolver ParameterResolvers}.
  *

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistrar.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/ExtensionRegistrar.java
@@ -50,7 +50,7 @@ public interface ExtensionRegistrar {
 	 * {@code source} and the {@code extension} should be the same object.
 	 * However, if an extension is registered <em>programmatically</em> via
 	 * {@link RegisterExtension @RegisterExtension}, the {@code source} object
-	 * should be the {@link java.lang.reflect.Field} that is annotated with
+	 * should be the {@link Field} that is annotated with
 	 * {@code @RegisterExtension}. Similarly, if an extension is registered
 	 * <em>programmatically</em> as a lambda expression or method reference, the
 	 * {@code source} object should be the underlying

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/OpenTest4JAndJUnit4AwareThrowableCollector.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/support/OpenTest4JAndJUnit4AwareThrowableCollector.java
@@ -22,7 +22,7 @@ import org.opentest4j.TestAbortedException;
 
 /**
  * Specialization of {@link ThrowableCollector} that treats instances of the
- * OTA's {@link org.opentest4j.TestAbortedException} and JUnit 4's
+ * OTA's {@link TestAbortedException} and JUnit 4's
  * {@code org.junit.AssumptionViolatedException} as <em>aborting</em>.
  *
  * @since 5.4

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/conditions/IgnoreCondition.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/conditions/IgnoreCondition.java
@@ -28,7 +28,7 @@ import org.junit.platform.commons.util.StringUtils;
  * annotation.
  *
  * @since 5.4
- * @see org.junit.Ignore @Ignore
+ * @see Ignore @Ignore
  * @see org.junit.jupiter.api.Disabled @Disabled
  * @see #evaluateExecutionCondition(ExtensionContext)
  * @see org.junit.jupiter.migrationsupport.EnableJUnit4MigrationSupport

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
@@ -34,7 +34,7 @@ import org.junit.rules.ExpectedException;
  *
  * @since 5.0
  * @see org.junit.jupiter.api.Assertions#assertThrows
- * @see org.junit.rules.ExpectedException
+ * @see ExpectedException
  * @see org.junit.rules.TestRule
  * @see org.junit.Rule
  * @deprecated Please use

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExternalResourceSupport.java
@@ -34,7 +34,7 @@ import org.junit.rules.ExternalResource;
  * of the rule-based model of JUnit 4.
  *
  * @since 5.0
- * @see org.junit.rules.ExternalResource
+ * @see ExternalResource
  * @see org.junit.rules.TestRule
  * @see org.junit.Rule
  * @deprecated Please use {@link org.junit.jupiter.api.AutoClose @AutoClose} instead.

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/VerifierSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/VerifierSupport.java
@@ -33,7 +33,7 @@ import org.junit.rules.Verifier;
  * of the rule-based model of JUnit 4.
  *
  * @since 5.0
- * @see org.junit.rules.Verifier
+ * @see Verifier
  * @see org.junit.rules.TestRule
  * @see org.junit.Rule
  * @deprecated Please implement {@link org.junit.jupiter.api.extension.AfterTestExecutionCallback} instead.

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClass.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedClass.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  *
  * <p>A {@code @ParameterizedClass} must specify at least one
  * {@link org.junit.jupiter.params.provider.ArgumentsProvider ArgumentsProvider}
- * via {@link org.junit.jupiter.params.provider.ArgumentsSource @ArgumentsSource}
+ * via {@link ArgumentsSource @ArgumentsSource}
  * or a corresponding composed annotation (such as {@code @ValueSource},
  * {@code @CsvSource}, etc.). The provider is responsible for providing a
  * {@link java.util.stream.Stream Stream} of
@@ -133,7 +133,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * @see ParameterizedTest
  * @see org.junit.jupiter.params.provider.Arguments
  * @see org.junit.jupiter.params.provider.ArgumentsProvider
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.provider.CsvFileSource
  * @see org.junit.jupiter.params.provider.CsvSource
  * @see org.junit.jupiter.params.provider.EnumSource
@@ -254,7 +254,7 @@ public @interface ParameterizedClass {
 	 * {@code false} to ensure that the argument is not closed between
 	 * invocations.
 	 *
-	 * @see java.lang.AutoCloseable
+	 * @see AutoCloseable
 	 */
 	boolean autoCloseArguments() default true;
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  *
  * <p>{@code @ParameterizedTest} methods must specify at least one
  * {@link org.junit.jupiter.params.provider.ArgumentsProvider ArgumentsProvider}
- * via {@link org.junit.jupiter.params.provider.ArgumentsSource @ArgumentsSource}
+ * via {@link ArgumentsSource @ArgumentsSource}
  * or a corresponding composed annotation (e.g., {@code @ValueSource},
  * {@code @CsvSource}, etc.). The provider is responsible for providing a
  * {@link java.util.stream.Stream Stream} of
@@ -118,7 +118,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * @see ParameterizedClass
  * @see org.junit.jupiter.params.provider.Arguments
  * @see org.junit.jupiter.params.provider.ArgumentsProvider
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.provider.CsvFileSource
  * @see org.junit.jupiter.params.provider.CsvSource
  * @see org.junit.jupiter.params.provider.EnumSource
@@ -340,7 +340,7 @@ public @interface ParameterizedTest {
 	 * invocations.
 	 *
 	 * @since 5.8
-	 * @see java.lang.AutoCloseable
+	 * @see AutoCloseable
 	 */
 	@API(status = STABLE, since = "5.10")
 	boolean autoCloseArguments() default true;

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ArgumentConverter.java
@@ -30,7 +30,7 @@ import org.junit.platform.commons.JUnitException;
  * {@link org.junit.jupiter.params.Parameter @Parameter}-annotated field of a
  * {@link org.junit.jupiter.params.ParameterizedClass @ParameterizedClass} with
  * the help of a
- * {@link org.junit.jupiter.params.converter.ConvertWith @ConvertWith}
+ * {@link ConvertWith @ConvertWith}
  * annotation.
  *
  * <p>Implementations must provide a no-args constructor or a single unambiguous
@@ -49,7 +49,7 @@ import org.junit.platform.commons.JUnitException;
  *
  * @since 5.0
  * @see org.junit.jupiter.params.ParameterizedTest
- * @see org.junit.jupiter.params.converter.ConvertWith
+ * @see ConvertWith
  * @see org.junit.jupiter.params.support.AnnotationConsumer
  * @see SimpleArgumentConverter
  * @see TypedArgumentConverter

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ConvertWith.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/ConvertWith.java
@@ -34,7 +34,7 @@ import org.apiguardian.api.API;
  *
  * @since 5.0
  * @see org.junit.jupiter.params.ParameterizedTest
- * @see org.junit.jupiter.params.converter.ArgumentConverter
+ * @see ArgumentConverter
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/DefaultArgumentConverter.java
@@ -45,8 +45,8 @@ import org.junit.platform.commons.util.ReflectionUtils;
  * be modified.
  *
  * @since 5.0
- * @see org.junit.jupiter.params.converter.ArgumentConverter
- * @see org.junit.platform.commons.support.conversion.ConversionSupport
+ * @see ArgumentConverter
+ * @see ConversionSupport
  */
 @API(status = INTERNAL, since = "5.0")
 public class DefaultArgumentConverter implements ArgumentConverter {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProvider.java
@@ -33,10 +33,10 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.10
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
- * @see org.junit.jupiter.params.provider.ArgumentsSource
- * @see org.junit.jupiter.params.provider.Arguments
- * @see org.junit.jupiter.params.provider.ArgumentsProvider
- * @see org.junit.jupiter.params.support.AnnotationConsumer
+ * @see ArgumentsSource
+ * @see Arguments
+ * @see ArgumentsProvider
+ * @see AnnotationConsumer
  */
 @API(status = MAINTAINED, since = "5.13.3")
 public abstract class AnnotationBasedArgumentsProvider<A extends Annotation>

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/Arguments.java
@@ -46,8 +46,8 @@ import org.junit.platform.commons.util.Preconditions;
  * @since 5.0
  * @see ArgumentSet
  * @see org.junit.jupiter.params.ParameterizedTest
- * @see org.junit.jupiter.params.provider.ArgumentsSource
- * @see org.junit.jupiter.params.provider.ArgumentsProvider
+ * @see ArgumentsSource
+ * @see ArgumentsProvider
  * @see org.junit.jupiter.params.converter.ArgumentConverter
  */
 @FunctionalInterface

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsProvider.java
@@ -38,8 +38,8 @@ import org.junit.platform.commons.JUnitException;
  * @since 5.0
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
- * @see org.junit.jupiter.params.provider.ArgumentsSource
- * @see org.junit.jupiter.params.provider.Arguments
+ * @see ArgumentsSource
+ * @see Arguments
  * @see org.junit.jupiter.params.support.AnnotationConsumer
  */
 @API(status = STABLE, since = "5.7")

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSource.java
@@ -36,7 +36,7 @@ import org.apiguardian.api.API;
  * <p>This annotation is {@linkplain Inherited inherited} within class hierarchies.
  *
  * @since 5.0
- * @see org.junit.jupiter.params.provider.ArgumentsProvider
+ * @see ArgumentsProvider
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
  */

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSources.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ArgumentsSources.java
@@ -34,7 +34,7 @@ import org.apiguardian.api.API;
  * <p>This annotation is {@linkplain Inherited inherited} within class hierarchies.
  *
  * @since 5.0
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileSource.java
@@ -74,7 +74,7 @@ import org.junit.jupiter.params.ParameterizedInvocationConstants;
  *
  * @since 5.0
  * @see CsvSource
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
  */

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvSource.java
@@ -79,7 +79,7 @@ import org.junit.jupiter.params.ParameterizedInvocationConstants;
  *
  * @since 5.0
  * @see CsvFileSource
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
  */

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptySource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptySource.java
@@ -32,7 +32,7 @@ import org.apiguardian.api.API;
  * parameter types.
  *
  * <ul>
- * <li>{@link java.lang.String}</li>
+ * <li>{@link String}</li>
  * <li>{@link java.util.Collection} and concrete subtypes with a public no-arg constructor</li>
  * <li>{@link java.util.List}</li>
  * <li>{@link java.util.Set}</li>
@@ -50,7 +50,7 @@ import org.apiguardian.api.API;
  * <p>This annotation is {@linkplain Inherited inherited} within class hierarchies.
  *
  * @since 5.4
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
  * @see NullSource

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EnumSource.java
@@ -49,7 +49,7 @@ import org.junit.platform.commons.util.Preconditions;
  * <p>This annotation is {@linkplain Inherited inherited} within class hierarchies.
  *
  * @since 5.0
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
  */

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/NullSource.java
@@ -35,7 +35,7 @@ import org.apiguardian.api.API;
  * <p>This annotation is {@linkplain Inherited inherited} within class hierarchies.
  *
  * @since 5.4
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
  * @see EmptySource

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueSource.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/ValueSource.java
@@ -40,7 +40,7 @@ import org.apiguardian.api.API;
  * <p>This annotation is {@linkplain Inherited inherited} within class hierarchies.
  *
  * @since 5.0
- * @see org.junit.jupiter.params.provider.ArgumentsSource
+ * @see ArgumentsSource
  * @see org.junit.jupiter.params.ParameterizedClass
  * @see org.junit.jupiter.params.ParameterizedTest
  */

--- a/junit-platform-commons/src/main/java/module-info.java
+++ b/junit-platform-commons/src/main/java/module-info.java
@@ -8,6 +8,8 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import org.junit.platform.commons.support.scanning.ClasspathScanner;
+
 /**
  * Common APIs and support utilities for the JUnit Platform.
  *
@@ -57,5 +59,5 @@ module org.junit.platform.commons {
 			org.junit.platform.suite.engine,
 			org.junit.platform.testkit,
 			org.junit.vintage.engine;
-	uses org.junit.platform.commons.support.scanning.ClasspathScanner;
+	uses ClasspathScanner;
 }

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/io/DefaultResource.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/io/DefaultResource.java
@@ -44,7 +44,7 @@ record DefaultResource(String name, URI uri) implements Resource {
 		if (obj == this) {
 			return true;
 		}
-		if (obj instanceof org.junit.platform.commons.io.Resource that) {
+		if (obj instanceof Resource that) {
 			return this.name.equals(that.getName()) //
 					&& this.uri.equals(that.getUri());
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/AnnotationSupport.java
@@ -273,7 +273,7 @@ public final class AnnotationSupport {
 	 * {@link AnnotatedElement}.
 	 *
 	 * <p>This method extends the functionality of
-	 * {@link java.lang.reflect.AnnotatedElement#getAnnotationsByType(Class)}
+	 * {@link AnnotatedElement#getAnnotationsByType(Class)}
 	 * with additional support for meta-annotations.
 	 *
 	 * <p>In addition, if the element is a class and the repeatable annotation

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -609,7 +609,7 @@ public final class ReflectionSupport {
 	 * {@code ClassLoader}, which allows parameter types to be resolved in different
 	 * {@code ClassLoader} arrangements.
 	 *
-	 * <p>The algorithm does not search for methods in {@link java.lang.Object}.
+	 * <p>The algorithm does not search for methods in {@link Object}.
 	 *
 	 * @param clazz the class or interface in which to find the method; never {@code null}
 	 * @param methodName the name of the method to find; never {@code null} or empty
@@ -629,7 +629,7 @@ public final class ReflectionSupport {
 	 * interface and traversing up the type hierarchy until such a method is
 	 * found or the type hierarchy is exhausted.
 	 *
-	 * <p>The algorithm does not search for methods in {@link java.lang.Object}.
+	 * <p>The algorithm does not search for methods in {@link Object}.
 	 *
 	 * @param clazz the class or interface in which to find the method; never {@code null}
 	 * @param methodName the name of the method to find; never {@code null} or empty

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CollectionUtils.java
@@ -132,7 +132,7 @@ public final class CollectionUtils {
 	 * <li>{@link Object} array</li>
 	 * <li>primitive array</li>
 	 * <li>any type that provides an
-	 * {@link java.util.Iterator Iterator}-returning {@code iterator()} method
+	 * {@link Iterator Iterator}-returning {@code iterator()} method
 	 * (such as, for example, a {@code kotlin.sequences.Sequence})</li>
 	 * </ul>
 	 *

--- a/junit-platform-console/src/main/java/module-info.java
+++ b/junit-platform-console/src/main/java/module-info.java
@@ -8,11 +8,15 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import java.util.spi.ToolProvider;
+
+import org.junit.platform.console.ConsoleLauncherToolProvider;
+
 /**
  * Support for launching the JUnit Platform from the console.
  *
  * @since 1.0
- * @provides java.util.spi.ToolProvider
+ * @provides ToolProvider
  */
 module org.junit.platform.console {
 
@@ -26,5 +30,5 @@ module org.junit.platform.console {
 
 	exports org.junit.platform.console.output to org.junit.start;
 
-	provides java.util.spi.ToolProvider with org.junit.platform.console.ConsoleLauncherToolProvider;
+	provides ToolProvider with ConsoleLauncherToolProvider;
 }

--- a/junit-platform-engine/src/main/java/module-info.java
+++ b/junit-platform-engine/src/main/java/module-info.java
@@ -8,6 +8,21 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import org.junit.platform.engine.discovery.ClassSelector;
+import org.junit.platform.engine.discovery.ClasspathResourceSelector;
+import org.junit.platform.engine.discovery.ClasspathRootSelector;
+import org.junit.platform.engine.discovery.DirectorySelector;
+import org.junit.platform.engine.discovery.DiscoverySelectorIdentifierParser;
+import org.junit.platform.engine.discovery.FileSelector;
+import org.junit.platform.engine.discovery.IterationSelector;
+import org.junit.platform.engine.discovery.MethodSelector;
+import org.junit.platform.engine.discovery.ModuleSelector;
+import org.junit.platform.engine.discovery.NestedClassSelector;
+import org.junit.platform.engine.discovery.NestedMethodSelector;
+import org.junit.platform.engine.discovery.PackageSelector;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
+import org.junit.platform.engine.discovery.UriSelector;
+
 /**
  * Public API for test engines.
  *
@@ -34,21 +49,21 @@ module org.junit.platform.engine {
 	exports org.junit.platform.engine.support.hierarchical;
 	exports org.junit.platform.engine.support.store;
 
-	uses org.junit.platform.engine.discovery.DiscoverySelectorIdentifierParser;
+	uses DiscoverySelectorIdentifierParser;
 
-	provides org.junit.platform.engine.discovery.DiscoverySelectorIdentifierParser with
-			org.junit.platform.engine.discovery.ClassSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.ClasspathResourceSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.ClasspathRootSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.DirectorySelector.IdentifierParser,
-			org.junit.platform.engine.discovery.FileSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.IterationSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.MethodSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.ModuleSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.NestedClassSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.NestedMethodSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.PackageSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.UniqueIdSelector.IdentifierParser,
-			org.junit.platform.engine.discovery.UriSelector.IdentifierParser;
+	provides DiscoverySelectorIdentifierParser with
+			ClassSelector.IdentifierParser,
+			ClasspathResourceSelector.IdentifierParser,
+			ClasspathRootSelector.IdentifierParser,
+			DirectorySelector.IdentifierParser,
+			FileSelector.IdentifierParser,
+			IterationSelector.IdentifierParser,
+			MethodSelector.IdentifierParser,
+			ModuleSelector.IdentifierParser,
+			NestedClassSelector.IdentifierParser,
+			NestedMethodSelector.IdentifierParser,
+			PackageSelector.IdentifierParser,
+			UniqueIdSelector.IdentifierParser,
+			UriSelector.IdentifierParser;
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/CancellationToken.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/CancellationToken.java
@@ -20,7 +20,7 @@ import org.apiguardian.api.API;
  *
  * <p>For example, this is used by the
  * {@link org.junit.platform.launcher.Launcher} and
- * {@link org.junit.platform.engine.TestEngine} implementations to determine
+ * {@link TestEngine} implementations to determine
  * whether the current test execution should be cancelled.
  *
  * <p>This interface is not intended to be implemented by clients.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/EngineDiscoveryRequest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.engine.reporting.OutputDirectoryProvider;
 
 /**
  * {@code EngineDiscoveryRequest} provides a {@link TestEngine} access to the
@@ -87,7 +88,7 @@ public interface EngineDiscoveryRequest {
 
 	/**
 	 * Get the
-	 * {@link org.junit.platform.engine.reporting.OutputDirectoryProvider} for
+	 * {@link OutputDirectoryProvider} for
 	 * this request.
 	 *
 	 * @return the output directory provider; never {@code null}
@@ -97,8 +98,8 @@ public interface EngineDiscoveryRequest {
 	@SuppressWarnings("removal")
 	@Deprecated(since = "1.14", forRemoval = true)
 	@API(status = DEPRECATED, since = "1.14")
-	default org.junit.platform.engine.reporting.OutputDirectoryProvider getOutputDirectoryProvider() {
-		return org.junit.platform.engine.reporting.OutputDirectoryProvider.castOrAdapt(getOutputDirectoryCreator());
+	default OutputDirectoryProvider getOutputDirectoryProvider() {
+		return OutputDirectoryProvider.castOrAdapt(getOutputDirectoryCreator());
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/ExecutionRequest.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/ExecutionRequest.java
@@ -20,6 +20,7 @@ import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.reporting.OutputDirectoryProvider;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 
@@ -148,7 +149,7 @@ public class ExecutionRequest {
 
 	/**
 	 * {@return the
-	 * {@link org.junit.platform.engine.reporting.OutputDirectoryProvider} for
+	 * {@link OutputDirectoryProvider} for
 	 * this request for writing reports and other output files}
 	 *
 	 * @throws PreconditionViolationException if the output directory provider
@@ -159,8 +160,8 @@ public class ExecutionRequest {
 	@Deprecated(since = "1.14", forRemoval = true)
 	@API(status = DEPRECATED, since = "1.14")
 	@SuppressWarnings("removal")
-	public org.junit.platform.engine.reporting.OutputDirectoryProvider getOutputDirectoryProvider() {
-		return org.junit.platform.engine.reporting.OutputDirectoryProvider.castOrAdapt(getOutputDirectoryCreator());
+	public OutputDirectoryProvider getOutputDirectoryProvider() {
+		return OutputDirectoryProvider.castOrAdapt(getOutputDirectoryCreator());
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestEngine.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestEngine.java
@@ -41,8 +41,8 @@ import org.junit.platform.commons.util.PackageUtils;
  * {@code @Testable} for further details.
  *
  * @since 1.0
- * @see org.junit.platform.engine.EngineDiscoveryRequest
- * @see org.junit.platform.engine.ExecutionRequest
+ * @see EngineDiscoveryRequest
+ * @see ExecutionRequest
  * @see org.junit.platform.commons.annotation.Testable
  */
 @API(status = STABLE, since = "1.0")

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassNameFilter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClassNameFilter.java
@@ -29,7 +29,7 @@ public interface ClassNameFilter extends DiscoveryFilter<String> {
 	/**
 	 * Standard include pattern in the form of a regular expression that is
 	 * used to match against fully qualified class names:
-	 * {@value org.junit.platform.engine.discovery.ClassNameFilter#STANDARD_INCLUDE_PATTERN}
+	 * {@value ClassNameFilter#STANDARD_INCLUDE_PATTERN}
 	 *
 	 * <p>This pattern matches against class names beginning with {@code Test}
 	 * or ending with {@code Test} or {@code Tests} (in any package).

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathRootSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathRootSelector.java
@@ -39,7 +39,7 @@ import org.junit.platform.engine.DiscoverySelectorIdentifier;
  * {@linkplain Thread thread} that uses this selector.
  *
  * @since 1.0
- * @see DiscoverySelectors#selectClasspathRoots(java.util.Set)
+ * @see DiscoverySelectors#selectClasspathRoots(Set)
  * @see ClasspathResourceSelector
  * @see Thread#getContextClassLoader()
  */

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DirectorySelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DirectorySelector.java
@@ -49,7 +49,7 @@ public final class DirectorySelector implements DiscoverySelector {
 	}
 
 	/**
-	 * Get the selected directory as a {@link java.io.File}.
+	 * Get the selected directory as a {@link File}.
 	 *
 	 * @see #getPath()
 	 * @see #getRawPath()
@@ -59,7 +59,7 @@ public final class DirectorySelector implements DiscoverySelector {
 	}
 
 	/**
-	 * Get the selected directory as a {@link java.nio.file.Path} using the
+	 * Get the selected directory as a {@link Path} using the
 	 * {@linkplain FileSystems#getDefault default} {@link FileSystem}.
 	 *
 	 * @see #getDirectory()

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FileSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/FileSelector.java
@@ -54,7 +54,7 @@ public final class FileSelector implements DiscoverySelector {
 	}
 
 	/**
-	 * Get the selected file as a {@link java.io.File}.
+	 * Get the selected file as a {@link File}.
 	 *
 	 * @see #getPath()
 	 * @see #getRawPath()
@@ -64,7 +64,7 @@ public final class FileSelector implements DiscoverySelector {
 	}
 
 	/**
-	 * Get the selected file as a {@link java.nio.file.Path} using the
+	 * Get the selected file as a {@link Path} using the
 	 * {@linkplain FileSystems#getDefault default} {@link FileSystem}.
 	 *
 	 * @see #getFile()

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -26,7 +26,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 import org.junit.platform.engine.TestSource;
 
 /**
- * Class based {@link org.junit.platform.engine.TestSource TestSource} with
+ * Class based {@link TestSource TestSource} with
  * an optional {@linkplain FilePosition file position}.
  *
  * <p>If a Java {@link Class} reference is provided, the {@code ClassSource}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
@@ -26,7 +26,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 import org.junit.platform.engine.TestSource;
 
 /**
- * <em>Classpath resource</em> based {@link org.junit.platform.engine.TestSource}
+ * <em>Classpath resource</em> based {@link TestSource}
  * with an optional {@linkplain FilePosition position}.
  *
  * @since 1.0

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/MethodSource.java
@@ -27,7 +27,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 import org.junit.platform.engine.TestSource;
 
 /**
- * Method based {@link org.junit.platform.engine.TestSource TestSource}.
+ * Method based {@link TestSource TestSource}.
  *
  * <p>This class stores the method name along with the names of its parameter
  * types because {@link Method} does not implement {@link java.io.Serializable}.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/PackageSource.java
@@ -21,7 +21,7 @@ import org.junit.platform.commons.util.ToStringBuilder;
 import org.junit.platform.engine.TestSource;
 
 /**
- * Package based {@link org.junit.platform.engine.TestSource}.
+ * Package based {@link TestSource}.
  *
  * <p>This class stores the package name because {@link Package} does not
  * implement {@link java.io.Serializable}.

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/UriSource.java
@@ -50,8 +50,8 @@ public interface UriSource extends TestSource {
 	 * @param uri the URI to use as the source; never {@code null}
 	 * @return an appropriate {@code UriSource} for the supplied {@code URI}
 	 * @since 1.3
-	 * @see org.junit.platform.engine.support.descriptor.FileSource
-	 * @see org.junit.platform.engine.support.descriptor.DirectorySource
+	 * @see FileSource
+	 * @see DirectorySource
 	 */
 	static UriSource from(URI uri) {
 		Preconditions.notNull(uri, "URI must not be null");

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/EngineDiscoveryRequestResolver.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
 import org.junit.platform.commons.io.ResourceFilter;
+import org.junit.platform.commons.support.Resource;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -233,11 +234,9 @@ public class EngineDiscoveryRequestResolver<T extends TestDescriptor> {
 		@API(status = DEPRECATED, since = "1.14")
 		@Deprecated(since = "1.14", forRemoval = true)
 		@SuppressWarnings("removal")
-		public Builder<T> addResourceContainerSelectorResolver(
-				Predicate<org.junit.platform.commons.support.Resource> resourceFilter) {
+		public Builder<T> addResourceContainerSelectorResolver(Predicate<Resource> resourceFilter) {
 			Preconditions.notNull(resourceFilter, "resourceFilter must not be null");
-			return addResourceContainerSelectorResolver(
-				ResourceFilter.of(r -> resourceFilter.test(org.junit.platform.commons.support.Resource.of(r))));
+			return addResourceContainerSelectorResolver(ResourceFilter.of(r -> resourceFilter.test(Resource.of(r))));
 		}
 
 		/**

--- a/junit-platform-launcher/src/main/java/module-info.java
+++ b/junit-platform-launcher/src/main/java/module-info.java
@@ -8,18 +8,26 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.launcher.LauncherDiscoveryListener;
+import org.junit.platform.launcher.LauncherInterceptor;
+import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.listeners.UniqueIdTrackingListener;
+
 /**
  * Public API for configuring and launching test plans.
  *
  * <p>This API is typically used by IDEs and build tools.
  *
  * @since 1.0
- * @uses org.junit.platform.engine.TestEngine
- * @uses org.junit.platform.launcher.LauncherDiscoveryListener
- * @uses org.junit.platform.launcher.LauncherInterceptor
- * @uses org.junit.platform.launcher.LauncherSessionListener
- * @uses org.junit.platform.launcher.PostDiscoveryFilter
- * @uses org.junit.platform.launcher.TestExecutionListener
+ * @uses TestEngine
+ * @uses LauncherDiscoveryListener
+ * @uses LauncherInterceptor
+ * @uses LauncherSessionListener
+ * @uses PostDiscoveryFilter
+ * @uses TestExecutionListener
  */
 module org.junit.platform.launcher {
 
@@ -36,13 +44,13 @@ module org.junit.platform.launcher {
 	exports org.junit.platform.launcher.listeners;
 	exports org.junit.platform.launcher.listeners.discovery;
 
-	uses org.junit.platform.engine.TestEngine;
-	uses org.junit.platform.launcher.LauncherDiscoveryListener;
-	uses org.junit.platform.launcher.LauncherInterceptor;
-	uses org.junit.platform.launcher.LauncherSessionListener;
-	uses org.junit.platform.launcher.PostDiscoveryFilter;
-	uses org.junit.platform.launcher.TestExecutionListener;
+	uses TestEngine;
+	uses LauncherDiscoveryListener;
+	uses LauncherInterceptor;
+	uses LauncherSessionListener;
+	uses PostDiscoveryFilter;
+	uses TestExecutionListener;
 
-	provides org.junit.platform.launcher.TestExecutionListener
-			with org.junit.platform.launcher.listeners.UniqueIdTrackingListener;
+	provides TestExecutionListener
+			with UniqueIdTrackingListener;
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/LauncherConstants.java
@@ -136,7 +136,7 @@ public class LauncherConstants {
 	 * the {@link Launcher}.
 	 *
 	 * @see #DEACTIVATE_ALL_LISTENERS_PATTERN
-	 * @see org.junit.platform.launcher.TestExecutionListener
+	 * @see TestExecutionListener
 	 */
 	public static final String DEACTIVATE_LISTENERS_PATTERN_PROPERTY_NAME = "junit.platform.execution.listeners.deactivate";
 
@@ -146,7 +146,7 @@ public class LauncherConstants {
 	 * {@value}
 	 *
 	 * @see #DEACTIVATE_LISTENERS_PATTERN_PROPERTY_NAME
-	 * @see org.junit.platform.launcher.TestExecutionListener
+	 * @see TestExecutionListener
 	 */
 	public static final String DEACTIVATE_ALL_LISTENERS_PATTERN = ClassNamePatternFilterUtils.ALL_PATTERN;
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestIdentifier.java
@@ -167,7 +167,7 @@ public final class TestIdentifier implements Serializable {
 	 *
 	 * @return the display name for this identifier; never {@code null} or blank
 	 * @see #getSource()
-	 * @see org.junit.platform.engine.TestDescriptor#getDisplayName()
+	 * @see TestDescriptor#getDisplayName()
 	 */
 	public String getDisplayName() {
 		return this.displayName;
@@ -181,7 +181,7 @@ public final class TestIdentifier implements Serializable {
 	 * <p>The default implementation delegates to {@link #getDisplayName()}.
 	 *
 	 * @return the legacy reporting name; never {@code null} or blank
-	 * @see org.junit.platform.engine.TestDescriptor#getLegacyReportingName()
+	 * @see TestDescriptor#getLegacyReportingName()
 	 * @see org.junit.platform.reporting.legacy.LegacyReportingUtils
 	 */
 	@SuppressWarnings("JavadocReference")

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -33,6 +33,7 @@ import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.OutputDirectoryCreator;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.reporting.OutputDirectoryProvider;
 
 /**
  * {@code TestPlan} describes the tree of tests and containers as discovered
@@ -263,7 +264,7 @@ public class TestPlan {
 
 	/**
 	 * Get the
-	 * {@link org.junit.platform.engine.reporting.OutputDirectoryProvider} for
+	 * {@link OutputDirectoryProvider} for
 	 * this test plan.
 	 *
 	 * @return the output directory provider; never {@code null}
@@ -273,8 +274,8 @@ public class TestPlan {
 	@SuppressWarnings("removal")
 	@API(status = DEPRECATED, since = "1.14")
 	@Deprecated(since = "1.14", forRemoval = true)
-	public org.junit.platform.engine.reporting.OutputDirectoryProvider getOutputDirectoryProvider() {
-		return org.junit.platform.engine.reporting.OutputDirectoryProvider.castOrAdapt(getOutputDirectoryCreator());
+	public OutputDirectoryProvider getOutputDirectoryProvider() {
+		return OutputDirectoryProvider.castOrAdapt(getOutputDirectoryCreator());
 	}
 
 	/**

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DelegatingLauncherDiscoveryRequest.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DelegatingLauncherDiscoveryRequest.java
@@ -16,6 +16,7 @@ import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.OutputDirectoryCreator;
+import org.junit.platform.engine.reporting.OutputDirectoryProvider;
 import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -64,7 +65,7 @@ class DelegatingLauncherDiscoveryRequest implements LauncherDiscoveryRequest {
 
 	@SuppressWarnings("removal")
 	@Override
-	public org.junit.platform.engine.reporting.OutputDirectoryProvider getOutputDirectoryProvider() {
+	public OutputDirectoryProvider getOutputDirectoryProvider() {
 		return this.request.getOutputDirectoryProvider();
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -32,6 +32,7 @@ import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.OutputDirectoryCreator;
+import org.junit.platform.engine.reporting.OutputDirectoryProvider;
 import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.LauncherConstants;
 import org.junit.platform.launcher.LauncherDiscoveryListener;
@@ -88,7 +89,7 @@ import org.junit.platform.launcher.listeners.discovery.LauncherDiscoveryListener
  * @since 1.0
  * @see org.junit.platform.engine.discovery.DiscoverySelectors
  * @see org.junit.platform.engine.discovery.ClassNameFilter
- * @see org.junit.platform.launcher.EngineFilter
+ * @see EngineFilter
  * @see org.junit.platform.launcher.TagFilter
  * @see LauncherExecutionRequestBuilder
  */
@@ -310,7 +311,7 @@ public final class LauncherDiscoveryRequestBuilder {
 
 	/**
 	 * Set the
-	 * {@link org.junit.platform.engine.reporting.OutputDirectoryProvider} to use for the request.
+	 * {@link OutputDirectoryProvider} to use for the request.
 	 *
 	 * <p>If not specified, a default provider will be used that can be
 	 * configured via the {@value LauncherConstants#OUTPUT_DIR_PROPERTY_NAME}
@@ -320,7 +321,7 @@ public final class LauncherDiscoveryRequestBuilder {
 	 *                                never {@code null}
 	 * @return this builder for method chaining
 	 * @since 1.12
-	 * @see org.junit.platform.engine.reporting.OutputDirectoryProvider
+	 * @see OutputDirectoryProvider
 	 * @see LauncherConstants#OUTPUT_DIR_PROPERTY_NAME
 	 * @deprecated Please use
 	 * {@link #outputDirectoryCreator(OutputDirectoryCreator)} instead
@@ -328,8 +329,7 @@ public final class LauncherDiscoveryRequestBuilder {
 	@SuppressWarnings("removal")
 	@API(status = DEPRECATED, since = "1.14")
 	@Deprecated(since = "1.14", forRemoval = true)
-	public LauncherDiscoveryRequestBuilder outputDirectoryProvider(
-			org.junit.platform.engine.reporting.OutputDirectoryProvider outputDirectoryProvider) {
+	public LauncherDiscoveryRequestBuilder outputDirectoryProvider(OutputDirectoryProvider outputDirectoryProvider) {
 		return outputDirectoryCreator(outputDirectoryProvider);
 	}
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
@@ -45,7 +45,7 @@ import org.junit.platform.launcher.jfr.JfrUtils;
  * {@link java.util.ServiceLoader ServiceLoader} mechanism. For that purpose, a
  * text file named {@code META-INF/services/org.junit.platform.engine.TestEngine}
  * has to be added to the engine's JAR file in which the fully qualified name
- * of the implementation class of the {@link org.junit.platform.engine.TestEngine}
+ * of the implementation class of the {@link TestEngine}
  * interface is declared.
  *
  * <p>By default, test execution listeners are discovered at runtime via the

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StackTracePruningEngineExecutionListener.java
@@ -26,7 +26,7 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
  * Prunes the stack trace in case of a failed event.
  *
  * @since 1.10
- * @see org.junit.platform.commons.util.ExceptionUtils#pruneStackTrace(Throwable, List)
+ * @see ExceptionUtils#pruneStackTrace(Throwable, List)
  */
 class StackTracePruningEngineExecutionListener extends DelegatingEngineExecutionListener {
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LoggingListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/LoggingListener.java
@@ -40,7 +40,7 @@ public class LoggingListener implements TestExecutionListener {
 
 	/**
 	 * Create a {@code LoggingListener} which delegates to a
-	 * {@link java.util.logging.Logger} using a log level of
+	 * {@link Logger} using a log level of
 	 * {@link Level#FINE FINE}.
 	 *
 	 * @see #forJavaUtilLogging(Level)
@@ -52,7 +52,7 @@ public class LoggingListener implements TestExecutionListener {
 
 	/**
 	 * Create a {@code LoggingListener} which delegates to a
-	 * {@link java.util.logging.Logger} using the supplied
+	 * {@link Logger} using the supplied
 	 * {@linkplain Level log level}.
 	 *
 	 * @param logLevel the log level to use; never {@code null}

--- a/junit-platform-reporting/src/main/java/module-info.java
+++ b/junit-platform-reporting/src/main/java/module-info.java
@@ -8,6 +8,11 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.reporting.open.xml.JUnitContributor;
+import org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener;
+import org.opentest4j.reporting.tooling.spi.htmlreport.Contributor;
+
 /**
  * Defines the JUnit Platform Reporting API.
  *
@@ -29,9 +34,9 @@ module org.junit.platform.reporting {
 	exports org.junit.platform.reporting.legacy.xml;
 	exports org.junit.platform.reporting.open.xml;
 
-	provides org.junit.platform.launcher.TestExecutionListener
-			with org.junit.platform.reporting.open.xml.OpenTestReportGeneratingListener;
+	provides TestExecutionListener
+			with OpenTestReportGeneratingListener;
 
-	provides org.opentest4j.reporting.tooling.spi.htmlreport.Contributor
-			with org.junit.platform.reporting.open.xml.JUnitContributor;
+	provides Contributor
+			with JUnitContributor;
 }

--- a/junit-platform-suite-engine/src/main/java/module-info.java
+++ b/junit-platform-suite-engine/src/main/java/module-info.java
@@ -8,12 +8,15 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.suite.engine.SuiteTestEngine;
+
 /**
- * Provides a {@link org.junit.platform.engine.TestEngine} for running
+ * Provides a {@link TestEngine} for running
  * declarative test suites.
  *
  * @since 1.8
- * @provides org.junit.platform.engine.TestEngine
+ * @provides TestEngine
  */
 module org.junit.platform.suite.engine {
 
@@ -25,6 +28,6 @@ module org.junit.platform.suite.engine {
 	requires org.junit.platform.engine;
 	requires org.junit.platform.launcher;
 
-	provides org.junit.platform.engine.TestEngine
-			with org.junit.platform.suite.engine.SuiteTestEngine;
+	provides TestEngine
+			with SuiteTestEngine;
 }

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteLauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteLauncherDiscoveryRequestBuilder.java
@@ -71,10 +71,10 @@ import org.junit.platform.suite.api.SelectUris;
  * suite execution.
  *
  * @since 1.8 (originally in junit-platform-suite-commons)
- * @see org.junit.platform.engine.discovery.DiscoverySelectors
- * @see org.junit.platform.engine.discovery.ClassNameFilter
- * @see org.junit.platform.launcher.EngineFilter
- * @see org.junit.platform.launcher.TagFilter
+ * @see DiscoverySelectors
+ * @see ClassNameFilter
+ * @see EngineFilter
+ * @see TagFilter
  */
 final class SuiteLauncherDiscoveryRequestBuilder {
 

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestEngine.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestEngine.java
@@ -27,7 +27,7 @@ import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 
 /**
- * The JUnit Platform Suite {@link org.junit.platform.engine.TestEngine TestEngine}.
+ * The JUnit Platform Suite {@link TestEngine TestEngine}.
  *
  * @since 1.8
  */

--- a/junit-platform-testkit/src/main/java/module-info.java
+++ b/junit-platform-testkit/src/main/java/module-info.java
@@ -8,11 +8,13 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import org.junit.platform.engine.TestEngine;
+
 /**
  * Defines the Test Kit API for the JUnit Platform.
  *
  * @since 1.4
- * @uses org.junit.platform.engine.TestEngine
+ * @uses TestEngine
  */
 module org.junit.platform.testkit {
 
@@ -28,5 +30,5 @@ module org.junit.platform.testkit {
 	// exports org.junit.platform.testkit; empty package
 	exports org.junit.platform.testkit.engine;
 
-	uses org.junit.platform.engine.TestEngine;
+	uses TestEngine;
 }

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EngineTestKit.java
@@ -41,6 +41,7 @@ import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.OutputDirectoryCreator;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.reporting.OutputDirectoryProvider;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.engine.support.store.NamespacedHierarchicalStore;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -143,7 +144,7 @@ public final class EngineTestKit {
 	 * mechanism, analogous to the manner in which test engines are loaded in
 	 * the JUnit Platform Launcher API.
 	 *
-	 * <p>{@link org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder}
+	 * <p>{@link LauncherDiscoveryRequestBuilder}
 	 * provides a convenient way to build an appropriate discovery request to
 	 * supply to this method. As an alternative, consider using
 	 * {@link #engine(TestEngine)} for a more fluent API.
@@ -169,7 +170,7 @@ public final class EngineTestKit {
 	 * Discover tests for the given {@link LauncherDiscoveryRequest} using the
 	 * supplied {@link TestEngine}.
 	 *
-	 * <p>{@link org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder}
+	 * <p>{@link LauncherDiscoveryRequestBuilder}
 	 * provides a convenient way to build an appropriate discovery request to
 	 * supply to this method. As an alternative, consider using
 	 * {@link #engine(TestEngine)} for a more fluent API.
@@ -202,7 +203,7 @@ public final class EngineTestKit {
 	 * mechanism, analogous to the manner in which test engines are loaded in
 	 * the JUnit Platform Launcher API.
 	 *
-	 * <p>{@link org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder}
+	 * <p>{@link LauncherDiscoveryRequestBuilder}
 	 * provides a convenient way to build an appropriate discovery request to
 	 * supply to this method. As an alternative, consider using
 	 * {@link #engine(TestEngine)} for a more fluent API.
@@ -227,7 +228,7 @@ public final class EngineTestKit {
 	 * Execute tests for the given {@link LauncherDiscoveryRequest} using the
 	 * supplied {@link TestEngine}.
 	 *
-	 * <p>{@link org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder}
+	 * <p>{@link LauncherDiscoveryRequestBuilder}
 	 * provides a convenient way to build an appropriate discovery request to
 	 * supply to this method. As an alternative, consider using
 	 * {@link #engine(TestEngine)} for a more fluent API.
@@ -443,7 +444,7 @@ public final class EngineTestKit {
 
 		/**
 		 * Set the
-		 * {@link org.junit.platform.engine.reporting.OutputDirectoryProvider}
+		 * {@link OutputDirectoryProvider}
 		 * to use.
 		 *
 		 * <p>If not specified, a default provider will be used that throws an
@@ -454,15 +455,14 @@ public final class EngineTestKit {
 		 * never {@code null}
 		 * @return this builder for method chaining
 		 * @since 1.12
-		 * @see org.junit.platform.engine.reporting.OutputDirectoryProvider
+		 * @see OutputDirectoryProvider
 		 * @deprecated Please use
 		 * {@link #outputDirectoryCreator(OutputDirectoryCreator)} instead
 		 */
 		@SuppressWarnings("removal")
 		@Deprecated(since = "1.14", forRemoval = true)
 		@API(status = DEPRECATED, since = "1.14")
-		public Builder outputDirectoryProvider(
-				org.junit.platform.engine.reporting.OutputDirectoryProvider outputDirectoryProvider) {
+		public Builder outputDirectoryProvider(OutputDirectoryProvider outputDirectoryProvider) {
 			return outputDirectoryCreator(outputDirectoryProvider);
 		}
 

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
@@ -351,11 +351,11 @@ public final class Events {
 	 * Shortcut for {@code org.assertj.core.api.Assertions.assertThat(events.list())}.
 	 *
 	 * @return an instance of {@link ListAssert} for events; never {@code null}
-	 * @see org.assertj.core.api.Assertions#assertThat(List)
-	 * @see org.assertj.core.api.ListAssert
+	 * @see Assertions#assertThat(List)
+	 * @see ListAssert
 	 */
 	public ListAssert<Event> assertThatEvents() {
-		return org.assertj.core.api.Assertions.assertThat(list());
+		return Assertions.assertThat(list());
 	}
 
 	// --- Diagnostics ---------------------------------------------------------

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Executions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Executions.java
@@ -181,7 +181,7 @@ public final class Executions {
 	 *
 	 * @return an instance of {@link ListAssert} for executions; never {@code null}
 	 * @see org.assertj.core.api.Assertions#assertThat(List)
-	 * @see org.assertj.core.api.ListAssert
+	 * @see ListAssert
 	 */
 	public ListAssert<Execution> assertThatExecutions() {
 		return org.assertj.core.api.Assertions.assertThat(list());

--- a/junit-vintage-engine/src/main/java/module-info.java
+++ b/junit-vintage-engine/src/main/java/module-info.java
@@ -8,12 +8,15 @@
  * https://www.eclipse.org/legal/epl-v20.html
  */
 
+import org.junit.platform.engine.TestEngine;
+import org.junit.vintage.engine.VintageTestEngine;
+
 /**
- * Provides a {@link org.junit.platform.engine.TestEngine} for running JUnit 3
+ * Provides a {@link TestEngine} for running JUnit 3
  * and 4 based tests on the platform.
  *
  * @since 4.12
- * @provides org.junit.platform.engine.TestEngine The {@code VintageTestEngine}
+ * @provides TestEngine The {@code VintageTestEngine}
  * runs JUnit 3 and 4 based tests on the platform.
  */
 @SuppressWarnings("deprecation")
@@ -25,6 +28,6 @@ module org.junit.vintage.engine {
 	requires junit; // 4
 	requires org.junit.platform.engine;
 
-	provides org.junit.platform.engine.TestEngine
-			with org.junit.vintage.engine.VintageTestEngine;
+	provides TestEngine
+			with VintageTestEngine;
 }

--- a/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit3/JUnit3SuiteWithSingleTestCaseWithSingleTestWhichFails.java
+++ b/junit-vintage-engine/src/testFixtures/java/org/junit/vintage/engine/samples/junit3/JUnit3SuiteWithSingleTestCaseWithSingleTestWhichFails.java
@@ -10,6 +10,7 @@
 
 package org.junit.vintage.engine.samples.junit3;
 
+import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
@@ -18,7 +19,7 @@ import junit.framework.TestSuite;
  */
 public class JUnit3SuiteWithSingleTestCaseWithSingleTestWhichFails extends TestCase {
 
-	public static junit.framework.Test suite() {
+	public static Test suite() {
 		var suite = new TestSuite();
 		suite.addTestSuite(PlainJUnit3TestCaseWithSingleTestWhichFails.class);
 		return suite;

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/HeavyweightTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/extension/HeavyweightTests.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 /**
- * Unit tests for {@link org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource}
+ * Unit tests for {@link ExtensionContext.Store.CloseableResource}
  * stored values.
  *
  * @since 1.1

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptorTests.java
@@ -46,7 +46,7 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
  * and {@link TestMethodTestDescriptor}.
  *
  * @since 5.0
- * @see org.junit.jupiter.engine.descriptor.LifecycleMethodUtilsTests
+ * @see LifecycleMethodUtilsTests
  */
 class JupiterTestDescriptorTests {
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedProgrammaticExtensionRegistrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedProgrammaticExtensionRegistrationTests.java
@@ -46,7 +46,7 @@ class OrderedProgrammaticExtensionRegistrationTests extends AbstractJupiterTestE
 
 	/**
 	 * This method basically verifies the implementation of
-	 * {@link java.lang.String#hashCode()} (which needn't really be tested)
+	 * {@link String#hashCode()} (which needn't really be tested)
 	 * in order to make reasonable assumptions about how fields are sorted
 	 * in {@link org.junit.platform.commons.util.ReflectionUtils#defaultFieldSorter(Field, Field)}.
 	 *

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
@@ -1720,7 +1720,7 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 		@Parameter(1)
 		String s;
 
-		@org.junit.jupiter.api.Test
+		@Test
 		void test() {
 			fail("should not be called");
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/AnnotationBasedArgumentsProviderTests.java
@@ -31,9 +31,8 @@ class AnnotationBasedArgumentsProviderTests {
 
 	private final AnnotationBasedArgumentsProvider<CsvSource> annotationBasedArgumentsProvider = new AnnotationBasedArgumentsProvider<>() {
 		@Override
-		protected Stream<? extends Arguments> provideArguments(
-				org.junit.jupiter.params.support.ParameterDeclarations parameters, ExtensionContext context,
-				CsvSource annotation) {
+		protected Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters,
+				ExtensionContext context, CsvSource annotation) {
 			return Stream.of(Arguments.of(annotation));
 		}
 	};
@@ -50,7 +49,7 @@ class AnnotationBasedArgumentsProviderTests {
 	@DisplayName("should invoke the provideArguments template method with the accepted annotation")
 	void shouldInvokeTemplateMethodWithTheAnnotationProvidedToAccept() {
 		var spiedProvider = spy(annotationBasedArgumentsProvider);
-		var parameters = mock(org.junit.jupiter.params.support.ParameterDeclarations.class);
+		var parameters = mock(ParameterDeclarations.class);
 		var extensionContext = mock(ExtensionContext.class);
 		var annotation = csvSource("0", "1", "2");
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/EnumArgumentsProviderTests.java
@@ -82,7 +82,7 @@ class EnumArgumentsProviderTests {
 
 	@Test
 	void providesEnumConstantsBasedOnTestMethod() {
-		org.junit.jupiter.params.support.ParameterDeclaration firstParameterDeclaration = mock();
+		ParameterDeclaration firstParameterDeclaration = mock();
 		when(firstParameterDeclaration.getParameterType()).thenAnswer(__ -> EnumWithFourConstants.class);
 		when(parameters.getFirst()).thenReturn(Optional.of(firstParameterDeclaration));
 

--- a/platform-tests/src/test/java/org/junit/platform/TestEngineTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/TestEngineTests.java
@@ -22,7 +22,7 @@ import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
 
 /**
- * Test cases for default implementations of {@link org.junit.platform.engine.TestEngine}.
+ * Test cases for default implementations of {@link TestEngine}.
  *
  * <p>Note: the package {@code org.junit.platform} this class resides in is
  * chosen on purpose. If it was in {@code org.junit.platform.engine} the default

--- a/platform-tooling-support-tests/src/archUnit/java/platform/tooling/support/tests/ArchUnitTests.java
+++ b/platform-tooling-support-tests/src/archUnit/java/platform/tooling/support/tests/ArchUnitTests.java
@@ -62,9 +62,12 @@ import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.api.extension.MediaType;
+import org.junit.platform.commons.support.Resource;
 import org.junit.platform.commons.support.scanning.ClasspathScanner;
 import org.junit.platform.engine.OutputDirectoryCreator;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.reporting.OutputDirectoryProvider;
 
 @AnalyzeClasses(packages = { "org.junit.platform", "org.junit.jupiter", "org.junit.vintage" })
 class ArchUnitTests {
@@ -160,18 +163,17 @@ class ArchUnitTests {
 				.ignoreDependency(nameContaining(".shadow."), nameContaining(".shadow.")) //
 
 				// https://github.com/junit-team/junit-framework/issues/4886
-				.ignoreDependency(TestReporter.class, org.junit.jupiter.api.extension.MediaType.class) //
+				.ignoreDependency(TestReporter.class, MediaType.class) //
 
 				// https://github.com/junit-team/junit-framework/issues/4885
-				.ignoreDependency(ClasspathScanner.class, org.junit.platform.commons.support.Resource.class) //
+				.ignoreDependency(ClasspathScanner.class, Resource.class) //
 
 				// https://github.com/junit-team/junit-framework/issues/4919
 				.ignoreDependency(org.junit.jupiter.params.support.ParameterInfo.class,
 					org.junit.jupiter.params.ParameterInfo.class)
 
 				// https://github.com/junit-team/junit-framework/issues/4923
-				.ignoreDependency(org.junit.platform.engine.reporting.OutputDirectoryProvider.class,
-					OutputDirectoryCreator.class) //
+				.ignoreDependency(OutputDirectoryProvider.class, OutputDirectoryCreator.class) //
 				.ignoreDependency(Class.forName("org.junit.platform.engine.reporting.OutputDirectoryProviderAdapter"),
 					OutputDirectoryCreator.class) //
 				.ignoreDependency(Class.forName("org.junit.platform.engine.reporting.OutputDirectoryProviderAdapter"),


### PR DESCRIPTION
- https://errorprone.info/bugpattern/UnnecessarilyFullyQualified


related to:
- https://github.com/gradle/gradle/pull/35882




again this some change to be picked by maintainer if got some spare time to recreate:

<img width="451" height="100" alt="image" src="https://github.com/user-attachments/assets/c4ab3d8a-ebb3-4136-96b0-3193567344e3" />


<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
