### PR TITLE
Fix some upcoming NullAway wildcard warnings

### DIFF
--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/CachingJupiterConfiguration.java
@@ -33,6 +33,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Constants;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -73,7 +74,8 @@ public class CachingJupiterConfiguration implements JupiterConfiguration {
 	}
 
 	@Override
-	public <T> Optional<T> getRawConfigurationParameter(String key, Function<? super String, ? extends T> transformer) {
+	public <T> Optional<T> getRawConfigurationParameter(String key,
+			Function<? super String, ? extends @Nullable T> transformer) {
 		return delegate.getRawConfigurationParameter(key, transformer);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/DefaultJupiterConfiguration.java
@@ -42,6 +42,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
@@ -160,7 +161,8 @@ public class DefaultJupiterConfiguration implements JupiterConfiguration {
 	}
 
 	@Override
-	public <T> Optional<T> getRawConfigurationParameter(String key, Function<? super String, ? extends T> transformer) {
+	public <T> Optional<T> getRawConfigurationParameter(String key,
+			Function<? super String, ? extends @Nullable T> transformer) {
 		return configurationParameters.get(key, transformer);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/config/JupiterConfiguration.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.apiguardian.api.API;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
@@ -41,7 +42,8 @@ public interface JupiterConfiguration {
 
 	Optional<String> getRawConfigurationParameter(String key);
 
-	<T> Optional<T> getRawConfigurationParameter(String key, Function<? super String, ? extends T> transformer);
+	<T> Optional<T> getRawConfigurationParameter(String key,
+			Function<? super String, ? extends @Nullable T> transformer);
 
 	boolean isParallelExecutionEnabled();
 


### PR DESCRIPTION
We're starting to work on wildcard support in NullAway (see https://github.com/uber/NullAway/pull/1520), and some warnings turned up when running that NullAway version on JUnit.  This PR fixes the warnings.  I think the fix makes sense: since `ConfigurationParameters#get` takes a `Function<? super String, ? extends @Nullable T>`, `org.junit.jupiter.engine.config.JupiterConfiguration#getRawConfigurationParameter` should take the same type for its `Function` parameter.

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

Most points N/A as this only changes annotations; no code behavior changes

- [X] There are no TODOs left in the code
- [X] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [X] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [x] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [X] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [x] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
