### PR TITLE
Add `org.junit.openrewrite.SanityCheck`

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,0 +1,48 @@
+name: Sanity Check 🕊
+on:
+  push:
+    branches:
+      - main
+      - 'releases/**'
+    paths:
+      - '.github/**'
+  pull_request:
+    paths:
+      - '.github/**'
+permissions: {}
+jobs:
+  validate:
+    name: Validate 📊
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository 📥
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Checkstyle ☑️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: checkstyleMain
+      - name: Spotless ✨
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: spotlessCheck
+      - name: ArchUnit 🏛️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: archUnit
+      - name: OSGi 🧩
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: verifyOSGiTask
+      - name: Rewrite ⚙️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: rewriteDryRun -Dorg.gradle.jvmargs=-Xmx2G

--- a/gradle/config/rewrite.yml
+++ b/gradle/config/rewrite.yml
@@ -1,0 +1,9 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.junit.openrewrite.SanityCheck
+displayName: Apply all common best practices
+description: Comprehensive code quality recipe combining modernization, security, and best practices.
+recipeList:
+  - org.openrewrite.staticanalysis.EqualsAvoidsNull
+  - tech.picnic.errorprone.refasterrules.TimeRulesRecipes
+---

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,6 +101,7 @@ commonCustomUserData = { id = "com.gradle.common-custom-user-data-gradle-plugin"
 develocity = { id = "com.gradle.develocity", version = "4.2.2" }
 download = { id = "de.undercouch.download", version = "5.6.0" }
 errorProne = { id = "net.ltgt.errorprone", version = "4.3.0" }
+rewrite = { id = "org.openrewrite.rewrite", version = "7.21.0" }
 foojayResolver = { id = "org.gradle.toolchains.foojay-resolver", version = "1.0.0" }
 gitPublish = { id = "org.ajoberstar.git-publish", version = "5.1.3" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }

--- a/gradle/plugins/common/build.gradle.kts
+++ b/gradle/plugins/common/build.gradle.kts
@@ -7,16 +7,17 @@ plugins {
 
 dependencies {
 	implementation("junitbuild.base:dsl-extensions")
-	implementation(projects.buildParameters)
 	implementation(projects.backwardCompatibility)
-	implementation(libs.plugins.kotlin.markerCoordinates)
+	implementation(projects.buildParameters)
 	implementation(libs.plugins.bnd.markerCoordinates)
 	implementation(libs.plugins.commonCustomUserData.markerCoordinates)
 	implementation(libs.plugins.develocity.markerCoordinates)
 	implementation(libs.plugins.errorProne.markerCoordinates)
 	implementation(libs.plugins.foojayResolver.markerCoordinates)
 	implementation(libs.plugins.jmh.markerCoordinates)
+	implementation(libs.plugins.kotlin.markerCoordinates)
 	implementation(libs.plugins.nullaway.markerCoordinates)
+	implementation(libs.plugins.rewrite.markerCoordinates)
 	implementation(libs.plugins.shadow.markerCoordinates)
 	implementation(libs.plugins.spotless.markerCoordinates)
 }

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.checkstyle-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.checkstyle-conventions.gradle.kts
@@ -20,7 +20,3 @@ checkstyle {
 	toolVersion = requiredVersionFromLibs("checkstyle")
 	configDirectory = rootProject.layout.projectDirectory.dir("gradle/config/checkstyle")
 }
-
-tasks.check {
-	dependsOn(tasks.withType<Checkstyle>())
-}

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-errorprone-conventions.gradle.kts
@@ -45,6 +45,7 @@ tasks.withType<JavaCompile>().configureEach {
 			error(
 				"CanonicalAnnotationSyntax",
 				"IsInstanceLambdaUsage",
+				"TryWithResourcesVariable",
 				"PackageLocation",
 				"RedundantStringConversion",
 				"RedundantStringEscape",

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 	id("junitbuild.eclipse-conventions")
 	id("junitbuild.jacoco-java-conventions")
 	id("junitbuild.java-errorprone-conventions")
+	id("junitbuild.rewrite-conventions")
 }
 
 val mavenizedProjects: List<Project> by rootProject.extra

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
@@ -99,14 +99,21 @@ val osgiVerificationClasspath = configurations.resolvable("osgiVerificationClass
 	extendsFrom(osgiVerification.get())
 }
 
+// Make the task available for calling from outside
+tasks.register("verifyOSGiTask") {
+	description = "Verifies OSGi metadata in the built jar"
+	group = "verification"
+	dependsOn(verify)
+}
+
 // Bnd's Resolve task is what verifies that a jar can be used in OSGi and
 // that its metadata is valid. If the metadata is invalid this task will
 // fail.
-val verifyOSGi by tasks.registering(Resolve::class) {
+val verify by tasks.registering(Resolve::class) {
 	bndrun = osgiProperties.flatMap { it.destinationFile }
 	outputBndrun = layout.buildDirectory.file("resolvedOSGiProperties.bndrun")
 	isReportOptional = false
-	// By default bnd will use jars found in:
+	// By default, bnd will use jars found in:
 	// 1. project.sourceSets.main.runtimeClasspath
 	// 2. project.configurations.archives.artifacts.files
 	// to validate the metadata.
@@ -115,8 +122,4 @@ val verifyOSGi by tasks.registering(Resolve::class) {
 	// end up in the dependencies of those projects.
 	bundles(osgiVerificationClasspath)
 	properties.empty()
-}
-
-tasks.check {
-	dependsOn(verifyOSGi)
 }

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.rewrite-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.rewrite-conventions.gradle.kts
@@ -1,0 +1,63 @@
+plugins {
+	id("org.openrewrite.rewrite")
+}
+
+dependencies {
+	rewrite("org.openrewrite.recipe:rewrite-static-analysis:2.22.0")
+}
+
+rewrite {
+	activeRecipe("org.junit.openrewrite.SanityCheck")
+	configFile = project.getRootProject().file("gradle/config/rewrite.yml")
+	exclusion(
+		// JupiterBestPractices: class scope issue;
+		"**AggregatorIntegrationTests.java",
+		"**BeforeAndAfterSuiteTests.java",
+		"**BridgeMethods.java",
+		"**CsvArgumentsProvider.java",
+		"**DefaultArgumentsAccessor.java",
+		"**DiscoverySelectorResolverTests.java",
+		"**DiscoveryTests.java",
+		"**DisplayNameGenerationTests.java",
+		"**DynamicNodeGenerationTests.java",
+		"**DynamicTestTests.java",
+		"**EngineDiscoveryResultValidatorTests.java", // fixable with @DisabledOnOs(WINDOWS)
+		"**ExceptionHandlingTests.java",
+		"**ExecutionCancellationTests.java",
+		"**ExtensionRegistrationViaParametersAndFieldsTests.java",
+		"**InvocationInterceptorTests.java",
+		"**IsTestMethodTests.java",
+		"**IsTestTemplateMethodTests.java",
+		"**JupiterTestDescriptorTests.java",
+		"**LifecycleMethodUtilsTests.java",
+		"**MultipleTestableAnnotationsTests.java",
+		"**NestedContainerEventConditionTests.java",
+		"**ParallelExecutionIntegrationTests.java",
+		"**ParameterResolverTests.java",
+		"**ParameterizedTestIntegrationTests.java",
+		"**RepeatedTestTests.java",
+		"**StaticPackagePrivateBeforeMethod.java",
+		"**SubclassedAssertionsTests.java",
+		"**TempDirectoryCleanupTests.java",
+		"**TestCase.java",
+		"**TestCases.java",
+		"**TestExecutionExceptionHandlerTests.java",
+		"**TestInstanceFactoryTests.java",
+		"**TestTemplateInvocationTestDescriptorTests.java",
+		"**TestTemplateInvocationTests.java",
+		"**TestTemplateTestDescriptorTests.java",
+		"**TestWatcherTests.java",
+		"**TimeoutExtensionTests.java",
+		"**UniqueIdTrackingListenerIntegrationTests.java",
+		"**WorkerThreadPoolHierarchicalTestExecutorServiceTests.java",
+		"**org/junit/jupiter/engine/bridge**",
+		// trivial import fix.
+		"**Assert**AssertionsTests.java",
+		"**DynamicContainerTests.java",
+		// legacy
+		"**documentation/src/test/java/example**",
+		"**testFixtures/java/org/junit/vintage/engine/samples**",
+	)
+	setExportDatatables(true)
+	setFailOnDryRunResults(true)
+}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachTests.java
@@ -231,7 +231,7 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 		);
 		// @formatter:on
 
-		List<String> expected = beforeEachMethodCallSequence.getFirst().equals("beforeEachMethod1") ? list1 : list2;
+		List<String> expected = "beforeEachMethod1".equals(beforeEachMethodCallSequence.getFirst()) ? list1 : list2;
 
 		assertEquals(expected, callSequence, "wrong call sequence");
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstancePreConstructCallbackTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstancePreConstructCallbackTests.java
@@ -540,7 +540,7 @@ class TestInstancePreConstructCallbackTests extends AbstractJupiterTestEngineTes
 		public void preConstructTestInstance(TestInstanceFactoryContext factoryContext, ExtensionContext context) {
 			assertThat(context.getTestInstance()).isNotPresent();
 			assertThat(context.getTestClass()).isPresent();
-			if (name.equals("legacy")) {
+			if ("legacy".equals(name)) {
 				assertThat(factoryContext.getTestClass()).isSameAs(context.getTestClass().get());
 			}
 			else if (context.getTestInstanceLifecycle().orElse(null) != TestInstance.Lifecycle.PER_CLASS) {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
@@ -1196,7 +1196,7 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 
 		@Test
 		void test() {
-			assertTrue(value.equals("foo") || value.equals("bar"));
+			assertTrue("foo".equals(value) || "bar".equals(value));
 		}
 	}
 
@@ -1213,7 +1213,7 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 
 		@Test
 		void test() {
-			assertTrue(value.equals("foo") || value.equals("bar"));
+			assertTrue("foo".equals(value) || "bar".equals(value));
 		}
 	}
 
@@ -1235,7 +1235,7 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 
 		@Test
 		void test() {
-			assertTrue(value.equals("foo") || value.equals("bar"));
+			assertTrue("foo".equals(value) || "bar".equals(value));
 		}
 	}
 
@@ -1250,7 +1250,7 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 
 		@Test
 		void test() {
-			assertTrue(value.equals("foo") || value.equals("bar"));
+			assertTrue("foo".equals(value) || "bar".equals(value));
 		}
 	}
 
@@ -1269,7 +1269,7 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 	record ArgumentsSourceConstructorInjectionTestCase(String value) {
 		@Test
 		void test() {
-			assertTrue(value.equals("foo") || value.equals("bar"));
+			assertTrue("foo".equals(value) || "bar".equals(value));
 		}
 	}
 
@@ -1282,7 +1282,7 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 
 		@Test
 		void test() {
-			assertTrue(value.equals("foo") || value.equals("bar"));
+			assertTrue("foo".equals(value) || "bar".equals(value));
 		}
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestExtensionTests.java
@@ -111,7 +111,7 @@ class ParameterizedTestExtensionTests {
 	void defaultDisplayNameWithEmptyStringInConfigurationIsIllegal() {
 		AtomicInteger invocations = new AtomicInteger();
 		Function<String, Optional<String>> configurationSupplier = key -> {
-			if (key.equals(ParameterizedInvocationNameFormatter.DISPLAY_NAME_PATTERN_KEY)) {
+			if (ParameterizedInvocationNameFormatter.DISPLAY_NAME_PATTERN_KEY.equals(key)) {
 				invocations.incrementAndGet();
 				return Optional.of("");
 			}

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/conversion/ConversionSupportTests.java
@@ -268,7 +268,7 @@ class ConversionSupportTests {
 	@Test
 	void convertsStringsToJavaTimeInstances() {
 		assertConverts("PT1234.5678S", Duration.class, Duration.ofSeconds(1234, 567800000));
-		assertConverts("1970-01-01T00:00:00Z", Instant.class, Instant.ofEpochMilli(0));
+		assertConverts("1970-01-01T00:00:00Z", Instant.class, Instant.EPOCH);
 		assertConverts("2017-03-14", LocalDate.class, LocalDate.of(2017, 3, 14));
 		assertConverts("2017-03-14T12:34:56.789", LocalDateTime.class,
 			LocalDateTime.of(2017, 3, 14, 12, 34, 56, 789_000_000));

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/DefaultClasspathScannerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/DefaultClasspathScannerTests.java
@@ -136,7 +136,7 @@ class DefaultClasspathScannerTests {
 	@Test
 	void scanForResourcesInClasspathRootWhenGenericRuntimeExceptionOccurs(LogRecordListener listener) throws Exception {
 		Predicate<Resource> runtimeExceptionSimulationFilter = resource -> {
-			if (resource.getName().equals("org/junit/platform/commons/other-example.resource")) {
+			if ("org/junit/platform/commons/other-example.resource".equals(resource.getName())) {
 				throw new RuntimeException("a generic exception");
 			}
 			return true;

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -100,7 +100,7 @@ import org.junit.platform.commons.util.pkg1.subpkg.SubclassWithNonStaticPackageP
  */
 class ReflectionUtilsTests {
 
-	private static final Predicate<Method> isFooMethod = method -> method.getName().equals("foo");
+	private static final Predicate<Method> isFooMethod = method -> "foo".equals(method.getName());
 	private static final Predicate<Method> methodContains1 = method -> method.getName().contains("1");
 	private static final Predicate<Method> methodContains2 = method -> method.getName().contains("2");
 	private static final Predicate<Method> methodContains4 = method -> method.getName().contains("4");
@@ -1270,7 +1270,7 @@ class ReflectionUtilsTests {
 
 		@Test
 		void isMethodPresent() {
-			Predicate<Method> isMethod1 = method -> (method.getName().equals("method1")
+			Predicate<Method> isMethod1 = method -> ("method1".equals(method.getName())
 					&& method.getParameterTypes().length == 1 && method.getParameterTypes()[0] == String.class);
 
 			assertThat(ReflectionUtils.isMethodPresent(MethodShadowingChild.class, isMethod1)).isTrue();
@@ -1504,7 +1504,7 @@ class ReflectionUtilsTests {
 		 */
 		@Test
 		void findMethodsFindsDistinctMethodsDeclaredInMultipleInterfaces() {
-			Predicate<Method> isStringsMethod = method -> method.getName().equals("strings");
+			Predicate<Method> isStringsMethod = method -> "strings".equals(method.getName());
 			assertThat(findMethods(DoubleInheritedInterfaceMethodTestCase.class, isStringsMethod)).hasSize(1);
 		}
 
@@ -1551,10 +1551,10 @@ class ReflectionUtilsTests {
 					.containsExactly(ChildClass.class.getMethod("otherMethod3"),
 						ParentClass.class.getMethod("otherMethod2"), GrandparentClass.class.getMethod("otherMethod1"));
 
-			assertThat(findMethods(ChildClass.class, method -> method.getName().equals("method2"), BOTTOM_UP))//
+			assertThat(findMethods(ChildClass.class, method -> "method2".equals(method.getName()), BOTTOM_UP))//
 					.containsExactly(ParentClass.class.getMethod("method2"));
 
-			assertThat(findMethods(ChildClass.class, method -> method.getName().equals("wrongName"), BOTTOM_UP))//
+			assertThat(findMethods(ChildClass.class, method -> "wrongName".equals(method.getName()), BOTTOM_UP))//
 					.isEmpty();
 
 			assertThat(findMethods(ParentClass.class, method -> method.getName().contains("method"), BOTTOM_UP))//
@@ -1573,10 +1573,10 @@ class ReflectionUtilsTests {
 					.containsExactly(GrandparentClass.class.getMethod("otherMethod1"),
 						ParentClass.class.getMethod("otherMethod2"), ChildClass.class.getMethod("otherMethod3"));
 
-			assertThat(findMethods(ChildClass.class, method -> method.getName().equals("method2"), TOP_DOWN))//
+			assertThat(findMethods(ChildClass.class, method -> "method2".equals(method.getName()), TOP_DOWN))//
 					.containsExactly(ParentClass.class.getMethod("method2"));
 
-			assertThat(findMethods(ChildClass.class, method -> method.getName().equals("wrongName"), TOP_DOWN))//
+			assertThat(findMethods(ChildClass.class, method -> "wrongName".equals(method.getName()), TOP_DOWN))//
 					.isEmpty();
 
 			assertThat(findMethods(ParentClass.class, method -> method.getName().contains("method"), TOP_DOWN))//

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -1023,7 +1023,7 @@ class DefaultLauncherTests {
 		inOrder.verify(executionListener).executionStarted(
 			argThat(d -> d.getUniqueIdObject().equals(UniqueId.forEngine("engine-id"))));
 		inOrder.verify(executionListener).executionSkipped(
-			argThat(d -> d.getUniqueIdObject().getLastSegment().getType().equals("container")),
+			argThat(d -> "container".equals(d.getUniqueIdObject().getLastSegment().getType())),
 			eq("Execution cancelled"));
 		inOrder.verify(executionListener).executionFinished(
 			argThat(d -> d.getUniqueIdObject().equals(UniqueId.forEngine("engine-id"))),

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JUnitStartTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/JUnitStartTests.java
@@ -50,12 +50,12 @@ class JUnitStartTests {
 			}
 			for (var module : Helper.loadModuleDirectoryNames()) {
 				if (module.startsWith("junit-platform") || module.startsWith("junit-jupiter")
-						|| module.equals("junit-start")) {
-					if (module.equals("junit-jupiter-migrationsupport"))
+						|| "junit-start".equals(module)) {
+					if ("junit-jupiter-migrationsupport".equals(module))
 						continue;
 					if (module.startsWith("junit-platform-suite"))
 						continue;
-					if (module.equals("junit-platform-testkit"))
+					if ("junit-platform-testkit".equals(module))
 						continue;
 					var jar = MavenRepo.jar(module);
 					Files.copy(jar, lib.resolve(module + ".jar"));

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManifestTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ManifestTests.java
@@ -56,7 +56,7 @@ class ManifestTests {
 			assertValue(attributes, "Bundle-SymbolicName", module);
 			assertValue(attributes, "Bundle-Version",
 				MavenVersion.parseMavenString(version).getOSGiVersion().toString());
-			if (module.equals("junit-platform-console")) {
+			if ("junit-platform-console".equals(module)) {
 				assertValue(attributes, "Main-Class", "org.junit.platform.console.ConsoleLauncher");
 			}
 			var domain = Domain.domain(manifest);

--- a/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ToolProviderTests.java
+++ b/platform-tooling-support-tests/src/test/java/platform/tooling/support/tests/ToolProviderTests.java
@@ -90,7 +90,7 @@ class ToolProviderTests {
 	void findAndRunJUnitOnTheClassPath() {
 		try (var loader = new URLClassLoader("junit", urls(lib), ClassLoader.getPlatformClassLoader())) {
 			var sl = ServiceLoader.load(ToolProvider.class, loader);
-			var junit = StreamSupport.stream(sl.spliterator(), false).filter(p -> p.name().equals("junit")).findFirst();
+			var junit = StreamSupport.stream(sl.spliterator(), false).filter(p -> "junit".equals(p.name())).findFirst();
 
 			assertTrue(junit.isPresent(), "Tool 'junit' not found in: " + lib);
 			assertJUnitPrintsHelpMessage(junit.get());
@@ -116,7 +116,7 @@ class ToolProviderTests {
 		var layer = bootLayer.defineModulesWithOneLoader(configuration, ClassLoader.getPlatformClassLoader());
 
 		var sl = ServiceLoader.load(layer, ToolProvider.class);
-		var junit = StreamSupport.stream(sl.spliterator(), false).filter(p -> p.name().equals("junit")).findFirst();
+		var junit = StreamSupport.stream(sl.spliterator(), false).filter(p -> "junit".equals(p.name())).findFirst();
 
 		assertTrue(junit.isPresent(), "Tool 'junit' not found in modules: " + modules);
 		assertJUnitPrintsHelpMessage(junit.get());


### PR DESCRIPTION
<!-- Please describe your changes here and list any open questions you might have. -->


### Add `org.junit.openrewrite.SanityCheck`

enabler for:


- https://docs.openrewrite.org/recipes/java/testing/junit/jupiterbestpractices
- https://docs.openrewrite.org/recipes/staticanalysis/commonstaticanalysis
- https://docs.openrewrite.org/recipes/java/migrate/upgradetojava17


related to:
- https://github.com/junit-team/junit-framework/pull/5191
- https://github.com/diffplug/spotless/pull/2651
- https://github.com/diffplug/spotless/pull/2636


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)


