### PR TITLE
Fix race condition in WorkerThreadPoolHierarchicalTestExecutorService

### DIFF
--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java
@@ -35,7 +35,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.SynchronousQueue;
@@ -848,10 +847,6 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 			return new ReacquisitionToken();
 		}
 
-		public boolean isAtLeastOneLeaseTaken() {
-			return semaphore.availablePermits() < parallelism;
-		}
-
 		private class ReacquisitionToken {
 
 			private boolean used = false;
@@ -912,15 +907,9 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 			implements RejectedExecutionHandler {
 		@Override
 		public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-			if (!(r instanceof RunLeaseAwareWorker worker)) {
-				return;
+			if (r instanceof RunLeaseAwareWorker worker) {
+				worker.workerLease.release(false);
 			}
-			worker.workerLease.release(false);
-			if (executor.isShutdown() || workerLeaseManager.isAtLeastOneLeaseTaken()
-					|| worker.parentDoneCondition.getAsBoolean()) {
-				return;
-			}
-			throw new RejectedExecutionException("Task with " + workerLeaseManager + " rejected from " + executor);
 		}
 	}
 }


### PR DESCRIPTION
I observed the `WorkerThreadPoolHierarchicalTestExecutorServiceTests::limitsWorkerThreadsToMaxPoolSize` test failing. 

```
WorkerThreadPoolHierarchicalTestExecutorServiceTests > limitsWorkerThreadsToMaxPoolSize() FAILED
    java.util.concurrent.ExecutionException: java.util.concurrent.RejectedExecutionException: Task with WorkerLeaseManager [parallelism = 3, semaphore = java.util.concurrent.Semaphore@1b98b530[Permits = 3]] rejected from java.util.concurrent.ThreadPoolExecutor@1faf5ac8[Running, pool size = 3, active threads = 1, queued tasks = 0, completed tasks = 2]
        at java.base@25.0.1/java.util.concurrent.CompletableFuture.wrapInExecutionException(CompletableFuture.java:345)
        at java.base@25.0.1/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:440)
        at java.base@25.0.1/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2094)
        at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorServiceTests.limitsWorkerThreadsToMaxPoolSize(WorkerThreadPoolHierarchicalTestExecutorServiceTests.java:405)

        Caused by:
        java.util.concurrent.RejectedExecutionException: Task with WorkerLeaseManager [parallelism = 3, semaphore = java.util.concurrent.Semaphore@1b98b530[Permits = 3]] rejected from java.util.concurrent.ThreadPoolExecutor@1faf5ac8[Running, pool size = 3, active threads = 1, queued tasks = 0, completed tasks = 2]
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService$LeaseAwareRejectedExecutionHandler.rejectedExecution(WorkerThreadPoolHierarchicalTestExecutorService.java:923)
            at java.base@25.0.1/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:787)
            at java.base@25.0.1/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1328)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService.maybeStartWorker(WorkerThreadPoolHierarchicalTestExecutorService.java:215)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService$WorkerLeaseManager.release(WorkerThreadPoolHierarchicalTestExecutorService.java:846)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService$WorkerLease.release(WorkerThreadPoolHierarchicalTestExecutorService.java:900)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService$WorkerLease.release(WorkerThreadPoolHierarchicalTestExecutorService.java:891)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService$WorkerThread.runBlocking(WorkerThreadPoolHierarchicalTestExecutorService.java:329)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService$WorkerThread.waitFor(WorkerThreadPoolHierarchicalTestExecutorService.java:445)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService$WorkerThread.invokeAll(WorkerThreadPoolHierarchicalTestExecutorService.java:360)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorService.invokeAll(WorkerThreadPoolHierarchicalTestExecutorService.java:183)
            at app//org.junit.platform.engine.support.hierarchical.WorkerThreadPoolHierarchicalTestExecutorServiceTests.lambda$limitsWorkerThreadsToMaxPoolSize$3(WorkerThreadPoolHierarchicalTestExecutorServiceTests.java:402)
```            

From this I'm concluding that the `RejectedExecutionException` isn't necessary. Or more precisely, that the problem it aims to guard against, can not be guarded against here.

The argument:

1.  There are two relevant variables. The max-workers in the threadpool, and the number of worker leases. The first is a hard limit enforced by the thread pool. The second is the ideal number of workers JUnit tries to keep active. 

2. Typically the latter is larger than the former. But in this instance max workers and worker leases are equal.

3. Workers can temporarily give up their lease when using `runBlocking`. JUnit will then try to compensate and by adding a new worker to the pool. 

4. Inspecting the code with this in mind, we can see that when pool already reached its maximum workers, one of which has given up its lease in `runBlocking`, the following code will try to add another worker. 

https://github.com/junit-team/junit-framework/blob/9656c00bf88891371bf0023f7ad73cf977ded8c9/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java#L207-L218

5. As such, checking the number of available leases does not provide any meaningful information about the number of workers that can be added.

6. Looking at the stacktrace we can see that it fails in the root node. Because the test execution prefers to execute the first node on the same thread, we know it must be awaiting child 2. So the current state look like this:

```
root  <- worker 1 (in runBlocking awaiting child2)
 |- child1
 | |- leaf1a
 | |- leaf1b
 |- child2 
 | |- leaf2a
 | |- leaf2b  
```

And because we by passed all checks here:

https://github.com/junit-team/junit-framework/blob/9656c00bf88891371bf0023f7ad73cf977ded8c9/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java#L918-L923

We can conclude that the pool was not shut down, there were 0 active leases and the `child2` task was not yet done. 

6. One possible situation where this could happen is if worker 2 was in `runBlocking` for `child2`. And it is relatively easy to get into this state. It happens immediately after worker 3 finishes.

```
root  <- worker 1 (in runBlocking awaiting child2, starting a new worker)
 |- child1
 | |- leaf1a
 | |- leaf1b
 |- child2 <- worker 2 (in runBlocking awaiting leaf2b)
 | |- leaf2a
 | |- leaf2b <- worker 3 (without lease, but terminating.
```

Specifically 
 * worker 1 must have been in `runBlocking` starting a new worker.
 * worker 2 must have been in `runBlocking` somewhere between [`blockingAction.run();` and `workerLease.reacquire();`](https://github.com/junit-team/junit-framework/blob/9656c00bf88891371bf0023f7ad73cf977ded8c9/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java#L330-L335).
 * worker 3 must have been in `RunLeaseAwareWorker.run` somewhere between [`workerLease.release(false);` and completing the method](https://github.com/junit-team/junit-framework/blob/9656c00bf88891371bf0023f7ad73cf977ded8c9/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java#L230-L235).

As such we have a situation where it is possible that the task we are waiting for is not yet done, and there are no workers with active leases at the same time. 

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [x] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [x] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
