### PR TITLE
[picnic] fix `StaticImport`

### DIFF
--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
@@ -1,6 +1,8 @@
 import junitbuild.extensions.dependencyFromLibs
 import net.ltgt.gradle.errorprone.errorprone
 import net.ltgt.gradle.nullaway.nullaway
+import org.gradle.jvm.toolchain.JvmImplementation.J9
+import java.lang.System.getenv
 
 plugins {
 	`java-library`
@@ -16,51 +18,56 @@ dependencies {
 
 tasks.withType<JavaCompile>().configureEach {
 	options.errorprone {
-		val shouldDisableErrorProne = java.toolchain.implementation.orNull == JvmImplementation.J9
-		if (name == "compileJava" && !shouldDisableErrorProne) {
-			disable(
-				"AnnotateFormatMethod", // We don`t want to use ErrorProne's annotations.
-				"BadImport", // This check is opinionated wrt. which method names it considers unsuitable for import which includes a few of our own methods in `ReflectionUtils` etc.
-				"DoNotCallSuggester", // We don`t want to use ErrorProne's annotations.
-				"ImmutableEnumChecker", // We don`t want to use ErrorProne's annotations.
-				"InlineMeSuggester", // We don`t want to use ErrorProne's annotations.
-				"MissingSummary", // Produces a lot of findings that we consider to be false positives, for example for package-private classes and methods.
-				"StringSplitter", // We don`t want to use Guava.
-				"UnnecessaryLambda", // The findings of this check are subjective because a named constant can be more readable in many cases.
+		val enableErrorProne = java.toolchain.implementation.orNull != J9
+		if (enableErrorProne && name == "compileJava") {
+			disableAllWarnings = true // considering this immense spam burden, remove this once to fix dedicated flaw. https://github.com/diffplug/spotless/pull/2766
+			disable( // We don`t want to use ErrorProne's annotations.
 				// picnic (https://error-prone.picnic.tech)
 				"ConstantNaming",
-				"DirectReturn", // We don`t want to use this: https://github.com/junit-team/junit-framework/pull/5006#discussion_r2403984446
+				"DirectReturn", // We don`t want to use this. https://github.com/junit-team/junit-framework/pull/5006#discussion_r2403984446
 				"FormatStringConcatenation",
 				"IdentityConversion",
-				"LexicographicalAnnotationAttributeListing", // We don`t want to use this: https://github.com/junit-team/junit-framework/pull/5043#pullrequestreview-3330615838
+				"LexicographicalAnnotationAttributeListing", // We don`t want to use this. https://github.com/junit-team/junit-framework/pull/5043#pullrequestreview-3330615838
 				"LexicographicalAnnotationListing",
 				"MissingTestCall",
 				"NestedOptionals",
-				"NonStaticImport",
 				"OptionalOrElseGet",
 				"PrimitiveComparison",
-				"StaticImport",
 				"TimeZoneUsage",
 			)
 			error(
 				"CanonicalAnnotationSyntax",
 				"IsInstanceLambdaUsage",
+				"MissingOverride",
+				"NonStaticImport",
 				"PackageLocation",
 				"RedundantStringConversion",
 				"RedundantStringEscape",
+				"SelfAssignment",
+				"StaticImport",
+				"StringCharset",
+				"StringJoin",
 			)
+			if (!getenv().containsKey("CI") && getenv("IN_PLACE").toBoolean()) {
+				errorproneArgs.addAll(
+					"-XepPatchLocation:IN_PLACE",
+					"-XepPatchChecks:" +
+							"NonStaticImport," +
+							"StaticImport,"
+				)
+			}
 		} else {
 			disableAllChecks = true
 		}
 		nullaway {
-			if (shouldDisableErrorProne) {
-				disable()
-			} else {
+			if (enableErrorProne) {
 				enable()
+			} else {
+				disable()
 			}
-			onlyNullMarked = true
-			isJSpecifyMode = true
 			checkContracts = true
+			isJSpecifyMode = true
+			onlyNullMarked = true
 			suppressionNameAliases.add("DataFlowIssue")
 		}
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/ClassOrderer.java
@@ -10,11 +10,12 @@
 
 package org.junit.jupiter.api;
 
+import static java.util.Collections.shuffle;
+import static java.util.Comparator.comparing;
 import static java.util.Comparator.comparingInt;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
-import java.util.Collections;
 import java.util.Comparator;
 
 import org.apiguardian.api.API;
@@ -148,7 +149,7 @@ public interface ClassOrderer {
 			context.getClassDescriptors().sort(comparator);
 		}
 
-		private static final Comparator<ClassDescriptor> comparator = Comparator.comparing(
+		private static final Comparator<ClassDescriptor> comparator = comparing(
 			descriptor -> descriptor.getTestClass().getName());
 	}
 
@@ -171,8 +172,7 @@ public interface ClassOrderer {
 			context.getClassDescriptors().sort(comparator);
 		}
 
-		private static final Comparator<ClassDescriptor> comparator = Comparator.comparing(
-			ClassDescriptor::getDisplayName);
+		private static final Comparator<ClassDescriptor> comparator = comparing(ClassDescriptor::getDisplayName);
 	}
 
 	/**
@@ -265,7 +265,7 @@ public interface ClassOrderer {
 		 */
 		@Override
 		public void orderClasses(ClassOrdererContext context) {
-			Collections.shuffle(context.getClassDescriptors(),
+			shuffle(context.getClassDescriptors(),
 				new java.util.Random(RandomOrdererUtils.getSeed(context::getConfigurationParameter, logger)));
 		}
 	}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/MethodOrderer.java
@@ -10,12 +10,13 @@
 
 package org.junit.jupiter.api;
 
+import static java.util.Collections.shuffle;
+import static java.util.Comparator.comparing;
 import static java.util.Comparator.comparingInt;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
 
@@ -214,8 +215,7 @@ public interface MethodOrderer {
 			context.getMethodDescriptors().sort(comparator);
 		}
 
-		private static final Comparator<MethodDescriptor> comparator = Comparator.comparing(
-			MethodDescriptor::getDisplayName);
+		private static final Comparator<MethodDescriptor> comparator = comparing(MethodDescriptor::getDisplayName);
 	}
 
 	/**
@@ -308,7 +308,7 @@ public interface MethodOrderer {
 		 */
 		@Override
 		public void orderMethods(MethodOrdererContext context) {
-			Collections.shuffle(context.getMethodDescriptors(),
+			shuffle(context.getMethodDescriptors(),
 				new java.util.Random(RandomOrdererUtils.getSeed(context::getConfigurationParameter, logger)));
 		}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstancePreDestroyCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstancePreDestroyCallback.java
@@ -10,10 +10,10 @@
 
 package org.junit.jupiter.api.extension;
 
+import static java.util.Collections.reverse;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -114,7 +114,7 @@ public interface TestInstancePreDestroyCallback extends Extension {
 			current.get().getTestInstances().map(TestInstances::getAllInstances).ifPresent(
 				destroyedInstances::removeAll);
 		}
-		Collections.reverse(destroyedInstances);
+		reverse(destroyedInstances);
 		destroyedInstances.forEach(callback);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import static java.util.Collections.reverse;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.apiguardian.api.API.Status.INTERNAL;
@@ -30,7 +31,6 @@ import static org.junit.jupiter.engine.support.JupiterThrowableCollectorFactory.
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -516,7 +516,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 		// synthesized AfterEachMethodAdapters are executed within TestMethodTestDescriptor,
 		// we have to reverse the afterEachMethods list to put them in top-down order before
 		// we register them as synthesized extensions.
-		Collections.reverse(afterEachMethods);
+		reverse(afterEachMethods);
 
 		registerMethodsAsExtensions(afterEachMethods, registrar, this::synthesizeAfterEachMethodAdapter);
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.engine.descriptor;
 
+import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
@@ -226,7 +227,7 @@ final class ExtensionUtils {
 	 * @since 5.4
 	 */
 	private static final Comparator<Field> orderComparator = //
-		Comparator.comparingInt(ExtensionUtils::getOrder);
+		comparingInt(ExtensionUtils::getOrder);
 
 	/**
 	 * @since 5.4

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -11,6 +11,7 @@
 package org.junit.jupiter.engine.descriptor;
 
 import static java.util.Collections.emptySet;
+import static java.util.Collections.reverse;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
@@ -108,7 +109,7 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 			Throwable throwable, ExceptionHandlerInvoker<E> handlerInvoker) {
 
 		List<E> extensions = registry.getExtensions(handlerType);
-		Collections.reverse(extensions);
+		reverse(extensions);
 		invokeExecutionExceptionHandlers(extensions, throwable, handlerInvoker);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultTestInstances.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultTestInstances.java
@@ -10,10 +10,10 @@
 
 package org.junit.jupiter.engine.execution;
 
+import static java.util.Collections.unmodifiableList;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Optional;
@@ -32,7 +32,7 @@ public class DefaultTestInstances implements TestInstances {
 	public static DefaultTestInstances of(TestInstances testInstances, Object instance) {
 		List<Object> allInstances = new ArrayList<>(testInstances.getAllInstances());
 		allInstances.add(instance);
-		return new DefaultTestInstances(Collections.unmodifiableList(allInstances));
+		return new DefaultTestInstances(unmodifiableList(allInstances));
 	}
 
 	private final List<Object> instances;

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -12,6 +12,7 @@ package org.junit.jupiter.engine.extension;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.FileVisitResult.SKIP_SUBTREE;
+import static java.util.Collections.emptySortedMap;
 import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.extension.TestInstantiationAwareExtension.ExtensionContextScope.TEST_METHOD;
 import static org.junit.jupiter.api.io.CleanupMode.DEFAULT;
@@ -39,7 +40,6 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributeView;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedMap;
@@ -371,7 +371,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 
 			Path rootDir = this.dir;
 			if (rootDir == null || Files.notExists(rootDir)) {
-				return Collections.emptySortedMap();
+				return emptySortedMap();
 			}
 
 			SortedMap<Path, IOException> failures = new TreeMap<>();

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/TestRuleSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/TestRuleSupport.java
@@ -10,6 +10,7 @@
 
 package org.junit.jupiter.migrationsupport.rules;
 
+import static java.util.Collections.reverse;
 import static java.util.Collections.unmodifiableList;
 import static org.junit.platform.commons.support.AnnotationSupport.findPublicAnnotatedFields;
 import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
@@ -19,7 +20,6 @@ import static org.junit.platform.commons.support.ReflectionSupport.findMethods;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -74,7 +74,7 @@ class TestRuleSupport implements BeforeEachCallback, TestExecutionExceptionHandl
 		// Due to how rules are applied (see RunRules), the last rule gets called first.
 		// Rules from fields get called before those from methods.
 		// Thus, we first add methods and then fields and reverse the list in the end.
-		Collections.reverse(result);
+		reverse(result);
 		return unmodifiableList(result);
 	}
 
@@ -120,7 +120,7 @@ class TestRuleSupport implements BeforeEachCallback, TestExecutionExceptionHandl
 
 		List<TestRuleAnnotatedMember> ruleAnnotatedMembers = getRuleAnnotatedMembers(context);
 		if (reverseOrder) {
-			Collections.reverse(ruleAnnotatedMembers);
+			reverse(ruleAnnotatedMembers);
 		}
 
 		AtomicInteger counter = new AtomicInteger();

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeArgumentConverter.java
@@ -10,6 +10,8 @@
 
 package org.junit.jupiter.params.converter;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -23,7 +25,6 @@ import java.time.chrono.ChronoLocalDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalQuery;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -48,7 +49,7 @@ class JavaTimeArgumentConverter extends AnnotationBasedArgumentConverter<JavaTim
 		queries.put(Year.class, Year::from);
 		queries.put(YearMonth.class, YearMonth::from);
 		queries.put(ZonedDateTime.class, ZonedDateTime::from);
-		TEMPORAL_QUERIES = Collections.unmodifiableMap(queries);
+		TEMPORAL_QUERIES = unmodifiableMap(queries);
 	}
 
 	@Override

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvReaderFactory.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvReaderFactory.java
@@ -12,12 +12,12 @@ package org.junit.jupiter.params.provider;
 
 import static de.siegmar.fastcsv.reader.CommentStrategy.NONE;
 import static de.siegmar.fastcsv.reader.CommentStrategy.SKIP;
+import static java.util.UUID.randomUUID;
 
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.nio.charset.Charset;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import de.siegmar.fastcsv.reader.CommentStrategy;
@@ -189,7 +189,7 @@ class CsvReaderFactory {
 		 * <p>The marker is generated with a unique ID to ensure it cannot conflict
 		 * with actual CSV content.
 		 */
-		static final String NULL_MARKER = "<null marker: %s>".formatted(UUID.randomUUID());
+		static final String NULL_MARKER = "<null marker: %s>".formatted(randomUUID());
 
 		@Override
 		public String modify(long unusedStartingLineNumber, int unusedFieldIdx, boolean quoted, String field) {

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/EmptyArgumentsProvider.java
@@ -10,13 +10,18 @@
 
 package org.junit.jupiter.params.provider;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptyNavigableMap;
+import static java.util.Collections.emptyNavigableSet;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.emptySortedMap;
+import static java.util.Collections.emptySortedSet;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.junit.platform.commons.util.ReflectionUtils.newInstance;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -32,6 +37,7 @@ import org.junit.jupiter.params.support.ParameterDeclaration;
 import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
  * @since 5.4
@@ -54,33 +60,33 @@ class EmptyArgumentsProvider implements ArgumentsProvider {
 			return Stream.of(arguments(""));
 		}
 		if (Collection.class.equals(parameterType)) {
-			return Stream.of(arguments(Collections.emptySet()));
+			return Stream.of(arguments(emptySet()));
 		}
 		if (List.class.equals(parameterType)) {
-			return Stream.of(arguments(Collections.emptyList()));
+			return Stream.of(arguments(emptyList()));
 		}
 		if (Set.class.equals(parameterType)) {
-			return Stream.of(arguments(Collections.emptySet()));
+			return Stream.of(arguments(emptySet()));
 		}
 		if (SortedSet.class.equals(parameterType)) {
-			return Stream.of(arguments(Collections.emptySortedSet()));
+			return Stream.of(arguments(emptySortedSet()));
 		}
 		if (NavigableSet.class.equals(parameterType)) {
-			return Stream.of(arguments(Collections.emptyNavigableSet()));
+			return Stream.of(arguments(emptyNavigableSet()));
 		}
 		if (Map.class.equals(parameterType)) {
-			return Stream.of(arguments(Collections.emptyMap()));
+			return Stream.of(arguments(emptyMap()));
 		}
 		if (SortedMap.class.equals(parameterType)) {
-			return Stream.of(arguments(Collections.emptySortedMap()));
+			return Stream.of(arguments(emptySortedMap()));
 		}
 		if (NavigableMap.class.equals(parameterType)) {
-			return Stream.of(arguments(Collections.emptyNavigableMap()));
+			return Stream.of(arguments(emptyNavigableMap()));
 		}
 		if (Collection.class.isAssignableFrom(parameterType) || Map.class.isAssignableFrom(parameterType)) {
 			Optional<Constructor<?>> defaultConstructor = getDefaultConstructor(parameterType);
 			if (defaultConstructor.isPresent()) {
-				return Stream.of(arguments(newInstance(defaultConstructor.get())));
+				return Stream.of(arguments(ReflectionUtils.newInstance(defaultConstructor.get())));
 			}
 		}
 		if (parameterType.isArray()) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/ReflectionSupport.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.commons.support;
 
+import static java.util.stream.Collectors.toCollection;
 import static org.apiguardian.api.API.Status.DEPRECATED;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
@@ -22,7 +23,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
@@ -787,7 +787,7 @@ public final class ReflectionSupport {
 
 	@SuppressWarnings("removal")
 	static Set<Resource> toSupportResourcesSet(Set<org.junit.platform.commons.io.Resource> resources) {
-		return toSupportResourcesStream(resources.stream()).collect(Collectors.toCollection(LinkedHashSet::new));
+		return toSupportResourcesStream(resources.stream()).collect(toCollection(LinkedHashSet::new));
 	}
 
 	@SuppressWarnings("removal")

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/FallbackStringToObjectConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/FallbackStringToObjectConverter.java
@@ -16,7 +16,6 @@ import static org.junit.platform.commons.support.ModifierSupport.isNotStatic;
 import static org.junit.platform.commons.support.ReflectionSupport.findMethods;
 import static org.junit.platform.commons.support.ReflectionSupport.invokeMethod;
 import static org.junit.platform.commons.util.ReflectionUtils.findConstructors;
-import static org.junit.platform.commons.util.ReflectionUtils.newInstance;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -28,6 +27,7 @@ import java.util.function.Predicate;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 /**
  * {@code FallbackStringToObjectConverter} is a {@link StringToObjectConverter}
@@ -115,7 +115,7 @@ class FallbackStringToObjectConverter implements StringToObjectConverter {
 		}
 		Constructor<?> constructor = findFactoryConstructor(targetType, parameterType);
 		if (constructor != null) {
-			return source -> newInstance(constructor, source);
+			return source -> ReflectionUtils.newInstance(constructor, source);
 		}
 		return null;
 	}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -11,6 +11,7 @@
 package org.junit.platform.commons.util;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static org.apiguardian.api.API.Status.INTERNAL;
 import static org.junit.platform.commons.util.ReflectionUtils.isInnerClass;
@@ -26,7 +27,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -258,7 +258,7 @@ public final class AnnotationUtils {
 			@Nullable Optional<? extends AnnotatedElement> element, Class<A> annotationType) {
 
 		if (element == null || element.isEmpty()) {
-			return Collections.emptyList();
+			return emptyList();
 		}
 
 		return findRepeatableAnnotations(element.get(), annotationType);
@@ -288,7 +288,7 @@ public final class AnnotationUtils {
 
 		// Short circuit the search algorithm.
 		if (element == null) {
-			return Collections.emptyList();
+			return emptyList();
 		}
 
 		// We use a LinkedHashSet because the search algorithm may discover

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.commons.util;
 
+import static java.util.function.Function.identity;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Arrays;
@@ -63,7 +64,7 @@ public class ClassNamePatternFilterUtils {
 	 * @param patterns a comma-separated list of patterns
 	 */
 	public static Predicate<String> excludeMatchingClassNames(@Nullable String patterns) {
-		return matchingClasses(patterns, Function.identity(), FilterType.EXCLUDE);
+		return matchingClasses(patterns, identity(), FilterType.EXCLUDE);
 	}
 
 	/**
@@ -84,7 +85,7 @@ public class ClassNamePatternFilterUtils {
 	 * @param patterns a comma-separated list of patterns
 	 */
 	public static Predicate<String> includeMatchingClassNames(@Nullable String patterns) {
-		return matchingClasses(patterns, Function.identity(), FilterType.INCLUDE);
+		return matchingClasses(patterns, identity(), FilterType.INCLUDE);
 	}
 
 	private enum FilterType {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.commons.util;
 
+import static java.util.Collections.reverse;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.io.PrintWriter;
@@ -17,7 +18,6 @@ import java.io.StringWriter;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -131,7 +131,7 @@ public final class ExceptionUtils {
 		List<StackTraceElement> prunedStackTrace = new ArrayList<>();
 		List<StackTraceElement> junitStartStackTrace = new ArrayList<>(0);
 
-		Collections.reverse(stackTrace);
+		reverse(stackTrace);
 
 		for (int i = 0; i < stackTrace.size(); i++) {
 			StackTraceElement element = stackTrace.get(i);
@@ -163,7 +163,7 @@ public final class ExceptionUtils {
 			prunedStackTrace = junitStartStackTrace;
 		}
 
-		Collections.reverse(prunedStackTrace);
+		reverse(prunedStackTrace);
 		throwable.setStackTrace(prunedStackTrace.toArray(new StackTraceElement[0]));
 	}
 

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java
@@ -10,7 +10,9 @@
 
 package org.junit.platform.commons.util;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.synchronizedMap;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 import static org.apiguardian.api.API.Status.INTERNAL;
@@ -213,7 +215,7 @@ public final class ReflectionUtils {
 			classNamesToTypes.put(type.getCanonicalName(), type);
 		});
 
-		classNameToTypeMap = Collections.unmodifiableMap(classNamesToTypes);
+		classNameToTypeMap = unmodifiableMap(classNamesToTypes);
 
 		primitiveToWrapperMap = createPrimitivesToWrapperMap();
 	}
@@ -231,7 +233,7 @@ public final class ReflectionUtils {
 		primitivesToWrappers.put(float.class, Float.class);
 		primitivesToWrappers.put(double.class, Double.class);
 
-		return Collections.unmodifiableMap(primitivesToWrappers);
+		return unmodifiableMap(primitivesToWrappers);
 	}
 
 	public static boolean isPublic(Class<?> clazz) {
@@ -1830,7 +1832,7 @@ public final class ReflectionUtils {
 	private static List<Field> getSuperclassFields(Class<?> clazz, HierarchyTraversalMode traversalMode) {
 		Class<?> superclass = clazz.getSuperclass();
 		if (!isSearchable(superclass)) {
-			return Collections.emptyList();
+			return emptyList();
 		}
 		return findAllFieldsInHierarchy(superclass, traversalMode);
 	}
@@ -1838,7 +1840,7 @@ public final class ReflectionUtils {
 	private static List<Method> getSuperclassMethods(Class<?> clazz, HierarchyTraversalMode traversalMode) {
 		Class<?> superclass = clazz.getSuperclass();
 		if (!isSearchable(superclass)) {
-			return Collections.emptyList();
+			return emptyList();
 		}
 		return findAllMethodsInHierarchy(superclass, traversalMode);
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/ListTestEnginesCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/ListTestEnginesCommand.java
@@ -10,8 +10,9 @@
 
 package org.junit.platform.console.command;
 
+import static java.util.Comparator.comparing;
+
 import java.io.PrintWriter;
-import java.util.Comparator;
 import java.util.StringJoiner;
 import java.util.stream.StreamSupport;
 
@@ -36,7 +37,7 @@ class ListTestEnginesCommand extends BaseCommand<Void> {
 		ServiceLoaderTestEngineRegistry registry = new ServiceLoaderTestEngineRegistry();
 		Iterable<TestEngine> engines = registry.loadTestEngines();
 		StreamSupport.stream(engines.spliterator(), false) //
-				.sorted(Comparator.comparing(TestEngine::getId)) //
+				.sorted(comparing(TestEngine::getId)) //
 				.forEach(engine -> displayEngine(out, engine));
 		out.flush();
 	}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/output/ColorPalette.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/output/ColorPalette.java
@@ -10,20 +10,20 @@
 
 package org.junit.platform.console.output;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 
@@ -96,11 +96,11 @@ public class ColorPalette {
 	}
 
 	private static Map<Style, String> toOverrideMap(Properties properties) {
-		Map<String, String> upperCaseProperties = properties.entrySet().stream().collect(Collectors.toMap(
-			entry -> ((String) entry.getKey()).toUpperCase(Locale.ROOT), entry -> (String) entry.getValue()));
+		Map<String, String> upperCaseProperties = properties.entrySet().stream().collect(
+			toMap(entry -> ((String) entry.getKey()).toUpperCase(Locale.ROOT), entry -> (String) entry.getValue()));
 
 		return Arrays.stream(Style.values()).filter(style -> upperCaseProperties.containsKey(style.name())).collect(
-			Collectors.toMap(Function.identity(), style -> upperCaseProperties.get(style.name())));
+			toMap(identity(), style -> upperCaseProperties.get(style.name())));
 	}
 
 	private static Properties getProperties(Reader reader) {
@@ -115,7 +115,7 @@ public class ColorPalette {
 	}
 
 	private static Properties getProperties(Path path) {
-		try (FileReader fileReader = new FileReader(path.toFile(), StandardCharsets.UTF_8)) {
+		try (FileReader fileReader = new FileReader(path.toFile(), UTF_8)) {
 			return getProperties(fileReader);
 		}
 		catch (IOException e) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -10,12 +10,13 @@
 
 package org.junit.platform.engine;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -135,7 +136,7 @@ public interface TestDescriptor {
 	@API(status = STABLE, since = "1.10")
 	default Set<? extends TestDescriptor> getAncestors() {
 		if (getParent().isEmpty()) {
-			return Collections.emptySet();
+			return emptySet();
 		}
 		TestDescriptor parent = getParent().get();
 		Set<TestDescriptor> ancestors = new LinkedHashSet<>();
@@ -144,7 +145,7 @@ public interface TestDescriptor {
 		if (parent.getParent().isPresent()) {
 			ancestors.addAll(parent.getAncestors());
 		}
-		return Collections.unmodifiableSet(ancestors);
+		return unmodifiableSet(ancestors);
 	}
 
 	/**
@@ -164,7 +165,7 @@ public interface TestDescriptor {
 		for (TestDescriptor child : getChildren()) {
 			descendants.addAll(child.getDescendants());
 		}
-		return Collections.unmodifiableSet(descendants);
+		return unmodifiableSet(descendants);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
@@ -10,13 +10,14 @@
 
 package org.junit.platform.engine;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.regex.Pattern.DOTALL;
 import static java.util.stream.Collectors.joining;
 
 import java.io.Serial;
 import java.io.Serializable;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -49,7 +50,7 @@ class UniqueIdFormat implements Serializable {
 	}
 
 	private static String encode(char c) {
-		return URLEncoder.encode(String.valueOf(c), StandardCharsets.UTF_8);
+		return URLEncoder.encode(String.valueOf(c), UTF_8);
 	}
 
 	private final char openSegment;
@@ -65,8 +66,7 @@ class UniqueIdFormat implements Serializable {
 		this.closeSegment = closeSegment;
 		this.segmentDelimiter = segmentDelimiter;
 		this.segmentPattern = Pattern.compile(
-			"%s(.+)%s(.+)%s".formatted(quote(openSegment), quote(typeValueSeparator), quote(closeSegment)),
-			Pattern.DOTALL);
+			"%s(.+)%s(.+)%s".formatted(quote(openSegment), quote(typeValueSeparator), quote(closeSegment)), DOTALL);
 
 		// Compute "forbidden" character encoding map.
 		// Note that the map is always empty at this point. Thus the use of
@@ -145,7 +145,7 @@ class UniqueIdFormat implements Serializable {
 	}
 
 	private static String decode(String s) {
-		return URLDecoder.decode(s, StandardCharsets.UTF_8);
+		return URLDecoder.decode(s, UTF_8);
 	}
 
 }

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/reporting/ReportEntry.java
@@ -10,11 +10,11 @@
 
 package org.junit.platform.engine.reporting;
 
+import static java.util.Collections.unmodifiableMap;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -79,7 +79,7 @@ public final class ReportEntry {
 	 * @return a copy of the map of key-value pairs; never {@code null}
 	 */
 	public Map<String, String> getKeyValuePairs() {
-		return Collections.unmodifiableMap(this.keyValuePairs);
+		return unmodifiableMap(this.keyValuePairs);
 	}
 
 	/**

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -11,10 +11,11 @@
 package org.junit.platform.engine.support.descriptor;
 
 import static java.util.Collections.emptySet;
+import static java.util.Collections.synchronizedSet;
+import static java.util.Collections.unmodifiableSet;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -66,7 +67,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 	 * <p>If a subclass overrides any of the methods related to children, this
 	 * set should be used instead of a set local to the subclass.
 	 */
-	protected final Set<TestDescriptor> children = Collections.synchronizedSet(new LinkedHashSet<>(16));
+	protected final Set<TestDescriptor> children = synchronizedSet(new LinkedHashSet<>(16));
 
 	/**
 	 * Create a new {@code AbstractTestDescriptor} with the supplied
@@ -148,7 +149,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	@Override
 	public final Set<? extends TestDescriptor> getChildren() {
-		return Collections.unmodifiableSet(this.children);
+		return unmodifiableSet(this.children);
 	}
 
 	@Override

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
@@ -11,12 +11,12 @@
 package org.junit.platform.launcher;
 
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.joining;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
@@ -168,7 +168,7 @@ public final class TagFilter {
 	}
 
 	private static String formatToString(List<String> tagExpressions) {
-		return tagExpressions.stream().map(String::strip).sorted().collect(Collectors.joining(","));
+		return tagExpressions.stream().map(String::strip).sorted().collect(joining(","));
 	}
 
 	private static List<TagExpression> parseAll(List<String> tagExpressions) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/HierarchicalOutputDirectoryCreator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/HierarchicalOutputDirectoryCreator.java
@@ -10,6 +10,8 @@
 
 package org.junit.platform.launcher.core;
 
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +33,7 @@ import org.junit.platform.engine.UniqueId.Segment;
  */
 class HierarchicalOutputDirectoryCreator implements OutputDirectoryCreator {
 
-	private static final Pattern FORBIDDEN_CHARS = Pattern.compile("[^a-z0-9.,_\\-() ]", Pattern.CASE_INSENSITIVE);
+	private static final Pattern FORBIDDEN_CHARS = Pattern.compile("[^a-z0-9.,_\\-() ]", CASE_INSENSITIVE);
 	private static final String REPLACEMENT = "_";
 
 	private final Supplier<Path> rootDirSupplier;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -11,6 +11,7 @@
 package org.junit.platform.launcher.core;
 
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,7 +29,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
@@ -70,8 +70,7 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 
 	@Override
 	public Set<String> keySet() {
-		return providers.stream().map(ParameterProvider::keySet).flatMap(Collection::stream).collect(
-			Collectors.toSet());
+		return providers.stream().map(ParameterProvider::keySet).flatMap(Collection::stream).collect(toSet());
 	}
 
 	private @Nullable String getProperty(String key) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ListenerRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ListenerRegistry.java
@@ -10,10 +10,11 @@
 
 package org.junit.platform.launcher.core;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -89,7 +90,7 @@ class ListenerRegistry<T> {
 	}
 
 	List<T> getListeners() {
-		return Collections.unmodifiableList(this.listeners);
+		return unmodifiableList(this.listeners);
 	}
 
 }

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/jfr/FlightRecordingExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/jfr/FlightRecordingExecutionListener.java
@@ -10,12 +10,12 @@
 
 package org.junit.platform.launcher.jfr;
 
+import static java.util.stream.Collectors.joining;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import jdk.jfr.Category;
 import jdk.jfr.Event;
@@ -60,8 +60,7 @@ class FlightRecordingExecutionListener implements TestExecutionListener {
 		this.testPlanExecutionEvent = null;
 		if (event != null && event.shouldCommit()) {
 			event.containsTests = plan.containsTests();
-			event.engineNames = plan.getRoots().stream().map(TestIdentifier::getDisplayName).collect(
-				Collectors.joining(", "));
+			event.engineNames = plan.getRoots().stream().map(TestIdentifier::getDisplayName).collect(joining(", "));
 			event.commit();
 		}
 	}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
@@ -12,12 +12,12 @@ package org.junit.platform.launcher.listeners;
 
 import static java.lang.String.join;
 import static java.util.Collections.synchronizedList;
+import static java.util.Collections.unmodifiableList;
 
 import java.io.PrintWriter;
 import java.io.Serial;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -215,7 +215,7 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 
 	@Override
 	public List<Failure> getFailures() {
-		return Collections.unmodifiableList(failures);
+		return unmodifiableList(failures);
 	}
 
 	private String describeTest(TestIdentifier testIdentifier) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListener.java
@@ -10,12 +10,12 @@
 
 package org.junit.platform.launcher.listeners;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.apiguardian.api.API.Status.STABLE;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -194,7 +194,7 @@ public class UniqueIdTrackingListener implements TestExecutionListener {
 			}
 
 			logger.debug(() -> "Writing unique IDs to output file " + outputFile.toAbsolutePath());
-			try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8))) {
+			try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(outputFile, UTF_8))) {
 				this.uniqueIds.forEach(writer::println);
 				writer.flush();
 			}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/ShuntingYard.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/ShuntingYard.java
@@ -10,7 +10,6 @@
 
 package org.junit.platform.launcher.tagexpression;
 
-import static java.lang.Integer.MIN_VALUE;
 import static java.util.Objects.requireNonNull;
 import static org.junit.platform.launcher.tagexpression.Operator.nullaryOperator;
 import static org.junit.platform.launcher.tagexpression.ParseStatus.emptyTagExpression;
@@ -34,7 +33,7 @@ class ShuntingYard {
 
 	private static final Operator RightParenthesis = nullaryOperator(")", -1);
 	private static final Operator LeftParenthesis = nullaryOperator("(", -2);
-	private static final Operator Sentinel = nullaryOperator("sentinel", MIN_VALUE);
+	private static final Operator Sentinel = nullaryOperator("sentinel", Integer.MIN_VALUE);
 	private static final Token SentinelToken = new Token(-1, "");
 
 	private final Operators validOperators = new Operators();

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListener.java
@@ -10,6 +10,7 @@
 
 package org.junit.platform.reporting.open.xml;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 import static org.junit.platform.commons.util.StringUtils.isNotBlank;
@@ -59,7 +60,6 @@ import java.io.Writer;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -151,7 +151,7 @@ public class OpenTestReportGeneratingListener implements TestExecutionListener {
 				.map(port -> {
 					try {
 						Socket socket = new Socket(InetAddress.getLoopbackAddress(), port);
-						Writer writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
+						Writer writer = new OutputStreamWriter(socket.getOutputStream(), UTF_8);
 						return Events.createDocumentWriter(namespaceRegistry, writer);
 					}
 					catch (Exception e) {

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/AdditionalDiscoverySelectors.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/AdditionalDiscoverySelectors.java
@@ -10,9 +10,10 @@
 
 package org.junit.platform.suite.engine;
 
+import static java.util.stream.Collectors.toSet;
+
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.platform.commons.util.Preconditions;
@@ -71,7 +72,7 @@ class AdditionalDiscoverySelectors {
 		Preconditions.notNull(moduleNames, "Module names must not be null");
 		Preconditions.containsNoNullElements(moduleNames, "Individual module names must not be null");
 
-		return DiscoverySelectors.selectModules(uniqueStreamOf(moduleNames).collect(Collectors.toSet()));
+		return DiscoverySelectors.selectModules(uniqueStreamOf(moduleNames).collect(toSet()));
 	}
 
 	static FileSelector selectFile(String path, int line, int column) {

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
@@ -10,9 +10,9 @@
 
 package org.junit.platform.testkit.engine;
 
-import static java.util.Collections.sort;
 import static java.util.function.Predicate.isEqual;
 import static org.apiguardian.api.API.Status.MAINTAINED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 import static org.junit.platform.testkit.engine.Event.byPayload;
 import static org.junit.platform.testkit.engine.Event.byType;
@@ -22,6 +22,7 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,7 +32,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.apiguardian.api.API;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.SoftAssertions;
@@ -355,7 +355,7 @@ public final class Events {
 	 * @see org.assertj.core.api.ListAssert
 	 */
 	public ListAssert<Event> assertThatEvents() {
-		return org.assertj.core.api.Assertions.assertThat(list());
+		return assertThat(list());
 	}
 
 	// --- Diagnostics ---------------------------------------------------------
@@ -416,7 +416,7 @@ public final class Events {
 
 	@SafeVarargs
 	private static void assertEventsMatchExactly(List<Event> events, Condition<? super Event>... conditions) {
-		Assertions.assertThat(events).hasSize(conditions.length);
+		assertThat(events).hasSize(conditions.length);
 
 		SoftAssertions softly = new SoftAssertions();
 		for (int i = 0; i < conditions.length; i++) {
@@ -437,7 +437,7 @@ public final class Events {
 	@SafeVarargs
 	@SuppressWarnings("varargs")
 	private static void assertEventsMatchLooselyInOrder(List<Event> events, Condition<? super Event>... conditions) {
-		Assertions.assertThat(conditions).hasSizeLessThanOrEqualTo(events.size());
+		assertThat(conditions).hasSizeLessThanOrEqualTo(events.size());
 		SoftAssertions softly = new SoftAssertions();
 
 		// @formatter:off
@@ -457,7 +457,7 @@ public final class Events {
 
 	private static boolean isNotInIncreasingOrder(List<Integer> indices) {
 		List<Integer> copy = new ArrayList<>(indices);
-		sort(copy);
+		Collections.sort(copy);
 
 		return !indices.equals(copy);
 	}

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Executions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Executions.java
@@ -11,6 +11,7 @@
 package org.junit.platform.testkit.engine;
 
 import static org.apiguardian.api.API.Status.MAINTAINED;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -184,7 +185,7 @@ public final class Executions {
 	 * @see org.assertj.core.api.ListAssert
 	 */
 	public ListAssert<Execution> assertThatExecutions() {
-		return org.assertj.core.api.Assertions.assertThat(list());
+		return assertThat(list());
 	}
 
 	// --- Diagnostics ---------------------------------------------------------

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/TestExecutionResultConditions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/TestExecutionResultConditions.java
@@ -12,6 +12,7 @@ package org.junit.platform.testkit.engine;
 
 import static java.util.function.Predicate.isEqual;
 import static org.apiguardian.api.API.Status.MAINTAINED;
+import static org.assertj.core.api.Assertions.allOf;
 import static org.junit.platform.commons.util.FunctionUtils.where;
 
 import java.util.ArrayList;
@@ -20,7 +21,6 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.util.FunctionUtils;
@@ -65,7 +65,7 @@ public final class TestExecutionResultConditions {
 				.map(TestExecutionResultConditions::throwable)//
 				.toList();
 
-		return Assertions.allOf(list);
+		return allOf(list);
 	}
 
 	/**
@@ -83,7 +83,7 @@ public final class TestExecutionResultConditions {
 				.map(TestExecutionResultConditions::cause)//
 				.toList();
 
-		return Assertions.allOf(list);
+		return allOf(list);
 	}
 
 	/**
@@ -103,7 +103,7 @@ public final class TestExecutionResultConditions {
 				.map(TestExecutionResultConditions::rootCause)//
 				.toList();
 
-		return Assertions.allOf(list);
+		return allOf(list);
 	}
 
 	/**
@@ -121,7 +121,7 @@ public final class TestExecutionResultConditions {
 				.map(condition -> suppressed(index, condition))//
 				.toList();
 
-		return Assertions.allOf(list);
+		return allOf(list);
 	}
 
 	/**

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -11,6 +11,7 @@
 package org.junit.vintage.engine.execution;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.reverse;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toMap;
@@ -21,7 +22,6 @@ import static org.junit.platform.engine.TestExecutionResult.successful;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,13 +83,13 @@ class TestRun {
 				.filter(entry -> entry.getValue().equals(EventType.SYNTHETIC)) //
 				.map(Entry::getKey) //
 				.collect(toCollection(ArrayList::new));
-		Collections.reverse(result);
+		reverse(result);
 		return result;
 	}
 
 	Collection<TestDescriptor> getInProgressTestDescriptors() {
 		List<TestDescriptor> result = new ArrayList<>(inProgressDescriptors.keySet());
-		Collections.reverse(result);
+		reverse(result);
 		return result;
 	}
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/support/UniqueIdStringifier.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/support/UniqueIdStringifier.java
@@ -10,6 +10,7 @@
 
 package org.junit.vintage.engine.support;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.io.ByteArrayOutputStream;
@@ -17,7 +18,6 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.Base64;
 import java.util.Locale;
@@ -31,7 +31,7 @@ import org.apiguardian.api.API;
 @API(status = INTERNAL, since = "4.12")
 public class UniqueIdStringifier implements Function<Serializable, String> {
 
-	static final Charset CHARSET = StandardCharsets.UTF_8;
+	static final Charset CHARSET = UTF_8;
 
 	@Override
 	public String apply(Serializable uniqueId) {


### PR DESCRIPTION
- https://error-prone.picnic.tech/bugpatterns/StaticImport


related to:
- https://github.com/junit-team/junit-framework/pull/5191


PS:
this the last PR, opening mainly for comparison reasons, thanks for contribution.

sorry for noisy spam...



<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
