### PR TITLE
[tryout fix] concurrency bug in `NamespacedHierarchicalStore#computeIfAbsent(Object, Object, Function)` #5171 #5209

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.0.2.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.0.2.adoc
@@ -17,6 +17,13 @@ repository on GitHub.
 ==== Bug Fixes
 
 * Make `ConsoleLauncher` compatible with JDK 26 by avoiding final field mutations.
+* Fix a concurrency bug in `NamespacedHierarchicalStore#computeIfAbsent(Object, Object, Function)` where
+  the `defaultCreator` function was executed while holding the store's internal
+  map lock. Under parallel execution, this could cause threads using the store to
+  block each other and temporarily see a missing or incorrectly initialized state
+  for values created via `computeIfAbsent`. The method now evaluates
+  `defaultCreator` outside the critical section using a memorizing supplier,
+  aligning its behavior with the deprecated `getOrComputeIfAbsent`.
 
 [[v6.0.2-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes


### PR DESCRIPTION
<!-- Please describe your changes here and list any open questions you might have. -->


### [tryout fix] concurrency bug in `NamespacedHierarchicalStore#computeIfAbsent(Object, Object, Function)` #5171 #5209


---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)




coverage:


before:



<html>
<body>

100% (7/7) | 97% (41/42) | 97% (132/136) | 87% (35/40)
-- | -- | -- | --



</body>
</html>�




after:


<html>
<body>

100% (7/7) | 97% (42/43) | 97% (137/140) | 90% (40/44)
-- | -- | -- | --



</body>
</html>�


<html>
<body>

100% (7/7) | 97% (42/43) | 97% (137/140) | 93% (41/44)
-- | -- | -- | --



</body>
</html> 