### PR TITLE
Fix race condition in NodeTestTask

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.0.4.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.0.4.adoc
@@ -16,7 +16,8 @@ repository on GitHub.
 [[v6.0.4-junit-platform-bug-fixes]]
 ==== Bug Fixes
 
-* ❓
+* A race condition in `NodeTestTask.parentContext` has been fixed.
+
 
 [[v6.0.4-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTestTask.java
@@ -56,7 +56,7 @@ class NodeTestTask<C extends EngineExecutionContext> implements TestTask {
 	private final Node<C> node;
 	private final Runnable finalizer;
 
-	private @Nullable C parentContext;
+	private volatile @Nullable C parentContext;
 
 	private @Nullable C context;
 


### PR DESCRIPTION
Fixed by making field `parentContext` volatile.

Issue: #5408

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
