### PR TITLE
Add Kotlin snippets for six User Guide sections

### DIFF
--- a/documentation/modules/ROOT/pages/writing-tests/assumptions.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/assumptions.adoc
@@ -16,10 +16,26 @@ references.
 
 All JUnit Jupiter assumptions are static methods in the `{Assumptions}` class.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/AssumptionsDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/AssumptionsDemo.kt[tags=user_guide]
+----
+--
+====
 
 NOTE: It is also possible to use methods from JUnit 4's `org.junit.Assume` class for
 assumptions. Specifically, JUnit Jupiter supports JUnit 4's `AssumptionViolatedException`

--- a/documentation/modules/ROOT/pages/writing-tests/dynamic-tests.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/dynamic-tests.adoc
@@ -76,10 +76,26 @@ For demonstration purposes, the `dynamicNodeSingleTest()` method generates a sin
 `DynamicTest` instead of a stream, and the `dynamicNodeSingleContainer()` method generates
 a nested hierarchy of dynamic tests utilizing `DynamicContainer`.
 
-[source,java]
+[tabs]
+====
+Java::
++
+--
+[source,java,indent=0]
 ----
 include::example$java/example/DynamicTestsDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/DynamicTestsDemo.kt[tags=user_guide]
+----
+--
+====
 
 [[named-support]]
 == Dynamic Tests and Named
@@ -90,10 +106,26 @@ shown in the first example below. The second example takes it one step further a
 to provide the code block that should be executed by implementing the `Executable`
 interface along with `Named` via the `NamedExecutable` base class.
 
-[source,java]
+[tabs]
+====
+Java::
++
+--
+[source,java,indent=0]
 ----
 include::example$java/example/DynamicTestsNamedDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/DynamicTestsNamedDemo.kt[tags=user_guide]
+----
+--
+====
 
 [[uri-test-source]]
 == URI Test Sources for Dynamic Tests
@@ -138,10 +170,26 @@ xref:writing-tests/parallel-execution.adoc[parallel execution]. You can configur
 `ExecutionMode` by using the `dynamicTest(Consumer)` and `dynamicContainer(Consumer)`
 factory methods as illustrated by the following example.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/DynamicTestsDemo.java[tags=execution_mode]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/DynamicTestsDemo.kt[tags=execution_mode]
+----
+--
+====
 
 Executing the above test factory method results in the following test tree and execution
 modes:

--- a/documentation/modules/ROOT/pages/writing-tests/exception-handling.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/exception-handling.adoc
@@ -26,10 +26,26 @@ In the following example, the `failsDueToUncaughtException()` method throws an
 `ArithmeticException`. Since the exception is not caught within the test method, JUnit
 Jupiter will mark the test as failed.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/exception/UncaughtExceptionHandlingDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/exception/UncaughtExceptionHandlingDemo.kt[tags=user_guide]
+----
+--
+====
 
 NOTE: It's important to note that specifying a `throws` clause in the test method has
 no effect on the outcome of the test. JUnit Jupiter does not interpret a `throws` clause
@@ -59,10 +75,26 @@ In the following example, the `failsDueToUncaughtAssertionError()` method throws
 `AssertionError`. Since the exception is not caught within the test method, JUnit Jupiter
 will mark the test as failed.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/exception/FailedAssertionDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/exception/FailedAssertionDemo.kt[tags=user_guide]
+----
+--
+====
 
 [[expected]]
 == Asserting Expected Exceptions
@@ -81,10 +113,26 @@ type of the thrown exception but also its subclasses, making it suitable for mor
 generalized exception handling tests. The `assertThrows()` assertion method returns the
 thrown exception object to allow performing additional assertions on it.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/exception/ExceptionAssertionDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/exception/ExceptionAssertionDemo.kt[tags=user_guide]
+----
+--
+====
 
 [[expected-assertThrowsExactly]]
 === Using `assertThrowsExactly()`
@@ -95,10 +143,26 @@ exception type. This is useful when precise exception handling behavior needs to
 validated. Similar to `assertThrows()`, the `assertThrowsExactly()` assertion method also
 returns the thrown exception object to allow performing additional assertions on it.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/exception/ExceptionAssertionExactDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/exception/ExceptionAssertionExactDemo.kt[tags=user_guide]
