### PR TITLE
Console selectors: accept Windows paths and spaces

### DIFF
--- a/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0-M2.adoc
+++ b/documentation/modules/ROOT/partials/release-notes/release-notes-6.1.0-M2.adoc
@@ -22,6 +22,8 @@ repository on GitHub.
   before rejecting an extraneous worker.
 * Missing precondition checks have been added to `Launcher` implementations.
 * Failures to resolve selectors are now propagated by the Suite Engine.
+* Console Launcher now accepts Windows file paths and paths with spaces for
+  `--select-file` and `--select-resource`, including line/column query parameters.
 
 [[v6.1.0-M2-junit-platform-deprecations-and-breaking-changes]]
 ==== Deprecations and Breaking Changes

--- a/junit-platform-console/junit-platform-console.gradle.kts
+++ b/junit-platform-console/junit-platform-console.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
 	osgiVerification(projects.junitJupiterEngine)
 	osgiVerification(projects.junitPlatformLauncher)
 	osgiVerification(libs.openTestReporting.tooling.spi)
+
+	testImplementation(projects.junitJupiter)
 }
 
 tasks {
@@ -73,5 +75,8 @@ tasks {
 		manifest {
 			attributes("Main-Class" to "org.junit.platform.console.ConsoleLauncher")
 		}
+	}
+	test {
+		useJUnitPlatform()
 	}
 }

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/SelectorConverter.java
@@ -21,7 +21,9 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqu
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUri;
 
 import java.net.URI;
+import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.util.ResourceUtils;
 import org.junit.platform.engine.DiscoverySelectorIdentifier;
@@ -42,6 +44,8 @@ import picocli.CommandLine.ITypeConverter;
 
 class SelectorConverter {
 
+	private static final Pattern URI_SCHEME = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*:.*");
+
 	static class Module implements ITypeConverter<ModuleSelector> {
 		@Override
 		public ModuleSelector convert(String value) {
@@ -59,9 +63,9 @@ class SelectorConverter {
 	static class File implements ITypeConverter<FileSelector> {
 		@Override
 		public FileSelector convert(String value) {
-			URI uri = URI.create(value);
-			String path = ResourceUtils.stripQueryComponent(uri).getPath();
-			FilePosition filePosition = FilePosition.fromQuery(uri.getQuery()).orElse(null);
+			ParsedSelectorInput parsed = parsePathAndQuery(value);
+			FilePosition filePosition = FilePosition.fromQuery(parsed.query).orElse(null);
+			String path = parsed.path;
 			return selectFile(path, filePosition);
 		}
 	}
@@ -99,9 +103,9 @@ class SelectorConverter {
 	static class ClasspathResource implements ITypeConverter<ClasspathResourceSelector> {
 		@Override
 		public ClasspathResourceSelector convert(String value) {
-			URI uri = URI.create(value);
-			String path = ResourceUtils.stripQueryComponent(uri).getPath();
-			FilePosition filePosition = FilePosition.fromQuery(uri.getQuery()).orElse(null);
+			ParsedSelectorInput parsed = parsePathAndQuery(value);
+			FilePosition filePosition = FilePosition.fromQuery(parsed.query).orElse(null);
+			String path = parsed.path;
 			return selectClasspathResource(path, filePosition);
 		}
 	}
@@ -127,6 +131,65 @@ class SelectorConverter {
 		@Override
 		public DiscoverySelectorIdentifier convert(String value) {
 			return DiscoverySelectorIdentifier.parse(value);
+		}
+	}
+
+	private static ParsedSelectorInput parsePathAndQuery(String value) {
+		if (looksLikeUri(value) && !looksLikeWindowsDrivePath(value)) {
+			@Nullable ParsedSelectorInput parsed = parseUri(value);
+			if (parsed != null) {
+				return parsed;
+			}
+			if (value.indexOf(' ') >= 0) {
+				parsed = parseUri(value.replace(" ", "%20"));
+				if (parsed != null) {
+					return parsed;
+				}
+			}
+			URI.create(value);
+		}
+		return parseRawPath(value);
+	}
+
+	private static @Nullable ParsedSelectorInput parseUri(String value) {
+		try {
+			URI uri = URI.create(value);
+			String path = ResourceUtils.stripQueryComponent(uri).getPath();
+			if (path == null) {
+				return null;
+			}
+			return new ParsedSelectorInput(path, uri.getQuery());
+		}
+		catch (IllegalArgumentException ex) {
+			return null;
+		}
+	}
+
+	private static ParsedSelectorInput parseRawPath(String value) {
+		int queryIndex = value.indexOf('?');
+		if (queryIndex < 0) {
+			return new ParsedSelectorInput(value, null);
+		}
+		String path = value.substring(0, queryIndex);
+		String query = value.substring(queryIndex + 1);
+		return new ParsedSelectorInput(path, query);
+	}
+
+	private static boolean looksLikeUri(String value) {
+		return URI_SCHEME.matcher(value).matches();
+	}
+
+	private static boolean looksLikeWindowsDrivePath(String value) {
+		return value.length() >= 2 && Character.isLetter(value.charAt(0)) && value.charAt(1) == ':';
+	}
+
+	private static final class ParsedSelectorInput {
+		private final String path;
+		private final @Nullable String query;
+
+		private ParsedSelectorInput(String path, @Nullable String query) {
+			this.path = path;
+			this.query = query;
 		}
 	}
 

--- a/junit-platform-console/src/test/java/org/junit/platform/console/options/SelectorConverterTests.java
+++ b/junit-platform-console/src/test/java/org/junit/platform/console/options/SelectorConverterTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit.platform.console.options;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.discovery.ClasspathResourceSelector;
+import org.junit.platform.engine.discovery.FilePosition;
+import org.junit.platform.engine.discovery.FileSelector;
+
+class SelectorConverterTests {
+
+	@Test
+	void fileSelectorAcceptsWindowsPathWithSpacesAndQuery() {
+		SelectorConverter.File converter = new SelectorConverter.File();
+		FileSelector selector = converter.convert("C:\\work\\My Tests\\FooTest.java?line=12&column=34");
+
+		assertEquals("C:\\work\\My Tests\\FooTest.java", selector.getRawPath());
+		FilePosition position = selector.getPosition().orElseThrow();
+		assertEquals(12, position.getLine());
+		assertEquals(34, position.getColumn().orElseThrow());
+	}
+
+	@Test
+	void classpathResourceSelectorAcceptsSpacesAndQuery() {
+		SelectorConverter.ClasspathResource converter = new SelectorConverter.ClasspathResource();
+		ClasspathResourceSelector selector = converter.convert("data files/my test.xml?line=5");
+
+		assertEquals("data files/my test.xml", selector.getClasspathResourceName());
+		FilePosition position = selector.getPosition().orElseThrow();
+		assertEquals(5, position.getLine());
+		assertTrue(position.getColumn().isEmpty());
+	}
+}


### PR DESCRIPTION
## Summary
- Allow --select-file and --select-resource to accept Windows drive paths and paths with spaces.
- Preserve URI handling and line/column query parsing.
- Add unit tests for Windows paths with spaces and classpath resources with spaces.

## Motivation
Console selectors currently treat inputs as URIs, which breaks common Windows paths (e.g., C:\...) and quoted paths with spaces. This change makes the CLI more robust while keeping existing URI support.

## Testing
- ./gradlew :junit-platform-console:test --tests org.junit.platform.console.options.SelectorConverterTests
