### PR TITLE
Conditionally disable build on JDK 27-ea 

### DIFF
--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -38,7 +38,8 @@ runs:
         javaToolchains \
         ${{ inputs.arguments }} || error_code=$?
         
-        if [ "$error_code" -eq 0 && "${{ inputs.broken-by-issue }}" != "" ]; then
+        # error_code is not set if the build was sucesfull.
+        if [ -z "$error_code" ] && [ -n "${{ inputs.broken-by-issue }}" ]; then
           echo "Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?"
           exit 1
         fi

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: build
   broken-by-issue:
     required: false
-    description: Expect the build to fail due the referenced issue
+    description: Expect the build to fail due the referenced GitHub issue
     default: ""
   encryptionKey:
     required: true

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -39,7 +39,7 @@ runs:
         ${{ inputs.arguments }} \
         || error_code=$?
         
-        if [ "$error_code" -eq 0 && ${{ inputs.broken-by-issue }} != "" ]; then
+        if [ "$error_code" -eq 0 && "${{ inputs.broken-by-issue }}" != "" ]; then
           echo "Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?"
           exit 1
         fi

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -36,8 +36,7 @@ runs:
         -Pjunit.develocity.predictiveTestSelection.selectRemainingTests=${{ github.event_name != 'pull_request' }} \
         "-Dscan.value.GitHub job=${{ github.job }}" \
         javaToolchains \
-        ${{ inputs.arguments }} \
-        || error_code=$?
+        ${{ inputs.arguments }} || error_code=$?
         
         if [ "$error_code" -eq 0 && "${{ inputs.broken-by-issue }}" != "" ]; then
           echo "Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?"

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -38,13 +38,19 @@ runs:
         javaToolchains \
         ${{ inputs.arguments }} || error_code=$?
         
-        # error_code is not set if the build was sucesfull.
-        if [ -z "$error_code" ] && [ -n "${{ inputs.broken-by-issue }}" ]; then
-          echo "Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?"
-          exit 1
+        
+        if [ -n "${{ inputs.broken-by-issue }}" ]; then
+          if [ -n "$error_code" ]; then
+            # we expected the build to fail, it failed => pass 
+            exit 0
+          else            
+            # we expected the build to fail, it didn't => fail
+            echo "Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?"
+            exit 1            
+          fi
         fi
         
-        # exit with the original error_code
-        if [ ! -z "$error_code" ]; then
+        # exit with the original error code if set
+        if [ -n "$error_code" ]; then
           exit "$error_code"
         fi

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -45,7 +45,9 @@ runs:
             exit 0
           else            
             # we expected the build to fail, it didn't => fail
-            echo "Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?"
+            RED='\033[0;31m'
+            RESET='\033[0m' # No Color
+            echo "${RED}Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?${RESET}"
             exit 1            
           fi
         fi

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -44,4 +44,7 @@ runs:
           exit 1
         fi
         
-        exit "$error_code"
+        # exit with the original error_code
+        if [ -n "$error_code" ]; then
+          exit "$error_code"
+        fi

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -45,6 +45,6 @@ runs:
         fi
         
         # exit with the original error_code
-        if [ -n "$error_code" ]; then
+        if [ ! -z "$error_code" ]; then
           exit "$error_code"
         fi

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -36,9 +36,12 @@ runs:
         -Pjunit.develocity.predictiveTestSelection.selectRemainingTests=${{ github.event_name != 'pull_request' }} \
         "-Dscan.value.GitHub job=${{ github.job }}" \
         javaToolchains \
-        ${{ inputs.arguments }}
+        ${{ inputs.arguments }} \
+        || error_code=$?
         
-        if [ "$?" -eq 0 && ${{ inputs.broken-by-issue }} != "" ]; then
+        if [ "$error_code" -eq 0 && ${{ inputs.broken-by-issue }} != "" ]; then
           echo "Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?"
           exit 1
         fi
+        
+        exit "$error_code"

--- a/.github/actions/run-gradle/action.yml
+++ b/.github/actions/run-gradle/action.yml
@@ -5,6 +5,10 @@ inputs:
     required: true
     description: Gradle arguments
     default: build
+  broken-by-issue:
+    required: false
+    description: Expect the build to fail due the referenced issue
+    default: ""
   encryptionKey:
     required: true
     description: Gradle cache encryption key
@@ -33,3 +37,8 @@ runs:
         "-Dscan.value.GitHub job=${{ github.job }}" \
         javaToolchains \
         ${{ inputs.arguments }}
