### PR TITLE
[prone] remove `disable` warning leftovers to finalize convention principle

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
@@ -1,6 +1,7 @@
 import junitbuild.extensions.dependencyFromLibs
 import net.ltgt.gradle.errorprone.errorprone
 import net.ltgt.gradle.nullaway.nullaway
+import org.gradle.jvm.toolchain.JvmImplementation.J9
 
 plugins {
 	`java-library`
@@ -16,17 +17,10 @@ dependencies {
 
 tasks.withType<JavaCompile>().configureEach {
 	options.errorprone {
-		val shouldDisableErrorProne = java.toolchain.implementation.orNull == JvmImplementation.J9
-		if (name == "compileJava" && !shouldDisableErrorProne) {
-			disable(
-				"AnnotateFormatMethod", // We don`t want to use ErrorProne's annotations.
-				"BadImport", // This check is opinionated wrt. which method names it considers unsuitable for import which includes a few of our own methods in `ReflectionUtils` etc.
-				"DoNotCallSuggester", // We don`t want to use ErrorProne's annotations.
-				"ImmutableEnumChecker", // We don`t want to use ErrorProne's annotations.
-				"InlineMeSuggester", // We don`t want to use ErrorProne's annotations.
-				"MissingSummary", // Produces a lot of findings that we consider to be false positives, for example for package-private classes and methods.
-				"StringSplitter", // We don`t want to use Guava.
-				"UnnecessaryLambda", // The findings of this check are subjective because a named constant can be more readable in many cases.
+		val enableErrorProne = java.toolchain.implementation.orNull != J9
+		if (name == "compileJava" && enableErrorProne) {
+			disableAllWarnings = true // considering this immense spam burden, remove this once to fix dedicated flaw. https://github.com/diffplug/spotless/pull/2766
+			disable( // We don`t want to use ErrorProne's annotations.
 				// picnic (https://error-prone.picnic.tech)
 				"ConstantNaming",
 				"DirectReturn", // We don`t want to use this: https://github.com/junit-team/junit-framework/pull/5006#discussion_r2403984446
@@ -45,18 +39,22 @@ tasks.withType<JavaCompile>().configureEach {
 			error(
 				"CanonicalAnnotationSyntax",
 				"IsInstanceLambdaUsage",
+				"MissingOverride",
 				"PackageLocation",
 				"RedundantStringConversion",
 				"RedundantStringEscape",
+				"SelfAssignment",
+				"StringCharset",
+				"StringJoin",
 			)
 		} else {
 			disableAllChecks = true
 		}
 		nullaway {
-			if (shouldDisableErrorProne) {
-				disable()
-			} else {
+			if (enableErrorProne) {
 				enable()
+			} else {
+				disable()
 			}
 			onlyNullMarked = true
 			isJSpecifyMode = true


### PR DESCRIPTION
<!-- Please describe your changes here and list any open questions you might have. -->

enabler for:

- https://github.com/junit-team/junit-framework/pull/5189

realted to:
- https://github.com/gradle/gradle/pull/35878

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
