### PR TITLE
Add `error-prone.picnic.tech/bugpatterns/NonStaticImport`

### DIFF
--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyArgumentsProvider.java
@@ -11,7 +11,6 @@
 package org.junit.jupiter.params.provider;
 
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.junit.platform.commons.util.ReflectionUtils.newInstance;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
@@ -32,6 +31,7 @@ import org.junit.jupiter.params.support.ParameterDeclaration;
 import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
  * @since 5.4
@@ -80,7 +80,7 @@ class EmptyArgumentsProvider implements ArgumentsProvider {
 		if (Collection.class.isAssignableFrom(parameterType) || Map.class.isAssignableFrom(parameterType)) {
 			Optional<Constructor<?>> defaultConstructor = getDefaultConstructor(parameterType);
 			if (defaultConstructor.isPresent()) {
-				return Stream.of(arguments(newInstance(defaultConstructor.get())));
+				return Stream.of(arguments(ReflectionUtils.newInstance(defaultConstructor.get())));
 			}
 		}
 		if (parameterType.isArray()) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/FallbackStringToObjectConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/FallbackStringToObjectConverter.java
@@ -16,7 +16,6 @@ import static org.junit.platform.commons.support.ModifierSupport.isNotStatic;
 import static org.junit.platform.commons.support.ReflectionSupport.findMethods;
 import static org.junit.platform.commons.support.ReflectionSupport.invokeMethod;
 import static org.junit.platform.commons.util.ReflectionUtils.findConstructors;
-import static org.junit.platform.commons.util.ReflectionUtils.newInstance;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -28,6 +27,7 @@ import java.util.function.Predicate;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
  * {@code FallbackStringToObjectConverter} is a {@link StringToObjectConverter}
@@ -115,7 +115,7 @@ class FallbackStringToObjectConverter implements StringToObjectConverter {
 		}
 		Constructor<?> constructor = findFactoryConstructor(targetType, parameterType);
 		if (constructor != null) {
-			return source -> newInstance(constructor, source);
+			return source -> ReflectionUtils.newInstance(constructor, source);
 		}
 		return null;
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/ShuntingYard.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/ShuntingYard.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.launcher.tagexpression;
 
-import static java.lang.Integer.MIN_VALUE;
 import static java.util.Objects.requireNonNull;
 import static org.junit.platform.launcher.tagexpression.Operator.nullaryOperator;
 import static org.junit.platform.launcher.tagexpression.ParseStatus.emptyTagExpression;
@@ -34,7 +33,7 @@ class ShuntingYard {
 
 	private static final Operator RightParenthesis = nullaryOperator(")", -1);
 	private static final Operator LeftParenthesis = nullaryOperator("(", -2);
-	private static final Operator Sentinel = nullaryOperator("sentinel", MIN_VALUE);
+	private static final Operator Sentinel = nullaryOperator("sentinel", Integer.MIN_VALUE);
 	private static final Token SentinelToken = new Token(-1, "");
 
 	private final Operators validOperators = new Operators();

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.testkit.engine;
 
-import static java.util.Collections.sort;
 import static java.util.function.Predicate.isEqual;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.FunctionUtils.where;
@@ -22,6 +21,7 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -457,7 +457,7 @@ public final class Events {
 
 	private static boolean isNotInIncreasingOrder(List<Integer> indices) {
 		List<Integer> copy = new ArrayList<>(indices);
-		sort(copy);
+		Collections.sort(copy);
 
 		return !indices.equals(copy);
 	}


### PR DESCRIPTION
### Add `error-prone.picnic.tech/bugpatterns/NonStaticImport`


- https://error-prone.picnic.tech/bugpatterns/NonStaticImport


related to:
- https://github.com/junit-team/junit-framework/pull/5189
- https://github.com/junit-team/junit-framework/pull/5190
- https://github.com/diffplug/spotless/issues/2743
- https://github.com/junit-team/junit-framework/pull/5193





<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