+        
+        if [ "$?" -eq 0 && ${{ inputs.broken-by-issue }} != "" ]; then
+          echo "Build was expected to fail, but it passed. Was ${{ inputs.broken-by-issue }} resolved?"
+          exit 1
+        fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,9 +55,9 @@ jobs:
       uses: ./.github/actions/run-gradle
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        arguments: |
-          --no-build-cache \
-          -Dscan.tag.CodeQL \
+        arguments: >
+          --no-build-cache
+          -Dscan.tag.CodeQL
           classes
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
       uses: ./.github/actions/run-gradle
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        arguments: >
+        arguments: >-
           --no-build-cache
           -Dscan.tag.CodeQL
           classes

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -113,7 +113,6 @@ jobs:
         uses: ./.github/actions/run-gradle
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          expect-failure: ${{ matrix.expect-failure }}
           # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
           arguments: >-
             -Ptesting.enableJaCoCo=false

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -34,14 +34,13 @@ jobs:
         - version: 26
           type: ea
           release: leyden
+          broken-by-issue: "TODO: Dummy for testing"
         - version: 27
           type: ea
           release: valhalla
-          # TODO: Turn back on again.
-          continue-on-error: true
+          broken-by-issue: "https://github.com/junit-team/junit-framework/issues/5605"
     name: "OpenJDK ${{ matrix.jdk.version }} (${{ matrix.jdk.release || matrix.jdk.type }})"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.continue-on-error || false }}
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -112,6 +111,7 @@ jobs:
         uses: ./.github/actions/run-gradle
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          expect-failure: ${{ matrix.expect-failure }}
           arguments: |
             -Ptesting.enableJaCoCo=false \
             -PjavaToolchain.version=${{ matrix.jdk }} \

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -37,8 +37,11 @@ jobs:
         - version: 27
           type: ea
           release: valhalla
+          # TODO: Turn back on again.
+          continue-on-error: true
     name: "OpenJDK ${{ matrix.jdk.version }} (${{ matrix.jdk.release || matrix.jdk.type }})"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue-on-error || false }}
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -31,6 +31,7 @@ jobs:
           type: ga
         - version: 27
           type: ea
+          broken-by-issue: "https://github.com/junit-team/junit-framework/issues/5605"
         - version: 26
           type: ea
           release: leyden
@@ -38,7 +39,6 @@ jobs:
         - version: 27
           type: ea
           release: valhalla
-          broken-by-issue: "https://github.com/junit-team/junit-framework/issues/5605"
     name: "OpenJDK ${{ matrix.jdk.version }} (${{ matrix.jdk.release || matrix.jdk.type }})"
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +77,7 @@ jobs:
             -Dscan.tag.JDK_${{ matrix.jdk.version }}
             build
             --no-configuration-cache
