### PR TITLE
Add -since for Javadoc (#5166)

### DIFF
--- a/documentation/documentation.gradle.kts
+++ b/documentation/documentation.gradle.kts
@@ -283,6 +283,27 @@ tasks {
 			jFlags("-Xmx1g")
 
 			this as StandardJavadocDocletOptions
+			addStringsOption("-since", ",").value = listOf(
+					    "6.2",
+                        "6.1",
+                        "6.0",
+                        "5.14",
+                        "5.13",
+                        "5.12",
+                        "5.11",
+                        "5.10",
+                        "5.9",
+                        "5.8",
+                        "5.7",
+                        "5.6",
+                        "5.5",
+                        "5.4",
+                        "5.3",
+                        "5.2",
+                        "5.1",
+                        "5.0",
+            )
+
 			splitIndex(true)
 			addBooleanOption("Xdoclint:all,-missing", true)
 			addBooleanOption("Werror", true)


### PR DESCRIPTION
<!-- Please describe your changes here and list any open questions you might have. -->
Fixes #5166

Adds the missing -since option so the aggregated Javadoc shows the correct version tabs.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
