### PR TITLE
Deprecate `JRE.OTHER`

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0-M2.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0-M2.adoc
@@ -46,7 +46,10 @@ repository on GitHub.
 [[v6.1.0-M2-junit-jupiter-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes
 
-* ❓
+* Deprecate `OTHER` constant of `{JRE}` in favor of the `int`/`int[]` annotation
+  attributes of `{EnabledOnJre}`, `{DisabledOnJre}`, `{EnabledForJreRange}`, and
+  `{DisabledForJreRange}` that allow referencing JRE versions later than those supported
+  by the `JRE` enum.
 
 [[v6.1.0-M2-junit-jupiter-new-features-and-improvements]]
 ==== New Features and Improvements

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
@@ -27,6 +27,8 @@ import org.junit.platform.commons.util.Preconditions;
 abstract class AbstractJreRangeCondition<A extends Annotation> extends BooleanExecutionCondition<A> {
 
 	private static final JRE DEFAULT_MINIMUM_JRE = JRE.JAVA_17;
+
+	@SuppressWarnings("deprecation")
 	private static final JRE DEFAULT_MAXIMUM_JRE = JRE.OTHER;
 
 	AbstractJreRangeCondition(Class<A> annotationType, Function<A, String> customDisabledReason) {

--- a/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
+++ b/junit-jupiter-api/src/templates/resources/main/org/junit/jupiter/api/condition/JRE.java.jte
@@ -80,7 +80,23 @@ public enum JRE {
 	 * <p>This constant returns {@link Integer#MAX_VALUE} for its
 	 * {@linkplain #version() version}. To retrieve the actual version number,
 	 * use {@link #currentVersionNumber()}.
+	 *
+	 * @deprecated You should not reference this constant directly. If you need
+	 * to reference a later version than supported by this enum, you should
+	 * instead use an {@code int} with one of the following annotation
+	 * attributes:
+	 *
+	 * <ul>
+	 *     <li>{@link EnabledOnJre#versions()}</li>
+	 *     <li>{@link DisabledOnJre#versions()}</li>
+	 *     <li>{@link EnabledForJreRange#minVersion()}</li>
+	 *     <li>{@link EnabledForJreRange#maxVersion()}</li>
+	 *     <li>{@link DisabledForJreRange#minVersion()}</li>
+	 *     <li>{@link DisabledForJreRange#maxVersion()}</li>
+	 * </ul>
 	 */
+	@API(status = DEPRECATED, since = "6.1") //
+	@Deprecated(since = "6.1")
 	OTHER(Integer.MAX_VALUE);
 
 	static final int UNDEFINED_VERSION = -1;

--- a/junit-jupiter-api/src/templates/resources/testFixtures/org/junit/jupiter/api/condition/JavaVersionPredicates.java.jte
+++ b/junit-jupiter-api/src/templates/resources/testFixtures/org/junit/jupiter/api/condition/JavaVersionPredicates.java.jte
@@ -20,6 +20,7 @@ public class JavaVersionPredicates {
 				|| @endif@endfor;
 	}
 
+	@SuppressWarnings("deprecation")
 	static boolean onOtherVersion() {
 		return JRE.OTHER.isCurrentVersion();
 	}

--- a/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java.jte
+++ b/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/DisabledOnJreIntegrationTests.java.jte
@@ -50,7 +50,7 @@ class DisabledOnJreIntegrationTests {
 	void version7() {
 	}
 
-	@SuppressWarnings("removal")
+	@SuppressWarnings({ "removal", "deprecation" })
 	@Test
 	@DisabledOnJre(disabledReason = "Disabled on every JRE", value = { //
 @for(var jre : allJres)<%--
@@ -76,6 +76,7 @@ class DisabledOnJreIntegrationTests {
 	}
 @endfor
 	@Test
+	@SuppressWarnings("deprecation")
 	@DisabledOnJre(JRE.OTHER)
 	void other() {
 		assertTrue(onKnownVersion());

--- a/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java.jte
+++ b/jupiter-tests/src/templates/resources/test/org/junit/jupiter/api/condition/EnabledOnJreIntegrationTests.java.jte
@@ -49,7 +49,7 @@ class EnabledOnJreIntegrationTests {
 	void version7() {
 	}
 
-	@SuppressWarnings("removal")
+	@SuppressWarnings({ "removal", "deprecation" })
 	@Test
 	@EnabledOnJre({ //
 @for(var jre : allJres)<%--
@@ -74,6 +74,7 @@ class EnabledOnJreIntegrationTests {
 	}
 @endfor
 	@Test
+	@SuppressWarnings("deprecation")
 	@EnabledOnJre(value = JRE.OTHER, disabledReason = "Disabled on almost every JRE")
 	void other() {
 		assertFalse(onKnownVersion());

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/DisabledForJreRangeIntegrationTests.java
@@ -45,6 +45,7 @@ class DisabledForJreRangeIntegrationTests {
 		fail("should result in a configuration exception");
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	@Disabled("Only used in a unit test via reflection")
 	@DisabledForJreRange(min = JAVA_17, max = OTHER)
@@ -75,6 +76,7 @@ class DisabledForJreRangeIntegrationTests {
 
 	@Test
 	@Disabled("Only used in a unit test via reflection")
+	@SuppressWarnings("deprecation")
 	@DisabledForJreRange(max = OTHER)
 	void maxOther() {
 		fail("should result in a configuration exception");
@@ -193,6 +195,7 @@ class DisabledForJreRangeIntegrationTests {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	@DisabledForJreRange(min = OTHER, max = OTHER)
 	void minOtherMaxOther() {
 		assertTrue(onKnownVersion() || onOtherVersion());

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/EnabledForJreRangeIntegrationTests.java
@@ -52,6 +52,7 @@ class EnabledForJreRangeIntegrationTests {
 		fail("should result in a configuration exception");
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	@Disabled("Only used in a unit test via reflection")
 	@EnabledForJreRange(min = JAVA_17, max = OTHER)
@@ -82,6 +83,7 @@ class EnabledForJreRangeIntegrationTests {
 
 	@Test
 	@Disabled("Only used in a unit test via reflection")
+	@SuppressWarnings("deprecation")
 	@EnabledForJreRange(max = OTHER)
 	void maxOther() {
 		fail("should result in a configuration exception");
@@ -247,6 +249,7 @@ class EnabledForJreRangeIntegrationTests {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	@EnabledForJreRange(min = OTHER, max = OTHER)
 	void minOtherMaxOther() {
 		assertFalse(onKnownVersion());

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/JRETests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/condition/JRETests.java
@@ -150,6 +150,7 @@ public class JRETests {
 		jre25();
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	@EnabledOnJre(OTHER)
 	void jreOther() {


### PR DESCRIPTION
To avoid referencing it from annotations since their `int` attributes
should be preferred.