-          broken-by-issue: ${{ matrix.broken-by-issue }}
+          broken-by-issue: ${{ matrix.jdk.broken-by-issue }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
         with:

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -112,6 +112,7 @@ jobs:
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           expect-failure: ${{ matrix.expect-failure }}
+          # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
           arguments: |
             -Ptesting.enableJaCoCo=false \
             -PjavaToolchain.version=${{ matrix.jdk }} \
@@ -119,7 +120,7 @@ jobs:
             -Dscan.tag.JDK_${{ matrix.jdk }} \
             -Dscan.tag.OpenJ9 \
             build \
-            --no-configuration-cache # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
+            --no-configuration-cache
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
         with:

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -77,6 +77,7 @@ jobs:
             -Dscan.tag.JDK_${{ matrix.jdk.version }}
             build
             --no-configuration-cache
+          broken-by-issue: ${{ matrix.broken-by-issue }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
         with:

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -70,12 +70,13 @@ jobs:
         uses: ./.github/actions/run-gradle
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
           arguments: |
             -Ptesting.enableJaCoCo=false \
             -PjavaToolchain.version=${{ matrix.jdk.version }} \
             -Dscan.tag.JDK_${{ matrix.jdk.version }} \
             build \
-            --no-configuration-cache #Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
+            --no-configuration-cache
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
         with:

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
-          arguments: >
+          arguments: >-
             -Ptesting.enableJaCoCo=false
             -PjavaToolchain.version=${{ matrix.jdk.version }}
             -Dscan.tag.JDK_${{ matrix.jdk.version }}
@@ -114,7 +114,7 @@ jobs:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           expect-failure: ${{ matrix.expect-failure }}
           # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
-          arguments: >
+          arguments: >-
             -Ptesting.enableJaCoCo=false
             -PjavaToolchain.version=${{ matrix.jdk }}
             -PjavaToolchain.implementation=j9

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -71,11 +71,11 @@ jobs:
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
-          arguments: |
-            -Ptesting.enableJaCoCo=false \
-            -PjavaToolchain.version=${{ matrix.jdk.version }} \
-            -Dscan.tag.JDK_${{ matrix.jdk.version }} \
-            build \
+          arguments: >
+            -Ptesting.enableJaCoCo=false
+            -PjavaToolchain.version=${{ matrix.jdk.version }}
+            -Dscan.tag.JDK_${{ matrix.jdk.version }}
+            build
             --no-configuration-cache
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
@@ -114,13 +114,13 @@ jobs:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           expect-failure: ${{ matrix.expect-failure }}
           # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
-          arguments: |
-            -Ptesting.enableJaCoCo=false \
-            -PjavaToolchain.version=${{ matrix.jdk }} \
-            -PjavaToolchain.implementation=j9 \
-            -Dscan.tag.JDK_${{ matrix.jdk }} \
-            -Dscan.tag.OpenJ9 \
-            build \
+          arguments: >
+            -Ptesting.enableJaCoCo=false
+            -PjavaToolchain.version=${{ matrix.jdk }}
+            -PjavaToolchain.implementation=j9
+            -Dscan.tag.JDK_${{ matrix.jdk }}
+            -Dscan.tag.OpenJ9
+            build
             --no-configuration-cache
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -35,7 +35,6 @@ jobs:
         - version: 26
           type: ea
           release: leyden
-          broken-by-issue: "TODO: Dummy for testing"
         - version: 27
           type: ea
           release: valhalla

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,11 +40,12 @@ jobs:
       uses: ./.github/actions/main-build
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+        # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
         arguments: |
           :platform-tooling-support-tests:test \
           build \
           jacocoRootReport \
-          --no-configuration-cache # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
+          --no-configuration-cache
     - name: Upload to Codecov.io
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,10 @@ jobs:
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
         # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
-        arguments: |
-          :platform-tooling-support-tests:test \
-          build \
-          jacocoRootReport \
+        arguments: >
+          :platform-tooling-support-tests:test
+          build
+          jacocoRootReport
           --no-configuration-cache
     - name: Upload to Codecov.io
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -98,8 +98,8 @@ jobs:
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        arguments: |
-          publishAllPublicationsToMavenCentralSnapshotsRepository -x check \
+        arguments: >
+          publishAllPublicationsToMavenCentralSnapshotsRepository -x check
           prepareGitHubAttestation
     - name: Generate build provenance attestations
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
@@ -128,9 +128,9 @@ jobs:
       uses: ./.github/actions/run-gradle
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        arguments: |
-          antora \
-          -Pantora.downloadNode=false \
+        arguments: >
+          antora
+          -Pantora.downloadNode=false
           -Dscan.tag.Documentation
 
   deploy_documentation:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
         # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
-        arguments: >
+        arguments: >-
           :platform-tooling-support-tests:test
           build
           jacocoRootReport
@@ -98,7 +98,7 @@ jobs:
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        arguments: >
+        arguments: >-
           publishAllPublicationsToMavenCentralSnapshotsRepository -x check
           prepareGitHubAttestation
     - name: Generate build provenance attestations
@@ -128,7 +128,7 @@ jobs:
       uses: ./.github/actions/run-gradle
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        arguments: >
+        arguments: >-
           antora
           -Pantora.downloadNode=false
           -Dscan.tag.Documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/run-gradle
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          arguments: >
+          arguments: >-
             --rerun-tasks
             -Pmanifest.buildTimestamp="${{ steps.referenceJar.outputs.buildTimestamp }}"
             -Pmanifest.createdBy="${{ steps.referenceJar.outputs.createdBy }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,11 @@ jobs:
         uses: ./.github/actions/run-gradle
         with:
           encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          arguments: |
-            --rerun-tasks \
-            -Pmanifest.buildTimestamp="${{ steps.referenceJar.outputs.buildTimestamp }}" \
-            -Pmanifest.createdBy="${{ steps.referenceJar.outputs.createdBy }}" \
-            :verifyArtifactsInStagingRepositoryAreReproducible \
+          arguments: >
+            --rerun-tasks
+            -Pmanifest.buildTimestamp="${{ steps.referenceJar.outputs.buildTimestamp }}"
+            -Pmanifest.createdBy="${{ steps.referenceJar.outputs.createdBy }}"
+            :verifyArtifactsInStagingRepositoryAreReproducible
             --remote-repo-url=${{ env.STAGING_REPO_URL }}
       - name: Generate build provenance attestations
         if: ${{ inputs.dryRun == false }}

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
         # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
-        arguments: >
+        arguments: >-
           --quiet
           --no-configuration-cache
     - name: Build and compare checksums

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -33,9 +33,10 @@ jobs:
       uses: ./.github/actions/run-gradle
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+        # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
         arguments: |
           --quiet \
-          --no-configuration-cache # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
+          --no-configuration-cache
     - name: Build and compare checksums
       shell: bash
       run: ./.github/scripts/checkBuildReproducibility.sh

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -34,8 +34,8 @@ jobs:
       with:
         encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
         # Disable configuration cache due to https://github.com/diffplug/spotless/issues/2318
-        arguments: |
-          --quiet \
+        arguments: >
+          --quiet
           --no-configuration-cache
     - name: Build and compare checksums
       shell: bash


### PR DESCRIPTION
Adds a `broken-by-issue` input to the `run-gradle` action. 

When set the build is expected to fail due to the given issue, if it does not, the now fixed issue will be written to the output.

Mitigates: https://github.com/junit-team/junit-framework/issues/5605

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/) and [Release Notes](https://docs.junit.org/snapshot/release-notes.html)
