### PR TITLE
Make Kotlin suspend function checks `ClassLoader`-agnostic

### DIFF
--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinFunctionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinFunctionUtils.java
@@ -41,7 +41,7 @@ class KotlinFunctionUtils {
 
 	static Class<?> getReturnType(Method method) {
 		var returnType = getJavaClass(getJvmErasure(getKotlinFunction(method).getReturnType()));
-		if (Unit.class.equals(returnType)) {
+		if (Unit.class.getName().equals(returnType.getName())) {
 			return void.class;
 		}
 		return returnType;


### PR DESCRIPTION
## Overview

This is done because with the current version of the code, in order for a method to be considered a Kotlin suspending method, Kotlin and the test class need to be loaded from the same `ClassLoader`, but in Quarkus that is not the case.

## Related Issues

- https://github.com/quarkusio/quarkus/issues/52480

----

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).