+----
+--
+====
 
 [[not-expected]]
 == Asserting That no Exception is Expected
@@ -109,10 +173,26 @@ _not_ thrown for a given code block within a test method. The `assertDoesNotThro
 assertion can be used when you want to verify that a particular piece of code does not
 throw any exceptions.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/exception/AssertDoesNotThrowExceptionDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/exception/AssertDoesNotThrowExceptionDemo.kt[tags=user_guide]
+----
+--
+====
 
 NOTE: Third-party assertion libraries often provide similar support. For example, AssertJ
 has `assertThatNoException().isThrownBy(() -> ...)`. See also:

--- a/documentation/modules/ROOT/pages/writing-tests/nested-tests.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/nested-tests.adoc
@@ -5,11 +5,27 @@ several groups of tests. Such nested tests make use of Java's nested classes and
 facilitate hierarchical thinking about the test structure. Here's an elaborate example,
 both as source code and as a screenshot of the execution within an IDE.
 
-[source,java,indent=0]
 .Nested test suite for testing a stack
+[tabs]
+====
+Java::
++
+--
+[source,java,indent=0]
 ----
 include::example$java/example/TestingAStackDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/TestingAStackDemo.kt[tags=user_guide]
+----
+--
+====
 
 When executing this example in an IDE, the test execution tree in the GUI will look
 similar to the following image.
@@ -39,10 +55,26 @@ class is parameterized.
 The following example illustrates how to combine `@Nested` with `@ParameterizedClass` and
 `@ParameterizedTest`.
 
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
 ----
 include::example$java/example/ParameterizedClassDemo.java[tags=nested]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/ParameterizedClassDemo.kt[tags=nested]
+----
+--
+====
 
 Executing the above test class yields the following output:
 

--- a/documentation/modules/ROOT/pages/writing-tests/repeated-tests.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/repeated-tests.adoc
@@ -8,6 +8,11 @@ desired. Each invocation of a repeated test behaves like the execution of a regu
 The following example demonstrates how to declare a test named `repeatedTest()` that
 will be automatically repeated 10 times.
 
+[tabs]
+====
+Java::
++
+--
 [source,java]
 ----
 @RepeatedTest(10)
@@ -15,6 +20,20 @@ void repeatedTest() {
 	// ...
 }
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin]
+----
+@RepeatedTest(10)
+fun repeatedTest() {
+    // ...
+}
+----
+--
+====
 
 `@RepeatedTest` can be configured with a failure threshold which signifies the number of
 failures after which remaining repetitions will be automatically skipped. Set the
@@ -125,10 +144,26 @@ INFO: About to execute repetition 4 of 5 for repeatedTestInGerman
 INFO: About to execute repetition 5 of 5 for repeatedTestInGerman
 ....
 
-[source,java]
+[tabs]
+====
+Java::
++
+--
+[source,java,indent=0]
 ----
 include::example$java/example/RepeatedTestsDemo.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/RepeatedTestsDemo.kt[tags=user_guide]
+----
+--
+====
 
 When using the `ConsoleLauncher` with the unicode theme enabled, execution of
 `RepeatedTestsDemo` results in the following output to the console.

--- a/documentation/modules/ROOT/pages/writing-tests/test-classes-and-methods.adoc
+++ b/documentation/modules/ROOT/pages/writing-tests/test-classes-and-methods.adoc
@@ -41,11 +41,27 @@ lifecycle methods. For further information on runtime semantics, see
 xref:writing-tests/test-execution-order.adoc[] and
 xref:extensions/relative-execution-order-of-user-code-and-extensions.adoc#wrapping-behavior[Wrapping Behavior of Callbacks].
 
+.A standard test class
+[tabs]
+====
+Java::
++
+--
 [source,java,indent=0]
-.A standard Java test class
 ----
 include::example$java/example/StandardTests.java[tags=user_guide]
 ----
+--
+
+Kotlin::
++
+--
+[source,kotlin,indent=0]
+----
+include::example$kotlin/example/kotlin/StandardTests.kt[tags=user_guide]
+----
+--
+====
 
 It is also possible to use Java `record` classes as test classes as illustrated by the
 following example.

--- a/documentation/src/test/kotlin/example/kotlin/AssumptionsDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/AssumptionsDemo.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+
+import example.util.Calculator
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Assumptions.assumingThat
+import org.junit.jupiter.api.Test
+
+class AssumptionsDemo {
+    private val calculator = Calculator()
+
+    @Test
+    fun testOnlyOnCiServer() {
+        assumeTrue(System.getenv("ENV") == "CI")
+        // remainder of test
+    }
+
+    @Test
+    fun testOnlyOnDeveloperWorkstation() {
+        assumeTrue(System.getenv("ENV") == "DEV") {
+            "Aborting test: not on developer workstation"
+        }
+        // remainder of test
+    }
+
+    @Test
+    fun testInAllEnvironments() {
+        assumingThat(System.getenv("ENV") == "CI") {
+            // perform these assertions only on the CI server
+            assertEquals(2, calculator.divide(4, 2))
+        }
+
+        // perform these assertions in all environments
+        assertEquals(42, calculator.multiply(6, 7))
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/DynamicTestsDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/DynamicTestsDemo.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import example.util.Calculator
+import example.util.StringUtils.isPalindrome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicContainer.dynamicContainer
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
+import org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD
+import java.util.Random
+import java.util.stream.IntStream
+import java.util.stream.Stream
+
+// end::user_guide[]
+// tag::user_guide[]
+class DynamicTestsDemo {
+    private val calculator = Calculator()
+
+    // This method will not be executed but produce a warning
+    @TestFactory
+    // end::user_guide[]
+    @Tag("exclude")
+    fun dummy(): DynamicTest = dynamicTest("dummy") {}
+
+    // tag::user_guide[]
+    fun dynamicTestsWithInvalidReturnType(): List<String> = listOf("Hello")
+
+    @TestFactory
+    fun dynamicTestsFromCollection(): Collection<DynamicTest> =
+        listOf(
+            dynamicTest("1st dynamic test") { assertTrue(isPalindrome("madam")) },
+            dynamicTest("2nd dynamic test") { assertEquals(4, calculator.multiply(2, 2)) }
+        )
+
+    @TestFactory
+    fun dynamicTestsFromIterable(): Iterable<DynamicTest> =
+        listOf(
+            dynamicTest("3rd dynamic test") { assertTrue(isPalindrome("madam")) },
+            dynamicTest("4th dynamic test") { assertEquals(4, calculator.multiply(2, 2)) }
+        )
+
+    @TestFactory
+    fun dynamicTestsFromIterator(): Iterator<DynamicTest> =
+        listOf(
+            dynamicTest("5th dynamic test") { assertTrue(isPalindrome("madam")) },
+            dynamicTest("6th dynamic test") { assertEquals(4, calculator.multiply(2, 2)) }
+        ).iterator()
+
+    @TestFactory
+    fun dynamicTestsFromArray(): Array<DynamicTest> =
+        arrayOf(
+            dynamicTest("7th dynamic test") { assertTrue(isPalindrome("madam")) },
+            dynamicTest("8th dynamic test") { assertEquals(4, calculator.multiply(2, 2)) }
+        )
+
+    @TestFactory
+    fun dynamicTestsFromStream(): Stream<DynamicTest> =
+        Stream
+            .of("racecar", "radar", "mom", "dad")
+            .map { text -> dynamicTest(text) { assertTrue(isPalindrome(text)) } }
+
+    @TestFactory
+    fun dynamicTestsFromSequence(): Sequence<DynamicTest> =
+        sequenceOf("racecar", "radar", "mom", "dad")
+            .map { text -> dynamicTest(text) { assertTrue(isPalindrome(text)) } }
+
+    @TestFactory
+    fun dynamicTestsFromIntStream(): Stream<DynamicTest> {
+        // Generates tests for the first 10 even integers.
+        return IntStream
+            .iterate(0) { n -> n + 2 }
+            .limit(10)
+            .mapToObj { n -> dynamicTest("test$n") { assertEquals(0, n % 2) } }
+    }
+
+    @TestFactory
+    fun generateRandomNumberOfTests(): Stream<DynamicTest> {
+        // Generates random positive integers between 0 and 100 until
+        // a number evenly divisible by 7 is encountered.
+        val inputGenerator =
+            object : Iterator<Int> {
+                var random = Random()
+
+                // end::user_guide[]
+                init {
+                    // Use fixed seed to always produce the same number of tests for execution on the CI server
+                    random = Random(23)
+                }
+
+                // tag::user_guide[]
+                var current = 0
+
+                override fun hasNext(): Boolean {
+                    current = random.nextInt(100)
+                    return current % 7 != 0
+                }
+
+                override fun next(): Int = current
+            }
+
+        // Generates display names like: input:5, input:37, input:85, etc.
+        val displayNameGenerator = { input: Int -> "input:$input" }
+
+        // Executes tests based on the current input value.
+        val testExecutor = { input: Int -> assertTrue(input % 7 != 0) }
+
+        // Returns a stream of dynamic tests.
+        return DynamicTest.stream(inputGenerator, displayNameGenerator, testExecutor)
+    }
+
+    @TestFactory
+    fun dynamicTestsFromStreamFactoryMethod(): Stream<DynamicTest> {
+        // Stream of palindromes to check
+        val inputStream = Stream.of("racecar", "radar", "mom", "dad")
+
+        // Generates display names like: racecar is a palindrome
+        val displayNameGenerator = { text: String -> "$text is a palindrome" }
+
+        // Executes tests based on the current input value.
+        val testExecutor = { text: String -> assertTrue(isPalindrome(text)) }
+
+        // Returns a stream of dynamic tests.
+        return DynamicTest.stream(inputStream, displayNameGenerator, testExecutor)
+    }
+
+    @TestFactory
+    fun dynamicTestsWithContainers(): Stream<DynamicNode> =
+        Stream
+            .of("A", "B", "C")
+            .map { input ->
+                dynamicContainer(
+                    "Container $input",
+                    Stream.of(
+                        dynamicTest("not null") { assertNotNull(input) },
+                        dynamicContainer(
+                            "properties",
+                            Stream.of(
+                                dynamicTest("length > 0") { assertTrue(input.length > 0) },
+                                dynamicTest("not empty") { assertFalse(input.isEmpty()) }
+                            )
+                        )
+                    )
+                )
+            }
+
+    // end::user_guide[]
+    // tag::execution_mode[]
+    @TestFactory
+    @Execution(CONCURRENT) // <1>
+    fun dynamicTestsWithConfiguredExecutionMode(): Stream<DynamicNode> =
+        Stream
+            .of("A", "B", "C")
+            .map { input ->
+                dynamicContainer { outer ->
+                    outer
+                        .displayName("Container $input")
+                        .children(
+                            dynamicTest { config ->
+                                config
+                                    .displayName("not null")
+                                    .executionMode(SAME_THREAD) // <2>
+                                    .executable { assertNotNull(input) }
+                            },
+                            dynamicContainer { inner ->
+                                inner
+                                    .displayName("properties")
+                                    .executionMode(CONCURRENT) // <3>
+                                    .childExecutionMode(SAME_THREAD) // <4>
+                                    .children(
+                                        dynamicTest { config ->
+                                            config
+                                                .displayName("length > 0")
+                                                .executionMode(CONCURRENT) // <5>
+                                                .executable { assertTrue(input.length > 0) }
+                                        },
+                                        dynamicTest { config ->
+                                            config
+                                                .displayName("not empty")
+                                                .executable { assertFalse(input.isEmpty()) }
+                                        }
+                                    )
+                            }
+                        )
+                }
+            }
+    // end::execution_mode[]
+
+    // tag::user_guide[]
+    @TestFactory
+    fun dynamicNodeSingleTest(): DynamicNode = dynamicTest("'pop' is a palindrome") { assertTrue(isPalindrome("pop")) }
+
+    @TestFactory
+    fun dynamicNodeSingleContainer(): DynamicNode =
+        dynamicContainer(
+            "palindromes",
+            Stream
+                .of("racecar", "radar", "mom", "dad")
+                .map { text -> dynamicTest(text) { assertTrue(isPalindrome(text)) } }
+        )
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/DynamicTestsNamedDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/DynamicTestsNamedDemo.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+
+import example.util.StringUtils.isPalindrome
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.api.NamedExecutable
+import org.junit.jupiter.api.TestFactory
+import java.util.stream.Stream
+
+class DynamicTestsNamedDemo {
+    @TestFactory
+    fun dynamicTestsFromStreamFactoryMethodWithNames(): Stream<DynamicTest> {
+        // Stream of palindromes to check
+        // end::user_guide[]
+        // tag::user_guide[]
+        val inputStream =
+            Stream.of(
+                named("racecar is a palindrome", "racecar"),
+                named("radar is also a palindrome", "radar"),
+                named("mom also seems to be a palindrome", "mom"),
+                named("dad is yet another palindrome", "dad")
+            )
+        // end::user_guide[]
+        // tag::user_guide[]
+
+        // Returns a stream of dynamic tests.
+        return DynamicTest.stream(inputStream) { text -> assertTrue(isPalindrome(text)) }
+    }
+
+    @TestFactory
+    fun dynamicTestsFromStreamFactoryMethodWithNamedExecutables(): Stream<DynamicTest> {
+        // Stream of palindromes to check
+        // end::user_guide[]
+        // tag::user_guide[]
+        val inputStream =
+            Stream
+                .of("racecar", "radar", "mom", "dad")
+                .map { PalindromeNamedExecutable(it) }
+        // end::user_guide[]
+        // tag::user_guide[]
+
+        // Returns a stream of dynamic tests based on NamedExecutables.
+        return DynamicTest.stream(inputStream)
+    }
+
+    class PalindromeNamedExecutable(
+        private val text: String
+    ) : NamedExecutable {
+        override fun getName(): String = "'$text' is a palindrome"
+
+        override fun execute() {
+            assertTrue(isPalindrome(text))
+        }
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/ParameterizedClassDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/ParameterizedClassDemo.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD
+import org.junit.jupiter.params.Parameter
+import org.junit.jupiter.params.ParameterizedClass
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.time.Duration
+
+class ParameterizedClassDemo {
+    @Nested
+    // tag::nested[]
+    @Execution(SAME_THREAD)
+    @ParameterizedClass
+    @ValueSource(strings = ["apple", "banana"])
+    inner class FruitTests {
+        @Parameter
+        lateinit var fruit: String
+
+        @Nested
+        @ParameterizedClass
+        @ValueSource(ints = [23, 42])
+        inner class QuantityTests {
+            @Parameter
+            var quantity: Int = 0
+
+            @ParameterizedTest
+            @ValueSource(strings = ["PT1H", "PT2H"])
+            fun test(duration: Duration) {
+                assertFruit(fruit)
+                assertQuantity(quantity)
+                assertFalse(duration.isNegative)
+            }
+        }
+    }
+    // end::nested[]
+
+    private fun assertFruit(fruit: String) {
+        assertTrue(
+            listOf("apple", "banana", "cherry", "dewberry").contains(fruit)
+        ) { "not a fruit: $fruit" }
+    }
+
+    private fun assertQuantity(quantity: Int) {
+        assertTrue(quantity > 0)
+    }
+}

--- a/documentation/src/test/kotlin/example/kotlin/RepeatedTestsDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/RepeatedTestsDemo.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.RepetitionInfo
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD
+import java.util.logging.Logger
+
+@Execution(SAME_THREAD)
+class RepeatedTestsDemo {
+    private val logger = // ...
+        // end::user_guide[]
+        Logger.getLogger(RepeatedTestsDemo::class.java.name)
+    // tag::user_guide[]
+
+    @BeforeEach
+    fun beforeEach(
+        testInfo: TestInfo,
+        repetitionInfo: RepetitionInfo
+    ) {
+        val currentRepetition = repetitionInfo.currentRepetition
+        val totalRepetitions = repetitionInfo.totalRepetitions
+        val methodName = testInfo.testMethod.get().name
+        logger.info("About to execute repetition $currentRepetition of $totalRepetitions for $methodName")
+    }
+
+    @RepeatedTest(10)
+    fun repeatedTest() {
+        // ...
+    }
+
+    @RepeatedTest(5)
+    fun repeatedTestWithRepetitionInfo(repetitionInfo: RepetitionInfo) {
+        assertEquals(5, repetitionInfo.totalRepetitions)
+    }
+
+    // end::user_guide[]
+    // Use fully qualified name to avoid having it show up in the imports.
+    @org.junit.jupiter.api.Disabled("intentional failures would break the build")
+    // tag::user_guide[]
+    @RepeatedTest(value = 8, failureThreshold = 2)
+    fun repeatedTestWithFailureThreshold(repetitionInfo: RepetitionInfo) {
+        // Simulate unexpected failure every second repetition
+        if (repetitionInfo.currentRepetition % 2 == 0) {
+            fail("Boom!")
+        }
+    }
+
+    @RepeatedTest(value = 1, name = "{displayName} {currentRepetition}/{totalRepetitions}")
+    @DisplayName("Repeat!")
+    fun customDisplayName(testInfo: TestInfo) {
+        assertEquals("Repeat! 1/1", testInfo.displayName)
+    }
+
+    @RepeatedTest(value = 1, name = RepeatedTest.LONG_DISPLAY_NAME)
+    @DisplayName("Details...")
+    fun customDisplayNameWithLongPattern(testInfo: TestInfo) {
+        assertEquals("Details... :: repetition 1 of 1", testInfo.displayName)
+    }
+
+    @RepeatedTest(value = 5, name = "Wiederholung {currentRepetition} von {totalRepetitions}")
+    fun repeatedTestInGerman() {
+        // ...
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/StandardTests.kt
+++ b/documentation/src/test/kotlin/example/kotlin/StandardTests.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+
+class StandardTests {
+    @BeforeEach
+    fun init() {
+    }
+
+    @Test
+    fun succeedingTest() {
+    }
+
+    // end::user_guide[]
+    @extensions.ExpectToFail
+    // tag::user_guide[]
+    @Test
+    fun failingTest() {
+        fail("a failing test")
+    }
+
+    @Test
+    @Disabled("for demonstration purposes")
+    fun skippedTest() {
+        // not executed
+    }
+
+    @Test
+    fun abortedTest() {
+        assumeTrue("abc".contains("Z"))
+        fail("test should have been aborted")
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun initAll() {
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun tearDownAll() {
+        }
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/TestingAStackDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/TestingAStackDemo.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin
+
+// tag::user_guide[]
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.EmptyStackException
+import java.util.Stack
+
+@DisplayName("A stack")
+class TestingAStackDemo {
+    @Test
+    @DisplayName("is instantiated with new Stack()")
+    fun isInstantiatedWithNew() {
+        Stack<Any>()
+    }
+
+    @Nested
+    @DisplayName("when new")
+    inner class WhenNew {
+        lateinit var stack: Stack<Any>
+
+        @BeforeEach
+        fun createNewStack() {
+            stack = Stack()
+        }
+
+        @Test
+        @DisplayName("is empty")
+        fun isEmpty() {
+            assertTrue(stack.isEmpty())
+        }
+
+        @Test
+        @DisplayName("throws EmptyStackException when popped")
+        fun throwsExceptionWhenPopped() {
+            assertThrows<EmptyStackException> { stack.pop() }
+        }
+
+        @Test
+        @DisplayName("throws EmptyStackException when peeked")
+        fun throwsExceptionWhenPeeked() {
+            assertThrows<EmptyStackException> { stack.peek() }
+        }
+
+        @Nested
+        @DisplayName("after pushing an element")
+        inner class AfterPushing {
+            val anElement = "an element"
+
+            @BeforeEach
+            fun pushAnElement() {
+                stack.push(anElement)
+            }
+
+            @Test
+            @DisplayName("it is no longer empty")
+            fun isNotEmpty() {
+                assertFalse(stack.isEmpty())
+            }
+
+            @Test
+            @DisplayName("returns the element when popped and is empty")
+            fun returnElementWhenPopped() {
+                assertEquals(anElement, stack.pop())
+                assertTrue(stack.isEmpty())
+            }
+
+            @Test
+            @DisplayName("returns the element when peeked but remains not empty")
+            fun returnElementWhenPeeked() {
+                assertEquals(anElement, stack.peek())
+                assertFalse(stack.isEmpty())
+            }
+        }
+    }
+}
+// end::user_guide[]

--- a/documentation/src/test/kotlin/example/kotlin/exception/AssertDoesNotThrowExceptionDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/exception/AssertDoesNotThrowExceptionDemo.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.exception
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class AssertDoesNotThrowExceptionDemo {
+    // tag::user_guide[]
+    @Test
+    fun testExceptionIsNotThrown() {
+        assertDoesNotThrow {
+            shouldNotThrowException()
+        }
+    }
+
+    fun shouldNotThrowException() {
+    }
+    // end::user_guide[]
+}

--- a/documentation/src/test/kotlin/example/kotlin/exception/ExceptionAssertionDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/exception/ExceptionAssertionDemo.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.exception
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ExceptionAssertionDemo {
+    // tag::user_guide[]
+    @Test
+    fun testExpectedExceptionIsThrown() {
+        // The following assertion succeeds because the code under assertion
+        // throws the expected IllegalArgumentException.
+        // The assertion also returns the thrown exception which can be used for
+        // further assertions like asserting the exception message.
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                throw IllegalArgumentException("expected message")
+            }
+        assertEquals("expected message", exception.message)
+
+        // The following assertion also succeeds because the code under assertion
+        // throws IllegalArgumentException which is a subclass of RuntimeException.
+        assertThrows<RuntimeException> {
+            throw IllegalArgumentException("expected message")
+        }
+    }
+    // end::user_guide[]
+}

--- a/documentation/src/test/kotlin/example/kotlin/exception/ExceptionAssertionExactDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/exception/ExceptionAssertionExactDemo.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.exception
+
+import extensions.ExpectToFail
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrowsExactly
+
+class ExceptionAssertionExactDemo {
+    @ExpectToFail
+    // tag::user_guide[]
+    @Test
+    fun testExpectedExceptionIsThrown() {
+        // The following assertion succeeds because the code under assertion throws
+        // IllegalArgumentException which is exactly equal to the expected type.
+        // The assertion also returns the thrown exception which can be used for
+        // further assertions like asserting the exception message.
+        val exception =
+            assertThrowsExactly<IllegalArgumentException> {
+                throw IllegalArgumentException("expected message")
+            }
+        assertEquals("expected message", exception.message)
+
+        // The following assertion fails because the assertion expects exactly
+        // RuntimeException to be thrown, not subclasses of RuntimeException.
+        assertThrowsExactly<RuntimeException> {
+            throw IllegalArgumentException("expected message")
+        }
+    }
+    // end::user_guide[]
+}

--- a/documentation/src/test/kotlin/example/kotlin/exception/FailedAssertionDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/exception/FailedAssertionDemo.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.exception
+
+import example.util.Calculator
+import extensions.ExpectToFail
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FailedAssertionDemo {
+    // tag::user_guide[]
+    private val calculator = Calculator()
+
+    // end::user_guide[]
+
+    @ExpectToFail
+    // tag::user_guide[]
+    @Test
+    fun failsDueToUncaughtAssertionError() {
+        // The following incorrect assertion will cause a test failure.
+        // The expected value should be 2 instead of 99.
+        assertEquals(99, calculator.add(1, 1))
+    }
+    // end::user_guide[]
+}

--- a/documentation/src/test/kotlin/example/kotlin/exception/UncaughtExceptionHandlingDemo.kt
+++ b/documentation/src/test/kotlin/example/kotlin/exception/UncaughtExceptionHandlingDemo.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package example.kotlin.exception
+
+import example.util.Calculator
+import extensions.ExpectToFail
+import org.junit.jupiter.api.Test
+
+class UncaughtExceptionHandlingDemo {
+    // tag::user_guide[]
+    private val calculator = Calculator()
+
+    // end::user_guide[]
+
+    @ExpectToFail
+    // tag::user_guide[]
+    @Test
+    fun failsDueToUncaughtException() {
+        // The following throws an ArithmeticException due to division by
+        // zero, which causes a test failure.
+        calculator.divide(1, 0)
+    }
+    // end::user_guide[]
+}


### PR DESCRIPTION
Adds Kotlin tabbed code snippets to six more User Guide sections,
continuing the effort started in #5316.

**Pages updated:**
- Nested Tests
- Dynamic Tests
- Assumptions
- Exception Handling
- Repeated Tests
- Test Classes and Methods

Each Java code block is wrapped in `[tabs]` with a corresponding
Kotlin example that mirrors the same test logic using idiomatic
Kotlin: property access, string templates, reified generics,
trailing lambdas, `companion object` + `@JvmStatic` for lifecycle
methods, etc.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- ~Method preconditions are checked~ _(N/A — documentation only)_
- [x] Coding conventions have been followed
- [x] Change is covered by automated tests
- ~Public API has Javadoc and `@API` annotations~ _(N/A — documentation only)_
- [x] Change is documented in the User Guide